### PR TITLE
Update foundation Storybook docs: status/presence/shadow tokens + client theming

### DIFF
--- a/stories/foundation/ClientThemes.mdx
+++ b/stories/foundation/ClientThemes.mdx
@@ -1,0 +1,126 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { ThemeOverview } from './_components';
+
+<Meta title="Foundations/Design Tokens/Client Theming" />
+
+# Client Theming
+
+BDS ships 9 built-in themes. Each theme overrides a curated set of semantic color and typography tokens while leaving primitives and spacing untouched.
+
+## How themes work
+
+Themes are applied by adding a class to `<body>`. The `ThemeProvider` component manages this automatically.
+
+```tsx
+// In your layout or app root:
+<ThemeProvider theme="theme-1">
+  <App />
+</ThemeProvider>
+```
+
+Internally, `ThemeProvider` sets `document.body.className = 'body theme-{n}'`. The CSS selector `.body.theme-N { ... }` in `tokens/overrides.css` then overrides the semantic tokens for that theme.
+
+## Built-in themes
+
+<ThemeOverview />
+
+| Class | Description |
+|-------|-------------|
+| *(default)* | Brik brand — Poppy red primary |
+| `.body.theme-1` | Blue light variant |
+| `.body.theme-2` | Theme 2 |
+| `.body.theme-3` | Theme 3 |
+| `.body.theme-4` | Theme 4 |
+| `.body.theme-5` | Theme 5 |
+| `.body.theme-6` | Theme 6 |
+| `.body.theme-7` | Theme 7 |
+| `.body.theme-8` | Theme 8 |
+| `.body.theme-client-sim` | Font override demo — not a color theme |
+
+Use the paintbrush icon in the Storybook toolbar to switch themes in real time.
+
+## Token cascade
+
+The full cascade order in a consuming project's `globals.css`:
+
+```css
+@import '@brikdesigns/bds/tokens.css';   /* 1. Primitives + semantic defaults + all .body.theme-N blocks */
+@import '@brikdesigns/bds/bridge.css';   /* 2. Clean name aliases (interaction renames, etc.) */
+@import '@brikdesigns/bds/styles.css';   /* 3. Component CSS */
+/* 4. Client brand overrides — see below */
+```
+
+`tokens.css` bundles everything: `figma-tokens.css` (primitives + semantic defaults), `overrides.css` (gap-fills, theme blocks, status/shadow tokens), and `bridge.css` (token rename aliases).
+
+## What each theme overrides
+
+Each `.body.theme-N` block overrides a fixed set of **semantic color tokens** — the same tokens that appear in the [Color](?path=/docs/foundations-design-tokens-color--docs) doc. These include:
+
+- `--background-brand-primary`, `--background-brand-secondary`
+- `--text-primary`, `--text-secondary`, `--text-muted`, `--text-brand-primary`
+- `--surface-primary`, `--surface-secondary`, `--surface-nav`, `--surface-brand-primary`
+- `--border-primary`, `--border-secondary`, `--border-brand-primary`
+- `--page-primary`, `--page-brand-primary`
+
+**Typography tokens** are NOT overridden by theme-1 through theme-8 — all themes share the Brik font stack. The `theme-client-sim` class demonstrates font family overrides only.
+
+**Spacing tokens** are not theme-controlled — spacing comes from the Base/Spacious mode set on `.body`, not from theme classes.
+
+## Adding a custom client brand
+
+For client projects, add a fourth CSS layer after the three BDS imports:
+
+```css
+/* globals.css in your consuming project */
+@import '@brikdesigns/bds/tokens.css';
+@import '@brikdesigns/bds/bridge.css';
+@import '@brikdesigns/bds/styles.css';
+
+/* Client brand — override semantic tokens at :root or .body level */
+:root {
+  --background-brand-primary: #2563EB;   /* client primary */
+  --text-brand-primary:       #2563EB;
+  --border-brand-primary:     #2563EB;
+  --surface-brand-primary:    #EFF6FF;
+  --font-family-heading:      'Neue Haas Grotesk', sans-serif;
+  --font-family-body:         'Inter', sans-serif;
+}
+```
+
+This overrides the defaults for every component in that project. No `.body.theme-N` class needed — the `:root` block always wins via cascade order.
+
+## Known gaps — what is NOT per-client overridable
+
+**Interaction states (hover/focus/press) are global, not per-theme.**
+
+Tokens like `--background-brand-primary-hover` and `--background-brand-primary-pressed` are defined once in `tokens/overrides.css` at the `:root` level. They are *not* inside any `.body.theme-N` block. This means:
+
+- If a client overrides `--background-brand-primary` to blue, the hover state still uses the default Poppy red tint.
+- Fix: also override the interaction tokens in your client `:root` block:
+
+```css
+:root {
+  --background-brand-primary:         #2563EB;
+  --background-brand-primary-hover:   #1D4ED8;   /* must set manually */
+  --background-brand-primary-pressed: #1E40AF;   /* must set manually */
+}
+```
+
+**Status and presence tokens are global.** `--background-status-error`, `--background-presence-online`, etc. are fixed values (red, green, yellow) — they are intentionally not theme-customizable. Do not override these per-client.
+
+**Shadow tokens are global.** `--shadow-sm` through `--shadow-xl` and `--background-overlay` use hardcoded `rgba()` values. They are not expected to vary per brand.
+
+## Typography-only client override
+
+To override fonts without changing any colors:
+
+```css
+:root {
+  --font-family-heading: 'Playfair Display', serif;
+  --font-family-body:    'Source Sans 3', sans-serif;
+  --font-family-label:   'Source Sans 3', sans-serif;
+  --font-family-display: 'Playfair Display', serif;
+}
+```
+
+This is exactly what `.body.theme-client-sim` demonstrates in the toolbar.

--- a/stories/foundation/Color.mdx
+++ b/stories/foundation/Color.mdx
@@ -86,18 +86,81 @@ Semantic tokens map to purpose, not appearance. These values change when you swi
 
 ## Interaction states
 
-Tokenized interaction colors for buttons and interactive elements. These replace all `filter: brightness()` and `opacity` hacks.
+Tokenized interaction colors for hover, press, and disabled states. These replace all `filter: brightness()` and `opacity` hacks. As of 2026-03-31, Figma dropped the `interaction/` group prefix — use the new aliases below.
 
 <ColorGrid
   colors={[
-    { name: 'brand-primary-hover', cssVar: '--interaction-background-brand-primary-hover' },
-    { name: 'brand-primary-pressed', cssVar: '--interaction-background-brand-primary-pressed' },
-    { name: 'secondary-hover', cssVar: '--interaction-surface-secondary-hover' },
-    { name: 'secondary-pressed', cssVar: '--interaction-surface-secondary-pressed' },
-    { name: 'subtle-hover', cssVar: '--interaction-surface-subtle-hover' },
-    { name: 'disabled-bg', cssVar: '--interaction-background-disabled' },
-    { name: 'disabled-text', cssVar: '--interaction-text-disabled', isText: true },
-    { name: 'focus-ring', cssVar: '--interaction-border-focus' },
+    { name: 'background-brand-primary-hover', cssVar: '--background-brand-primary-hover' },
+    { name: 'background-brand-primary-pressed', cssVar: '--background-brand-primary-pressed' },
+    { name: 'background-secondary-hover', cssVar: '--background-secondary-hover' },
+    { name: 'background-secondary-pressed', cssVar: '--background-secondary-pressed' },
+    { name: 'background-outline-hover', cssVar: '--background-outline-hover' },
+    { name: 'background-outline-pressed', cssVar: '--background-outline-pressed' },
+    { name: 'background-disabled', cssVar: '--background-disabled' },
+    { name: 'text-disabled', cssVar: '--text-disabled', isText: true },
+    { name: 'border-disabled', cssVar: '--border-disabled' },
+  ]}
+  columns={3}
+/>
+
+## Status tokens
+
+Semantic tokens for error, success, warning, info, and other status states. Use these in components — never use `--color-system-*` primitives directly.
+
+### Background status
+
+<ColorGrid
+  colors={[
+    { name: 'background-status-error', cssVar: '--background-status-error' },
+    { name: 'background-status-error-subtle', cssVar: '--background-status-error-subtle' },
+    { name: 'background-status-success', cssVar: '--background-status-success' },
+    { name: 'background-status-success-subtle', cssVar: '--background-status-success-subtle' },
+    { name: 'background-status-warning', cssVar: '--background-status-warning' },
+    { name: 'background-status-warning-subtle', cssVar: '--background-status-warning-subtle' },
+    { name: 'background-status-info', cssVar: '--background-status-info' },
+    { name: 'background-status-info-subtle', cssVar: '--background-status-info-subtle' },
+    { name: 'background-status-neutral', cssVar: '--background-status-neutral' },
+    { name: 'background-status-purple', cssVar: '--background-status-purple' },
+    { name: 'background-status-orange', cssVar: '--background-status-orange' },
+  ]}
+  columns={4}
+/>
+
+### Text status
+
+<ColorGrid
+  colors={[
+    { name: 'text-status-error', cssVar: '--text-status-error', isText: true },
+    { name: 'text-status-success', cssVar: '--text-status-success', isText: true },
+    { name: 'text-status-warning', cssVar: '--text-status-warning', isText: true },
+    { name: 'text-status-info', cssVar: '--text-status-info', isText: true },
+    { name: 'text-status-neutral', cssVar: '--text-status-neutral', isText: true },
+  ]}
+  columns={3}
+/>
+
+### Surface status
+
+<ColorGrid
+  colors={[
+    { name: 'surface-status-error', cssVar: '--surface-status-error' },
+    { name: 'surface-status-success', cssVar: '--surface-status-success' },
+    { name: 'surface-status-warning', cssVar: '--surface-status-warning' },
+    { name: 'surface-status-info', cssVar: '--surface-status-info' },
+  ]}
+  columns={4}
+/>
+
+## Presence tokens
+
+Online/presence indicator tokens used by Avatar, Dot, and presence-aware components.
+
+<ColorGrid
+  colors={[
+    { name: 'background-presence-online', cssVar: '--background-presence-online' },
+    { name: 'background-presence-away', cssVar: '--background-presence-away' },
+    { name: 'background-presence-busy', cssVar: '--background-presence-busy' },
+    { name: 'background-presence-offline', cssVar: '--background-presence-offline' },
   ]}
   columns={4}
 />

--- a/stories/foundation/DesignTokens.mdx
+++ b/stories/foundation/DesignTokens.mdx
@@ -35,33 +35,54 @@ Primitives (raw scale values)          Semantic tokens (purpose-bound)
 | Border | `--border-radius-md`, `--border-width-lg` | Border properties |
 | Scale | `--font-size-700`, `--space-400` | Primitive scale steps |
 
-## Multi-platform outputs
+## Token pipeline
 
-Tokens are generated for multiple platforms from the same source:
+Tokens flow in one direction — Figma is the source of truth:
 
-| Platform | Format | Location |
-|----------|--------|----------|
-| CSS | Custom properties | `tokens/variables.css` |
-| JavaScript | ES6 exports | `build/figma/js/tokens.mjs` |
-| TypeScript | Type declarations | `build/figma/js/tokens.d.ts` |
-| SwiftUI | Static enums | `build/figma/swift/*.swift` |
+```
+Figma Variables → design-tokens/tokens-studio.json → Style Dictionary → tokens/figma-tokens.css
+                                                                        build/figma/js/tokens.mjs
+                                                                        build/figma/swift/*.swift
+```
+
+To regenerate after a Figma change: `npm run build:sd-figma`
+
+**Published npm package exports** (`@brikdesigns/bds`):
+
+| Export | File | Contents |
+|--------|------|----------|
+| `@brikdesigns/bds/tokens.css` | `dist/tokens.css` | All tokens: primitives + semantic defaults + all theme overrides |
+| `@brikdesigns/bds/bridge.css` | `dist/bridge.css` | Clean name aliases for Astro/Next.js consumption |
+| `@brikdesigns/bds/styles.css` | `dist/styles.css` | All component CSS |
+
+**Load order in consuming project `globals.css`:**
+
+```css
+@import '@brikdesigns/bds/tokens.css';   /* 1. All token values + theme blocks */
+@import '@brikdesigns/bds/bridge.css';   /* 2. Clean name aliases */
+@import '@brikdesigns/bds/styles.css';   /* 3. Component CSS */
+/* 4. Your client brand overrides (optional — see Client Theming) */
+```
 
 ## Themes
 
-BDS ships 9 theme variants. Each theme overrides semantic color, typography, and spacing tokens while preserving the primitive scale.
+BDS ships 9 built-in themes. Each applies via a `.body.theme-N` class on `<body>` and overrides semantic color, typography, and spacing tokens while leaving primitives unchanged.
 
 <ThemeOverview />
 
 Use the paintbrush icon in the toolbar to switch themes. All Foundation pages and components update in real time.
 
+See [Client Theming](?path=/docs/foundations-design-tokens-client-theming--docs) for how to configure a client brand.
+
 ## Token categories
 
 | Category | Tokens | Description |
 |----------|--------|-------------|
-| [Color](?path=/docs/foundation-color--docs) | Grayscale, palettes, semantic roles | All color decisions |
-| [Typography](?path=/docs/foundation-typography--docs) | Font families, sizes, weights, line heights | All type decisions |
-| [Spacing](?path=/docs/foundation-spacing--docs) | Space scale, gaps, padding | All spacing decisions |
-| [Border radius](?path=/docs/foundation-border-radius--docs) | Radius scale, semantic radius | Corner rounding |
-| [Border width](?path=/docs/foundation-border-width--docs) | Width scale, semantic widths | Border thickness |
-| [Shadow](?path=/docs/foundation-shadow--docs) | Blur, spread, offset | Elevation and depth |
-| [Size](?path=/docs/foundation-size--docs) | Size scale, breakpoints, containers | Dimensional constraints |
+| [Color](?path=/docs/foundations-design-tokens-color--docs) | Grayscale, palettes, semantic roles, status, interaction | All color decisions |
+| [Typography](?path=/docs/foundations-design-tokens-typography--docs) | Font families, sizes, weights, line heights | All type decisions |
+| [Spacing](?path=/docs/foundations-design-tokens-spacing--docs) | Space scale, gaps, padding | All spacing decisions |
+| [Border radius](?path=/docs/foundations-design-tokens-border-radius--docs) | Radius scale, semantic radius | Corner rounding |
+| [Border width](?path=/docs/foundations-design-tokens-border-width--docs) | Width scale, semantic widths | Border thickness |
+| [Shadow](?path=/docs/foundations-design-tokens-shadow--docs) | Composed elevation tokens + primitive scales | Elevation and depth |
+| [Size](?path=/docs/foundations-design-tokens-size--docs) | Size scale, breakpoints, containers | Dimensional constraints |
+| [Client Theming](?path=/docs/foundations-design-tokens-client-theming--docs) | Theme system, cascade, custom brand guide | How to apply a client brand |

--- a/stories/foundation/Shadow.mdx
+++ b/stories/foundation/Shadow.mdx
@@ -20,19 +20,21 @@ Controls how far a shadow extends outward.
 
 <ShadowScale scale={shadowSpreadScale} prefix="shadow-spread" label="spread" />
 
-## Semantic shadow tokens
+## Composed shadow tokens
 
-| Token | CSS Variable | Description |
-|-------|-------------|-------------|
-| Medium box shadow | `--box-shadow-md` | Default elevation |
-| Medium blur radius | `--blur-radius-md` | Default blur |
+Ready-to-use `box-shadow` values defined in `tokens/overrides.css`. Use these in component CSS — never compose raw blur/spread values manually.
 
-## Elevation modes
+| Token | CSS Variable | Value | Use case |
+|-------|-------------|-------|----------|
+| Small | `--shadow-sm` | `0px 2px 4px 0px rgba(0,0,0,0.06)` | Subtle cards, inputs |
+| Medium | `--shadow-md` | `0px 4px 8px 0px rgba(0,0,0,0.08)` | Cards, panels |
+| Large | `--shadow-lg` | `0px 8px 16px 0px rgba(0,0,0,0.10)` | Dropdowns, popovers |
+| Extra large | `--shadow-xl` | `0px 16px 32px 0px rgba(0,0,0,0.12)` | Modals, dialogs |
 
-Figma uses elevation modes to control shadow intensity:
+### Overlay
 
-| Mode | Effect | Use case |
-|------|--------|----------|
-| Subtle | Minimal shadow | Default, clean |
-| Soft | Gentle shadow | Cards, surfaces |
-| Raised | Prominent shadow | Modals, dropdowns |
+| Token | CSS Variable | Value |
+|-------|-------------|-------|
+| Overlay | `--background-overlay` | `rgba(0, 0, 0, 0.4)` |
+
+Used for modal backdrops and drawer overlays.

--- a/stories/foundation/Spacing.mdx
+++ b/stories/foundation/Spacing.mdx
@@ -73,4 +73,4 @@ Dedicated spacing tokens for specific component types.
 | `--padding-xl` | 32px | 52px |
 | `--padding-huge` | 48px | 88px |
 
-Storybook uses Base mode (overridden in `storybook-overrides.css`). Webflow marketing sites use Spacious mode via the `.body` class default.
+Storybook uses Base mode (overridden in `storybook-overrides.css`). Spacious mode is available for marketing sites that need more generous spacing via the `.body` class default.


### PR DESCRIPTION
## Summary

- **Color.mdx** — updates interaction state token names to 2026-03-31 aliases (`--background-brand-primary-hover`, etc.); adds new Status tokens section (background/text/surface variants); adds Presence tokens section
- **Shadow.mdx** — replaces stale semantic token table with actual composed tokens (`--shadow-sm/md/lg/xl`, `--background-overlay`)
- **Spacing.mdx** — removes Webflow-specific language from spacing modes note
- **ClientThemes.mdx** (new) — documents the `.body.theme-N` class mechanism, built-in themes list, full token cascade order, what IS and ISN'T per-client overridable, custom brand `:root` override pattern, and the known gap (interaction states are not inside theme blocks and must be manually overridden per client)

## Test plan

- [ ] Run Storybook (`npm run storybook`) and verify the four updated/new doc pages render correctly
- [ ] Confirm theme switcher in toolbar still works on Client Theming page
- [ ] Verify Color.mdx shows swatches for all status + presence token sections
- [ ] Confirm Shadow.mdx shows the composed shadow token table (not old stale rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)