### PR TITLE
feat: add --font-family-subtitle token

### DIFF
--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -33,6 +33,7 @@
 .bds-badge--sm {
   padding: var(--padding-tiny) var(--padding-sm);
   gap: var(--gap-xs);
+  font-family: var(--font-family-subtitle);
   font-size: var(--subtitle-sm);
 }
 
@@ -46,6 +47,7 @@
 .bds-badge--lg {
   padding: var(--padding-sm) var(--padding-md);
   gap: var(--gap-md);
+  font-family: var(--font-family-subtitle);
   font-size: var(--subtitle-lg);
 }
 

--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -128,12 +128,11 @@
 }
 
 /*
- * Column header subtitle — label family (not body).
- * Subtitles are UI metadata labels; they belong to the label family.
+ * Column header subtitle — subtitle family.
  * --subtitle-md matches the visual size with correct semantics.
  */
 .bds-board-header__subtitle {
-  font-family: var(--font-family-label);
+  font-family: var(--font-family-subtitle);
   font-size: var(--subtitle-md);
   font-weight: var(--font-weight-regular);
   color: var(--text-on-color-dark);
@@ -215,11 +214,11 @@
 }
 
 /*
- * Card subtitle — label family (not body).
+ * Card subtitle — subtitle family.
  * Uses --subtitle-md (11.54px) for correct semantic sizing.
  */
 .bds-board-card__subtitle {
-  font-family: var(--font-family-label);
+  font-family: var(--font-family-subtitle);
   font-size: var(--subtitle-md);
   font-weight: var(--font-weight-regular);
   color: var(--text-primary);

--- a/components/ui/Table/Table.css
+++ b/components/ui/Table/Table.css
@@ -55,7 +55,7 @@
 .bds-table-subheader {
   background-color: var(--surface-secondary);
   color: var(--text-muted);
-  font-family: var(--font-family-label);
+  font-family: var(--font-family-subtitle);
   font-size: var(--subtitle-sm);
   font-weight: var(--font-weight-semi-bold);
   text-transform: uppercase;

--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -40,6 +40,7 @@
 .bds-tag--sm {
   padding: var(--padding-tiny) var(--padding-sm);
   gap: var(--gap-xs);
+  font-family: var(--font-family-subtitle);
   font-size: var(--subtitle-sm);
   border-radius: var(--border-radius-sm);
 }
@@ -55,6 +56,7 @@
 .bds-tag--lg {
   padding: var(--padding-sm) var(--padding-md);
   gap: var(--gap-md);
+  font-family: var(--font-family-subtitle);
   font-size: var(--subtitle-lg);
   border-radius: var(--border-radius-md);
 }

--- a/tokens/overrides.css
+++ b/tokens/overrides.css
@@ -105,6 +105,12 @@
   --text-transform-body: none;
   --text-transform-display: none;
 
+  /* ── Font Family Subtitle ──
+     Semantic font-family for subtitle-sized text (--subtitle-sm/md/lg).
+     Defaults to label family. Override per-theme to visually differentiate.
+     TODO: promote to Figma variables once stable. */
+  --font-family-subtitle: var(--font-family-label);
+
   /* ── System Color Extras ── */
   --color-system-transparent: #0000;
   --color-system-lightbox: #000000a3;
@@ -302,6 +308,7 @@
 
   /* Typography */
   --font-family-label: "Open Sans", sans-serif;
+  --font-family-subtitle: var(--font-family-label);
   --font-family-body: "Open Sans", sans-serif;
   --font-family-heading: "Droid Sans", sans-serif;
   --font-family-display: "Droid Sans", sans-serif;
@@ -390,6 +397,7 @@
 
   /* Typography */
   --font-family-label: "Geist Mono", sans-serif;
+  --font-family-subtitle: var(--font-family-label);
   --font-family-body: "Geist Mono", sans-serif;
   --font-family-heading: Geist, sans-serif;
   --font-family-display: Geist, sans-serif;
@@ -455,6 +463,7 @@
 
   /* Typography */
   --font-family-label: "Source Sans 3", sans-serif;
+  --font-family-subtitle: var(--font-family-label);
   --font-family-body: "Source Sans 3", sans-serif;
   --font-family-heading: "IBM Plex Sans", sans-serif;
   --font-family-display: "IBM Plex Sans", sans-serif;
@@ -523,6 +532,7 @@
 
   /* Typography */
   --font-family-label: Hind, sans-serif;
+  --font-family-subtitle: var(--font-family-label);
   --font-family-body: Hind, sans-serif;
   --font-family-heading: Lato, Arial, sans-serif;
   --font-family-display: Lato, Arial, sans-serif;
@@ -591,6 +601,7 @@
 
   /* Typography */
   --font-family-label: "Open Sans", sans-serif;
+  --font-family-subtitle: var(--font-family-label);
   --font-family-body: "Open Sans", sans-serif;
   --font-family-heading: Newsreader, sans-serif;
   --font-family-display: Newsreader, sans-serif;
@@ -662,6 +673,7 @@
 
   /* Typography */
   --font-family-label: "Geist Mono", sans-serif;
+  --font-family-subtitle: var(--font-family-label);
   --font-family-body: "Geist Mono", sans-serif;
   --font-family-heading: Geist, sans-serif;
   --font-family-display: Geist, sans-serif;
@@ -731,6 +743,7 @@
 
   /* Typography */
   --font-family-label: Hind, sans-serif;
+  --font-family-subtitle: var(--font-family-label);
   --font-family-body: Hind, sans-serif;
   --font-family-heading: Lato, Arial, sans-serif;
   --font-family-display: Lato, Arial, sans-serif;
@@ -800,6 +813,7 @@
 
   /* Typography */
   --font-family-label: Hind, sans-serif;
+  --font-family-subtitle: var(--font-family-label);
   --font-family-body: Hind, sans-serif;
   --font-family-heading: "Playfair Display", sans-serif;
   --font-family-display: "Playfair Display", sans-serif;
@@ -834,15 +848,17 @@
  * Assigns maximally distinct system fonts to each family token so that any
  * component using the wrong family token is immediately legible during development.
  *
- *   --font-family-heading  → Georgia (serif)         ← heading/title elements
- *   --font-family-display  → Georgia (serif)         ← display/hero elements
- *   --font-family-label    → Courier New (monospace) ← labels, badges, tags, buttons
- *   --font-family-body     → Verdana (sans-serif)    ← body copy, descriptions
+ *   --font-family-heading   → Georgia (serif)         ← heading/title elements
+ *   --font-family-display   → Georgia (serif)         ← display/hero elements
+ *   --font-family-label     → Courier New (monospace) ← labels, badges, tags, buttons
+ *   --font-family-subtitle  → Impact (condensed)      ← subtitle-sized text (badge sm/lg, table subheader, board subtitle)
+ *   --font-family-body      → Verdana (sans-serif)    ← body copy, descriptions
  *
  * If you see:
- *   - A heading rendered in Verdana or Courier New  → wrong font-family token
- *   - A badge/label rendered in Georgia or Verdana  → wrong font-family token
- *   - Body copy rendered in Georgia or Courier New  → wrong font-family token
+ *   - A heading rendered in Verdana, Courier New, or Impact  → wrong font-family token
+ *   - A badge/label rendered in Georgia, Verdana, or Impact  → wrong font-family token
+ *   - Subtitle text rendered in Georgia, Verdana, or Courier → wrong font-family token
+ *   - Body copy rendered in Georgia, Courier New, or Impact  → wrong font-family token
  *
  * This theme is NOT for client delivery. Run it in Storybook toolbar when:
  *   1. Building a new component
@@ -853,6 +869,7 @@
   --font-family-heading: Georgia, "Times New Roman", serif;
   --font-family-display: Georgia, "Times New Roman", serif;
   --font-family-label: "Courier New", Courier, monospace;
+  --font-family-subtitle: Impact, "Arial Narrow", sans-serif;
   --font-family-body: Verdana, Geneva, sans-serif;
   --font-family-icon: "Font Awesome 6 Pro Solid 900", Arial, sans-serif;
 }


### PR DESCRIPTION
## Summary

- Adds `--font-family-subtitle` to `tokens/overrides.css` — defaults to `var(--font-family-label)` so no visual change, but provides a distinct override point for client themes
- Added to `:root` and all 8 theme blocks; `theme-client-sim` uses Impact for distinct validation rendering
- Updated Badge (sm/lg), Tag (sm/lg), Board (header + card subtitle), and Table (subheader) CSS to use `var(--font-family-subtitle)` wherever `--subtitle-sm/md/lg` sizes appear

## Motivation

All subtitle-sized text now declares a semantically distinct font-family token, making it easy to:
1. Review which elements use subtitle sizing at a glance in CSS/DevTools
2. Override subtitle type separately from label type per client theme

## Test plan
- [ ] Load Storybook and confirm Badge/Tag/Board/Table render identically (subtitle defaults to label family)
- [ ] Switch to `theme-client-sim` in Storybook toolbar — subtitle-sized elements should render in Impact, visually distinct from Courier New (label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)