### PR TITLE
feat(tokens): wire shadow/overlay tokens into component CSS — expose override surface

### DIFF
--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -178,8 +178,8 @@
 }
 
 .bds-board-card:hover {
-  box-shadow: inset 0 0 0 999px var(--state-hover-overlay, rgba(0, 0, 0, 0.04)),
-    0 4px 12px rgba(0, 0, 0, 0.12); /* bds-lint-ignore — elevation shadow */
+  box-shadow: inset 0 0 0 999px var(--state-hover-overlay),
+    var(--shadow-md);
   transform: translateY(-1px);
 }
 

--- a/components/ui/CardControl/CardControl.css
+++ b/components/ui/CardControl/CardControl.css
@@ -8,7 +8,7 @@
   background-color: var(--surface-primary);
   border: var(--border-width-md) solid var(--border-muted);
   border-radius: var(--border-radius-lg);
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.06); /* bds-lint-ignore — shadow tokens resolve to zero */
+  box-shadow: var(--shadow-sm);
   width: 100%;
   box-sizing: border-box;
   flex-wrap: wrap;

--- a/components/ui/Dialog/Dialog.css
+++ b/components/ui/Dialog/Dialog.css
@@ -3,7 +3,7 @@
 .bds-dialog-backdrop {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.4); /* bds-lint-ignore — no overlay token */
+  background-color: var(--background-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -13,7 +13,7 @@
 .bds-dialog {
   background-color: var(--surface-primary);
   border-radius: var(--border-radius-md);
-  box-shadow: 0px 4px 32px rgba(0, 0, 0, 0.24); /* bds-lint-ignore — no shadow token */
+  box-shadow: var(--shadow-overlay);
   max-width: 440px; /* bds-lint-ignore — design constraint */
   width: 100%;
   box-sizing: border-box;

--- a/components/ui/FilterButton/FilterButton.css
+++ b/components/ui/FilterButton/FilterButton.css
@@ -68,7 +68,7 @@
   background-color: var(--background-primary);
   border-radius: var(--border-radius-lg);
   padding: var(--padding-md);
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.12); /* bds-lint-ignore — shadow tokens resolve to zero */
+  box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;
   gap: var(--gap-md);

--- a/components/ui/Menu/Menu.css
+++ b/components/ui/Menu/Menu.css
@@ -8,7 +8,7 @@
   background-color: var(--background-primary);
   border-radius: var(--border-radius-lg);
   padding: var(--padding-md);
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.12); /* bds-lint-ignore — shadow tokens resolve to zero */
+  box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;
   gap: var(--gap-md);

--- a/components/ui/Modal/Modal.css
+++ b/components/ui/Modal/Modal.css
@@ -6,7 +6,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.4); /* bds-lint-ignore — overlay, no token exists */
+  background-color: var(--background-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -20,7 +20,7 @@
   max-height: 90vh;
   background-color: var(--surface-primary);
   border-radius: var(--border-radius-lg);
-  box-shadow: 0px 4px 32px 0px rgba(0, 0, 0, 0.24); /* bds-lint-ignore — shadow tokens resolve to zero */
+  box-shadow: var(--shadow-overlay);
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/components/ui/Popover/Popover.css
+++ b/components/ui/Popover/Popover.css
@@ -17,7 +17,7 @@
   position: absolute;
   background-color: var(--background-primary);
   border-radius: var(--border-radius-lg);
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.12); /* bds-lint-ignore — no shadow token */
+  box-shadow: var(--shadow-lg);
   border: var(--border-width-sm) solid var(--border-secondary);
   padding: var(--padding-md);
   z-index: 100;

--- a/components/ui/Select/Select.css
+++ b/components/ui/Select/Select.css
@@ -39,6 +39,10 @@
 /* ─── Select element ─────────────────────────────────────────── */
 
 .bds-select {
+  /* ─── Component-scoped override surface ── */
+  --select-chevron-color: var(--text-muted);
+  --select-icon-color: var(--text-muted);
+
   display: inline-block;
   width: 100%;
   font-family: var(--font-family-body);
@@ -131,7 +135,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-muted);
+  color: var(--select-chevron-color); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   pointer-events: none;
   z-index: 1;
   font-size: 0.75em; /* bds-lint-ignore — relative to input font size */
@@ -145,7 +149,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-muted);
+  color: var(--select-icon-color); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   pointer-events: none;
   z-index: 1;
 }

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -7,14 +7,14 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.4); /* bds-lint-ignore — overlay, matches Modal */
+  background-color: var(--background-overlay);
   z-index: 1000;
 }
 
 .bds-sheet {
   position: fixed;
   background-color: var(--surface-primary);
-  box-shadow: 0px 4px 32px 0px rgba(0, 0, 0, 0.24); /* bds-lint-ignore — matches Modal elevation */
+  box-shadow: var(--shadow-overlay);
   display: flex;
   flex-direction: column;
   z-index: 1001;

--- a/components/ui/Slider/Slider.css
+++ b/components/ui/Slider/Slider.css
@@ -2,6 +2,11 @@
 /* --bds-slider-track-height, --bds-slider-thumb-size, --bds-slider-percent are component-local
    custom properties set by Slider.tsx. The --bds-* prefix marks them as non-global. */
 
+/* ─── Component-scoped override surface ── */
+.bds-slider {
+  --slider-thumb-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* bds-lint-ignore — lighter than --shadow-sm; promote to Figma */
+}
+
 .bds-slider-input {
   -webkit-appearance: none;
   appearance: none;
@@ -43,7 +48,7 @@
   border-radius: 50%;
   background: var(--surface-primary);
   border: var(--border-width-200) solid var(--background-brand-primary);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--slider-thumb-shadow); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   cursor: pointer;
   margin-top: calc((var(--bds-slider-track-height, 6px) - var(--bds-slider-thumb-size, 20px)) / 2);
   transition: box-shadow 0.15s ease;
@@ -55,7 +60,7 @@
   border-radius: 50%;
   background: var(--surface-primary);
   border: var(--border-width-200) solid var(--background-brand-primary);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--slider-thumb-shadow); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   cursor: pointer;
   transition: box-shadow 0.15s ease;
 }

--- a/components/ui/Snackbar/Snackbar.css
+++ b/components/ui/Snackbar/Snackbar.css
@@ -1,13 +1,16 @@
 /* ─── Snackbar ───────────────────────────────────────────────── */
 
 .bds-snackbar {
+  /* ─── Component-scoped override surface ── */
+  --snackbar-shadow: 0px 4px 16px rgba(0, 0, 0, 0.2); /* bds-lint-ignore — stronger alpha than --shadow-lg; promote to Figma */
+
   position: fixed;
   display: flex;
   align-items: center;
   gap: var(--gap-lg);
   padding: var(--padding-md) var(--padding-lg);
   border-radius: var(--border-radius-lg);
-  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.2); /* bds-lint-ignore — shadow tokens resolve to zero */
+  box-shadow: var(--snackbar-shadow); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   z-index: 1100;
   max-width: 560px; /* bds-lint-ignore — design constraint */
   min-width: 280px; /* bds-lint-ignore — design constraint */

--- a/components/ui/Switch/Switch.css
+++ b/components/ui/Switch/Switch.css
@@ -45,5 +45,5 @@
   background-color: var(--surface-primary);
   border-radius: 50%;
   transition: transform 0.2s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06); /* bds-lint-ignore — knob shadow, shadow tokens resolve to zero */
+  box-shadow: var(--shadow-sm);
 }

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -1,6 +1,9 @@
 /* ─── TaskConsole ─────────────────────────────────────────────── */
 
 .bds-task-console {
+  /* ─── Component-scoped override surface ── */
+  --task-console-btn-hover-bg: var(--state-hover-overlay);
+
   position: fixed;
   z-index: 9999;
   width: 360px; /* bds-lint-ignore — design constraint matching Google Drive widget */
@@ -10,7 +13,7 @@
   background-color: var(--surface-primary);
   border: var(--border-width-lg) solid var(--border-primary);
   border-radius: var(--border-radius-lg);
-  box-shadow: 0px 8px 24px 4px rgba(0, 0, 0, 0.20); /* bds-lint-ignore — elevated shadow */
+  box-shadow: var(--shadow-xl);
   overflow: hidden;
   font-family: var(--font-family-body);
 }
@@ -104,7 +107,7 @@
 
 .bds-task-console__btn:hover {
   opacity: 1;
-  background-color: rgba(0, 0, 0, 0.06);
+  background-color: var(--task-console-btn-hover-bg); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
 }
 
 /* ─── Progress bar ───────────────────────────────────────────── */

--- a/components/ui/Toast/Toast.css
+++ b/components/ui/Toast/Toast.css
@@ -1,13 +1,16 @@
 /* ─── Toast ──────────────────────────────────────────────────── */
 
 .bds-toast {
+  /* ─── Component-scoped override surface ── */
+  --toast-shadow: 0px 4px 12px 4px rgba(0, 0, 0, 0.24); /* bds-lint-ignore — unique spread, no token equivalent; promote to Figma */
+
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   background-color: var(--surface-primary);
   border: var(--border-width-lg) solid var(--border-primary);
   border-radius: var(--border-radius-lg);
-  box-shadow: 0px 4px 12px 4px rgba(0, 0, 0, 0.24); /* bds-lint-ignore — Figma shadow-subtle */
+  box-shadow: var(--toast-shadow); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   padding: var(--padding-lg);
   width: 100%;
   max-width: 600px; /* bds-lint-ignore — design constraint */

--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -158,6 +158,7 @@
   --shadow-md:      0px 4px 12px 0px rgba(0, 0, 0, 0.12);
   --shadow-lg:      0px 4px 16px 0px rgba(0, 0, 0, 0.12);
   --shadow-xl:      0px 8px 24px 4px rgba(0, 0, 0, 0.20);
+  --shadow-overlay: 0px 4px 32px 0px rgba(0, 0, 0, 0.24); /* elevated panel shadow — Modal, Dialog, Sheet */
 
   /* Bridge aliases — consuming projects (tokens.ts) reference --box-shadow-*;
      these ensure the default values resolve even without a client theme file.


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `rgba()` shadow/overlay values in component CSS with semantic tokens from `gap-fills.css`
- Adds `--shadow-overlay` token to `gap-fills.css` for elevated panel shadow (Modal, Dialog, Sheet)
- Introduces component-scoped CSS custom properties on 5 components so client themes can override internal styling without touching submodule internals

## Token wiring

| Component | Before | After |
|---|---|---|
| Modal, Dialog, Sheet backdrop | `rgba(0,0,0,0.4)` | `var(--background-overlay)` |
| Modal, Dialog, Sheet panel | hardcoded rgba | `var(--shadow-overlay)` |
| CardControl, Switch | hardcoded rgba | `var(--shadow-sm)` |
| FilterButton, Popover, Menu | hardcoded rgba | `var(--shadow-lg)` |
| TaskConsole main | hardcoded rgba | `var(--shadow-xl)` |
| Board card hover elevation | hardcoded rgba | `var(--shadow-md)` |

## Component-scoped override surface

For unique shadow geometries with no token equivalent, the hardcoded value is preserved as a default on a component-scoped variable consumers can override in their theme:

- `Select` — `--select-chevron-color`, `--select-icon-color`
- `Toast` — `--toast-shadow`
- `Snackbar` — `--snackbar-shadow`
- `Slider` — `--slider-thumb-shadow`
- `TaskConsole` — `--task-console-btn-hover-bg`

No visual change in existing consumers — all variables default to the current design value.

## Test plan
- [ ] Verify Modal, Dialog, Sheet backdrops and panels render correctly in Storybook
- [ ] Verify Select chevron/icon color unchanged at default
- [ ] Verify Toast, Snackbar, Slider, TaskConsole shadows unchanged at default
- [ ] Confirm token linter passes (done in pre-commit hook)
- [ ] Confirm Storybook build passes (done in pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)