### PR TITLE
feat: add TimePicker component

### DIFF
--- a/components/ui/TimePicker/TimePicker.css
+++ b/components/ui/TimePicker/TimePicker.css
@@ -1,0 +1,180 @@
+@layer bds-components {
+/**
+ * BDS TimePicker — Class-based styles
+ *
+ * Token-based time picker with Radix Popover for accessible behavior.
+ * Matches BDS form component conventions (label, helper, error, size variants).
+ *
+ * Naming: BEM-lite — .bds-time-picker, .bds-time-picker__trigger
+ */
+
+/* ─── Wrapper ────────────────────────────────────────────────── */
+
+.bds-time-picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  color: var(--text-primary);
+}
+
+.bds-time-picker--full-width {
+  width: 100%;
+}
+
+/* ─── Label ──────────────────────────────────────────────────── */
+
+.bds-time-picker__label {
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  text-transform: capitalize;
+}
+
+.bds-time-picker__label--error {
+  color: var(--color-system-red);
+}
+
+/* Label sizes */
+.bds-time-picker--sm .bds-time-picker__label { font-size: var(--label-sm); }
+.bds-time-picker--md .bds-time-picker__label { font-size: var(--label-md); }
+.bds-time-picker--lg .bds-time-picker__label { font-size: var(--label-lg); }
+
+/* ─── Trigger ────────────────────────────────────────────────── */
+
+.bds-time-picker__trigger {
+  width: 100%;
+  padding: var(--padding-xs);
+  font-family: var(--font-family-body);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-primary);
+  background-color: var(--background-input);
+  border: var(--border-width-md) solid var(--border-input);
+  border-radius: var(--border-radius-md);
+  outline: none;
+  transition: border-color var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out);
+  box-sizing: border-box;
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.bds-time-picker__trigger:hover:not(:disabled) {
+  border-color: var(--border-primary);
+}
+
+.bds-time-picker__trigger--error {
+  border-color: var(--color-system-red);
+}
+
+.bds-time-picker__trigger--error:hover:not(:disabled) {
+  border-color: var(--color-system-red);
+}
+
+.bds-time-picker__trigger--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bds-time-picker__trigger--open {
+  border-color: var(--border-brand-primary);
+  box-shadow: 0 0 0 1px var(--border-brand-primary);
+}
+
+/* Trigger sizes */
+.bds-time-picker--sm .bds-time-picker__trigger { font-size: var(--body-sm); }
+.bds-time-picker--md .bds-time-picker__trigger { font-size: var(--body-md); }
+.bds-time-picker--lg .bds-time-picker__trigger { font-size: var(--body-lg); }
+
+/* ─── Trigger placeholder & icon ─────────────────────────────── */
+
+.bds-time-picker__placeholder {
+  color: var(--text-muted);
+}
+
+.bds-time-picker__icon {
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.125em; /* bds-lint-ignore — relative to trigger font size */
+}
+
+/* ─── Helper / Error text ────────────────────────────────────── */
+
+.bds-time-picker__helper {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+}
+
+.bds-time-picker__helper--error {
+  color: var(--color-system-red);
+}
+
+/* ─── Popover panel ──────────────────────────────────────────── */
+
+.bds-time-picker__popover {
+  outline: none;
+}
+
+.bds-time-picker__columns {
+  display: flex;
+  background-color: var(--surface-primary);
+  border-radius: var(--border-radius-md);
+  box-shadow: var(--box-shadow-lg);
+  border: var(--border-width-md) solid var(--border-muted);
+  overflow: hidden;
+}
+
+/* ─── Scroll column ──────────────────────────────────────────── */
+
+.bds-time-picker__column {
+  display: flex;
+  flex-direction: column;
+  max-height: 224px; /* bds-lint-ignore — 7 rows × 32px = 224px visible area */
+  overflow-y: auto;
+  min-width: 56px; /* bds-lint-ignore — minimum column width for two-digit values */
+  scrollbar-width: none; /* Firefox */
+}
+
+.bds-time-picker__column::-webkit-scrollbar {
+  display: none; /* Chrome/Safari */
+}
+
+/* Column dividers (not on the last column) */
+.bds-time-picker__column:not(:last-child) {
+  border-right: var(--border-width-sm) solid var(--border-muted);
+}
+
+/* ─── Cell ───────────────────────────────────────────────────── */
+
+.bds-time-picker__cell {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  font-weight: var(--font-weight-regular);
+  line-height: 1;
+  color: var(--text-primary);
+  padding: var(--padding-xs) var(--padding-sm);
+  text-align: center;
+  transition: background-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.bds-time-picker__cell:hover:not(.bds-time-picker__cell--selected) {
+  background-color: var(--surface-secondary);
+}
+
+.bds-time-picker__cell--selected {
+  background-color: var(--surface-brand-primary);
+  color: var(--text-inverse);
+  font-weight: var(--font-weight-semi-bold);
+}
+
+} /* end @layer bds-components */

--- a/components/ui/TimePicker/TimePicker.stories.tsx
+++ b/components/ui/TimePicker/TimePicker.stories.tsx
@@ -1,0 +1,292 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { TimePicker } from './TimePicker';
+
+/* ─── Layout Helpers (story-only) ─────────────────────────────── */
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <div style={{
+    fontFamily: 'var(--font-family-label)',
+    fontSize: 'var(--body-xs)', // bds-lint-ignore
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginBottom: 'var(--gap-md)',
+    color: 'var(--text-muted)',
+  }}>
+    {children}
+  </div>
+);
+
+const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
+);
+
+const Row = ({ children, gap = 'var(--padding-sm)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', gap, flexWrap: 'wrap', alignItems: 'flex-start' }}>{children}</div>
+);
+
+/* ─── Meta ────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof TimePicker> = {
+  title: 'Components/Form/time-picker',
+  component: TimePicker,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    helperText: { control: 'text' },
+    error: { control: 'text' },
+    fullWidth: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    minuteStep: { control: 'number' },
+    use24Hour: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TimePicker>;
+
+/* ═══════════════════════════════════════════════════════════════
+   1. PLAYGROUND — Args-based, use Controls panel to explore
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Playground: Story = {
+  args: {
+    placeholder: 'Select time',
+    size: 'md',
+    value: '09:00',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '09:00');
+    return (
+      <div style={{ width: 280 }}>
+        <TimePicker {...args} value={value} onChange={setValue} />
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button');
+
+    // Open time picker
+    await userEvent.click(trigger);
+
+    // Popover opens in a Radix portal
+    const body = within(document.body);
+    const dialog = await body.findByRole('dialog');
+    await expect(dialog).toBeVisible();
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   2. DEFAULT — 12-hour format
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('09:00');
+    return (
+      <div style={{ width: 280 }}>
+        <TimePicker
+          placeholder="Select time"
+          value={value}
+          onChange={setValue}
+        />
+      </div>
+    );
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   3. WITH LABEL — Label + helper text
+   ═══════════════════════════════════════════════════════════════ */
+
+export const WithLabel: Story = {
+  render: () => {
+    const [value, setValue] = useState('09:00');
+    return (
+      <div style={{ width: 280 }}>
+        <TimePicker
+          label="Start Time"
+          placeholder="Select time"
+          helperText="Appointment will be scheduled at this time"
+          value={value}
+          onChange={setValue}
+          fullWidth
+        />
+      </div>
+    );
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   4. WITH ERROR — Error state
+   ═══════════════════════════════════════════════════════════════ */
+
+export const WithError: Story = {
+  render: () => {
+    const [value, setValue] = useState('09:00');
+    return (
+      <div style={{ width: 280 }}>
+        <TimePicker
+          label="End Time"
+          placeholder="Select time"
+          error="End time must be after start time"
+          value={value}
+          onChange={setValue}
+          fullWidth
+        />
+      </div>
+    );
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   5. 24-HOUR FORMAT
+   ═══════════════════════════════════════════════════════════════ */
+
+export const TwentyFourHour: Story = {
+  render: () => {
+    const [value, setValue] = useState('14:30');
+    return (
+      <div style={{ width: 280 }}>
+        <TimePicker
+          label="Time (24h)"
+          value={value}
+          onChange={setValue}
+          use24Hour
+          fullWidth
+        />
+      </div>
+    );
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   6. MINUTE STEP — 5-minute intervals
+   ═══════════════════════════════════════════════════════════════ */
+
+export const MinuteStep: Story = {
+  render: () => {
+    const [value, setValue] = useState('09:00');
+    return (
+      <div style={{ width: 280 }}>
+        <TimePicker
+          label="Appointment Time"
+          helperText="Available in 5-minute intervals"
+          value={value}
+          onChange={setValue}
+          minuteStep={5}
+          fullWidth
+        />
+      </div>
+    );
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   7. MINUTE STEP 15 — Quarter-hour intervals
+   ═══════════════════════════════════════════════════════════════ */
+
+export const QuarterHour: Story = {
+  render: () => {
+    const [value, setValue] = useState('09:00');
+    return (
+      <div style={{ width: 280 }}>
+        <TimePicker
+          label="Meeting Time"
+          helperText="15-minute blocks"
+          value={value}
+          onChange={setValue}
+          minuteStep={15}
+          fullWidth
+        />
+      </div>
+    );
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   8. DISABLED
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ width: 280 }}>
+      <TimePicker
+        label="Locked Time"
+        value="08:00"
+        disabled
+        fullWidth
+      />
+    </div>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   9. VARIANTS — All sizes and states at a glance
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Variants: Story = {
+  render: () => {
+    const [sm, setSm] = useState('09:00');
+    const [md, setMd] = useState('14:30');
+    const [lg, setLg] = useState('17:00');
+    const [errVal, setErrVal] = useState('09:00');
+
+    return (
+      <div style={{ width: 480 }}>
+        <Stack>
+          {/* Sizes */}
+          <div>
+            <SectionLabel>Sizes</SectionLabel>
+            <Stack gap="var(--gap-lg)">
+              <TimePicker size="sm" label="Small (sm)" value={sm} onChange={setSm} fullWidth />
+              <TimePicker size="md" label="Medium (md) — default" value={md} onChange={setMd} fullWidth />
+              <TimePicker size="lg" label="Large (lg)" value={lg} onChange={setLg} fullWidth />
+            </Stack>
+          </div>
+
+          {/* States */}
+          <div>
+            <SectionLabel>States</SectionLabel>
+            <Stack gap="var(--gap-lg)">
+              <TimePicker label="Default" value="09:00" onChange={() => {}} fullWidth />
+              <TimePicker label="Helper text" value="09:00" helperText="Pick the best time" onChange={() => {}} fullWidth />
+              <TimePicker label="Error" error="Time is required" value={errVal} onChange={setErrVal} fullWidth />
+              <TimePicker label="Disabled" value="08:00" disabled fullWidth />
+            </Stack>
+          </div>
+
+          {/* Format */}
+          <div>
+            <SectionLabel>Format</SectionLabel>
+            <Row gap="var(--gap-lg)">
+              <div style={{ flex: 1 }}>
+                <TimePicker label="12-hour" value="14:30" onChange={() => {}} fullWidth />
+              </div>
+              <div style={{ flex: 1 }}>
+                <TimePicker label="24-hour" value="14:30" onChange={() => {}} use24Hour fullWidth />
+              </div>
+            </Row>
+          </div>
+
+          {/* Form context — Start/End pair */}
+          <div>
+            <SectionLabel>Form context — Start / End pair</SectionLabel>
+            <Row gap="var(--gap-lg)">
+              <div style={{ flex: 1 }}>
+                <TimePicker size="sm" label="Start Time" value="09:00" onChange={() => {}} fullWidth />
+              </div>
+              <div style={{ flex: 1 }}>
+                <TimePicker size="sm" label="End Time" value="10:00" onChange={() => {}} fullWidth />
+              </div>
+            </Row>
+          </div>
+        </Stack>
+      </div>
+    );
+  },
+};

--- a/components/ui/TimePicker/TimePicker.tsx
+++ b/components/ui/TimePicker/TimePicker.tsx
@@ -1,0 +1,346 @@
+import {
+  forwardRef,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
+import * as Popover from '@radix-ui/react-popover';
+import { Icon } from '@iconify/react';
+import { Clock } from '../../icons';
+import { bdsClass } from '../../utils';
+import './TimePicker.css';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type TimePickerSize = 'sm' | 'md' | 'lg';
+
+export interface TimePickerProps {
+  /** Selected time value in HH:mm (24h) format */
+  value?: string;
+  /** Called when a time is selected — value in HH:mm (24h) format */
+  onChange?: (value: string) => void;
+  /** Size variant matching BDS form components */
+  size?: TimePickerSize;
+  /** Optional label */
+  label?: string;
+  /** Helper text below input */
+  helperText?: string;
+  /** Error message (triggers error state) */
+  error?: string;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Full width */
+  fullWidth?: boolean;
+  /** Disabled state */
+  disabled?: boolean;
+  /** Minute step interval (default 1) */
+  minuteStep?: number;
+  /** Use 24-hour display (default false — shows AM/PM) */
+  use24Hour?: boolean;
+  /** Input id */
+  id?: string;
+  /** Additional className */
+  className?: string;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function pad(n: number): string {
+  return n.toString().padStart(2, '0');
+}
+
+function parse24(value: string): { hour: number; minute: number } {
+  const [h, m] = value.split(':').map(Number);
+  return { hour: h ?? 0, minute: m ?? 0 };
+}
+
+function to12(hour24: number): { hour12: number; period: 'AM' | 'PM' } {
+  const period: 'AM' | 'PM' = hour24 >= 12 ? 'PM' : 'AM';
+  let hour12 = hour24 % 12;
+  if (hour12 === 0) hour12 = 12;
+  return { hour12, period };
+}
+
+function to24(hour12: number, period: 'AM' | 'PM'): number {
+  if (period === 'AM') return hour12 === 12 ? 0 : hour12;
+  return hour12 === 12 ? 12 : hour12 + 12;
+}
+
+function formatDisplay(value: string, use24Hour: boolean): string {
+  const { hour, minute } = parse24(value);
+  if (use24Hour) return `${pad(hour)}:${pad(minute)}`;
+  const { hour12, period } = to12(hour);
+  return `${pad(hour12)}:${pad(minute)} ${period}`;
+}
+
+function generateMinutes(step: number): number[] {
+  const minutes: number[] = [];
+  for (let m = 0; m < 60; m += step) minutes.push(m);
+  return minutes;
+}
+
+// ─── ScrollColumn Sub-component ─────────────────────────────────────
+
+function ScrollColumn({
+  items,
+  selected,
+  onSelect,
+  ariaLabel,
+}: {
+  items: { value: number | string; label: string }[];
+  selected: number | string;
+  onSelect: (value: number | string) => void;
+  ariaLabel: string;
+}) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  // Scroll selected item into view on mount and when selection changes
+  useEffect(() => {
+    if (selectedRef.current && listRef.current) {
+      const list = listRef.current;
+      const item = selectedRef.current;
+      const listRect = list.getBoundingClientRect();
+      const itemRect = item.getBoundingClientRect();
+      const offset = itemRect.top - listRect.top - list.clientHeight / 2 + itemRect.height / 2;
+      list.scrollTop += offset;
+    }
+  }, [selected]);
+
+  return (
+    <div
+      ref={listRef}
+      className="bds-time-picker__column"
+      role="listbox"
+      aria-label={ariaLabel}
+    >
+      {items.map((item) => {
+        const isSelected = item.value === selected;
+        return (
+          <button
+            key={item.value}
+            ref={isSelected ? selectedRef : undefined}
+            type="button"
+            role="option"
+            className={bdsClass(
+              'bds-time-picker__cell',
+              isSelected && 'bds-time-picker__cell--selected',
+            )}
+            aria-selected={isSelected}
+            onClick={(e: ReactMouseEvent) => {
+              e.preventDefault();
+              onSelect(item.value);
+            }}
+          >
+            {item.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── TimePicker Component ───────────────────────────────────────────
+
+/**
+ * TimePicker - BDS themed time picker component
+ *
+ * Fully token-based — all styles reference BDS semantic design tokens.
+ * Uses Radix UI Popover for accessible popover behavior.
+ * Matches form component conventions: label, helperText, error, size variants.
+ *
+ * @example
+ * ```tsx
+ * <TimePicker size="sm" label="Start Time" placeholder="Select time" />
+ * <TimePicker size="md" label="End Time" value="14:30" minuteStep={5} />
+ * <TimePicker size="lg" label="Appointment" use24Hour error="Time is required" />
+ * ```
+ */
+export const TimePicker = forwardRef<HTMLButtonElement, TimePickerProps>(
+  (
+    {
+      value = '09:00',
+      onChange,
+      size = 'md',
+      label,
+      helperText,
+      error,
+      placeholder = 'Select time',
+      fullWidth = false,
+      disabled = false,
+      minuteStep = 1,
+      use24Hour = false,
+      id,
+      className = '',
+    },
+    ref
+  ) => {
+    const [open, setOpen] = useState(false);
+    const inputId = id || `timepicker-${Math.random().toString(36).substring(2, 11)}`;
+    const hasError = Boolean(error);
+
+    const { hour: hour24, minute } = parse24(value);
+    const { hour12, period } = to12(hour24);
+
+    // ── Column data ──
+
+    const hours = use24Hour
+      ? Array.from({ length: 24 }, (_, i) => ({ value: i, label: pad(i) }))
+      : Array.from({ length: 12 }, (_, i) => {
+          const h = i + 1; // 1–12
+          return { value: h, label: pad(h) };
+        });
+
+    const minutes = generateMinutes(minuteStep).map((m) => ({
+      value: m,
+      label: pad(m),
+    }));
+
+    const periods = [
+      { value: 'AM' as const, label: 'AM' },
+      { value: 'PM' as const, label: 'PM' },
+    ];
+
+    // ── Handlers ──
+
+    const emit = useCallback(
+      (h24: number, m: number) => {
+        onChange?.(`${pad(h24)}:${pad(m)}`);
+      },
+      [onChange],
+    );
+
+    const handleHourSelect = useCallback(
+      (h: number | string) => {
+        const numH = Number(h);
+        if (use24Hour) {
+          emit(numH, minute);
+        } else {
+          emit(to24(numH, period), minute);
+        }
+      },
+      [use24Hour, minute, period, emit],
+    );
+
+    const handleMinuteSelect = useCallback(
+      (m: number | string) => {
+        emit(hour24, Number(m));
+      },
+      [hour24, emit],
+    );
+
+    const handlePeriodSelect = useCallback(
+      (p: number | string) => {
+        emit(to24(hour12, p as 'AM' | 'PM'), minute);
+      },
+      [hour12, minute, emit],
+    );
+
+    return (
+      <div
+        className={bdsClass(
+          'bds-time-picker',
+          `bds-time-picker--${size}`,
+          fullWidth && 'bds-time-picker--full-width',
+          className,
+        )}
+      >
+        {label && (
+          <label
+            htmlFor={inputId}
+            className={bdsClass(
+              'bds-time-picker__label',
+              hasError && 'bds-time-picker__label--error',
+            )}
+          >
+            {label}
+          </label>
+        )}
+
+        <Popover.Root open={open} onOpenChange={setOpen}>
+          <Popover.Trigger asChild disabled={disabled}>
+            <button
+              ref={ref}
+              id={inputId}
+              type="button"
+              className={bdsClass(
+                'bds-time-picker__trigger',
+                hasError && 'bds-time-picker__trigger--error',
+                disabled && 'bds-time-picker__trigger--disabled',
+                open && 'bds-time-picker__trigger--open',
+              )}
+              aria-invalid={hasError}
+              aria-describedby={
+                error ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined
+              }
+            >
+              <span className={value ? undefined : 'bds-time-picker__placeholder'}>
+                {value ? formatDisplay(value, use24Hour) : placeholder}
+              </span>
+              <span className="bds-time-picker__icon" aria-hidden>
+                <Icon icon={Clock} />
+              </span>
+            </button>
+          </Popover.Trigger>
+
+          <Popover.Portal>
+            <Popover.Content
+              sideOffset={4}
+              align="start"
+              className="bds-time-picker__popover"
+            >
+              <div
+                className="bds-time-picker__columns"
+                role="dialog"
+                aria-label="Choose time"
+              >
+                <ScrollColumn
+                  items={hours}
+                  selected={use24Hour ? hour24 : hour12}
+                  onSelect={handleHourSelect}
+                  ariaLabel="Hour"
+                />
+                <ScrollColumn
+                  items={minutes}
+                  selected={minute}
+                  onSelect={handleMinuteSelect}
+                  ariaLabel="Minute"
+                />
+                {!use24Hour && (
+                  <ScrollColumn
+                    items={periods}
+                    selected={period}
+                    onSelect={handlePeriodSelect}
+                    ariaLabel="AM or PM"
+                  />
+                )}
+              </div>
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
+
+        {error && (
+          <span
+            id={`${inputId}-error`}
+            className="bds-time-picker__helper bds-time-picker__helper--error"
+            role="alert"
+          >
+            {error}
+          </span>
+        )}
+
+        {helperText && !error && (
+          <span id={`${inputId}-helper`} className="bds-time-picker__helper">
+            {helperText}
+          </span>
+        )}
+      </div>
+    );
+  }
+);
+
+TimePicker.displayName = 'TimePicker';
+
+export default TimePicker;

--- a/components/ui/TimePicker/index.ts
+++ b/components/ui/TimePicker/index.ts
@@ -1,0 +1,2 @@
+export { TimePicker, type TimePickerProps, type TimePickerSize } from './TimePicker';
+export { default } from './TimePicker';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -61,6 +61,7 @@ export * from './Table';
 export * from './Tag';
 export * from './TextArea';
 export * from './TextInput';
+export * from './TimePicker';
 export * from './TextLink';
 export * from './TaskConsole';
 export * from './Toast';


### PR DESCRIPTION
## Summary
- New `TimePicker` component with scroll-column UI (hour, minute, AM/PM) — fully token-based, themeable across all client products
- Uses Radix Popover (same pattern as DatePicker) with Clock icon trigger
- Supports 12-hour (default) and 24-hour display, configurable `minuteStep`, and all BDS form field conventions (label, helperText, error, size variants)

## Motivation
Native `<input type="time">` renders browser-native pickers that can't be styled with BDS tokens. Client themes will have mismatched time pickers. This component replaces that with a fully controlled, themeable alternative.

## Test plan
- [ ] Verify in Storybook: all stories render correctly (Playground, Default, WithLabel, WithError, TwentyFourHour, MinuteStep, QuarterHour, Disabled, Variants)
- [ ] Test keyboard navigation (Escape to close)
- [ ] Verify scroll-to-selected works on popover open
- [ ] Test in a consumer app (renew-pms schedule form) after submodule sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)