### PR TITLE
docs: fix all broken MDX tables + move Animation to Animations folder

### DIFF
--- a/stories/foundation/Animation.mdx
+++ b/stories/foundation/Animation.mdx
@@ -13,17 +13,22 @@ import {
   CodeSnippet,
 } from './_animation-components';
 
-<Meta title="Foundations/Animation" />
+<Meta title="Animations/Animation" />
 
 # Animation
 
 BDS provides a three-tier animation system. Every tier builds on the previous one — load only what you need.
 
-| Tier | Files | Use when |
-|------|-------|----------|
-| **Lightweight** | `animations.css` + `scroll-animations.js` | Default for every mockup. Fade/slide reveals, hover effects, stagger. |
-| **GSAP** | + `gsap-scroll-effects.js/css` | Design calls for pinning, scrubbing, horizontal scroll, text splitting. |
-| **Premium** | + `premium-effects.css` + `premium-scroll.js` | Design calls for atmosphere: hero sequences, color morphs, grain, magnetic buttons, video scrub. |
+<table>
+  <thead>
+    <tr><th>Tier</th><th>Files</th><th>Use when</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><strong>Lightweight</strong></td><td>{'animations.css + scroll-animations.js'}</td><td>Default for every mockup. Fade/slide reveals, hover effects, stagger.</td></tr>
+    <tr><td><strong>GSAP</strong></td><td>{'+ gsap-scroll-effects.js/css'}</td><td>Design calls for pinning, scrubbing, horizontal scroll, text splitting.</td></tr>
+    <tr><td><strong>Premium</strong></td><td>{'+ premium-effects.css + premium-scroll.js'}</td><td>Design calls for atmosphere: hero sequences, color morphs, grain, magnetic buttons, video scrub.</td></tr>
+  </tbody>
+</table>
 
 ---
 
@@ -245,38 +250,48 @@ Pinned section that switches content as you scroll — like Daylight Computer's 
 
 Compositions inspired by real reference sites. See `ANIMATION-REFERENCE.md` for full recipes.
 
-| Recipe | Key techniques |
-|--------|---------------|
-| **Daylight Computer** | `morph-light-to-dark`, `grain-overlay`, `ken-burns`, `data-scroll-text-split`, `data-scroll-horizontal`, `magnetic` |
-| **RealFood.gov** | `section-warm` + `section-dark` alternation, `clip-rise-reveal`, `data-premium-counter`, `image-gradient-bottom`, `text-highlight` |
-| **Legend.xyz** | `section-dark`, `glass-card`, `text-gradient`, `data-scroll-batch`, `divider-gradient`, `cursor-spotlight`, `hover-glow` |
-| **Luxury / Law** | `grain-overlay--light`, `ken-burns--slow`, `clip-curtain-reveal`, `morph-light-to-dark`, `text-stroke`, `glass--light` nav |
-| **Modern Medical** | `video-bg--gradient` hero, `data-premium-hero`, `data-premium-counter`, `image-reveal`, `section-warm`, `text-highlight` |
+<table>
+  <thead>
+    <tr><th>Recipe</th><th>Key techniques</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><strong>Daylight Computer</strong></td><td>{'morph-light-to-dark, grain-overlay, ken-burns, data-scroll-text-split, data-scroll-horizontal, magnetic'}</td></tr>
+    <tr><td><strong>RealFood.gov</strong></td><td>{'section-warm + section-dark alternation, clip-rise-reveal, data-premium-counter, image-gradient-bottom, text-highlight'}</td></tr>
+    <tr><td><strong>Legend.xyz</strong></td><td>{'section-dark, glass-card, text-gradient, data-scroll-batch, divider-gradient, cursor-spotlight, hover-glow'}</td></tr>
+    <tr><td><strong>Luxury / Law</strong></td><td>{'grain-overlay--light, ken-burns--slow, clip-curtain-reveal, morph-light-to-dark, text-stroke, glass--light nav'}</td></tr>
+    <tr><td><strong>Modern Medical</strong></td><td>{'video-bg--gradient hero, data-premium-hero, data-premium-counter, image-reveal, section-warm, text-highlight'}</td></tr>
+  </tbody>
+</table>
 
 ---
 
 ## Choosing a Tier
 
-| Need | Tier |
-|------|------|
-| Fade/slide/scale reveals on scroll | Lightweight |
-| Staggered entrance animations | Lightweight |
-| Hover effects on buttons/cards | Lightweight (CSS only) |
-| Parallax backgrounds | Lightweight (`parallax.js`) |
-| Pinned/sticky scroll sections | GSAP |
-| Scroll-scrubbed animations | GSAP |
-| Horizontal scroll sections | GSAP |
-| Text split / letter animations | GSAP |
-| Film grain / texture overlays | Premium (CSS) |
-| Glassmorphism / frosted glass | Premium (CSS) |
-| Gradient text / stroke text | Premium (CSS) |
-| Video backgrounds | Premium (CSS) |
-| Clip-path image reveals | Premium (CSS) |
-| Hero entrance orchestration | Premium (JS) |
-| Background color morphs | Premium (JS) |
-| Animated number counters | Premium (JS) |
-| Magnetic cursor buttons | Premium (JS) |
-| Scroll-scrubbed video | Premium (JS) |
-| Scroll-activated tab switching | Premium (JS) |
+<table>
+  <thead>
+    <tr><th>Need</th><th>Tier</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Fade/slide/scale reveals on scroll</td><td>Lightweight</td></tr>
+    <tr><td>Staggered entrance animations</td><td>Lightweight</td></tr>
+    <tr><td>Hover effects on buttons/cards</td><td>Lightweight (CSS only)</td></tr>
+    <tr><td>Parallax backgrounds</td><td>{'Lightweight (parallax.js)'}</td></tr>
+    <tr><td>Pinned/sticky scroll sections</td><td>GSAP</td></tr>
+    <tr><td>Scroll-scrubbed animations</td><td>GSAP</td></tr>
+    <tr><td>Horizontal scroll sections</td><td>GSAP</td></tr>
+    <tr><td>Text split / letter animations</td><td>GSAP</td></tr>
+    <tr><td>Film grain / texture overlays</td><td>Premium (CSS)</td></tr>
+    <tr><td>Glassmorphism / frosted glass</td><td>Premium (CSS)</td></tr>
+    <tr><td>Gradient text / stroke text</td><td>Premium (CSS)</td></tr>
+    <tr><td>Video backgrounds</td><td>Premium (CSS)</td></tr>
+    <tr><td>Clip-path image reveals</td><td>Premium (CSS)</td></tr>
+    <tr><td>Hero entrance orchestration</td><td>Premium (JS)</td></tr>
+    <tr><td>Background color morphs</td><td>Premium (JS)</td></tr>
+    <tr><td>Animated number counters</td><td>Premium (JS)</td></tr>
+    <tr><td>Magnetic cursor buttons</td><td>Premium (JS)</td></tr>
+    <tr><td>Scroll-scrubbed video</td><td>Premium (JS)</td></tr>
+    <tr><td>Scroll-activated tab switching</td><td>Premium (JS)</td></tr>
+  </tbody>
+</table>
 
 **Default to Lightweight.** Only escalate when the design audit specifically calls for the effect.

--- a/stories/foundation/DesignTokens.mdx
+++ b/stories/foundation/DesignTokens.mdx
@@ -77,19 +77,24 @@ Primitives define the palette. Semantics define the intent. Components only know
 --[category]-[role]-[variant]
 ```
 
-| Category | Pattern | Examples |
-|----------|---------|---------|
-| Background | `--background-{role}` | `--background-brand-primary`, `--background-primary-hover`, `--background-info` |
-| Text | `--text-{role}` | `--text-primary`, `--text-brand-primary`, `--text-info` |
-| Surface | `--surface-{role}` | `--surface-primary`, `--surface-secondary`, `--surface-info` |
-| Border | `--border-{role}` | `--border-primary`, `--border-brand-primary`, `--border-info` |
-| Page | `--page-{role}` | `--page-primary`, `--page-secondary` |
-| Font family | `--font-family-{role}` | `--font-family-heading`, `--font-family-body`, `--font-family-label` |
-| Typography | `--{style}-{size}` | `--heading-lg`, `--body-md`, `--label-sm` |
-| Spacing | `--padding-{size}`, `--gap-{size}` | `--padding-lg`, `--gap-md` |
-| Border radius | `--border-radius-{size}` | `--border-radius-sm`, `--border-radius-md` |
-| Shadow | `--shadow-{size}` | `--shadow-sm`, `--shadow-lg` |
-| Scale step | `--{category}-{index}` | `--space-400`, `--font-size-700`, `--color-grayscale-dark` |
+<table>
+  <thead>
+    <tr><th>Category</th><th>Pattern</th><th>Examples</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Background</td><td>{'--background-{role}'}</td><td>{'--background-brand-primary, --background-primary-hover, --background-info'}</td></tr>
+    <tr><td>Text</td><td>{'--text-{role}'}</td><td>{'--text-primary, --text-brand-primary, --text-info'}</td></tr>
+    <tr><td>Surface</td><td>{'--surface-{role}'}</td><td>{'--surface-primary, --surface-secondary, --surface-info'}</td></tr>
+    <tr><td>Border</td><td>{'--border-{role}'}</td><td>{'--border-primary, --border-brand-primary, --border-info'}</td></tr>
+    <tr><td>Page</td><td>{'--page-{role}'}</td><td>{'--page-primary, --page-secondary'}</td></tr>
+    <tr><td>Font family</td><td>{'--font-family-{role}'}</td><td>{'--font-family-heading, --font-family-body, --font-family-label'}</td></tr>
+    <tr><td>Typography</td><td>{'--{style}-{size}'}</td><td>{'--heading-lg, --body-md, --label-sm'}</td></tr>
+    <tr><td>Spacing</td><td>{'--padding-{size}, --gap-{size}'}</td><td>{'--padding-lg, --gap-md'}</td></tr>
+    <tr><td>Border radius</td><td>{'--border-radius-{size}'}</td><td>{'--border-radius-sm, --border-radius-md'}</td></tr>
+    <tr><td>Shadow</td><td>{'--shadow-{size}'}</td><td>{'--shadow-sm, --shadow-lg'}</td></tr>
+    <tr><td>Scale step</td><td>{'--{category}-{index}'}</td><td>{'--space-400, --font-size-700, --color-grayscale-dark'}</td></tr>
+  </tbody>
+</table>
 
 ---
 
@@ -97,16 +102,21 @@ Primitives define the palette. Semantics define the intent. Components only know
 
 Figma organises variables into named collections. Each collection has modes. Style Dictionary flattens the active mode of each collection into `figma-tokens.css`.
 
-| Figma collection | Active modes used | What it generates |
-|-----------------|-------------------|-------------------|
-| `primitives` | `value` | Raw scale: `--color-poppy-*`, `--space-*`, `--font-size-*`, `--border-radius-*`, `--shadow-blur-*` |
-| `color` | `light` / `dark` | Semantic roles: `--background-*`, `--text-*`, `--surface-*`, `--border-*`, `--page-*` |
-| `typography` | `default` | Composite tokens: `--heading-lg`, `--body-md`, `--label-sm`, `--font-family-*` |
-| `spacing` | `default` | `--padding-*`, `--gap-*` |
-| `border-radius` | `soft` | `--border-radius-sm/md/lg` |
-| `border-width` | `default` | `--border-width-sm/md/lg` |
-| `elevation` | `subtle` | `--shadow-sm/md/lg/xl`, `--blur-radius-*` |
-| `breakpoint` | `default` | `--breakpoint-web/tablet/mobile` |
+<table>
+  <thead>
+    <tr><th>Figma collection</th><th>Active mode</th><th>What it generates</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>{'primitives'}</td><td>{'value'}</td><td>{'Raw scale: --color-poppy-*, --space-*, --font-size-*, --border-radius-*, --shadow-blur-*'}</td></tr>
+    <tr><td>{'color'}</td><td>{'light / dark'}</td><td>{'Semantic roles: --background-*, --text-*, --surface-*, --border-*, --page-*'}</td></tr>
+    <tr><td>{'typography'}</td><td>{'default'}</td><td>{'Composite tokens: --heading-lg, --body-md, --label-sm, --font-family-*'}</td></tr>
+    <tr><td>{'spacing'}</td><td>{'default'}</td><td>{'--padding-*, --gap-*'}</td></tr>
+    <tr><td>{'border-radius'}</td><td>{'soft'}</td><td>{'--border-radius-sm/md/lg'}</td></tr>
+    <tr><td>{'border-width'}</td><td>{'default'}</td><td>{'--border-width-sm/md/lg'}</td></tr>
+    <tr><td>{'elevation'}</td><td>{'subtle'}</td><td>{'--shadow-sm/md/lg/xl, --blur-radius-*'}</td></tr>
+    <tr><td>{'breakpoint'}</td><td>{'default'}</td><td>{'--breakpoint-web/tablet/mobile'}</td></tr>
+  </tbody>
+</table>
 
 **Light vs dark mode:** `figma-tokens.css` uses the `light` mode of the `color` collection. `figma-tokens-dark.css` uses the `dark` mode. Both files use identical variable names — consuming projects import dark after light, and the browser applies whichever matches `[data-theme="dark"]`.
 


### PR DESCRIPTION
## Summary
- Convert all broken markdown tables to HTML `<table>` with JSX string literals — MDX2 was treating `{…}` inside backtick code spans as JSX expressions, breaking the entire table block into inline prose
- Move Animation page from `Foundations/Animation` → `Animations/Animation`

**Tables fixed:**
- DesignTokens.mdx: Naming convention + Figma variable collections
- Animation.mdx: Tier overview + Dream Site Recipes + Choosing a Tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)