### PR TITLE
feat: Sheet variant prop + SheetStack provider

### DIFF
--- a/components/providers/SheetStackProvider.tsx
+++ b/components/providers/SheetStackProvider.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  type ReactNode,
+} from 'react';
+import type { SheetVariant } from '../ui/Sheet';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface SheetFrame {
+  /** Unique key for React reconciliation */
+  key: string;
+  /** Entity type from the consumer's registry (e.g. 'request', 'vendor') */
+  type: string;
+  /** Props to pass to the sheet component (typically `{ id: string }`) */
+  props: Record<string, unknown>;
+  /** Sheet variant — defaults to 'floating' for view sheets */
+  variant: SheetVariant;
+  /** Title to display in the sheet header */
+  title?: string;
+}
+
+export interface SheetStackContextValue {
+  /** Current navigation stack (last = topmost) */
+  stack: SheetFrame[];
+  /** Whether any sheet is open */
+  isOpen: boolean;
+  /** Whether the topmost frame is animating out */
+  isExiting: boolean;
+  /** Direction of the current transition ('forward' | 'back') */
+  direction: 'forward' | 'back';
+  /** Clear the stack and open a single sheet (for opening from outside) */
+  openSheet: (type: string, props: Record<string, unknown>, opts?: { variant?: SheetVariant; title?: string }) => void;
+  /** Push a sheet onto the existing stack (for drilling into related records) */
+  pushSheet: (type: string, props: Record<string, unknown>, opts?: { variant?: SheetVariant; title?: string }) => void;
+  /** Pop the topmost sheet (animated). If stack becomes empty, sheet closes. */
+  back: () => void;
+  /** Close the entire stack immediately */
+  closeAll: () => void;
+}
+
+const SheetStackContext = createContext<SheetStackContextValue | undefined>(undefined);
+
+// ─── Provider ───────────────────────────────────────────────────────────────
+
+let frameCounter = 0;
+function nextKey(type: string): string {
+  return `${type}-${++frameCounter}`;
+}
+
+export interface SheetStackProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * SheetStackProvider — manages a navigation stack of sheet frames.
+ *
+ * Wrap your app (or auth layout) with this provider.
+ * Use `useSheetStack()` to open/push/pop sheets from any component.
+ *
+ * The provider owns the stack state. A companion `SheetStackRenderer`
+ * reads this context and renders the active frame inside a BDS `<Sheet>`.
+ */
+export function SheetStackProvider({ children }: SheetStackProviderProps) {
+  const [stack, setStack] = useState<SheetFrame[]>([]);
+  const [isExiting, setIsExiting] = useState(false);
+  const [direction, setDirection] = useState<'forward' | 'back'>('forward');
+  const exitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearExitTimer = useCallback(() => {
+    if (exitTimer.current) {
+      clearTimeout(exitTimer.current);
+      exitTimer.current = null;
+    }
+  }, []);
+
+  const openSheet = useCallback((
+    type: string,
+    props: Record<string, unknown>,
+    opts?: { variant?: SheetVariant; title?: string },
+  ) => {
+    clearExitTimer();
+    setIsExiting(false);
+    setDirection('forward');
+    setStack([{
+      key: nextKey(type),
+      type,
+      props,
+      variant: opts?.variant ?? 'floating',
+      title: opts?.title,
+    }]);
+  }, [clearExitTimer]);
+
+  const pushSheet = useCallback((
+    type: string,
+    props: Record<string, unknown>,
+    opts?: { variant?: SheetVariant; title?: string },
+  ) => {
+    clearExitTimer();
+    setIsExiting(false);
+    setDirection('forward');
+    setStack((prev) => [...prev, {
+      key: nextKey(type),
+      type,
+      props,
+      variant: opts?.variant ?? 'floating',
+      title: opts?.title,
+    }]);
+  }, [clearExitTimer]);
+
+  const back = useCallback(() => {
+    if (stack.length <= 1) {
+      // Last frame — close the sheet
+      setStack([]);
+      return;
+    }
+    // Animate out, then pop
+    setDirection('back');
+    setIsExiting(true);
+    clearExitTimer();
+    exitTimer.current = setTimeout(() => {
+      setIsExiting(false);
+      setStack((prev) => prev.slice(0, -1));
+    }, 150);
+  }, [stack.length, clearExitTimer]);
+
+  const closeAll = useCallback(() => {
+    clearExitTimer();
+    setIsExiting(false);
+    setStack([]);
+  }, [clearExitTimer]);
+
+  const value: SheetStackContextValue = {
+    stack,
+    isOpen: stack.length > 0,
+    isExiting,
+    direction,
+    openSheet,
+    pushSheet,
+    back,
+    closeAll,
+  };
+
+  return (
+    <SheetStackContext.Provider value={value}>
+      {children}
+    </SheetStackContext.Provider>
+  );
+}
+
+// ─── Hook ───────────────────────────────────────────────────────────────────
+
+/**
+ * useSheetStack — access the global sheet navigation stack.
+ *
+ * @throws Error if used outside of SheetStackProvider
+ *
+ * @example
+ * ```tsx
+ * const { openSheet, pushSheet, back } = useSheetStack();
+ *
+ * // Open a request from a notification
+ * openSheet('request', { id: 'abc123' });
+ *
+ * // Drill into a vendor from inside a request sheet
+ * pushSheet('vendor', { id: req.vendor_id });
+ *
+ * // Go back to the request
+ * back();
+ * ```
+ */
+export function useSheetStack(): SheetStackContextValue {
+  const context = useContext(SheetStackContext);
+  if (context === undefined) {
+    throw new Error('useSheetStack must be used within a SheetStackProvider');
+  }
+  return context;
+}
+
+export default SheetStackProvider;

--- a/components/providers/SheetStackRenderer.tsx
+++ b/components/providers/SheetStackRenderer.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { type ReactNode, type CSSProperties } from 'react';
+import { Icon } from '@iconify/react';
+import { Sheet } from '../ui/Sheet';
+import { useSheetStack, type SheetFrame } from './SheetStackProvider';
+import { bdsClass } from '../utils';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface RenderFrameContext {
+  /** Close the entire sheet stack */
+  closeAll: () => void;
+  /** Push a new sheet onto the stack (drill into related record) */
+  pushSheet: (type: string, props: Record<string, unknown>, opts?: { variant?: 'default' | 'floating'; title?: string }) => void;
+  /** Pop the current sheet (go back) */
+  back: () => void;
+  /** Current stack depth */
+  depth: number;
+}
+
+export interface SheetStackRendererProps {
+  /**
+   * Render function called for the topmost stack frame.
+   * Return the sheet body content (the View/Edit component).
+   */
+  renderFrame: (frame: SheetFrame, ctx: RenderFrameContext) => ReactNode;
+  /** Sheet width (default: '600px') */
+  width?: string;
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const backBtnStyle: CSSProperties = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  padding: 0,
+  display: 'flex',
+  alignItems: 'center',
+  opacity: 0.6,
+  transition: 'opacity 0.2s',
+};
+
+const headerRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--gap-sm)',
+};
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+/**
+ * SheetStackRenderer — reads the sheet stack context and renders the
+ * topmost frame inside a BDS `<Sheet>`.
+ *
+ * Place this once in your app layout, alongside `SheetStackProvider`.
+ *
+ * The `renderFrame` callback maps frame types to your app's sheet components.
+ * BDS doesn't know about your entity types — the app defines the mapping.
+ *
+ * @example
+ * ```tsx
+ * <SheetStackRenderer
+ *   renderFrame={(frame, ctx) => {
+ *     const Component = sheetComponents[frame.type];
+ *     return <Component {...frame.props} onClose={ctx.closeAll} onNavigate={ctx.pushSheet} />;
+ *   }}
+ * />
+ * ```
+ */
+export function SheetStackRenderer({ renderFrame, width = '600px' }: SheetStackRendererProps) {
+  const { stack, isOpen, isExiting, direction, back, closeAll, pushSheet } = useSheetStack();
+
+  if (!isOpen) return null;
+
+  const topFrame = stack[stack.length - 1];
+  const isDeep = stack.length > 1;
+
+  const ctx: RenderFrameContext = {
+    closeAll,
+    pushSheet,
+    back,
+    depth: stack.length,
+  };
+
+  // Build the title — includes back arrow when stack is deep
+  const titleContent = isDeep ? (
+    <span style={headerRowStyle}>
+      <button
+        type="button"
+        style={backBtnStyle}
+        onClick={back}
+        aria-label="Back"
+        className="bds-sheet__back-btn"
+      >
+        <Icon icon="ph:arrow-left-bold" />
+      </button>
+      {topFrame.title ?? topFrame.type}
+    </span>
+  ) : (
+    topFrame.title ?? topFrame.type
+  );
+
+  // Animation class for frame content
+  const frameClass = bdsClass(
+    'bds-sheet-stack__frame',
+    isExiting ? 'bds-sheet-stack__frame--exiting' : '',
+    !isExiting && direction === 'back' ? 'bds-sheet-stack__frame--back' : '',
+  );
+
+  return (
+    <Sheet
+      isOpen
+      onClose={closeAll}
+      title={titleContent}
+      width={width}
+      variant={topFrame.variant}
+      closeOnEscape
+    >
+      <div className={frameClass} key={topFrame.key}>
+        {renderFrame(topFrame, ctx)}
+      </div>
+    </Sheet>
+  );
+}
+
+export default SheetStackRenderer;

--- a/components/providers/index.ts
+++ b/components/providers/index.ts
@@ -1,2 +1,8 @@
 export { ThemeProvider, useTheme } from './ThemeProvider';
 export type { ThemeProviderProps, ThemeContextValue } from './ThemeProvider';
+
+export { SheetStackProvider, useSheetStack } from './SheetStackProvider';
+export type { SheetStackProviderProps, SheetStackContextValue, SheetFrame } from './SheetStackProvider';
+
+export { SheetStackRenderer } from './SheetStackRenderer';
+export type { SheetStackRendererProps, RenderFrameContext } from './SheetStackRenderer';

--- a/components/ui/ProgressBar/ProgressBar.css
+++ b/components/ui/ProgressBar/ProgressBar.css
@@ -24,4 +24,3 @@
   transition: width var(--duration-500) var(--ease-in-out);
 }
 }
-}

--- a/components/ui/Select/Select.css
+++ b/components/ui/Select/Select.css
@@ -169,4 +169,3 @@
   color: var(--text-negative);
 }
 }
-}

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -29,6 +29,25 @@
 .bds-sheet--left   { top: 0; left: 0; bottom: 0; max-width: 90vw; }
 .bds-sheet--bottom { left: 0; right: 0; bottom: 0; max-height: 80vh; }
 
+/* ─── Floating variant — no backdrop, rounded, elevated ─────── */
+
+.bds-sheet--floating {
+  border-radius: var(--border-radius-md);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.12), 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.bds-sheet--floating.bds-sheet--right {
+  top: var(--padding-lg);
+  right: var(--padding-lg);
+  bottom: var(--padding-lg);
+}
+
+.bds-sheet--floating.bds-sheet--left {
+  top: var(--padding-lg);
+  left: var(--padding-lg);
+  bottom: var(--padding-lg);
+}
+
 /* ─── Header (matches Modal) ────────────────────────────────── */
 
 .bds-sheet__header {
@@ -145,5 +164,69 @@
   flex-wrap: wrap;
   flex-shrink: 0;
   border-top: var(--border-width-sm) solid var(--border-muted);
+}
+
+/* ─── Stack frame transitions ──────────────────────────────────── */
+
+.bds-sheet-stack__frame {
+  animation: bds-sheet-frame-enter 0.2s ease-out;
+}
+
+.bds-sheet-stack__frame--exiting {
+  animation: bds-sheet-frame-exit 0.15s ease-in forwards;
+}
+
+.bds-sheet-stack__frame--back {
+  animation: bds-sheet-frame-back 0.2s ease-out;
+}
+
+@keyframes bds-sheet-frame-enter {
+  from { opacity: 0; transform: translateX(40px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes bds-sheet-frame-exit {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(40px); }
+}
+
+@keyframes bds-sheet-frame-back {
+  from { opacity: 0; transform: translateX(-40px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* ─── Back button (sheet stack header) ─────────────────────────── */
+
+.bds-sheet__back-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  color: var(--text-primary);
+  opacity: 0.6;
+  transition: opacity 0.2s;
+}
+
+.bds-sheet__back-btn:hover {
+  opacity: 1;
+}
+
+/* ─── Nav link (clickable entity reference inside sheets) ──────── */
+
+.bds-sheet__nav-link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--text-brand);
+  font: inherit;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.bds-sheet__nav-link:hover {
+  text-decoration: underline;
 }
 }

--- a/components/ui/Sheet/Sheet.tsx
+++ b/components/ui/Sheet/Sheet.tsx
@@ -13,6 +13,8 @@ export interface SheetTab {
   content: ReactNode;
 }
 
+export type SheetVariant = 'default' | 'floating';
+
 export interface SheetProps {
   isOpen: boolean;
   onClose: () => void;
@@ -21,6 +23,12 @@ export interface SheetProps {
   title?: ReactNode;
   /** Width for left/right sheets (default: 400px) */
   width?: string;
+  /**
+   * Visual variant:
+   * - `default` — full-height overlay with backdrop (forms, edit workflows)
+   * - `floating` — rounded floating panel with elevation, no backdrop (read-only detail views)
+   */
+  variant?: SheetVariant;
   closeOnBackdrop?: boolean;
   closeOnEscape?: boolean;
   showCloseButton?: boolean;
@@ -50,6 +58,7 @@ export function Sheet({
   side = 'right',
   title,
   width = '400px',
+  variant = 'default',
   closeOnBackdrop = true,
   closeOnEscape = true,
   showCloseButton = true,
@@ -58,6 +67,7 @@ export function Sheet({
   activeTab: controlledTab,
   onTabChange,
 }: SheetProps) {
+  const isFloating = variant === 'floating';
   const [internalTab, setInternalTab] = useState(tabs?.[0]?.id ?? '');
 
   const activeTab = controlledTab ?? internalTab;
@@ -78,11 +88,11 @@ export function Sheet({
   }, [isOpen, closeOnEscape, onClose]);
 
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && !isFloating) {
       document.body.style.overflow = 'hidden';
       return () => { document.body.style.overflow = ''; };
     }
-  }, [isOpen]);
+  }, [isOpen, isFloating]);
 
   if (!isOpen) return null;
 
@@ -106,11 +116,11 @@ export function Sheet({
 
   const sheet = (
     <>
-      <div className="bds-sheet-backdrop" onClick={handleBackdropClick} />
+      {!isFloating && <div className="bds-sheet-backdrop" onClick={handleBackdropClick} />}
       <div
-        className={bdsClass('bds-sheet', `bds-sheet--${side}`)}
+        className={bdsClass('bds-sheet', `bds-sheet--${side}`, isFloating ? 'bds-sheet--floating' : '')}
         role="dialog"
-        aria-modal="true"
+        aria-modal={!isFloating}
         style={widthStyle}
       >
         {(title || showCloseButton) && (

--- a/components/ui/Sheet/index.ts
+++ b/components/ui/Sheet/index.ts
@@ -1,1 +1,1 @@
-export { Sheet, type SheetProps, type SheetSide, type SheetTab } from './Sheet';
+export { Sheet, type SheetProps, type SheetSide, type SheetTab, type SheetVariant } from './Sheet';


### PR DESCRIPTION
## Summary
- Add `variant` prop to Sheet (`default` | `floating`) with floating styles
- Add `SheetStackProvider` and `SheetStackRenderer` for push/pop/replace sheet navigation
- Export `useSheetStack` hook from providers barrel

## Context
Required by renew-pms global sheet navigation. These changes were built locally but never committed to BDS — blocking CI on the renew-pms staging→main PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)