### PR TITLE
fix: tighten tooltip padding; allow tooltips to escape board columns

### DIFF
--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -40,10 +40,16 @@
   max-width: 400px;
   scroll-snap-align: start;
   border-radius: var(--border-radius-200);
+  /* overflow: visible — allows tooltip bubbles to escape column bounds.
+     Clip is applied only when a background is present (see below). */
+  overflow: visible;
+}
+
+/* When column has a background color, clip to rounded corners + add internal padding */
+.bds-board-column[style*="background"] {
   overflow: clip;
 }
 
-/* When column has a background color, apply internal padding */
 .bds-board-column[style*="background"] .bds-board-column__items {
   padding: 0 var(--padding-sm);
 }

--- a/components/ui/Tooltip/Tooltip.css
+++ b/components/ui/Tooltip/Tooltip.css
@@ -11,7 +11,7 @@
 
 .bds-tooltip__bubble {
   position: absolute;
-  padding: var(--padding-sm) var(--padding-lg);
+  padding: var(--padding-tiny) var(--padding-md);
   background-color: var(--tooltip-background);
   color: var(--tooltip-text);
   font-family: var(--font-family-label);


### PR DESCRIPTION
## Summary

- **Tooltip padding**: `var(--padding-sm) var(--padding-lg)` (8px 24px) → `var(--padding-tiny) var(--padding-md)` (4px 16px) — the 24px horizontal padding was the default but is too wide for a compact contextual label
- **Board clip**: `overflow: clip` on `.bds-board-column` was clipping tooltip bubbles at column boundaries. Now `overflow: visible` by default; `overflow: clip` only applied when the column has an inline background (`[style*="background"]`), which is the only case needing corner clipping

## Test plan
- [ ] Tooltips appear compact (not over-padded)
- [ ] Tooltip on a board card renders above/beside the card without being cut off at column edge
- [ ] Board columns with a background color still have rounded corners clipping their children

🤖 Generated with [Claude Code](https://claude.com/claude-code)