### PR TITLE
Refactor 11 components to use semantic status tokens

### DIFF
--- a/components/ui/Avatar/Avatar.css
+++ b/components/ui/Avatar/Avatar.css
@@ -47,7 +47,7 @@
 .bds-avatar--lg .bds-avatar__status,
 .bds-avatar--xl .bds-avatar__status { width: 12px; height: 12px; }
 
-.bds-avatar__status--online  { background-color: var(--color-system-green); }
-.bds-avatar__status--offline { background-color: var(--color-grayscale-light); }
-.bds-avatar__status--busy    { background-color: var(--color-system-red); }
-.bds-avatar__status--away    { background-color: var(--color-system-yellow); }
+.bds-avatar__status--online  { background-color: var(--background-presence-online); }
+.bds-avatar__status--offline { background-color: var(--background-presence-offline); }
+.bds-avatar__status--busy    { background-color: var(--background-presence-busy); }
+.bds-avatar__status--away    { background-color: var(--background-presence-away); }

--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -84,53 +84,53 @@
 /* ─── Status × Dark (default) ─────────────────────────────────── */
 
 .bds-badge--dark.bds-badge--positive {
-  background-color: var(--color-system-green);
+  background-color: var(--background-status-success);
   color: var(--text-on-color-dark);
 }
 
 .bds-badge--dark.bds-badge--warning {
-  background-color: var(--color-system-yellow);
-  color: var(--color-system-neutral);
+  background-color: var(--background-status-warning);
+  color: var(--text-status-neutral);
 }
 
 .bds-badge--dark.bds-badge--error {
-  background-color: var(--color-system-red);
+  background-color: var(--background-status-error);
   color: var(--text-on-color-dark);
 }
 
 .bds-badge--dark.bds-badge--info {
-  background-color: var(--color-system-neutral-light);
-  color: var(--color-system-neutral);
+  background-color: var(--background-status-neutral);
+  color: var(--text-status-neutral);
 }
 
 .bds-badge--dark.bds-badge--progress {
-  background-color: var(--color-system-blue);
+  background-color: var(--background-status-info);
   color: var(--text-on-color-dark);
 }
 
 /* ─── Status × Light (pastel bg, saturated text) ─────────────── */
 
 .bds-badge--light.bds-badge--positive {
-  background-color: var(--color-system-green-light);
-  color: var(--color-system-green);
+  background-color: var(--background-status-success-subtle);
+  color: var(--text-status-success);
 }
 
 .bds-badge--light.bds-badge--warning {
-  background-color: var(--color-system-yellow-light);
-  color: var(--color-system-neutral);
+  background-color: var(--background-status-warning-subtle);
+  color: var(--text-status-neutral);
 }
 
 .bds-badge--light.bds-badge--error {
-  background-color: var(--color-system-red-light);
-  color: var(--color-system-red);
+  background-color: var(--background-status-error-subtle);
+  color: var(--text-status-error);
 }
 
 .bds-badge--light.bds-badge--info {
-  background-color: var(--color-system-neutral-light);
-  color: var(--color-system-neutral);
+  background-color: var(--background-status-neutral);
+  color: var(--text-status-neutral);
 }
 
 .bds-badge--light.bds-badge--progress {
-  background-color: var(--color-system-blue-light);
-  color: var(--color-system-blue);
+  background-color: var(--background-status-info-subtle);
+  color: var(--text-status-info);
 }

--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -109,12 +109,12 @@
 /* ─── System Variants (semantic actions) ─────────────────────── */
 
 .bds-button--destructive {
-  background-color: var(--color-system-red);
+  background-color: var(--background-status-error);
   color: var(--text-on-color-dark);
 }
 
 .bds-button--positive {
-  background-color: var(--color-system-green);
+  background-color: var(--background-status-success);
   color: var(--text-on-color-dark);
 }
 
@@ -221,12 +221,12 @@
 .bds-button--danger-outline:focus-visible,
 .bds-button--danger-ghost:focus-visible,
 .bds-button--destructive:focus-visible {
-  outline-color: var(--color-system-red);
+  outline-color: var(--text-status-error);
 }
 
 /* Positive: green focus ring */
 .bds-button--positive:focus-visible {
-  outline-color: var(--color-system-green);
+  outline-color: var(--text-status-success);
 }
 
 /* ─── Loading State ───────────────────────────────────────────── */

--- a/components/ui/CardTestimonial/CardTestimonial.css
+++ b/components/ui/CardTestimonial/CardTestimonial.css
@@ -91,5 +91,5 @@
   font-family: var(--font-family-icon);
   font-size: var(--heading-lg);
   line-height: var(--font-line-height-snug);
-  color: var(--color-system-yellow);
+  color: var(--background-status-warning);
 }

--- a/components/ui/Dialog/Dialog.css
+++ b/components/ui/Dialog/Dialog.css
@@ -83,6 +83,6 @@
 }
 
 .bds-dialog__button--destructive {
-  background-color: var(--color-system-red);
+  background-color: var(--background-status-error);
   color: var(--text-on-color-dark);
 }

--- a/components/ui/Dot/Dot.css
+++ b/components/ui/Dot/Dot.css
@@ -16,11 +16,11 @@
 /* ─── Status colors ──────────────────────────────────────────── */
 
 .bds-dot--default  { background-color: var(--background-brand-primary); }
-.bds-dot--positive { background-color: var(--color-system-green); }
-.bds-dot--warning  { background-color: var(--color-system-yellow); }
-.bds-dot--error    { background-color: var(--color-system-red); }
-.bds-dot--info     { background-color: var(--color-system-blue); }
-.bds-dot--neutral  { background-color: var(--color-grayscale-light); }
+.bds-dot--positive { background-color: var(--background-status-success); }
+.bds-dot--warning  { background-color: var(--background-status-warning); }
+.bds-dot--error    { background-color: var(--background-status-error); }
+.bds-dot--info     { background-color: var(--background-status-info); }
+.bds-dot--neutral  { background-color: var(--background-status-neutral); }
 
 /* ─── Pulse animation ────────────────────────────────────────── */
 

--- a/components/ui/FileUploader/FileUploader.css
+++ b/components/ui/FileUploader/FileUploader.css
@@ -8,7 +8,7 @@
  * - --border-radius-lg
  * - --padding-xl
  * - --gap-sm, --gap-md
- * - --color-system-red (error)
+ * - --text-status-error (error)
  */
 
 /* ─── Wrapper ─────────────────────────────────────────────────── */
@@ -50,7 +50,7 @@
 }
 
 .bds-file-uploader__dropzone--error {
-  border-color: var(--color-system-red);
+  border-color: var(--text-status-error);
 }
 
 /* ─── Icon ────────────────────────────────────────────────────── */
@@ -88,7 +88,7 @@
   font-size: var(--body-sm);
   font-weight: var(--font-weight-regular);
   line-height: var(--font-line-height-normal);
-  color: var(--color-system-red);
+  color: var(--text-status-error);
   margin: 0;
 }
 

--- a/components/ui/Form/Form.css
+++ b/components/ui/Form/Form.css
@@ -5,7 +5,7 @@
  * - --gap-sm, --gap-md, --gap-lg, --gap-xl
  * - --padding-sm, --padding-md
  * - --border-radius-md
- * - --color-system-red, --color-system-green
+ * - --text-status-error, --text-status-success
  */
 
 /* ─── Container ───────────────────────────────────────────────── */
@@ -56,10 +56,10 @@
   font-size: var(--body-sm);
   font-weight: var(--font-weight-regular);
   line-height: var(--font-line-height-normal);
-  color: var(--color-system-red);
+  color: var(--text-status-error);
   margin: 0;
   padding: var(--padding-sm);
-  background: color-mix(in srgb, var(--color-system-red) 8%, transparent);
+  background: color-mix(in srgb, var(--text-status-error) 8%, transparent);
   border-radius: var(--border-radius-md);
 }
 
@@ -68,10 +68,10 @@
   font-size: var(--body-sm);
   font-weight: var(--font-weight-regular);
   line-height: var(--font-line-height-normal);
-  color: var(--color-system-green);
+  color: var(--text-status-success);
   margin: 0;
   padding: var(--padding-sm);
-  background: color-mix(in srgb, var(--color-system-green) 8%, transparent);
+  background: color-mix(in srgb, var(--text-status-success) 8%, transparent);
   border-radius: var(--border-radius-md);
 }
 

--- a/components/ui/Select/Select.css
+++ b/components/ui/Select/Select.css
@@ -25,7 +25,7 @@
 .bds-select-label--lg { font-size: var(--label-lg); }
 
 .bds-select-label--error {
-  color: var(--color-system-red);
+  color: var(--text-status-error);
 }
 
 /* ─── Field wrapper ──────────────────────────────────────────── */
@@ -110,17 +110,17 @@
 
 /* Error state */
 .bds-select--error {
-  border-color: var(--color-system-red);
+  border-color: var(--text-status-error);
 }
 
 .bds-select--error:hover:not(:disabled) {
-  border-color: var(--color-system-red);
+  border-color: var(--text-status-error);
 }
 
 .bds-select--error:focus,
 .bds-select--error:focus-visible {
-  border-color: var(--color-system-red);
-  box-shadow: 0 0 0 1px var(--color-system-red);
+  border-color: var(--text-status-error);
+  box-shadow: 0 0 0 1px var(--text-status-error);
 }
 
 /* ─── Chevron icon ───────────────────────────────────────────── */
@@ -160,5 +160,5 @@
 }
 
 .bds-select-helper--error {
-  color: var(--color-system-red);
+  color: var(--text-status-error);
 }

--- a/components/ui/Snackbar/Snackbar.css
+++ b/components/ui/Snackbar/Snackbar.css
@@ -17,22 +17,22 @@
 /* ─── Variants ───────────────────────────────────────────────── */
 
 .bds-snackbar--default {
-  background-color: var(--color-grayscale-black);
+  background-color: var(--background-inverse);
   color: var(--text-inverse);
 }
 
 .bds-snackbar--success {
-  background-color: var(--color-system-green);
+  background-color: var(--background-status-success);
   color: var(--text-on-color-dark);
 }
 
 .bds-snackbar--error {
-  background-color: var(--color-system-red);
+  background-color: var(--background-status-error);
   color: var(--text-on-color-dark);
 }
 
 .bds-snackbar--warning {
-  background-color: var(--color-system-orange);
+  background-color: var(--background-status-orange);
   color: var(--text-on-color-light);
 }
 

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -42,11 +42,11 @@
 }
 
 .bds-task-console--success .bds-task-console__header {
-  background-color: var(--color-system-green-surface);
+  background-color: var(--surface-status-success);
 }
 
 .bds-task-console--has-errors .bds-task-console__header {
-  background-color: var(--color-system-red-surface);
+  background-color: var(--surface-status-error);
 }
 
 .bds-task-console__header-text {
@@ -117,13 +117,13 @@
 
 .bds-task-console__progress-fill {
   height: 100%;
-  background-color: var(--color-system-blue);
+  background-color: var(--background-status-info);
   transition: width 0.4s ease;
   border-radius: 0 2px 2px 0; /* bds-lint-ignore — progress bar cap */
 }
 
 .bds-task-console__progress-fill--error {
-  background-color: var(--color-system-red);
+  background-color: var(--background-status-error);
 }
 
 /* ─── Item list ──────────────────────────────────────────────── */
@@ -151,11 +151,11 @@
 }
 
 .bds-task-console__item--in_progress {
-  background-color: var(--color-system-blue-surface);
+  background-color: var(--surface-status-info);
 }
 
 .bds-task-console__item--failed {
-  background-color: var(--color-system-red-surface);
+  background-color: var(--surface-status-error);
 }
 
 /* ─── Item content ───────────────────────────────────────────── */
@@ -188,7 +188,7 @@
   font-size: var(--body-sm);
   font-weight: var(--font-weight-semi-bold);
   line-height: var(--font-line-height-normal);
-  color: var(--color-system-blue);
+  color: var(--text-status-info);
   text-decoration: none;
   cursor: pointer;
 }
@@ -214,15 +214,15 @@
 }
 
 .bds-task-console__icon--completed {
-  color: var(--color-system-green);
+  color: var(--text-status-success);
 }
 
 .bds-task-console__icon--failed {
-  color: var(--color-system-red);
+  color: var(--text-status-error);
 }
 
 .bds-task-console__icon--in-progress {
-  color: var(--color-system-blue);
+  color: var(--text-status-info);
 }
 
 .bds-task-console__icon--pending {


### PR DESCRIPTION
## Summary

- All `--color-system-*` and `--color-grayscale-black` primitive references replaced with semantic status tokens across 11 components
- Components now fully respond to client theme overrides — a client theme can redefine `--background-status-error` once and it cascades to Button destructive, Dialog destructive, Select error, Form error, FileUploader error, Snackbar error, TaskConsole failed states
- Avatar presence indicators use `--background-presence-*` tokens
- Snackbar default variant uses `--background-inverse` instead of hardcoded black

**Components changed:** Avatar, Badge, Button, CardTestimonial, Dialog, Dot, FileUploader, Form, Select, Snackbar, TaskConsole

## No visual changes
Token values map to identical color primitives — this is a semantic rename only. All existing appearances are preserved.

## Test plan
- [ ] `npm run lint-tokens -- --errors-only` → 0 errors
- [ ] Storybook: Badge, Dot, Avatar, Button, Form, Select, Snackbar, TaskConsole all render correctly
- [ ] Storybook: Apply a client theme — status colors now update across all components

🤖 Generated with [Claude Code](https://claude.com/claude-code)