### PR TITLE
Use label family for board card title; top-align sheet header

### DIFF
--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -203,14 +203,14 @@
 }
 
 /*
- * Card title — heading family, semibold.
- * Uses --heading-tiny (18px) — the minimum heading size.
- * Client themes that need a more compact card title can override
- * font-size in their globals.css; the family must remain heading.
+ * Card title — label family, lg size.
+ * Task titles are UI metadata, not editorial headings — label family
+ * gives better legibility at card density. --label-lg (16px) is the
+ * largest label size and reads well in a compact Kanban card.
  */
 .bds-board-card__title {
-  font-family: var(--font-family-heading);
-  font-size: var(--heading-tiny);
+  font-family: var(--font-family-label);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-semi-bold);
   color: var(--text-primary);
   line-height: var(--font-line-height-tight);

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -32,7 +32,7 @@
 
 .bds-sheet__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   padding: var(--padding-lg);
   border-bottom: var(--border-width-sm) solid var(--border-muted);
@@ -73,7 +73,7 @@
   font-size: var(--icon-md);
   line-height: var(--font-line-height-tight);
   cursor: pointer;
-  padding: var(--padding-md);
+  padding: 0 var(--padding-md) var(--padding-md);
   margin-right: calc(-1 * var(--padding-md));
   color: var(--text-primary);
   opacity: 0.6;


### PR DESCRIPTION
## Summary
- **BoardCard title**: switch from `--font-family-heading` / `--heading-tiny` to `--font-family-label` / `--label-lg` — task titles are UI metadata, not editorial headings; label family improves legibility at card density
- **Sheet header**: change `align-items` from `center` to `flex-start` so title and close button are top-aligned; remove top padding from close button so the icon sits flush with the title top edge

## Test plan
- [ ] Board page — card titles render in Avenir (label family) at a readable size, not Century Schoolbook
- [ ] Open any sheet — close × icon aligns to the top of the title, not vertically centered
- [ ] Dark mode — no regressions on either component

🤖 Generated with [Claude Code](https://claude.com/claude-code)