### PR TITLE
feat(tokens): add negative/positive/warning semantic aliases + surface-navigation

### DIFF
--- a/tokens/overrides.css
+++ b/tokens/overrides.css
@@ -138,6 +138,7 @@
 
   /* ── Semantic Tokens Not Yet in Figma/SD ── */
   --surface-nav: var(--color-grayscale-white);
+  --surface-navigation: var(--color-grayscale-white); /* canonical; --surface-nav kept for backward compat */
   --surface-brand-secondary: var(--theme-blue-green);
   --background-brand-secondary: white;
   --background-image: #17171799;
@@ -175,6 +176,21 @@
   --surface-status-success: var(--color-system-green-light);
   --surface-status-warning: var(--color-system-yellow-light);
   --surface-status-info:    var(--color-system-blue-light);
+
+  /* ── Negative / Positive / Warning semantic aliases ──
+     Alternative naming convention used by client themes (Renew et al.) and some
+     BDS components for semantic status coloring. Override these in your theme
+     to use brand-appropriate tints while keeping component contracts intact.
+     BDS default maps to the same system colors as --*-status-* above. */
+  --surface-negative: var(--color-system-red-light);
+  --surface-positive: var(--color-system-green-light);
+  --surface-warning:  var(--color-system-yellow-light);
+  --text-negative:    var(--color-system-red);
+  --text-positive:    var(--color-system-green);
+  --text-warning:     var(--color-system-yellow);
+  --border-negative:  var(--color-system-red);
+  --border-positive:  var(--color-system-green);
+  --border-warning:   var(--color-system-yellow);
 
   /* Presence (for Avatar online/away/busy/offline indicators) */
   --background-presence-online:  var(--color-system-green);


### PR DESCRIPTION
## Summary

- Adds `--surface-negative/positive/warning`, `--text-negative/positive/warning`, `--border-negative/positive/warning` as gap-fill aliases to `:root` in `overrides.css` — pointing to existing `--color-system-*` primitives by default
- Adds `--surface-navigation` as the canonical name alongside legacy `--surface-nav` (kept for backward compat)
- Consumer themes (Renew PMS, future clients) override these to use brand-appropriate tints while maintaining component contracts

**Why:** Renew PMS Figma library uses the `negative/positive/warning` naming convention for status surfaces. Without these in BDS, the tokens were undefined at the framework level — client themes had to define them in a vacuum with no BDS fallback. This closes the gap so the naming convention is official across the ecosystem.

## Test plan
- [x] `npm run build:sd-figma` — clean
- [x] `npm run typecheck` — clean
- [x] Storybook build — clean (triggered by push hook)
- [ ] Visual check: status surfaces in TaskConsole, AlertBanner, Badge still render correctly after submodule sync in renew-pms

🤖 Generated with [Claude Code](https://claude.com/claude-code)