### PR TITLE
Extend token linter to catch stale var() in CSS files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -42,14 +42,19 @@ if [ -n "$MISSING_INDEX" ] || [ -n "$MISSING_EXPORT" ]; then
   exit 1
 fi
 
-# Lint only staged .tsx files (not all components)
-STAGED=$(git diff --cached --name-only --diff-filter=ACM -- 'components/**/*.tsx')
+# Lint staged .tsx and .css files for token violations
+STAGED_TSX=$(git diff --cached --name-only --diff-filter=ACM -- 'components/**/*.tsx')
+STAGED_CSS=$(git diff --cached --name-only --diff-filter=ACM -- 'components/**/*.css')
 
-if [ -n "$STAGED" ]; then
-  echo "Linting $(echo "$STAGED" | wc -l | tr -d ' ') staged .tsx files..."
-  node scripts/lint-tokens.js --errors-only --files $STAGED
+if [ -n "$STAGED_TSX" ] || [ -n "$STAGED_CSS" ]; then
+  TSX_COUNT=$([ -n "$STAGED_TSX" ] && echo "$STAGED_TSX" | wc -l | tr -d ' ' || echo "0")
+  CSS_COUNT=$([ -n "$STAGED_CSS" ] && echo "$STAGED_CSS" | wc -l | tr -d ' ' || echo "0")
+  echo "Linting $TSX_COUNT staged .tsx + $CSS_COUNT staged .css files..."
+  node scripts/lint-tokens.js --errors-only \
+    ${STAGED_TSX:+--files $STAGED_TSX} \
+    ${STAGED_CSS:+--css-files $STAGED_CSS}
 else
-  echo "No staged .tsx files — skipping token lint."
+  echo "No staged component files — skipping token lint."
 fi
 
 # Typecheck always runs (fast, catches real errors)

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -617,11 +617,22 @@ function main() {
   const tsxFiles = explicitFiles
     ? explicitFiles.filter(f => /\.tsx$/.test(f)).map(f => path.resolve(f))
     : findFiles(COMPONENTS_DIR, /\.tsx$/);
-  if (tsxFiles.length === 0) {
-    console.log('  No .tsx files to scan — skipping.\n');
+
+  // CSS files: explicit list (from pre-commit hook) or full scan
+  const cssFilesIdx = args.indexOf('--css-files');
+  const explicitCssFiles = cssFilesIdx !== -1
+    ? args.slice(cssFilesIdx + 1).filter(f => !f.startsWith('--'))
+    : null;
+  const cssFiles = explicitCssFiles
+    ? explicitCssFiles.filter(f => /\.css$/.test(f)).map(f => path.resolve(f))
+    : findFiles(COMPONENTS_DIR, /\.css$/);
+
+  const totalFiles = tsxFiles.length + cssFiles.length;
+  if (totalFiles === 0) {
+    console.log('  No files to scan — skipping.\n');
     process.exit(0);
   }
-  console.log(`  Scanning ${tsxFiles.length} files...\n`);
+  console.log(`  Scanning ${tsxFiles.length} .tsx + ${cssFiles.length} .css files...\n`);
 
   // 3. Scan components for token usage violations
   const allViolations = [];
@@ -641,6 +652,26 @@ function main() {
       allViolations.push(...checkUnknownTokens(line, lineNum, file, tokens, isComponent));
 
       // Rule 4: grid compliance (opt-in via --check-grid)
+      if (checkGrid) {
+        allViolations.push(...checkGridCompliance(line, lineNum, file));
+      }
+    }
+  }
+
+  // CSS files: apply token-reference rules only (no TSX style-object rules)
+  for (const file of cssFiles) {
+    const content = fs.readFileSync(file, 'utf8');
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lineNum = i + 1;
+
+      // Rule 1: primitive token usage in CSS
+      allViolations.push(...checkPrimitiveTokens(line, lineNum, file, true));
+      // Rule 3: unknown token references in CSS (catches stale var() after renames)
+      allViolations.push(...checkUnknownTokens(line, lineNum, file, tokens, true));
+
       if (checkGrid) {
         allViolations.push(...checkGridCompliance(line, lineNum, file));
       }


### PR DESCRIPTION
## Summary

The token linter previously only validated `.tsx` files. Component CSS files were never checked, which allowed renamed tokens to silently break all interactive states (hover, focus, disabled) without any build-time signal.

**Root cause of the 2026-03-31 incident:** Figma dropped the `interaction/` group prefix from all interaction tokens. `Button.css` still referenced the old `--interaction-*` names. No linter ran on CSS files, so it shipped undetected until a visual regression was noticed.

## Changes

- `scripts/lint-tokens.js` — new `--css-files` flag; CSS files get Rules 1 (primitive tokens) + 3 (unknown/stale token references) at error severity
- `.husky/pre-commit` — lints both staged `.tsx` and staged `.css` files

## What this catches going forward
Any `var(--token-name)` in a component CSS file that doesn't exist in `figma-tokens.css` or `overrides.css` is now a **hard error at commit time**.

## Test plan
- [ ] Stage a `.css` file with a stale `var(--interaction-background-brand-primary-hover)` → commit should be blocked
- [ ] Stage a `.css` file with correct token names → commit should pass
- [ ] Stage only `.tsx` files → behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)