### PR TITLE
Fix lopsided padding in Tag and Badge: line-height 1

### DIFF
--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -13,7 +13,7 @@
   align-items: center;
   font-family: var(--font-family-label);
   font-weight: var(--font-weight-semi-bold);
-  line-height: var(--font-line-height-tight);
+  line-height: 1; /* bds-lint-ignore — collapse line box so padding controls spacing symmetrically */
   border-radius: var(--border-radius-pill);
   white-space: nowrap;
 }

--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -14,7 +14,7 @@
   align-items: center;
   font-family: var(--font-family-label);
   font-weight: var(--font-weight-semi-bold);
-  line-height: var(--font-line-height-tight);
+  line-height: 1; /* bds-lint-ignore — collapse line box so padding controls spacing symmetrically */
   color: var(--text-primary);
   background-color: var(--background-secondary);
   text-decoration: none;


### PR DESCRIPTION
## Summary
- Both `Tag` and `Badge` base classes had `line-height: var(--font-line-height-tight)` (~1.2), which distributes leading unevenly based on Avenir's ascender/descender ratio — causing the text to appear to sit lower, making top padding look smaller than bottom
- Since both components are `inline-flex` + `align-items: center`, padding already owns vertical spacing; the line-height was fighting it
- Fix: `line-height: 1` collapses the text line box to the em square so padding controls spacing symmetrically on both sides

## Test plan
- [ ] Tag sm/md/lg — visual padding appears equal top and bottom
- [ ] Badge sm/md/lg — same check, including icon+label variants
- [ ] No regressions on multiline tag content (should be rare/none — tags are `white-space: nowrap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)