### PR TITLE
docs: fix Animation folder path to Foundations/Animations

### DIFF
--- a/stories/foundation/Animation.mdx
+++ b/stories/foundation/Animation.mdx
@@ -13,7 +13,7 @@ import {
   CodeSnippet,
 } from './_animation-components';
 
-<Meta title="Animations/Animation" />
+<Meta title="Foundations/Animations/Animation" />
 
 # Animation
 


### PR DESCRIPTION
Corrects meta title to Foundations/Animations/Animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)