### PR TITLE
feat: add Brik Brand dark mode theme

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -98,10 +98,17 @@ const withTheme: Decorator = (Story, context) => {
   // useLayoutEffect runs synchronously before paint — no flash of old theme.
   useLayoutEffect(() => {
     const body = document.body;
-    // Strip any previous theme class
+    // Strip any previous theme and dark/light classes
     body.className = body.className.replace(/\btheme-\S+/g, '');
-    // .body.theme-X matches our CSS selectors in themes.css
-    body.classList.add('body', `theme-${themeNumber}`);
+    body.classList.remove('dark', 'light');
+
+    // Handle brik-dark: apply .theme-brik.dark (two classes)
+    // All other themes: apply .theme-X as before
+    if (themeNumber === 'brik-dark') {
+      body.classList.add('body', 'theme-brik', 'dark');
+    } else {
+      body.classList.add('body', `theme-${themeNumber}`, 'light');
+    }
 
     // Set dark mode data attribute for CSS selectors that need light/dark branching
     const isDark = storybookThemes[themeNumber]?.base === 'dark';
@@ -157,7 +164,8 @@ const preview: Preview = {
       toolbar: {
         icon: 'paintbrush',
         items: [
-          { value: 'brik', title: 'Brik Brand (Poppins)' },
+          { value: 'brik', title: 'Brik Brand' },
+          { value: 'brik-dark', title: 'Brik Brand (Dark)' },
           { value: '1', title: '1: Default (Open Sans)' },
           { value: '2', title: '2: Dark (Geist)' },
           { value: '3', title: '3: Blue (Source Sans 3)' },

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -28,7 +28,7 @@
  *   heading=Georgia (serif), body=Verdana (sans), label=Courier New (mono).
  *   Any component using the wrong family token becomes immediately visible.
  */
-export type ThemeNumber = '1' | '8' | '2' | '3' | '4' | '5' | '6' | '7' | 'brik' | 'client-sim';
+export type ThemeNumber = '1' | '8' | '2' | '3' | '4' | '5' | '6' | '7' | 'brik' | 'brik-dark' | 'client-sim';
 
 /**
  * Color mode type (friendly names)
@@ -87,6 +87,7 @@ export const themeMetadata: Record<ThemeNumber, { name: string; description: str
   '7': { name: 'Warm', description: 'Tan earth tones (Lato / Hind)', isDark: false },
   '8': { name: 'Vibrant', description: 'Bold green and purple accents (Playfair Display / Hind)', isDark: false },
   'brik': { name: 'Brik Brand', description: 'Company brand — poppy red, near-black, tan (Poppins)', isDark: false },
+  'brik-dark': { name: 'Brik Brand (Dark)', description: 'Dark mode — poppy red on near-black (Poppins)', isDark: true },
   'client-sim': { name: 'Client Sim', description: 'Font-family audit tool — Georgia/Verdana/Courier New exposes semantic token misuse', isDark: false },
 };
 

--- a/tokens/storybook-themes.ts
+++ b/tokens/storybook-themes.ts
@@ -242,5 +242,26 @@ export const storybookThemes: Record<ThemeNumber, StorybookThemeConfig> = {
     "inputBorder": "#bdbdbd",
     "inputTextColor": "#333",
     "fontBase": "Poppins, sans-serif"
+  },
+  "brik-dark": {
+    "base": "dark",
+    "name": "Brik Brand (Dark)",
+    "colorPrimary": "#e35335",
+    "colorSecondary": "#e35335",
+    "appBg": "black",
+    "appContentBg": "black",
+    "appPreviewBg": "transparent",
+    "appBorderColor": "#4f4f4f",
+    "textColor": "#f2f2f2",
+    "textInverseColor": "#333",
+    "textMutedColor": "#828282",
+    "barTextColor": "#828282",
+    "barSelectedColor": "#e35335",
+    "barHoverColor": "#e35335",
+    "barBg": "black",
+    "inputBg": "#333",
+    "inputBorder": "#828282",
+    "inputTextColor": "#f2f2f2",
+    "fontBase": "Poppins, sans-serif"
   }
 };

--- a/tokens/theme-brik.css
+++ b/tokens/theme-brik.css
@@ -1,27 +1,33 @@
 /**
- * Brik Brand Theme — Light mode
+ * Brik Brand Theme — Light + Dark modes
  *
  * The canonical theme for brikdesigns.com, brik-client-portal, and Storybook default.
  * Color + typography overrides only; spacing uses Base mode defaults from figma-tokens.css.
  *
- * Dark mode, high-contrast, and accessibility variants will be added below
- * as `.theme-brik.dark { ... }` blocks in a future phase.
+ * Dark mode values sourced from figma-tokens-dark.css (Figma color/dark mode),
+ * re-scoped from :root[data-theme="dark"] to .theme-brik.dark for class-based switching.
  */
+
+/* ─── Light mode ─────────────────────────────────────────────── */
+
 .theme-brik {
-  /* Color */
+  /* Page */
   --page-primary: var(--color-grayscale-white);
   --page-secondary: var(--color-grayscale-lightest);
   --page-brand-primary: #e35335;
+  /* Text */
   --text-primary: var(--color-grayscale-darkest);
   --text-secondary: var(--color-grayscale-dark);
   --text-muted: var(--color-grayscale-light);
   --text-inverse: var(--color-grayscale-white);
   --text-brand-primary: #e35335;
+  /* Surface */
   --surface-primary: var(--color-grayscale-white);
   --surface-secondary: var(--color-grayscale-lightest);
   --surface-brand-primary: #e35335;
   --surface-brand-secondary: #f1f0ec;
   --surface-nav: var(--color-grayscale-white);
+  /* Background */
   --background-brand-primary: #e35335;
   --background-brand-secondary: #f1f0ec;
   --background-primary: var(--color-grayscale-white);
@@ -30,6 +36,7 @@
   --background-input: var(--color-grayscale-white);
   --background-image: #17171799;
   --background-image-brand: #e35335;
+  /* Border */
   --border-primary: var(--color-grayscale-darkest);
   --border-secondary: var(--color-grayscale-lighter);
   --border-muted: var(--color-grayscale-lighter);
@@ -37,6 +44,7 @@
   --border-input: var(--color-grayscale-light);
   --border-inverse: var(--color-grayscale-white);
   --border-on-color-dark: white;
+  /* Theme palette aliases */
   --theme-blue-blue-light: #e35335;
   --theme-blue-blue-lighter: #f1f0ec;
   --theme-blue-green: #f4d364;
@@ -47,4 +55,110 @@
   --font-family-label: Poppins, sans-serif;
   --font-family-heading: Poppins, sans-serif;
   --font-family-display: Poppins, sans-serif;
+}
+
+/* ─── Dark mode (explicit class) ─────────────────────────────── */
+
+.theme-brik.dark {
+  /* Page */
+  --page-primary: var(--color-grayscale-black);
+  --page-secondary: var(--color-grayscale-darker);
+  --page-brand-primary: #e35335;
+  /* Text */
+  --text-primary: var(--color-grayscale-lightest);
+  --text-secondary: var(--color-grayscale-light);
+  --text-muted: var(--color-grayscale-dark);
+  --text-inverse: var(--color-grayscale-black);
+  --text-brand-primary: #e35335;
+  --text-on-color-dark: var(--color-grayscale-white);
+  --text-on-color-light: var(--color-grayscale-black);
+  --text-disabled: var(--color-grayscale-dark);
+  /* Surface */
+  --surface-primary: var(--color-grayscale-black);
+  --surface-secondary: var(--color-grayscale-darker);
+  --surface-brand-primary: #e35335;
+  --surface-brand-secondary: var(--color-grayscale-darkest);
+  --surface-nav: var(--color-grayscale-black);
+  --surface-muted: var(--color-grayscale-darkest);
+  --surface-overlay: var(--color-grayscale-black);
+  /* Background */
+  --background-brand-primary: #e35335;
+  --background-brand-secondary: var(--color-grayscale-darkest);
+  --background-primary: var(--color-grayscale-black);
+  --background-secondary: var(--color-grayscale-light);
+  --background-inverse: var(--color-grayscale-black);
+  --background-input: var(--color-grayscale-black);
+  --background-muted: var(--color-grayscale-darker);
+  --background-image: #000000cc;
+  --background-image-brand: #e35335;
+  --background-brand-primary-hover: var(--color-poppy-lighter);
+  --background-brand-primary-pressed: var(--color-poppy-lightest);
+  --background-disabled: var(--color-grayscale-darker);
+  --background-primary-hover: var(--color-grayscale-darkest);
+  --background-primary-pressed: var(--color-grayscale-darker);
+  --background-secondary-hover: var(--color-grayscale-dark);
+  --background-secondary-pressed: var(--color-grayscale-darker);
+  /* Border */
+  --border-primary: var(--color-grayscale-darker);
+  --border-secondary: var(--color-grayscale-light);
+  --border-muted: var(--color-grayscale-dark);
+  --border-brand-primary: #e35335;
+  --border-input: var(--color-grayscale-dark);
+  --border-inverse: var(--color-grayscale-black);
+  --border-on-color-dark: var(--color-grayscale-black);
+  --border-disabled: var(--color-grayscale-darker);
+}
+
+/* ─── Dark mode (system preference auto-switch) ──────────────── */
+
+@media (prefers-color-scheme: dark) {
+  .theme-brik:not(.light) {
+    /* Page */
+    --page-primary: var(--color-grayscale-black);
+    --page-secondary: var(--color-grayscale-darker);
+    --page-brand-primary: #e35335;
+    /* Text */
+    --text-primary: var(--color-grayscale-lightest);
+    --text-secondary: var(--color-grayscale-light);
+    --text-muted: var(--color-grayscale-dark);
+    --text-inverse: var(--color-grayscale-black);
+    --text-brand-primary: #e35335;
+    --text-on-color-dark: var(--color-grayscale-white);
+    --text-on-color-light: var(--color-grayscale-black);
+    --text-disabled: var(--color-grayscale-dark);
+    /* Surface */
+    --surface-primary: var(--color-grayscale-black);
+    --surface-secondary: var(--color-grayscale-darker);
+    --surface-brand-primary: #e35335;
+    --surface-brand-secondary: var(--color-grayscale-darkest);
+    --surface-nav: var(--color-grayscale-black);
+    --surface-muted: var(--color-grayscale-darkest);
+    --surface-overlay: var(--color-grayscale-black);
+    /* Background */
+    --background-brand-primary: #e35335;
+    --background-brand-secondary: var(--color-grayscale-darkest);
+    --background-primary: var(--color-grayscale-black);
+    --background-secondary: var(--color-grayscale-light);
+    --background-inverse: var(--color-grayscale-black);
+    --background-input: var(--color-grayscale-black);
+    --background-muted: var(--color-grayscale-darker);
+    --background-image: #000000cc;
+    --background-image-brand: #e35335;
+    --background-brand-primary-hover: var(--color-poppy-lighter);
+    --background-brand-primary-pressed: var(--color-poppy-lightest);
+    --background-disabled: var(--color-grayscale-darker);
+    --background-primary-hover: var(--color-grayscale-darkest);
+    --background-primary-pressed: var(--color-grayscale-darker);
+    --background-secondary-hover: var(--color-grayscale-dark);
+    --background-secondary-pressed: var(--color-grayscale-darker);
+    /* Border */
+    --border-primary: var(--color-grayscale-darker);
+    --border-secondary: var(--color-grayscale-light);
+    --border-muted: var(--color-grayscale-dark);
+    --border-brand-primary: #e35335;
+    --border-input: var(--color-grayscale-dark);
+    --border-inverse: var(--color-grayscale-black);
+    --border-on-color-dark: var(--color-grayscale-black);
+    --border-disabled: var(--color-grayscale-darker);
+  }
 }


### PR DESCRIPTION
## Summary
Phase 1 of the theme separation plan — adds dark mode to the Brik Brand theme.

- `.theme-brik.dark { ... }` — explicit dark mode via class
- `@media (prefers-color-scheme: dark)` — auto-switch for system preference
- `.theme-brik:not(.light)` — opt-out pattern (add `.light` to force light)
- Storybook toolbar now shows **Brik Brand** and **Brik Brand (Dark)**
- Manager chrome (sidebar, toolbar) also themes dark with Poppins + poppy red

Dark values sourced from `figma-tokens-dark.css` (Figma color/dark mode), re-scoped to `.theme-brik.dark` for class-based switching.

## Test plan
- [ ] Select "Brik Brand (Dark)" in toolbar — preview background goes black, text goes light
- [ ] Manager sidebar/toolbar themes dark with poppy red accents
- [ ] Switch back to "Brik Brand" — returns to light mode
- [ ] All components render correctly in both modes
- [ ] Font Audit still works (font families don't change between light/dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)