### PR TITLE
fix: portal-render tooltip to escape overflow containers

### DIFF
--- a/components/ui/Tooltip/Tooltip.css
+++ b/components/ui/Tooltip/Tooltip.css
@@ -60,6 +60,19 @@
   margin-left: var(--padding-md);
 }
 
+/* ─── Portal mode (fixed positioning, escapes overflow) ── */
+
+.bds-tooltip__bubble--portal {
+  /* Override placement absolute positioning — inline fixed styles take over */
+  position: fixed;
+  top: auto;
+  bottom: auto;
+  left: auto;
+  right: auto;
+  transform: none;
+  margin: 0;
+}
+
 /* ─── Arrow ───────────────────────────────────────────── */
 
 .bds-tooltip__arrow {

--- a/components/ui/Tooltip/Tooltip.tsx
+++ b/components/ui/Tooltip/Tooltip.tsx
@@ -1,6 +1,10 @@
-import { type ReactNode, type HTMLAttributes, useState, useRef, useCallback } from 'react';
+import { type ReactNode, type HTMLAttributes, useState, useRef, useCallback, useLayoutEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { bdsClass } from '../../utils';
 import './Tooltip.css';
+
+/** Gap between trigger and bubble (matches --padding-md fallback) */
+const TOOLTIP_GAP = 8;
 
 /**
  * Tooltip placement positions
@@ -25,7 +29,8 @@ export interface TooltipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'cont
  * Tooltip - BDS themed tooltip component
  *
  * Shows contextual information on hover/focus.
- * Positioned relative to trigger element with arrow indicator.
+ * Bubble renders via portal to `document.body` so it escapes
+ * overflow containers (board columns, scroll areas, etc.).
  *
  * @example
  * ```tsx
@@ -33,7 +38,7 @@ export interface TooltipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'cont
  *   <button>Edit</button>
  * </Tooltip>
  *
- * <Tooltip content="Helpful info" placement="right">
+ * <Tooltip content="Helpful info" placement="right" delay={800}>
  *   <span>?</span>
  * </Tooltip>
  * ```
@@ -48,7 +53,10 @@ export function Tooltip({
   ...props
 }: TooltipProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const bubbleRef = useRef<HTMLDivElement>(null);
 
   const clearTimer = useCallback(() => {
     if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
@@ -66,10 +74,64 @@ export function Tooltip({
   const hide = useCallback(() => {
     clearTimer();
     setIsVisible(false);
+    setPos(null);
   }, [clearTimer]);
+
+  // Calculate fixed position once the bubble is mounted and measurable
+  useLayoutEffect(() => {
+    if (!isVisible || !triggerRef.current || !bubbleRef.current) return;
+
+    const tr = triggerRef.current.getBoundingClientRect();
+    const br = bubbleRef.current.getBoundingClientRect();
+
+    let top = 0;
+    let left = 0;
+
+    switch (placement) {
+      case 'top':
+        top = tr.top - br.height - TOOLTIP_GAP;
+        left = tr.left + tr.width / 2 - br.width / 2;
+        break;
+      case 'bottom':
+        top = tr.bottom + TOOLTIP_GAP;
+        left = tr.left + tr.width / 2 - br.width / 2;
+        break;
+      case 'left':
+        top = tr.top + tr.height / 2 - br.height / 2;
+        left = tr.left - br.width - TOOLTIP_GAP;
+        break;
+      case 'right':
+        top = tr.top + tr.height / 2 - br.height / 2;
+        left = tr.right + TOOLTIP_GAP;
+        break;
+    }
+
+    setPos({ top, left });
+  }, [isVisible, placement]);
+
+  // Portal bubble — fixed positioning escapes all overflow boundaries
+  const bubble = (
+    <div
+      ref={bubbleRef}
+      role="tooltip"
+      className={bdsClass(
+        'bds-tooltip__bubble',
+        'bds-tooltip__bubble--portal',
+        isVisible && pos && 'bds-tooltip__bubble--visible',
+      )}
+      style={pos
+        ? { position: 'fixed', top: pos.top, left: pos.left }
+        : { position: 'fixed', opacity: 0, pointerEvents: 'none' as const }
+      }
+    >
+      {content}
+      <div className={bdsClass('bds-tooltip__arrow', `bds-tooltip__arrow--${placement}`)} />
+    </div>
+  );
 
   return (
     <div
+      ref={triggerRef}
       className={bdsClass('bds-tooltip', className)}
       style={style}
       onMouseEnter={show}
@@ -79,17 +141,7 @@ export function Tooltip({
       {...props}
     >
       {children}
-      <div
-        role="tooltip"
-        className={bdsClass(
-          'bds-tooltip__bubble',
-          `bds-tooltip__bubble--${placement}`,
-          isVisible && 'bds-tooltip__bubble--visible',
-        )}
-      >
-        {content}
-        <div className={bdsClass('bds-tooltip__arrow', `bds-tooltip__arrow--${placement}`)} />
-      </div>
+      {isVisible && typeof document !== 'undefined' && createPortal(bubble, document.body)}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Tooltip bubble now renders via `createPortal` to `document.body` with fixed positioning
- Prevents clipping by `overflow: clip/hidden/auto` parents (board columns, scroll areas)
- Bubble only mounts in the portal when visible (no idle DOM cost)
- Position calculated via `useLayoutEffect` before paint — no flash
- Added `--portal` CSS modifier to override absolute placement rules

## Context
Board columns in renew-pms use `overflow: clip` for rounded corners, which clips tooltips on card indicators. This is a systemic fix — all BDS Tooltip consumers benefit.

## Test plan
- [ ] Hover tooltips on board card indicators (priority, overdue, vendor, assignee)
- [ ] Verify tooltip escapes board column overflow boundary
- [ ] Verify placement (top, bottom, left, right) positions correctly
- [ ] Verify tooltip disappears on mouse leave
- [ ] Verify delay prop still works
- [ ] Check sidebar nav tooltips still work (placement="right")

🤖 Generated with [Claude Code](https://claude.com/claude-code)