### PR TITLE
fix: resolve Chromatic interaction test failures

### DIFF
--- a/components/ui/DatePicker/DatePicker.stories.tsx
+++ b/components/ui/DatePicker/DatePicker.stories.tsx
@@ -70,8 +70,9 @@ export const Playground: Story = {
     // Open calendar
     await userEvent.click(trigger);
 
-    // Calendar opens in a portal
-    const dialog = within(document.body).getByRole('dialog');
+    // Calendar opens in a Radix portal — use findByRole to wait for async render
+    const body = within(document.body);
+    const dialog = await body.findByRole('dialog');
     await expect(dialog).toBeVisible();
 
     // Click a day cell

--- a/components/ui/Switch/Switch.stories.tsx
+++ b/components/ui/Switch/Switch.stories.tsx
@@ -54,7 +54,7 @@ export const Playground: Story = {
     const toggle = canvas.getByRole('switch');
 
     await expect(toggle).toBeVisible();
-    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(toggle).not.toBeChecked();
     await userEvent.click(toggle);
     await expect(args.onChange).toHaveBeenCalledTimes(1);
   },


### PR DESCRIPTION
## Summary
- **Switch Playground**: `toHaveAttribute('aria-checked', 'false')` → `not.toBeChecked()` — native checkbox inputs expose checked state through the property, not a DOM attribute
- **DatePicker Playground**: `getByRole('dialog')` → `findByRole('dialog')` — Radix portal renders asynchronously in Chromatic's headless environment

## Test plan
- [ ] Chromatic build passes with 0 component errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)