### PR TITLE
Align Button sm and TextInput sm to 44px 4px-grid height

### DIFF
--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -42,8 +42,12 @@
 }
 
 .bds-button--sm {
-  padding: var(--padding-sm);
+  /* Block padding aligned with TextInput sm (--padding-xs = 10px) so both
+   * components share the same natural height. min-height: 44px snaps to 4px grid. */
+  padding-block: var(--padding-xs);
+  padding-inline: var(--padding-sm);
   font-size: var(--label-sm);
+  min-height: 44px;
 }
 
 .bds-button--md {

--- a/components/ui/TextInput/TextInput.tsx
+++ b/components/ui/TextInput/TextInput.tsx
@@ -132,7 +132,8 @@ const helperBaseStyles: CSSProperties = {
 const sizeStyles: Record<TextInputSize, { label: CSSProperties; input: CSSProperties }> = {
   sm: {
     label: { fontSize: 'var(--label-sm)' },
-    input: { fontSize: 'var(--body-sm)' },
+    // min-height: 44px snaps to 4px grid and aligns with Button sm
+    input: { fontSize: 'var(--body-sm)', minHeight: '44px' },
   },
   md: {
     label: { fontSize: 'var(--label-md)' },


### PR DESCRIPTION
## Summary

- **Button sm**: split `padding: --padding-sm` into `padding-block: --padding-xs` (10px) and `padding-inline: --padding-sm` (12px), matching TextInput sm's block padding and bringing natural height from 47px → 43px
- **Both components**: add `min-height: 44px` to snap to the 4px grid
- End result: Button sm and TextInput sm both render at **44px** — aligned, consistent, and on-grid

## Why

`14px × 150% line-height = 21px` (odd). With symmetric even padding, all sm form components land on odd heights. This causes mismatched heights when Button sm and TextInput sm sit side-by-side (e.g. inline add-task rows). The fix aligns block padding across both components and uses `min-height` to reach the nearest 4px grid increment.

## Test plan

- [ ] Verify Button sm renders at 44px in Storybook (all variants: primary, secondary, ghost, outline)
- [ ] Verify TextInput sm renders at 44px in Storybook
- [ ] Confirm Button sm + TextInput sm sitting side-by-side are flush
- [ ] Confirm Button md/lg heights are unaffected
- [ ] Confirm IconButton sm is unaffected (uses its own padding rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)