### PR TITLE
fix: MDX docs theme switching + CardTestimonial CSS syntax error

### DIFF
--- a/stories/foundation/_components/SpacingScale.tsx
+++ b/stories/foundation/_components/SpacingScale.tsx
@@ -157,14 +157,14 @@ const thStyle: React.CSSProperties = {
 
 const tdStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '1px solid var(--border-muted, #e0e0e0)',
+  borderBottom: '1px solid var(--border-muted)',
   verticalAlign: 'middle',
 };
 
 const codeStyle: React.CSSProperties = {
   fontFamily: 'ui-monospace, SFMono-Regular, monospace',
   fontSize: '12px',
-  background: 'var(--surface-secondary, #f2f2f2)',
+  background: 'var(--surface-secondary)',
   padding: '2px 6px',
   borderRadius: '3px',
 };

--- a/stories/foundation/_components/ThemeComparison.tsx
+++ b/stories/foundation/_components/ThemeComparison.tsx
@@ -164,6 +164,6 @@ const thStyle: React.CSSProperties = {
 
 const tdStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '1px solid var(--border-muted, #e0e0e0)',
+  borderBottom: '1px solid var(--border-muted)',
   verticalAlign: 'middle',
 };

--- a/stories/foundation/_components/TokenTable.tsx
+++ b/stories/foundation/_components/TokenTable.tsx
@@ -147,14 +147,14 @@ const thStyle: React.CSSProperties = {
 
 const tdStyle: React.CSSProperties = {
   padding: '8px 12px',
-  borderBottom: '1px solid var(--border-muted, #e0e0e0)',
+  borderBottom: '1px solid var(--border-muted)',
   verticalAlign: 'middle',
 };
 
 const codeStyle: React.CSSProperties = {
   fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
   fontSize: '12px',
-  background: 'var(--surface-secondary, #f2f2f2)',
+  background: 'var(--surface-secondary)',
   padding: '2px 6px',
   borderRadius: '3px',
   color: 'inherit',

--- a/stories/foundation/_components/TypographyScale.tsx
+++ b/stories/foundation/_components/TypographyScale.tsx
@@ -32,7 +32,7 @@ export function TypographyScale({ title, scale, prefix }: TypographyScaleProps) 
               alignItems: 'baseline',
               gap: '16px',
               padding: '6px 0',
-              borderBottom: '1px solid var(--border-muted, #e0e0e0)',
+              borderBottom: '1px solid var(--border-muted)',
             }}
           >
             <code
@@ -168,7 +168,7 @@ export function SemanticTypographyTable({ title, tokens, category }: SemanticTyp
                 alignItems: 'baseline',
                 gap: '16px',
                 padding: '8px 0',
-                borderBottom: '1px solid var(--border-muted, #e0e0e0)',
+                borderBottom: '1px solid var(--border-muted)',
               }}
             >
               <code
@@ -233,7 +233,7 @@ export function FontWeightShowcase({ weights }: FontWeightShowcaseProps) {
               alignItems: 'baseline',
               gap: '16px',
               padding: '6px 0',
-              borderBottom: '1px solid var(--border-muted, #e0e0e0)',
+              borderBottom: '1px solid var(--border-muted)',
             }}
           >
             <code


### PR DESCRIPTION
## Summary
- Remove hardcoded `#e0e0e0` and `#f2f2f2` fallbacks from foundation doc components (TypographyScale, SpacingScale, TokenTable, ThemeComparison)
- Semantic tokens (`--border-muted`, `--surface-secondary`) now resolve correctly in both light and dark themes

## Test plan
- [ ] Switch to Brik Brand (Dark) on Color/Typography/Spacing pages — borders and backgrounds should go dark
- [ ] Switch back to Brik Brand — light values return

🤖 Generated with [Claude Code](https://claude.com/claude-code)