### PR TITLE
Add showDivider, flush, and size props to PageHeader

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -10,6 +10,11 @@
   width: 100%;
 }
 
+.bds-page-header--flush {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 /* ─── Title row ──────────────────────────────────────────────── */
 
 .bds-page-header__inner {
@@ -49,6 +54,14 @@
   margin: 0;
 }
 
+.bds-page-header--md .bds-page-header__title {
+  font-size: var(--heading-md);
+}
+
+.bds-page-header--sm .bds-page-header__title {
+  font-size: var(--heading-sm);
+}
+
 .bds-page-header__subtitle {
   font-family: var(--font-family-body);
   font-size: var(--body-lg);
@@ -78,12 +91,20 @@
   border-top: var(--border-width-sm) solid var(--border-secondary);
 }
 
+.bds-page-header__metadata--no-divider {
+  border-top: none;
+}
+
 .bds-page-header__metadata-inner {
   display: flex;
   gap: var(--gap-sm);
   align-items: flex-start;
   padding-top: var(--padding-xl);
   width: 100%;
+}
+
+.bds-page-header__metadata--no-divider .bds-page-header__metadata-inner {
+  padding-top: 0;
 }
 
 .bds-page-header__metadata-item {
@@ -116,4 +137,10 @@
 
 .bds-page-header__tabs {
   width: 100%;
+  border-bottom: var(--border-width-sm) solid var(--border-secondary);
+}
+
+.bds-page-header__tabs .bds-tab-bar--tab .bds-tab-bar-item {
+  border-bottom-width: var(--border-width-sm);
+  margin-bottom: calc(-1 * var(--border-width-sm));
 }

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -16,6 +16,12 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
   actions?: ReactNode;
   tabs?: ReactNode;
   metadata?: MetadataItem[];
+  /** Show divider and top padding above metadata. Default: true */
+  showDivider?: boolean;
+  /** Remove horizontal padding (for layouts that provide their own). Default: false */
+  flush?: boolean;
+  /** Title scale. Default: 'lg' */
+  size?: 'sm' | 'md' | 'lg';
 }
 
 /**
@@ -29,13 +35,16 @@ export function PageHeader({
   actions,
   tabs,
   metadata,
+  showDivider = true,
+  flush = false,
+  size = 'lg',
   className,
   style,
   ...props
 }: PageHeaderProps) {
   return (
     <div
-      className={bdsClass('bds-page-header', className)}
+      className={bdsClass('bds-page-header', flush && 'bds-page-header--flush', size !== 'lg' && `bds-page-header--${size}`, className)}
       style={style}
       {...props}
     >
@@ -53,7 +62,7 @@ export function PageHeader({
       </div>
 
       {metadata && metadata.length > 0 && (
-        <div className="bds-page-header__metadata">
+        <div className={bdsClass('bds-page-header__metadata', !showDivider && 'bds-page-header__metadata--no-divider')}>
           <div className="bds-page-header__metadata-inner">
             {metadata.map((item) => (
               <div key={item.label} className="bds-page-header__metadata-item">

--- a/components/ui/ServiceBadge/ServiceBadge.tsx
+++ b/components/ui/ServiceBadge/ServiceBadge.tsx
@@ -9,7 +9,10 @@ export type ServiceBadgeMode = 'badge' | 'label';
 export interface ServiceBadgeProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Service category */
   category: ServiceCategory;
-  /** Display mode */
+  /**
+   * Display mode
+   * @deprecated Use `ServiceTag` for text/label display. ServiceBadge is icon-only going forward.
+   */
   mode?: ServiceBadgeMode;
   /** Size variant */
   size?: ServiceBadgeSize;
@@ -25,7 +28,7 @@ export const categoryConfig: Record<ServiceCategory, { token: string; label: str
   service: { token: 'orange', label: 'Back Office' },
 };
 
-const serviceIconOverrides: Record<string, string> = {
+export const serviceIconOverrides: Record<string, string> = {
   // Brand
   'Brand Identity Bundle': 'brand-design',
   'Logo Update': 'brand-logo',
@@ -62,11 +65,11 @@ const serviceIconOverrides: Record<string, string> = {
   'Training Setup & Organization': 'back-office-consulting',
 };
 
-function normalizeServiceName(name: string): string {
+export function normalizeServiceName(name: string): string {
   return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
 }
 
-function getServiceIconPath(category: ServiceCategory, serviceName: string): string {
+export function getServiceIconPath(category: ServiceCategory, serviceName: string): string {
   if (serviceIconOverrides[serviceName]) {
     return `/icons/${category}/${serviceIconOverrides[serviceName]}.svg`;
   }

--- a/components/ui/ServiceBadge/ServiceTag.css
+++ b/components/ui/ServiceBadge/ServiceTag.css
@@ -1,0 +1,48 @@
+/* ─── ServiceTag ─────────────────────────────────────────────── */
+
+.bds-service-tag {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  white-space: nowrap;
+  border-radius: var(--border-radius-sm);
+}
+
+.bds-service-tag--has-icon {
+  gap: var(--gap-xs);
+}
+
+/* ─── Sizes ──────────────────────────────────────────────────── */
+
+.bds-service-tag--sm {
+  padding: var(--padding-tiny) var(--padding-sm);
+  font-size: var(--body-tiny);
+}
+
+.bds-service-tag--md {
+  padding: var(--padding-tiny) var(--padding-sm);
+  font-size: var(--label-sm);
+}
+
+.bds-service-tag--lg {
+  padding: var(--padding-sm) var(--padding-md);
+  font-size: var(--label-md);
+}
+
+/* ─── Category colors ────────────────────────────────────────── */
+
+.bds-service-tag--brand       { background-color: var(--background-service-brand);       color: var(--text-service-brand); }
+.bds-service-tag--marketing   { background-color: var(--background-service-marketing);   color: var(--text-service-marketing); }
+.bds-service-tag--information { background-color: var(--background-service-information); color: var(--text-service-information); }
+.bds-service-tag--product     { background-color: var(--background-service-product);     color: var(--text-service-product); }
+.bds-service-tag--service     { background-color: var(--background-service-service);     color: var(--text-service-service); }
+
+/* ─── Icon ───────────────────────────────────────────────────── */
+
+.bds-service-tag__icon {
+  object-fit: contain;
+  display: block;
+  flex-shrink: 0;
+}

--- a/components/ui/ServiceBadge/ServiceTag.stories.tsx
+++ b/components/ui/ServiceBadge/ServiceTag.stories.tsx
@@ -1,0 +1,306 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ServiceTag } from './ServiceTag';
+import { categoryConfig } from './ServiceBadge';
+import type { ServiceCategory } from './ServiceBadge';
+
+/* ─── Meta ────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof ServiceTag> = {
+  title: 'Components/Indicator/service-tag',
+  component: ServiceTag,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    category: {
+      control: 'select',
+      options: ['brand', 'marketing', 'information', 'product', 'service'],
+    },
+    variant: {
+      control: 'select',
+      options: ['text', 'icon-text'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ServiceTag>;
+
+/* ─── Layout Helpers (story-only) ─────────────────────────────── */
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <div style={{
+    fontFamily: 'var(--font-family-label)',
+    fontSize: 'var(--body-xs)', // bds-lint-ignore
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginBottom: 'var(--gap-md)',
+    color: 'var(--text-muted)',
+  }}>
+    {children}
+  </div>
+);
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: 'flex', gap: 'var(--gap-md)', flexWrap: 'wrap', alignItems: 'center' }}>{children}</div>
+);
+
+const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
+);
+
+/* ─── Shared data ─────────────────────────────────────────────── */
+
+const categories = Object.keys(categoryConfig) as ServiceCategory[];
+
+// One representative service per category for icon-text stories
+const categoryServices: Record<ServiceCategory, { serviceName: string; label: string }> = {
+  brand:       { serviceName: 'Brand Identity Bundle',                         label: 'Brand Design' },
+  marketing:   { serviceName: 'Custom Standard Web Development and Design',    label: 'Marketing Design' },
+  information: { serviceName: 'Information Design',                            label: 'Information Design' },
+  product:     { serviceName: 'Product Design Systems',                        label: 'Product Design' },
+  service:     { serviceName: 'Digital File Organization',                     label: 'Back Office' },
+};
+
+// Full service list for the icon-text catalog story
+const allServices: Record<ServiceCategory, { serviceName: string; label: string }[]> = {
+  brand: [
+    { serviceName: 'Brand Business Card',                                    label: 'Business Card' },
+    { serviceName: 'Brand Identity Bundle',                                  label: 'Brand Design' },
+    { serviceName: 'Brand Email Signature',                                  label: 'Email Signature' },
+    { serviceName: 'Brand Guidelines',                                       label: 'Guidelines' },
+    { serviceName: 'Brand Listings',                                         label: 'Listings' },
+    { serviceName: 'Premium Logo Design',                                    label: 'Logo' },
+    { serviceName: 'Brand Stationary',                                       label: 'Stationary' },
+  ],
+  marketing: [
+    { serviceName: 'Comprehensive Marketing Audit & Consultation',           label: 'Consulting' },
+    { serviceName: 'Marketing Design',                                       label: 'Design' },
+    { serviceName: 'Email Drip Campaign (Up to 6 Emails)',                   label: 'Email' },
+    { serviceName: 'Landing Pages',                                          label: 'Landing Pages' },
+    { serviceName: 'Social Media Graphic Designs',                           label: 'Social Graphics' },
+    { serviceName: 'Swag and Merchandise Design',                            label: 'Swag' },
+    { serviceName: 'Custom Standard Web Development and Design',             label: 'Web Design' },
+  ],
+  information: [
+    { serviceName: 'Digital Design',                                         label: 'Digital Design' },
+    { serviceName: 'Infographics',                                           label: 'Infographics' },
+    { serviceName: 'Layout Design',                                          label: 'Layout Design' },
+    { serviceName: 'Print Design',                                           label: 'Print Design' },
+    { serviceName: 'Welcome Kit',                                            label: 'Welcome Kit' },
+    { serviceName: 'Information Design',                                     label: 'Information Design' },
+  ],
+  product: [
+    { serviceName: 'Product App Design',                                     label: 'App Design' },
+    { serviceName: 'Product Content Design',                                 label: 'Content Design' },
+    { serviceName: 'Product Design Systems',                                 label: 'Design Systems' },
+    { serviceName: 'Product Design',                                         label: 'Design' },
+    { serviceName: 'Product Enterprise Design',                              label: 'Enterprise Design' },
+  ],
+  service: [
+    { serviceName: 'Software and Subscription Audit',                        label: 'Audit' },
+    { serviceName: 'Software Automation Setup',                              label: 'Automated Workflow' },
+    { serviceName: 'Automated Workflow and AI Integration',                  label: 'Automation & AI' },
+    { serviceName: 'Back Office Consulting',                                 label: 'Consulting' },
+    { serviceName: 'CRM Setup and Data Cleanup',                             label: 'CRM & Data' },
+    { serviceName: 'Back Office Customer Support',                           label: 'Customer Support' },
+    { serviceName: 'Digital File Organization',                              label: 'File Organization' },
+    { serviceName: 'Customer Journey Mapping',                               label: 'Journey Mapping' },
+    { serviceName: 'Back Office SOP Creation',                               label: 'SOP Creation' },
+    { serviceName: 'Back Office Training Setup',                             label: 'Training Setup' },
+  ],
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   1. PLAYGROUND — Args-based, use Controls panel to explore
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Playground: Story = {
+  args: {
+    category: 'marketing',
+    variant: 'icon-text',
+    size: 'md',
+    label: 'Marketing Design',
+    serviceName: 'Custom Standard Web Development and Design',
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   2. VARIANTS — Both display variants × all categories × sizes
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Variants: Story = {
+  render: () => (
+    <Stack>
+      <div>
+        <SectionLabel>Text — all categories</SectionLabel>
+        <Row>
+          {categories.map((cat) => (
+            <ServiceTag key={cat} category={cat} label={categoryConfig[cat].label} />
+          ))}
+        </Row>
+      </div>
+
+      <div>
+        <SectionLabel>Text — sizes</SectionLabel>
+        <Stack gap="var(--gap-lg)">
+          {(['sm', 'md', 'lg'] as const).map((size) => (
+            <Row key={size}>
+              {categories.map((cat) => (
+                <ServiceTag key={cat} category={cat} size={size} />
+              ))}
+            </Row>
+          ))}
+        </Stack>
+      </div>
+
+      <div>
+        <SectionLabel>Icon + text — all categories</SectionLabel>
+        <Row>
+          {categories.map((cat) => (
+            <ServiceTag
+              key={cat}
+              category={cat}
+              variant="icon-text"
+              label={categoryServices[cat].label}
+              serviceName={categoryServices[cat].serviceName}
+            />
+          ))}
+        </Row>
+      </div>
+
+      <div>
+        <SectionLabel>Icon + text — sizes</SectionLabel>
+        <Stack gap="var(--gap-lg)">
+          {(['sm', 'md', 'lg'] as const).map((size) => (
+            <Row key={size}>
+              {categories.map((cat) => (
+                <ServiceTag
+                  key={cat}
+                  category={cat}
+                  variant="icon-text"
+                  size={size}
+                  label={categoryServices[cat].label}
+                  serviceName={categoryServices[cat].serviceName}
+                />
+              ))}
+            </Row>
+          ))}
+        </Stack>
+      </div>
+    </Stack>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   3. ALL SERVICES — Complete icon-text catalog by category
+   ═══════════════════════════════════════════════════════════════ */
+
+export const AllServices: Story = {
+  name: 'All services (icon-text)',
+  parameters: { layout: 'padded' },
+  render: () => (
+    <Stack>
+      {categories.map((cat) => (
+        <div key={cat}>
+          <SectionLabel>{`${categoryConfig[cat].label} (${allServices[cat].length})`}</SectionLabel>
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+            gap: 'var(--gap-md)',
+          }}>
+            {allServices[cat].map(({ serviceName, label }) => (
+              <ServiceTag
+                key={serviceName}
+                category={cat}
+                variant="icon-text"
+                size="md"
+                label={label}
+                serviceName={serviceName}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </Stack>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   4. PATTERNS — Real-world usage contexts
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Patterns: Story = {
+  parameters: { layout: 'padded' },
+  render: () => (
+    <Stack>
+      <div>
+        <SectionLabel>Table cell — service line</SectionLabel>
+        <div style={{
+          border: '1px solid var(--border-secondary)',
+          borderRadius: 'var(--border-radius-md)',
+          overflow: 'hidden',
+          width: '500px',
+        }}>
+          {[
+            { category: 'marketing' as const, name: 'Website Design & Development',  label: 'Marketing Design' },
+            { category: 'brand' as const,     name: 'Logo Design & Brand Guidelines', label: 'Brand' },
+            { category: 'service' as const,   name: 'CRM Setup & Data Cleanup',       label: 'Back Office' },
+            { category: 'information' as const, name: 'Print Collateral',             label: 'Information Design' },
+            { category: 'product' as const,   name: 'Design Systems & Libraries',     label: 'Product Design' },
+          ].map(({ category, name, label }, i) => (
+            <div key={name} style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: 'var(--padding-sm) var(--padding-md)',
+              borderTop: i > 0 ? '1px solid var(--border-secondary)' : undefined,
+            }}>
+              <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-sm)', color: 'var(--text-primary)' }}>
+                {name}
+              </span>
+              <ServiceTag category={category} label={label} size="sm" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <SectionLabel>Table cell — icon + service name</SectionLabel>
+        <div style={{
+          border: '1px solid var(--border-secondary)',
+          borderRadius: 'var(--border-radius-md)',
+          overflow: 'hidden',
+          width: '500px',
+        }}>
+          {[
+            { category: 'marketing' as const,   serviceName: 'Custom Standard Web Development and Design', label: 'Website Design & Development' },
+            { category: 'brand' as const,        serviceName: 'Brand Identity Bundle',                     label: 'Brand Identity Bundle' },
+            { category: 'service' as const,      serviceName: 'CRM Setup and Data Cleanup',                label: 'CRM Setup & Data Cleanup' },
+            { category: 'information' as const,  serviceName: 'Print Design',                              label: 'Print Collateral' },
+            { category: 'product' as const,      serviceName: 'Product Design Systems',                    label: 'Design Systems' },
+          ].map(({ category, serviceName, label }, i) => (
+            <div key={label} style={{
+              display: 'flex',
+              alignItems: 'center',
+              padding: 'var(--padding-sm) var(--padding-md)',
+              borderTop: i > 0 ? '1px solid var(--border-secondary)' : undefined,
+            }}>
+              <ServiceTag
+                category={category}
+                variant="icon-text"
+                size="sm"
+                label={label}
+                serviceName={serviceName}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </Stack>
+  ),
+};

--- a/components/ui/ServiceBadge/ServiceTag.tsx
+++ b/components/ui/ServiceBadge/ServiceTag.tsx
@@ -1,0 +1,89 @@
+import { type HTMLAttributes, useState } from 'react';
+import { bdsClass } from '../../utils';
+import {
+  categoryConfig,
+  getServiceIconPath,
+  type ServiceCategory,
+  type ServiceBadgeSize,
+} from './ServiceBadge';
+import './ServiceTag.css';
+
+export type ServiceTagVariant = 'text' | 'icon-text';
+
+export interface ServiceTagProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'children'> {
+  /** Service category — determines color and default label */
+  category: ServiceCategory;
+  /** Display variant. Default: 'text' */
+  variant?: ServiceTagVariant;
+  /** Size variant. Default: 'md' */
+  size?: ServiceBadgeSize;
+  /** Display label — defaults to the category name (e.g. "Back Office"). Pass a service name to label a specific service. */
+  label?: string;
+  /** Service name for icon resolution — required for icon-text variant to show an icon */
+  serviceName?: string;
+}
+
+// bds-lint-ignore — icon pixel sizes are Figma-driven
+const tagIconSizeMap: Record<ServiceBadgeSize, number> = { sm: 12, md: 16, lg: 20 };
+
+/**
+ * ServiceTag — text label for a Brik service category or individual service.
+ *
+ * Two variants:
+ * - `text` — colored pill with label text only
+ * - `icon-text` — colored pill with service icon + label text
+ *
+ * @example
+ * // Service line label
+ * <ServiceTag category="marketing" />
+ *
+ * // Service line with custom label
+ * <ServiceTag category="marketing" label="Marketing Design" />
+ *
+ * // Individual service with icon
+ * <ServiceTag category="marketing" variant="icon-text" serviceName="Email Drip Campaign" label="Email Drip Campaign" />
+ */
+export function ServiceTag({
+  category,
+  variant = 'text',
+  size = 'md',
+  label,
+  serviceName,
+  className,
+  style,
+  ...props
+}: ServiceTagProps) {
+  const config = categoryConfig[category];
+  const displayLabel = label ?? config.label;
+  const [imageError, setImageError] = useState(false);
+  const iconSize = tagIconSizeMap[size];
+  const showIcon = variant === 'icon-text' && !!serviceName && !imageError;
+
+  return (
+    <span
+      className={bdsClass(
+        'bds-service-tag',
+        `bds-service-tag--${size}`,
+        `bds-service-tag--${category}`,
+        showIcon && 'bds-service-tag--has-icon',
+        className,
+      )}
+      style={style}
+      {...props}
+    >
+      {showIcon && (
+        <img
+          src={getServiceIconPath(category, serviceName!)}
+          alt=""
+          width={iconSize}
+          height={iconSize}
+          className="bds-service-tag__icon"
+          onError={() => setImageError(true)}
+        />
+      )}
+      {displayLabel}
+    </span>
+  );
+}
+
+export default ServiceTag;

--- a/components/ui/ServiceBadge/index.ts
+++ b/components/ui/ServiceBadge/index.ts
@@ -5,3 +5,6 @@ export type {
   ServiceBadgeSize,
   ServiceBadgeMode,
 } from './ServiceBadge';
+
+export { ServiceTag } from './ServiceTag';
+export type { ServiceTagProps, ServiceTagVariant } from './ServiceTag';

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -183,6 +183,20 @@
   color: var(--text-muted);
 }
 
+.bds-task-console__item-link {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-normal);
+  color: var(--color-system-blue);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.bds-task-console__item-link:hover {
+  text-decoration: underline;
+}
+
 .bds-task-console__item-detail {
   font-family: var(--font-family-body);
   font-size: var(--body-sm);

--- a/components/ui/TaskConsole/TaskConsole.tsx
+++ b/components/ui/TaskConsole/TaskConsole.tsx
@@ -20,6 +20,8 @@ export interface TaskConsoleItem {
   status: TaskItemStatus;
   /** Optional detail text (shown below label when in_progress) */
   detail?: string;
+  /** Optional URL — shown as "View" link when completed */
+  href?: string;
 }
 
 export interface TaskConsoleProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
@@ -170,6 +172,17 @@ export function TaskConsole({
                 <span className="bds-task-console__item-label">{item.label}</span>
                 {item.detail && item.status === 'in_progress' && (
                   <span className="bds-task-console__item-detail">{item.detail}</span>
+                )}
+                {item.href && item.status === 'completed' && (
+                  <a
+                    href={item.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="bds-task-console__item-link"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    View →
+                  </a>
                 )}
               </div>
               <StatusIcon status={item.status} />


### PR DESCRIPTION
## Summary
- `showDivider?: boolean` — hides border-top and padding-top on metadata (default `true`)
- `flush?: boolean` — removes default 80px horizontal padding for layout-managed consumers (default `false`)
- `size?: 'sm' | 'md' | 'lg'` — controls title font scale via modifier class (default `'lg'`)
- Fix tabs: move full-width border-bottom + overlap fix into BDS CSS so consumers don't need globals.css hacks

## Motivation
The portal was fighting CSS specificity wars in globals.css to override PageHeader defaults. These are legitimate variant needs that belong as first-class props, not consumer-level hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)