### PR TITLE
Port renew-pms component improvements to BDS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,26 @@ The copy at `brik-llm/foundations/brik-bds/` is a git submodule.
 
 ---
 
+## Token Rename History
+
+When Figma reorganizes variable groups, token names change. Log every rename here so consuming project CSS can be audited.
+
+| Date | Change | Old CSS name → New CSS name |
+|------|--------|-----------------------------|
+| 2026-03-31 | Figma dropped `interaction/` group prefix from all interaction tokens | `--interaction-background-brand-primary-hover` → `--background-brand-primary-hover` |
+| | | `--interaction-background-brand-primary-pressed` → `--background-brand-primary-pressed` |
+| | | `--interaction-background-secondary-hover` → `--background-secondary-hover` |
+| | | `--interaction-background-secondary-pressed` → `--background-secondary-pressed` |
+| | | `--interaction-background-outline-hover` → `--background-outline-hover` |
+| | | `--interaction-background-outline-pressed` → `--background-outline-pressed` |
+| | | `--interaction-background-disabled` → `--background-disabled` |
+| | | `--interaction-text-disabled` → `--text-disabled` |
+| | | `--interaction-border-disabled` → `--border-disabled` |
+
+**After any Figma sync that renames tokens:** run `node scripts/lint-tokens.js` against all component CSS files to catch stale references before committing.
+
+---
+
 ## Quick Reference — Wrong vs Right
 
 The most commonly broken patterns across all Brik projects.

--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -87,24 +87,18 @@
 /* ─── Board header (column header with avatar + progress) */
 
 .bds-board-header {
-  background-color: var(--surface-primary);
   border-radius: var(--border-radius-200);
-  padding: var(--padding-md);
+  padding: var(--padding-md) 0;
   display: flex;
   flex-direction: column;
-  gap: var(--gap-sm);
+  gap: var(--gap-md);
   flex-shrink: 0;
-  transition: box-shadow var(--duration-200) ease;
 }
 
-.bds-board-header:hover {
-  box-shadow: var(--shadow-sm);
-}
-
-.bds-board-header__header {
+.bds-board-header__profile {
   display: flex;
   align-items: center;
-  gap: var(--gap-sm);
+  gap: var(--gap-md);
 }
 
 .bds-board-header__info {
@@ -118,7 +112,7 @@
   font-family: var(--font-family-body);
   font-size: var(--font-size-100);
   font-weight: var(--font-weight-extra-bold);
-  color: var(--text-primary);
+  color: var(--text-on-color-dark);
   line-height: var(--font-line-height-tight);
   margin: 0;
   white-space: nowrap;
@@ -130,7 +124,8 @@
   font-family: var(--font-family-body);
   font-size: var(--body-sm);
   font-weight: var(--font-weight-regular);
-  color: var(--text-primary);
+  color: var(--text-on-color-dark);
+  opacity: 0.8;
   line-height: var(--font-line-height-tight);
   margin: 0;
   white-space: nowrap;
@@ -139,7 +134,7 @@
 }
 
 .bds-board-header__progress {
-  padding-left: calc(48px + var(--gap-sm)); /* Align with text, past avatar */
+  /* Full width below avatar + name row */
 }
 
 /* Avatar size override — board headers always use lg */
@@ -156,20 +151,22 @@
 /* ─── Board card (task card) ─────────────────────────── */
 
 .bds-board-card {
-  --bds-board-card-accent: var(--border-primary);
+  --bds-board-card-accent: var(--border-primary); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   background-color: var(--surface-primary);
-  border-left: var(--border-width-xl) solid var(--bds-board-card-accent);
+  border-left: var(--border-width-xl) solid var(--bds-board-card-accent); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   border-radius: var(--border-radius-200);
   padding: var(--space-500) var(--padding-md);
   display: flex;
   flex-direction: column;
   gap: var(--gap-md);
   flex-shrink: 0;
-  transition: box-shadow var(--duration-200) ease;
+  transition: box-shadow var(--duration-200) ease, transform var(--duration-200) ease;
 }
 
 .bds-board-card:hover {
-  box-shadow: var(--shadow-sm);
+  box-shadow: inset 0 0 0 999px var(--state-hover-overlay, rgba(0, 0, 0, 0.04)),
+    0 4px 12px rgba(0, 0, 0, 0.12); /* bds-lint-ignore — elevation shadow */
+  transform: translateY(-1px);
 }
 
 .bds-board-card--checked {
@@ -221,26 +218,29 @@
   align-items: center;
   justify-content: center;
   border-radius: var(--border-radius-circle);
-  border: var(--border-width-lg) solid var(--border-primary);
-  background-color: rgba(255, 255, 255, 0.15);
+  border: var(--border-width-md) solid var(--border-input);
+  background-color: var(--background-input);
   cursor: pointer;
   padding: 0;
-  transition: background-color var(--duration-200) ease;
+  transition: background-color var(--duration-200) ease, border-color var(--duration-200) ease;
 }
 
 .bds-board-card__check:hover {
-  background-color: rgba(255, 255, 255, 0.3);
+  border-color: var(--border-primary);
+}
+
+.bds-board-card__check:focus-visible {
+  outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
+  outline-offset: 2px;
 }
 
 .bds-board-card__check--checked {
-  background-color: var(--background-input);
-  border-color: var(--border-primary);
+  background-color: var(--background-brand-primary);
+  border-color: var(--background-brand-primary);
 }
 
 .bds-board-card__check-icon {
   display: block;
-  width: 12px;
-  height: 12px;
   /* CSS-only checkmark */
   border-left: 2px solid var(--text-on-color-dark, #fff);
   border-bottom: 2px solid var(--text-on-color-dark, #fff);

--- a/components/ui/Board/BoardCard.tsx
+++ b/components/ui/Board/BoardCard.tsx
@@ -76,7 +76,7 @@ export function BoardCard({
               'bds-board-card__check',
               checked && 'bds-board-card__check--checked'
             )}
-            onClick={() => onCheckedChange(!checked)}
+            onClick={(e) => { e.stopPropagation(); onCheckedChange(!checked); }}
             aria-label={checked ? 'Mark incomplete' : 'Mark complete'}
             aria-pressed={checked}
           >

--- a/components/ui/Chip/Chip.css
+++ b/components/ui/Chip/Chip.css
@@ -23,11 +23,16 @@
 }
 
 .bds-chip:hover:not(.bds-chip--disabled) {
-  filter: brightness(0.9);
+  box-shadow: inset 0 0 0 999px var(--state-hover-overlay, rgba(0, 0, 0, 0.04));
 }
 
 .bds-chip:active:not(.bds-chip--disabled) {
-  filter: brightness(0.85);
+  box-shadow: inset 0 0 0 999px var(--state-pressed-overlay, rgba(0, 0, 0, 0.08));
+}
+
+.bds-chip:focus-visible {
+  outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
+  outline-offset: 2px;
 }
 
 /* ─── Sizes ───────────────────────────────────────────────────── */
@@ -53,14 +58,19 @@
 /* ─── Variant + Appearance ────────────────────────────────────── */
 
 .bds-chip--primary-dark {
-  background-color: var(--background-brand-primary);
-  color: var(--text-on-color-dark);
+  background-color: var(--background-inverse);
+  color: var(--text-inverse);
 }
 
 .bds-chip--primary-light {
   background-color: transparent;
   color: var(--text-brand-primary);
   border: var(--border-width-md) solid var(--border-brand-primary);
+}
+
+.bds-chip--primary-solid {
+  background-color: var(--background-inverse);
+  color: var(--text-inverse);
 }
 
 .bds-chip--secondary-dark {
@@ -77,7 +87,7 @@
 /* ─── Disabled ────────────────────────────────────────────────── */
 
 .bds-chip--disabled {
-  opacity: 0.5;
+  opacity: var(--state-disabled-opacity, 0.4);
   cursor: not-allowed;
   pointer-events: none;
 }

--- a/components/ui/Chip/Chip.tsx
+++ b/components/ui/Chip/Chip.tsx
@@ -6,7 +6,7 @@ import './Chip.css';
 
 export type ChipSize = 'sm' | 'md' | 'lg';
 export type ChipVariant = 'primary' | 'secondary';
-export type ChipAppearance = 'dark' | 'light';
+export type ChipAppearance = 'dark' | 'light' | 'solid';
 
 export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Chip label text */

--- a/components/ui/Modal/Modal.css
+++ b/components/ui/Modal/Modal.css
@@ -66,6 +66,7 @@
   line-height: var(--font-line-height-tight);
   cursor: pointer;
   padding: var(--padding-md);
+  margin-right: calc(-1 * var(--padding-md));
   color: var(--text-primary);
   opacity: 0.6;
   transition: opacity 0.2s;
@@ -76,6 +77,12 @@
 }
 
 .bds-modal__close:hover {
+  opacity: 1;
+}
+
+.bds-modal__close:focus-visible {
+  outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
+  outline-offset: 2px;
   opacity: 1;
 }
 

--- a/components/ui/ProgressBar/ProgressBar.css
+++ b/components/ui/ProgressBar/ProgressBar.css
@@ -5,9 +5,8 @@
 .bds-progress-bar {
   position: relative;
   width: 100%;
-  height: 6px; /* bds-lint-ignore — Figma-driven track height */
-  background-color: var(--background-input);
-  border: var(--border-width-sm) solid var(--border-muted);
+  height: var(--space-200);
+  background-color: var(--background-muted);
   border-radius: var(--border-radius-sm);
   overflow: hidden;
 }
@@ -21,5 +20,5 @@
   bottom: 0;
   background-color: var(--background-brand-primary);
   border-radius: var(--border-radius-sm);
-  transition: width 0.3s ease;
+  transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -39,6 +39,21 @@
   flex-shrink: 0;
 }
 
+/* When tabs are present, header becomes a column layout */
+.bds-sheet__header--has-tabs {
+  flex-direction: column;
+  align-items: stretch;
+  padding-bottom: 0;
+  gap: 0;
+}
+
+.bds-sheet__header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
 /* ─── Title (matches Modal) ─────────────────────────────────── */
 
 .bds-sheet__title {
@@ -59,6 +74,7 @@
   line-height: var(--font-line-height-tight);
   cursor: pointer;
   padding: var(--padding-md);
+  margin-right: calc(-1 * var(--padding-md));
   color: var(--text-primary);
   opacity: 0.6;
   transition: opacity 0.2s;
@@ -72,11 +88,48 @@
   opacity: 1;
 }
 
+.bds-sheet__close:focus-visible {
+  outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
+  outline-offset: 2px;
+  opacity: 1;
+}
+
+/* ─── Tabs (optional, renders below title row) ──────────────── */
+
+.bds-sheet__tabs {
+  display: flex;
+  gap: var(--gap-lg);
+  width: 100%;
+}
+
+.bds-sheet__tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: var(--padding-sm) 0;
+  font-family: var(--font-family-label);
+  font-size: var(--body-sm);
+  font-weight: var(--font-weight-semi-bold);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.bds-sheet__tab:hover {
+  color: var(--text-primary);
+}
+
+.bds-sheet__tab--active {
+  color: var(--text-primary);
+  border-bottom-color: var(--border-brand-primary);
+}
+
 /* ─── Body ───────────────────────────────────────────────────── */
 
 .bds-sheet__body {
   flex: 1;
-  padding: var(--padding-xl);
+  padding: var(--padding-xl) var(--padding-lg);
   overflow-y: auto;
   min-height: 0;
 }

--- a/components/ui/Sheet/Sheet.tsx
+++ b/components/ui/Sheet/Sheet.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type CSSProperties, useEffect } from 'react';
+import { type ReactNode, type CSSProperties, useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
@@ -7,10 +7,16 @@ import './Sheet.css';
 
 export type SheetSide = 'right' | 'left' | 'bottom';
 
+export interface SheetTab {
+  id: string;
+  label: string;
+  content: ReactNode;
+}
+
 export interface SheetProps {
   isOpen: boolean;
   onClose: () => void;
-  children: ReactNode;
+  children?: ReactNode;
   side?: SheetSide;
   title?: ReactNode;
   /** Width for left/right sheets (default: 400px) */
@@ -20,6 +26,12 @@ export interface SheetProps {
   showCloseButton?: boolean;
   /** Optional footer pinned to bottom of sheet */
   footer?: ReactNode;
+  /** Optional tabs rendered below the header. When provided, children is ignored. */
+  tabs?: SheetTab[];
+  /** Controlled active tab id (defaults to first tab) */
+  activeTab?: string;
+  /** Called when a tab is selected */
+  onTabChange?: (tabId: string) => void;
 }
 
 /**
@@ -27,6 +39,9 @@ export interface SheetProps {
  *
  * Width is a runtime value passed via inline style since it's user-configurable.
  * Close icon matches Modal dismiss treatment (FontAwesome xmark).
+ *
+ * Tab variant: pass `tabs` array to render a tab bar below the header.
+ * Each tab's content replaces `children` in the body area.
  */
 export function Sheet({
   isOpen,
@@ -39,7 +54,20 @@ export function Sheet({
   closeOnEscape = true,
   showCloseButton = true,
   footer,
+  tabs,
+  activeTab: controlledTab,
+  onTabChange,
 }: SheetProps) {
+  const [internalTab, setInternalTab] = useState(tabs?.[0]?.id ?? '');
+
+  const activeTab = controlledTab ?? internalTab;
+
+  useEffect(() => {
+    if (tabs && !controlledTab) {
+      setInternalTab(tabs[0]?.id ?? '');
+    }
+  }, [tabs, controlledTab]);
+
   useEffect(() => {
     if (!isOpen || !closeOnEscape) return;
     const handleEscape = (e: KeyboardEvent) => {
@@ -62,9 +90,19 @@ export function Sheet({
     if (closeOnBackdrop && e.target === e.currentTarget) onClose();
   };
 
+  const handleTabClick = (tabId: string) => {
+    if (onTabChange) {
+      onTabChange(tabId);
+    } else {
+      setInternalTab(tabId);
+    }
+  };
+
   // Width is runtime-configurable, so it stays as inline style
   const widthStyle: CSSProperties | undefined =
     side !== 'bottom' ? { width } : undefined;
+
+  const activeTabContent = tabs?.find((t) => t.id === activeTab)?.content;
 
   const sheet = (
     <>
@@ -76,21 +114,44 @@ export function Sheet({
         style={widthStyle}
       >
         {(title || showCloseButton) && (
-          <div className="bds-sheet__header">
-            {title && <h2 className="bds-sheet__title">{title}</h2>}
-            {showCloseButton && (
-              <button
-                type="button"
-                onClick={onClose}
-                className="bds-sheet__close"
-                aria-label="Close"
-              >
-                <FontAwesomeIcon icon={faXmark} />
-              </button>
+          <div className={bdsClass('bds-sheet__header', tabs ? 'bds-sheet__header--has-tabs' : '')}>
+            <div className="bds-sheet__header-top">
+              {title && <h2 className="bds-sheet__title">{title}</h2>}
+              {showCloseButton && (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="bds-sheet__close"
+                  aria-label="Close"
+                >
+                  <FontAwesomeIcon icon={faXmark} />
+                </button>
+              )}
+            </div>
+            {tabs && (
+              <div className="bds-sheet__tabs" role="tablist">
+                {tabs.map((tab) => (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === tab.id}
+                    className={bdsClass(
+                      'bds-sheet__tab',
+                      activeTab === tab.id ? 'bds-sheet__tab--active' : ''
+                    )}
+                    onClick={() => handleTabClick(tab.id)}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
             )}
           </div>
         )}
-        <div className="bds-sheet__body">{children}</div>
+        <div className="bds-sheet__body">
+          {tabs ? activeTabContent : children}
+        </div>
         {footer && <div className="bds-sheet__footer">{footer}</div>}
       </div>
     </>

--- a/components/ui/Sheet/index.ts
+++ b/components/ui/Sheet/index.ts
@@ -1,1 +1,1 @@
-export { Sheet, type SheetProps, type SheetSide } from './Sheet';
+export { Sheet, type SheetProps, type SheetSide, type SheetTab } from './Sheet';

--- a/components/ui/Table/Table.css
+++ b/components/ui/Table/Table.css
@@ -69,6 +69,18 @@
   background-color: transparent;
 }
 
+/* ─── Flush (remove outer padding on first/last cells) ────── */
+
+.bds-table[data-flush="true"] .bds-table-head:first-child,
+.bds-table[data-flush="true"] .bds-table-cell:first-child {
+  padding-left: 0;
+}
+
+.bds-table[data-flush="true"] .bds-table-head:last-child,
+.bds-table[data-flush="true"] .bds-table-cell:last-child {
+  padding-right: 0;
+}
+
 /* ─── Body cell ──────────────────────────────────────────────── */
 
 .bds-table-cell {

--- a/components/ui/Table/Table.tsx
+++ b/components/ui/Table/Table.tsx
@@ -16,6 +16,8 @@ export type TableSize = 'default' | 'comfortable';
 export interface TableProps extends HTMLAttributes<HTMLTableElement> {
   striped?: boolean;
   size?: TableSize;
+  /** Remove left padding on first cell, right padding on last cell */
+  flush?: boolean;
   children: ReactNode;
 }
 
@@ -29,6 +31,7 @@ export interface TableProps extends HTMLAttributes<HTMLTableElement> {
 export function Table({
   striped = false,
   size = 'default',
+  flush = false,
   children,
   className,
   style,
@@ -40,6 +43,7 @@ export function Table({
       style={style}
       data-striped={striped || undefined}
       data-size={size}
+      data-flush={flush || undefined}
       {...props}
     >
       {children}

--- a/tokens/overrides.css
+++ b/tokens/overrides.css
@@ -154,6 +154,12 @@
   --background-service-service: var(--services--orange);
   --background-service-service-secondary: var(--services--orange-dark);
   --text-service-service: var(--services--orange-dark);
+
+  /* ── Interaction state overlays (gap-fill — add to Figma when interaction tokens land) */
+  --state-hover-overlay: rgba(0, 0, 0, 0.04); /* bds-lint-ignore — rgba overlay, no token equivalent */
+  --state-pressed-overlay: rgba(0, 0, 0, 0.08); /* bds-lint-ignore — rgba overlay, no token equivalent */
+  --state-focus: currentColor; /* bds-lint-ignore — resolves at use-site */
+  --state-disabled-opacity: 0.4;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary

Ports component improvements developed in renew-pms back to the canonical BDS source so all consumers benefit.

- **Sheet** — New tabbed variant: pass `tabs` array to render a tab bar below the header. Supports controlled (`activeTab`/`onTabChange`) and uncontrolled modes. `children` made optional.
- **Modal + Sheet** — Close button now flushes to the panel edge (`margin-right: -padding-md`). Both get `focus-visible` outline.
- **Table** — New `flush` prop removes left/right padding on first/last cells for tables inside cards or panels.
- **Board** — Column header cleaned up (transparent bg, wider gaps, `text-on-color-dark`). Card hover lifts with shadow + `translateY(-1px)`. Check button uses `background-brand-primary` when checked, `stopPropagation` on click, `focus-visible`.
- **Chip** — Hover/active states replaced `filter:brightness()` with overlay approach (consistent with Button). New `solid` appearance variant. `focus-visible`. Token-based disabled opacity.
- **ProgressBar** — Track height via `--space-200`, `background-muted` track, smoother fill easing.
- **overrides.css** — Added `--state-hover-overlay`, `--state-pressed-overlay`, `--state-focus`, `--state-disabled-opacity` as gap-fill tokens (not yet in Figma).
- **CLAUDE.md** — Token rename history section added.

## Test plan
- [ ] Sheet tabbed variant renders and switches tabs correctly (controlled + uncontrolled)
- [ ] Modal and Sheet close buttons align flush to edge
- [ ] Table `flush` prop removes outer padding
- [ ] Board card check button marks complete with brand color, doesn't bubble click
- [ ] Chip hover uses overlay not brightness filter
- [ ] ProgressBar track is visibly thicker (space-200 vs 6px)
- [ ] Token linter passes (already validated in pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)