### PR TITLE
fix(LinkButton): reuse ButtonVariant and ButtonSize types

### DIFF
--- a/components/ui/Button/LinkButton.tsx
+++ b/components/ui/Button/LinkButton.tsx
@@ -1,13 +1,14 @@
 import { forwardRef, type AnchorHTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
+import type { ButtonVariant, ButtonSize } from './Button';
 import './Button.css';
 
 /** LinkButton props — href is required */
 export interface LinkButtonProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Visual style variant */
-  variant?: 'primary' | 'outline' | 'secondary' | 'ghost' | 'danger' | 'danger-outline' | 'danger-ghost';
+  variant?: ButtonVariant;
   /** Size of the button */
-  size?: 'sm' | 'md' | 'lg';
+  size?: ButtonSize;
   /** Full width */
   fullWidth?: boolean;
   /** Link destination (required) */


### PR DESCRIPTION
## Summary
- LinkButton had a hardcoded subset of variant/size types that drifted from Button's canonical `ButtonVariant` and `ButtonSize` types
- Missing: `inverse`, `destructive`, `positive`, `selected`, `tiny`, `xl`
- Now imports types directly from `./Button` so they stay in sync

## Test plan
- [ ] Storybook build passes (verified in pre-push hook)
- [ ] TypeScript compiles with `variant="inverse"` on LinkButton
- [ ] After merge, sync submodule in brikdesigns + brik-client-portal + renew-pms

🤖 Generated with [Claude Code](https://claude.com/claude-code)