### PR TITLE
Fix Board semantic font-family errors + add Client Sim Storybook theme

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -160,6 +160,7 @@ const preview: Preview = {
           { value: '6', title: '6: Minimal (Source Sans 3)' },
           { value: '7', title: '7: Warm (Hind / Lato)' },
           { value: '8', title: '8: Vibrant (Hind / Playfair)' },
+          { value: 'client-sim', title: '★ Client Sim (Georgia / Verdana / Courier — font-family audit)' },
         ],
         dynamicTitle: true,
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,25 @@ style={{ fontSize: font.size.body.md, fontFamily: font.family.heading }}
 import { text } from '@/lib/styles';
 style={text.body}  // family + size + lineHeight, always matched correctly
 
+// ❌ WRONG: Heading/title element using body font family
+.bds-card__name { font-family: var(--font-family-body); }
+// ✅ RIGHT: Semantic family matches element role
+.bds-card__name { font-family: var(--font-family-heading); }
+// Rule: Font family token MUST match the element's semantic role.
+//   Heading/title/name elements     → --font-family-heading
+//   Label/badge/tag/button/caption  → --font-family-label
+//   Body copy/description/paragraph → --font-family-body
+//
+// WHY THIS MATTERS: BDS defaults all three tokens to Poppins, so misuse is
+// invisible during BDS development. The violation surfaces only when a client
+// theme assigns distinct typefaces per family (e.g. Century Schoolbook for
+// heading, Avenir for body/label). Always validate component CSS with the
+// ★ Client Sim theme in Storybook — it assigns Georgia/Verdana/Courier New
+// to expose mismatches instantly before any client theme reveals them.
+//
+// HEADING SCALE STARTS AT 18px: --heading-tiny = font-size/200 = 18px.
+// font-size/100 (16px) is body/label territory. Never use it on a heading element.
+
 // ❌ WRONG: Editing the submodule directly
 // brik-client-portal/brik-bds/components/ui/Button/Button.css ← NEVER
 // ✅ RIGHT: Edit in standalone repo, sync to consumers

--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -108,10 +108,17 @@
   flex: 1;
 }
 
+/*
+ * Column header name — heading family, semibold.
+ * Heading scale minimum is --heading-tiny (18px / font-size-200).
+ * --font-size-100 (16px) is body/label territory; never use it for a heading.
+ * --font-weight-extra-bold (800) is inappropriate on heading family;
+ * semibold (600) is the standard heading weight.
+ */
 .bds-board-header__name {
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-100);
-  font-weight: var(--font-weight-extra-bold);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-tiny);
+  font-weight: var(--font-weight-semi-bold);
   color: var(--text-on-color-dark);
   line-height: var(--font-line-height-tight);
   margin: 0;
@@ -120,9 +127,14 @@
   text-overflow: ellipsis;
 }
 
+/*
+ * Column header subtitle — label family (not body).
+ * Subtitles are UI metadata labels; they belong to the label family.
+ * --subtitle-sm matches the visual size (10.26px) with correct semantics.
+ */
 .bds-board-header__subtitle {
-  font-family: var(--font-family-body);
-  font-size: var(--body-sm);
+  font-family: var(--font-family-label);
+  font-size: var(--subtitle-sm);
   font-weight: var(--font-weight-regular);
   color: var(--text-on-color-dark);
   opacity: 0.8;
@@ -190,18 +202,28 @@
   flex: 1;
 }
 
+/*
+ * Card title — heading family, semibold.
+ * Uses --heading-tiny (18px) — the minimum heading size.
+ * Client themes that need a more compact card title can override
+ * font-size in their globals.css; the family must remain heading.
+ */
 .bds-board-card__title {
-  font-family: var(--font-family-label);
-  font-size: var(--font-size-100);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-tiny);
   font-weight: var(--font-weight-semi-bold);
   color: var(--text-primary);
   line-height: var(--font-line-height-tight);
   margin: 0;
 }
 
+/*
+ * Card subtitle — label family (not body).
+ * Uses --subtitle-md (11.54px) for correct semantic sizing.
+ */
 .bds-board-card__subtitle {
-  font-family: var(--font-family-body);
-  font-size: var(--body-xs);
+  font-family: var(--font-family-label);
+  font-size: var(--subtitle-md);
   font-weight: var(--font-weight-regular);
   color: var(--text-primary);
   line-height: var(--font-line-height-normal);

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -20,8 +20,12 @@
  * - theme-7: Warm — tan earth tones, Lato
  * - theme-8: Vibrant — green/purple accents, Playfair Display
  * - theme-brik: Brik Brand — poppy red, Poppins
+ * - theme-client-sim: Client Simulation — intentionally distinct system fonts per family.
+ *   Use this theme during component development to validate semantic font-family usage.
+ *   heading=Georgia (serif), body=Verdana (sans), label=Courier New (mono).
+ *   Any component using the wrong family token becomes immediately visible.
  */
-export type ThemeNumber = '1' | '8' | '2' | '3' | '4' | '5' | '6' | '7' | 'brik';
+export type ThemeNumber = '1' | '8' | '2' | '3' | '4' | '5' | '6' | '7' | 'brik' | 'client-sim';
 
 /**
  * Color mode type (friendly names)
@@ -80,6 +84,7 @@ export const themeMetadata: Record<ThemeNumber, { name: string; description: str
   '7': { name: 'Warm', description: 'Tan earth tones (Lato / Hind)', isDark: false },
   '8': { name: 'Vibrant', description: 'Bold green and purple accents (Playfair Display / Hind)', isDark: false },
   'brik': { name: 'Brik Brand', description: 'Company brand — poppy red, near-black, tan (Poppins)', isDark: false },
+  'client-sim': { name: 'Client Sim', description: 'Font-family audit tool — Georgia/Verdana/Courier New exposes semantic token misuse', isDark: false },
 };
 
 /**

--- a/tokens/overrides.css
+++ b/tokens/overrides.css
@@ -728,3 +728,33 @@
   --icon-md: var(--font-size-100);
   --icon-lg: var(--font-size-200);
 }
+
+/*
+ * ── Client Simulation Theme (theme-client-sim) ────────────────────────────────
+ *
+ * PURPOSE: Semantic font-family validation tool.
+ * Assigns maximally distinct system fonts to each family token so that any
+ * component using the wrong family token is immediately legible during development.
+ *
+ *   --font-family-heading  → Georgia (serif)         ← heading/title elements
+ *   --font-family-display  → Georgia (serif)         ← display/hero elements
+ *   --font-family-label    → Courier New (monospace) ← labels, badges, tags, buttons
+ *   --font-family-body     → Verdana (sans-serif)    ← body copy, descriptions
+ *
+ * If you see:
+ *   - A heading rendered in Verdana or Courier New  → wrong font-family token
+ *   - A badge/label rendered in Georgia or Verdana  → wrong font-family token
+ *   - Body copy rendered in Georgia or Courier New  → wrong font-family token
+ *
+ * This theme is NOT for client delivery. Run it in Storybook toolbar when:
+ *   1. Building a new component
+ *   2. Reviewing a component PR
+ *   3. Validating a client theme override will work correctly
+ */
+.body.theme-client-sim {
+  --font-family-heading: Georgia, "Times New Roman", serif;
+  --font-family-display: Georgia, "Times New Roman", serif;
+  --font-family-label: "Courier New", Courier, monospace;
+  --font-family-body: Verdana, Geneva, sans-serif;
+  --font-family-icon: "Font Awesome 6 Pro Solid 900", Arial, sans-serif;
+}

--- a/tokens/storybook-themes.ts
+++ b/tokens/storybook-themes.ts
@@ -201,6 +201,27 @@ export const storybookThemes: Record<ThemeNumber, StorybookThemeConfig> = {
     "inputTextColor": "#333",
     "fontBase": "Hind, sans-serif"
   },
+  "client-sim": {
+    "base": "light",
+    "name": "Client Sim",
+    "colorPrimary": "#333",
+    "colorSecondary": "#333",
+    "appBg": "white",
+    "appContentBg": "white",
+    "appPreviewBg": "transparent",
+    "appBorderColor": "#bdbdbd",
+    "textColor": "#333",
+    "textInverseColor": "white",
+    "textMutedColor": "#828282",
+    "barTextColor": "#828282",
+    "barSelectedColor": "#333",
+    "barHoverColor": "#333",
+    "barBg": "white",
+    "inputBg": "white",
+    "inputBorder": "#bdbdbd",
+    "inputTextColor": "#333",
+    "fontBase": "Verdana, sans-serif"
+  },
   "brik": {
     "base": "light",
     "name": "Brik Brand",


### PR DESCRIPTION
## Summary

- **Board.css**: Fix 4 semantic font-family errors where heading/subtitle elements used the wrong family token. Only visible when a client theme assigns distinct typefaces per family (e.g. Century Schoolbook for heading, Avenir for body/label) — invisible with BDS Poppins default.
- **Storybook**: Add `★ Client Sim` theme (Georgia / Verdana / Courier New) to toolbar so font-family misuse is immediately visible during component development
- **CLAUDE.md**: Document font-family semantic rules and heading scale minimum (18px)

## What changed in Board.css

| Element | Before | After |
|---------|--------|-------|
| `.bds-board-header__name` | `font-family-body` + `font-size-100` (16px) + `extra-bold` | `font-family-heading` + `heading-tiny` (18px) + `semi-bold` |
| `.bds-board-header__subtitle` | `font-family-body` + `body-sm` | `font-family-label` + `subtitle-sm` |
| `.bds-board-card__title` | `font-family-label` + `font-size-100` (16px) | `font-family-heading` + `heading-tiny` (18px) |
| `.bds-board-card__subtitle` | `font-family-body` + `body-xs` | `font-family-label` + `subtitle-md` |

## Root cause

BDS defaults all three font-family tokens to Poppins, masking semantic misuse during BDS development. The violation only surfaces when a client theme assigns distinct typefaces per family. Discovered during Renew Dental integration (Century Schoolbook heading / Avenir body+label).

## Client Sim theme

Added `theme-client-sim` to `overrides.css`, `storybook-themes.ts`, `tokens/index.ts`, and the Storybook toolbar. Assigns maximally distinct system fonts:
- `--font-family-heading` → Georgia (serif)
- `--font-family-body` → Verdana (sans-serif)
- `--font-family-label` → Courier New (monospace)

Any component using the wrong family renders in the obviously wrong typeface. Use during development and PR review for all new components.

## Test plan

- [ ] Open Storybook → Board stories → switch to `★ Client Sim` theme
- [ ] Verify column header names render in Georgia (serif)
- [ ] Verify column header subtitles render in Courier New (monospace)
- [ ] Verify card titles render in Georgia (serif)
- [ ] Verify card subtitles render in Courier New (monospace)
- [ ] Run `bds-sync.sh` in renew-pms after merge to pull fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)