### PR TITLE
Remove overflow clipping from BoardHeader subtitle

### DIFF
--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -140,9 +140,6 @@
   opacity: 0.8;
   line-height: var(--font-line-height-tight);
   margin: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .bds-board-header__progress {


### PR DESCRIPTION
white-space: nowrap + overflow: hidden + text-overflow: ellipsis was cropping subtitle text — descenders clipped and long role names truncated hard. Subtitle now flows naturally within the column's own overflow boundary.