### PR TITLE
Migrate Storybook foundation components from Webflow tokens to SD format

### DIFF
--- a/.storybook/storybook-overrides.css
+++ b/.storybook/storybook-overrides.css
@@ -446,7 +446,6 @@ div[class*="Subtitle"] {
   /* Color */
   --page-primary: var(--color-grayscale-white);
   --page-secondary: var(--color-grayscale-lightest);
-  --_color---page--accent: #f1f0ec;
   --page-brand-primary: #e35335;
   --text-primary: var(--color-grayscale-darkest);
   --text-secondary: var(--color-grayscale-dark);

--- a/stories/Welcome.mdx
+++ b/stories/Welcome.mdx
@@ -28,22 +28,22 @@ Design tokens are the atomic visual decisions that power BDS. Explore each categ
 
 ## Token system
 
-Components use CSS variables from the Webflow export. The naming convention is:
+Components use CSS custom properties from the Style Dictionary token pipeline. The naming convention is:
 
 ```
---_[category]---[type]--[variant]
+--[category]-[type]-[variant]
 ```
 
 **Primitives** (raw scale values, never in components):
-- `--space--400` — 16px
-- `--font-size--700` — 32px
-- `--grayscale--darkest` — #333
+- `--space-400` — 16px
+- `--font-size-700` — 32px
+- `--color-grayscale-darkest` — #333
 
 **Semantic** (purpose-bound, used in components):
-- `--_color---background--brand-primary` — brand background color
-- `--_typography---font-family--heading` — heading font family
-- `--_space---lg` — large spacing value
-- `--_border-radius---button` — button corner radius
+- `--background-brand-primary` — brand background color
+- `--font-family-heading` — heading font family
+- `--padding-lg` — large spacing value
+- `--border-radius-md` — button corner radius
 
 ## Components
 

--- a/stories/foundation/_components/BorderRadiusPreview.tsx
+++ b/stories/foundation/_components/BorderRadiusPreview.tsx
@@ -12,14 +12,14 @@ export function BorderRadiusPreview({ title, scale }: BorderRadiusPreviewProps) 
   });
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -29,7 +29,7 @@ export function BorderRadiusPreview({ title, scale }: BorderRadiusPreviewProps) 
         style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fill, minmax(100px, 1fr))',
-          gap: 'var(--_space---gap--lg, 16px)',
+          gap: 'var(--gap-lg, 16px)',
         }}
       >
         {entries.map(([step, value]) => (
@@ -38,7 +38,7 @@ export function BorderRadiusPreview({ title, scale }: BorderRadiusPreviewProps) 
               style={{
                 width: '72px',
                 height: '72px',
-                backgroundColor: 'var(--_color---background--brand-primary)',
+                backgroundColor: 'var(--background-brand-primary)',
                 borderRadius: value,
                 margin: '0 auto 8px',
                 opacity: 0.8,
@@ -48,7 +48,7 @@ export function BorderRadiusPreview({ title, scale }: BorderRadiusPreviewProps) 
               style={{
                 fontSize: '12px',
                 fontWeight: 600,
-                color: 'var(--_color---text--primary)',
+                color: 'var(--text-primary)',
               }}
             >
               {step}
@@ -56,7 +56,7 @@ export function BorderRadiusPreview({ title, scale }: BorderRadiusPreviewProps) 
             <code
               style={{
                 fontSize: '11px',
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
                 fontFamily: 'ui-monospace, SFMono-Regular, monospace',
               }}
             >
@@ -81,14 +81,14 @@ export function BorderWidthPreview({ title, scale, prefix }: BorderWidthPreviewP
   );
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -111,7 +111,7 @@ export function BorderWidthPreview({ title, scale, prefix }: BorderWidthPreviewP
                 fontSize: '12px',
                 width: '180px',
                 flexShrink: 0,
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
               }}
             >
               {prefix}--{step}
@@ -120,14 +120,14 @@ export function BorderWidthPreview({ title, scale, prefix }: BorderWidthPreviewP
               style={{
                 width: '200px',
                 height: '0',
-                borderTop: `${value} solid var(--_color---border--brand)`,
+                borderTop: `${value} solid var(--border-brand-primary)`,
                 flexShrink: 0,
               }}
             />
             <span
               style={{
                 fontSize: '12px',
-                color: 'var(--_color---text--secondary)',
+                color: 'var(--text-secondary)',
                 fontFamily: 'ui-monospace, SFMono-Regular, monospace',
               }}
             >

--- a/stories/foundation/_components/ColorGrid.tsx
+++ b/stories/foundation/_components/ColorGrid.tsx
@@ -43,9 +43,9 @@ function ColorSwatch({ name, cssVar, isText }: ColorSwatchProps) {
         style={{
           width: '100%',
           height: '56px',
-          backgroundColor: isText ? 'var(--_color---surface--primary)' : `var(${cssVar})`,
-          borderRadius: 'var(--_border-radius---sm, 2px)',
-          border: '1px solid var(--_color---border--secondary)',
+          backgroundColor: isText ? 'var(--surface-primary)' : `var(${cssVar})`,
+          borderRadius: 'var(--border-radius-sm, 2px)',
+          border: '1px solid var(--border-secondary)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -61,7 +61,7 @@ function ColorSwatch({ name, cssVar, isText }: ColorSwatchProps) {
           style={{
             fontSize: '12px',
             fontWeight: 600,
-            color: 'var(--_color---text--primary)',
+            color: 'var(--text-primary)',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -72,7 +72,7 @@ function ColorSwatch({ name, cssVar, isText }: ColorSwatchProps) {
         <div
           style={{
             fontSize: '11px',
-            color: copied ? 'var(--_color---text--brand)' : 'var(--_color---text--muted)',
+            color: copied ? 'var(--text-brand-primary)' : 'var(--text-muted)',
             fontFamily: 'ui-monospace, SFMono-Regular, monospace',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
@@ -94,14 +94,14 @@ interface ColorGridProps {
 
 export function ColorGrid({ title, colors, columns = 6 }: ColorGridProps) {
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -111,7 +111,7 @@ export function ColorGrid({ title, colors, columns = 6 }: ColorGridProps) {
         style={{
           display: 'grid',
           gridTemplateColumns: `repeat(auto-fill, minmax(${Math.floor(600 / columns)}px, 1fr))`,
-          gap: 'var(--_space---gap--md, 8px)',
+          gap: 'var(--gap-md, 8px)',
         }}
       >
         {colors.map((c) => (
@@ -141,14 +141,14 @@ export function PaletteGrid({ title, palette, prefix, columns = 8 }: PaletteGrid
   }));
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -158,7 +158,7 @@ export function PaletteGrid({ title, palette, prefix, columns = 8 }: PaletteGrid
         style={{
           display: 'grid',
           gridTemplateColumns: `repeat(auto-fill, minmax(${Math.floor(600 / columns)}px, 1fr))`,
-          gap: 'var(--_space---gap--md, 8px)',
+          gap: 'var(--gap-md, 8px)',
         }}
       >
         {colors.map((c) => (
@@ -168,15 +168,15 @@ export function PaletteGrid({ title, palette, prefix, columns = 8 }: PaletteGrid
                 width: '100%',
                 height: '56px',
                 backgroundColor: c.hex,
-                borderRadius: 'var(--_border-radius---sm, 2px)',
-                border: '1px solid var(--_color---border--secondary)',
+                borderRadius: 'var(--border-radius-sm, 2px)',
+                border: '1px solid var(--border-secondary)',
               }}
             />
             <div
               style={{
                 fontSize: '12px',
                 fontWeight: 600,
-                color: 'var(--_color---text--primary)',
+                color: 'var(--text-primary)',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
@@ -187,7 +187,7 @@ export function PaletteGrid({ title, palette, prefix, columns = 8 }: PaletteGrid
             <div
               style={{
                 fontSize: '11px',
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
                 fontFamily: 'ui-monospace, SFMono-Regular, monospace',
               }}
             >

--- a/stories/foundation/_components/ShadowPreview.tsx
+++ b/stories/foundation/_components/ShadowPreview.tsx
@@ -11,14 +11,14 @@ export function ShadowScale({ title, scale, prefix, label }: ShadowScaleProps) {
   );
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -28,7 +28,7 @@ export function ShadowScale({ title, scale, prefix, label }: ShadowScaleProps) {
         style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
-          gap: 'var(--_space---gap--lg, 16px)',
+          gap: 'var(--gap-lg, 16px)',
         }}
       >
         {entries.map(([step, value]) => {
@@ -46,8 +46,8 @@ export function ShadowScale({ title, scale, prefix, label }: ShadowScaleProps) {
                 style={{
                   width: '80px',
                   height: '80px',
-                  backgroundColor: 'var(--_color---surface--primary)',
-                  borderRadius: 'var(--_border-radius---md, 4px)',
+                  backgroundColor: 'var(--surface-primary)',
+                  borderRadius: 'var(--border-radius-md, 4px)',
                   boxShadow: shadow,
                   margin: '16px auto',
                 }}
@@ -56,7 +56,7 @@ export function ShadowScale({ title, scale, prefix, label }: ShadowScaleProps) {
                 style={{
                   fontSize: '12px',
                   fontWeight: 600,
-                  color: 'var(--_color---text--primary)',
+                  color: 'var(--text-primary)',
                 }}
               >
                 {prefix}--{step}
@@ -64,7 +64,7 @@ export function ShadowScale({ title, scale, prefix, label }: ShadowScaleProps) {
               <code
                 style={{
                   fontSize: '11px',
-                  color: 'var(--_color---text--muted)',
+                  color: 'var(--text-muted)',
                   fontFamily: 'ui-monospace, SFMono-Regular, monospace',
                 }}
               >

--- a/stories/foundation/_components/SpacingScale.tsx
+++ b/stories/foundation/_components/SpacingScale.tsx
@@ -12,14 +12,14 @@ export function SpacingScale({ title, scale, prefix }: SpacingScaleProps) {
   );
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -44,7 +44,7 @@ export function SpacingScale({ title, scale, prefix }: SpacingScaleProps) {
                   fontSize: '12px',
                   width: '160px',
                   flexShrink: 0,
-                  color: 'var(--_color---text--muted)',
+                  color: 'var(--text-muted)',
                 }}
               >
                 {prefix}--{step}
@@ -53,7 +53,7 @@ export function SpacingScale({ title, scale, prefix }: SpacingScaleProps) {
                 style={{
                   width: `${Math.min(px, 300)}px`,
                   height: '20px',
-                  backgroundColor: 'var(--_color---background--brand-primary)',
+                  backgroundColor: 'var(--background-brand-primary)',
                   borderRadius: '2px',
                   opacity: 0.7,
                   transition: 'width 200ms ease',
@@ -63,7 +63,7 @@ export function SpacingScale({ title, scale, prefix }: SpacingScaleProps) {
               <span
                 style={{
                   fontSize: '12px',
-                  color: 'var(--_color---text--secondary)',
+                  color: 'var(--text-secondary)',
                   fontFamily: 'ui-monospace, SFMono-Regular, monospace',
                   flexShrink: 0,
                 }}
@@ -88,14 +88,14 @@ export function SemanticSpacing({ title, tokens, varPrefix }: SemanticSpacingPro
   const entries = Object.entries(tokens);
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -121,7 +121,7 @@ export function SemanticSpacing({ title, tokens, varPrefix }: SemanticSpacingPro
                       width: `var(${fullVar}, 16px)`,
                       maxWidth: '100px',
                       height: '16px',
-                      backgroundColor: 'var(--_color---background--brand-primary)',
+                      backgroundColor: 'var(--background-brand-primary)',
                       borderRadius: '2px',
                       opacity: 0.7,
                     }}
@@ -147,8 +147,8 @@ export function SemanticSpacing({ title, tokens, varPrefix }: SemanticSpacingPro
 
 const thStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '2px solid var(--_color---border--secondary)',
-  color: 'var(--_color---text--muted)',
+  borderBottom: '2px solid var(--border-secondary)',
+  color: 'var(--text-muted)',
   fontSize: '12px',
   fontWeight: 600,
   textTransform: 'uppercase',
@@ -157,14 +157,14 @@ const thStyle: React.CSSProperties = {
 
 const tdStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '1px solid var(--_color---border--muted, #e0e0e0)',
+  borderBottom: '1px solid var(--border-muted, #e0e0e0)',
   verticalAlign: 'middle',
 };
 
 const codeStyle: React.CSSProperties = {
   fontFamily: 'ui-monospace, SFMono-Regular, monospace',
   fontSize: '12px',
-  background: 'var(--_color---surface--secondary, #f2f2f2)',
+  background: 'var(--surface-secondary, #f2f2f2)',
   padding: '2px 6px',
   borderRadius: '3px',
 };

--- a/stories/foundation/_components/ThemeComparison.tsx
+++ b/stories/foundation/_components/ThemeComparison.tsx
@@ -10,16 +10,16 @@ interface ThemeComparisonProps {
 
 export function ThemeComparison({
   tokens = [
-    '--_color---page--primary',
-    '--_color---surface--primary',
-    '--_color---background--brand-primary',
-    '--_color---text--primary',
-    '--_color---text--brand',
-    '--_color---border--brand',
+    '--page-primary',
+    '--surface-primary',
+    '--background-brand-primary',
+    '--text-primary',
+    '--text-brand-primary',
+    '--border-brand-primary',
   ],
 }: ThemeComparisonProps) {
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)', overflowX: 'auto' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)', overflowX: 'auto' }}>
       <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
         <thead>
           <tr>
@@ -41,7 +41,7 @@ export function ThemeComparison({
                     fontSize: '11px',
                   }}
                 >
-                  {token.replace('--_color---', '')}
+                  {token.replace(/^--/, '')}
                 </code>
               </td>
               {THEME_KEYS.map((key) => (
@@ -66,7 +66,7 @@ function ThemeColorCell({ themeKey, cssVar }: { themeKey: ThemeNumber; cssVar: s
         width: '32px',
         height: '32px',
         borderRadius: '4px',
-        border: '1px solid var(--_color---border--secondary)',
+        border: '1px solid var(--border-secondary)',
         backgroundColor: `var(${cssVar})`,
       }}
     />
@@ -79,8 +79,8 @@ export function ThemeOverview() {
       style={{
         display: 'grid',
         gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
-        gap: 'var(--_space---gap--md, 8px)',
-        marginBottom: 'var(--_space---xl, 32px)',
+        gap: 'var(--gap-md, 8px)',
+        marginBottom: 'var(--padding-xl, 32px)',
       }}
     >
       {THEME_KEYS.map((key) => {
@@ -91,16 +91,16 @@ export function ThemeOverview() {
             className={`body theme-${key}`}
             style={{
               padding: '16px',
-              borderRadius: 'var(--_border-radius---md, 4px)',
-              backgroundColor: 'var(--_color---page--primary)',
-              border: '1px solid var(--_color---border--secondary)',
+              borderRadius: 'var(--border-radius-md, 4px)',
+              backgroundColor: 'var(--page-primary)',
+              border: '1px solid var(--border-secondary)',
             }}
           >
             <div
               style={{
                 fontWeight: 700,
                 fontSize: '14px',
-                color: 'var(--_color---text--primary)',
+                color: 'var(--text-primary)',
                 marginBottom: '4px',
               }}
             >
@@ -109,7 +109,7 @@ export function ThemeOverview() {
             <div
               style={{
                 fontSize: '12px',
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
                 marginBottom: '8px',
               }}
             >
@@ -121,8 +121,8 @@ export function ThemeOverview() {
                   width: '24px',
                   height: '24px',
                   borderRadius: '50%',
-                  backgroundColor: 'var(--_color---background--brand-primary)',
-                  border: '1px solid var(--_color---border--secondary)',
+                  backgroundColor: 'var(--background-brand-primary)',
+                  border: '1px solid var(--border-secondary)',
                 }}
               />
               <div
@@ -130,8 +130,8 @@ export function ThemeOverview() {
                   width: '24px',
                   height: '24px',
                   borderRadius: '50%',
-                  backgroundColor: 'var(--_color---surface--secondary)',
-                  border: '1px solid var(--_color---border--secondary)',
+                  backgroundColor: 'var(--surface-secondary)',
+                  border: '1px solid var(--border-secondary)',
                 }}
               />
               <div
@@ -139,8 +139,8 @@ export function ThemeOverview() {
                   width: '24px',
                   height: '24px',
                   borderRadius: '50%',
-                  backgroundColor: 'var(--_color---text--brand)',
-                  border: '1px solid var(--_color---border--secondary)',
+                  backgroundColor: 'var(--text-brand-primary)',
+                  border: '1px solid var(--border-secondary)',
                 }}
               />
             </div>
@@ -153,8 +153,8 @@ export function ThemeOverview() {
 
 const thStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '2px solid var(--_color---border--secondary)',
-  color: 'var(--_color---text--muted)',
+  borderBottom: '2px solid var(--border-secondary)',
+  color: 'var(--text-muted)',
   fontSize: '11px',
   fontWeight: 600,
   textTransform: 'uppercase',
@@ -164,6 +164,6 @@ const thStyle: React.CSSProperties = {
 
 const tdStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '1px solid var(--_color---border--muted, #e0e0e0)',
+  borderBottom: '1px solid var(--border-muted, #e0e0e0)',
   verticalAlign: 'middle',
 };

--- a/stories/foundation/_components/TokenTable.tsx
+++ b/stories/foundation/_components/TokenTable.tsx
@@ -31,7 +31,7 @@ function CopyButton({ text }: { text: string }) {
         cursor: 'pointer',
         padding: '2px 6px',
         fontSize: '11px',
-        color: copied ? 'var(--_color---text--brand)' : 'var(--_color---text--muted)',
+        color: copied ? 'var(--text-brand-primary)' : 'var(--text-muted)',
         opacity: copied ? 1 : 0.6,
         transition: 'opacity 150ms',
       }}
@@ -54,14 +54,14 @@ export function TokenTable({ tokens, title, showSearch = true }: TokenTableProps
     : tokens;
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -78,12 +78,12 @@ export function TokenTable({ tokens, title, showSearch = true }: TokenTableProps
             width: '100%',
             maxWidth: '320px',
             padding: '6px 12px',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            border: '1px solid var(--_color---border--secondary)',
-            borderRadius: 'var(--_border-radius---sm, 2px)',
-            background: 'var(--_color---background--primary)',
-            color: 'var(--_color---text--primary)',
-            fontFamily: 'var(--_typography---font-family--body)',
+            marginBottom: 'var(--gap-md, 8px)',
+            border: '1px solid var(--border-secondary)',
+            borderRadius: 'var(--border-radius-sm, 2px)',
+            background: 'var(--background-primary)',
+            color: 'var(--text-primary)',
+            fontFamily: 'var(--font-family-body)',
             fontSize: '14px',
             boxSizing: 'border-box' as const,
           }}
@@ -94,7 +94,7 @@ export function TokenTable({ tokens, title, showSearch = true }: TokenTableProps
         style={{
           width: '100%',
           borderCollapse: 'collapse',
-          fontFamily: 'var(--_typography---font-family--body)',
+          fontFamily: 'var(--font-family-body)',
           fontSize: '14px',
         }}
       >
@@ -124,7 +124,7 @@ export function TokenTable({ tokens, title, showSearch = true }: TokenTableProps
           ))}
           {filtered.length === 0 && (
             <tr>
-              <td colSpan={4} style={{ ...tdStyle, textAlign: 'center', color: 'var(--_color---text--muted)' }}>
+              <td colSpan={4} style={{ ...tdStyle, textAlign: 'center', color: 'var(--text-muted)' }}>
                 No tokens match "{filter}"
               </td>
             </tr>
@@ -137,8 +137,8 @@ export function TokenTable({ tokens, title, showSearch = true }: TokenTableProps
 
 const thStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '2px solid var(--_color---border--secondary)',
-  color: 'var(--_color---text--muted)',
+  borderBottom: '2px solid var(--border-secondary)',
+  color: 'var(--text-muted)',
   fontSize: '12px',
   fontWeight: 600,
   textTransform: 'uppercase' as const,
@@ -147,14 +147,14 @@ const thStyle: React.CSSProperties = {
 
 const tdStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '1px solid var(--_color---border--muted, #e0e0e0)',
+  borderBottom: '1px solid var(--border-muted, #e0e0e0)',
   verticalAlign: 'middle',
 };
 
 const codeStyle: React.CSSProperties = {
   fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
   fontSize: '12px',
-  background: 'var(--_color---surface--secondary, #f2f2f2)',
+  background: 'var(--surface-secondary, #f2f2f2)',
   padding: '2px 6px',
   borderRadius: '3px',
   color: 'inherit',

--- a/stories/foundation/_components/TypographyScale.tsx
+++ b/stories/foundation/_components/TypographyScale.tsx
@@ -10,14 +10,14 @@ export function TypographyScale({ title, scale, prefix }: TypographyScaleProps) 
   );
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -32,7 +32,7 @@ export function TypographyScale({ title, scale, prefix }: TypographyScaleProps) 
               alignItems: 'baseline',
               gap: '16px',
               padding: '6px 0',
-              borderBottom: '1px solid var(--_color---border--muted, #e0e0e0)',
+              borderBottom: '1px solid var(--border-muted, #e0e0e0)',
             }}
           >
             <code
@@ -41,7 +41,7 @@ export function TypographyScale({ title, scale, prefix }: TypographyScaleProps) 
                 fontSize: '12px',
                 width: '140px',
                 flexShrink: 0,
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
               }}
             >
               {prefix}--{step}
@@ -50,8 +50,8 @@ export function TypographyScale({ title, scale, prefix }: TypographyScaleProps) 
               style={{
                 fontSize: value,
                 lineHeight: 1.2,
-                fontFamily: 'var(--_typography---font-family--body)',
-                color: 'var(--_color---text--primary)',
+                fontFamily: 'var(--font-family-body)',
+                color: 'var(--text-primary)',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
@@ -63,7 +63,7 @@ export function TypographyScale({ title, scale, prefix }: TypographyScaleProps) 
             <span
               style={{
                 fontSize: '12px',
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
                 fontFamily: 'ui-monospace, SFMono-Regular, monospace',
                 flexShrink: 0,
                 marginLeft: 'auto',
@@ -84,23 +84,23 @@ interface FontFamilyShowcaseProps {
 
 export function FontFamilyShowcase({ families }: FontFamilyShowcaseProps) {
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--_space---gap--lg, 16px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg, 16px)' }}>
         {families.map((f) => (
           <div
             key={f.cssVar}
             style={{
-              padding: 'var(--_space---md, 16px)',
-              backgroundColor: 'var(--_color---surface--secondary)',
-              borderRadius: 'var(--_border-radius---md, 4px)',
-              border: '1px solid var(--_color---border--muted)',
+              padding: 'var(--padding-md, 16px)',
+              backgroundColor: 'var(--surface-secondary)',
+              borderRadius: 'var(--border-radius-md, 4px)',
+              border: '1px solid var(--border-muted)',
             }}
           >
             <div
               style={{
                 fontSize: '12px',
                 fontWeight: 600,
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
                 textTransform: 'uppercase',
                 letterSpacing: '0.05em',
                 marginBottom: '8px',
@@ -112,7 +112,7 @@ export function FontFamilyShowcase({ families }: FontFamilyShowcaseProps) {
               style={{
                 fontFamily: `var(${f.cssVar})`,
                 fontSize: '28px',
-                color: 'var(--_color---text--primary)',
+                color: 'var(--text-primary)',
                 marginBottom: '4px',
               }}
             >
@@ -122,7 +122,7 @@ export function FontFamilyShowcase({ families }: FontFamilyShowcaseProps) {
               style={{
                 fontFamily: 'ui-monospace, SFMono-Regular, monospace',
                 fontSize: '11px',
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
               }}
             >
               {f.cssVar} → {f.value}
@@ -144,14 +144,14 @@ export function SemanticTypographyTable({ title, tokens, category }: SemanticTyp
   const entries = Object.entries(tokens).filter(([name]) => name.startsWith(category));
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       {title && (
         <h3
           style={{
-            fontFamily: 'var(--_typography---font-family--heading)',
-            fontSize: 'var(--_typography---heading--small, 20px)',
-            marginBottom: 'var(--_space---gap--md, 8px)',
-            color: 'var(--_color---text--primary)',
+            fontFamily: 'var(--font-family-heading)',
+            fontSize: 'var(--heading-sm, 20px)',
+            marginBottom: 'var(--gap-md, 8px)',
+            color: 'var(--text-primary)',
           }}
         >
           {title}
@@ -159,7 +159,7 @@ export function SemanticTypographyTable({ title, tokens, category }: SemanticTyp
       )}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
         {entries.map(([name, value]) => {
-          const cssVar = `--_typography---${name}`;
+          const cssVar = `--${name}`;
           return (
             <div
               key={name}
@@ -168,7 +168,7 @@ export function SemanticTypographyTable({ title, tokens, category }: SemanticTyp
                 alignItems: 'baseline',
                 gap: '16px',
                 padding: '8px 0',
-                borderBottom: '1px solid var(--_color---border--muted, #e0e0e0)',
+                borderBottom: '1px solid var(--border-muted, #e0e0e0)',
               }}
             >
               <code
@@ -177,7 +177,7 @@ export function SemanticTypographyTable({ title, tokens, category }: SemanticTyp
                   fontSize: '12px',
                   width: '200px',
                   flexShrink: 0,
-                  color: 'var(--_color---text--muted)',
+                  color: 'var(--text-muted)',
                 }}
               >
                 {cssVar}
@@ -186,8 +186,8 @@ export function SemanticTypographyTable({ title, tokens, category }: SemanticTyp
                 style={{
                   fontSize: `var(${cssVar})`,
                   lineHeight: 1.3,
-                  fontFamily: 'var(--_typography---font-family--body)',
-                  color: 'var(--_color---text--primary)',
+                  fontFamily: 'var(--font-family-body)',
+                  color: 'var(--text-primary)',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
@@ -201,7 +201,7 @@ export function SemanticTypographyTable({ title, tokens, category }: SemanticTyp
                 style={{
                   fontFamily: 'ui-monospace, SFMono-Regular, monospace',
                   fontSize: '11px',
-                  color: 'var(--_color---text--muted)',
+                  color: 'var(--text-muted)',
                   flexShrink: 0,
                 }}
               >
@@ -223,7 +223,7 @@ export function FontWeightShowcase({ weights }: FontWeightShowcaseProps) {
   const entries = Object.entries(weights).sort((a, b) => parseInt(a[1]) - parseInt(b[1]));
 
   return (
-    <div style={{ marginBottom: 'var(--_space---xl, 32px)' }}>
+    <div style={{ marginBottom: 'var(--padding-xl, 32px)' }}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
         {entries.map(([name, value]) => (
           <div
@@ -233,7 +233,7 @@ export function FontWeightShowcase({ weights }: FontWeightShowcaseProps) {
               alignItems: 'baseline',
               gap: '16px',
               padding: '6px 0',
-              borderBottom: '1px solid var(--_color---border--muted, #e0e0e0)',
+              borderBottom: '1px solid var(--border-muted, #e0e0e0)',
             }}
           >
             <code
@@ -242,7 +242,7 @@ export function FontWeightShowcase({ weights }: FontWeightShowcaseProps) {
                 fontSize: '12px',
                 width: '200px',
                 flexShrink: 0,
-                color: 'var(--_color---text--muted)',
+                color: 'var(--text-muted)',
               }}
             >
               --font-weight--{name}
@@ -251,8 +251,8 @@ export function FontWeightShowcase({ weights }: FontWeightShowcaseProps) {
               style={{
                 fontWeight: parseInt(value) as unknown as number,
                 fontSize: '18px',
-                fontFamily: 'var(--_typography---font-family--body)',
-                color: 'var(--_color---text--primary)',
+                fontFamily: 'var(--font-family-body)',
+                color: 'var(--text-primary)',
               }}
             >
               The quick brown fox ({value})


### PR DESCRIPTION
## Summary

Audit found 144 Webflow-format token references (`--_color---*`, `--_space---*`, etc.) still active in 7 Storybook foundation visualisation components and Welcome.mdx. These were the UI chrome of the docs themselves — a contradiction since BDS components have used the SD single-dash format for months.

- **7 `_components/*.tsx` files** migrated: ColorGrid, SpacingScale, ShadowPreview, BorderRadiusPreview, TypographyScale, TokenTable, ThemeComparison
- **Welcome.mdx** token system section updated to reflect SD naming
- **storybook-overrides.css** orphan `--_color---page--accent` removed
- **No component CSS changes** — `components/ui/**` was already clean

## Token mapping applied

| Old (Webflow) | New (SD) |
|---|---|
| `--_color---text--primary` | `--text-primary` |
| `--_color---surface--primary` | `--surface-primary` |
| `--_color---background--brand-primary` | `--background-brand-primary` |
| `--_space---xl` | `--padding-xl` |
| `--_space---gap--md` | `--gap-md` |
| `--_typography---font-family--heading` | `--font-family-heading` |
| `--_border-radius---md` | `--border-radius-md` |
| (+ 15 more) | |

## Test plan

- [ ] Run Storybook and verify Color, Typography, Spacing, Shadow, BorderRadius doc pages render correctly
- [ ] Confirm theme switcher still works (swatches update per theme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)