### PR TITLE
fix: radio brand styling + modal 640px min-width

### DIFF
--- a/components/ui/Modal/Modal.css
+++ b/components/ui/Modal/Modal.css
@@ -27,11 +27,18 @@
   overflow: hidden;
 }
 
+/* ─── Desktop min-width ──────────────────────────────────────── */
+/* bds-lint-ignore — design-spec min-width */
+
+@media (min-width: 768px) {
+  .bds-modal { min-width: 640px; }
+}
+
 /* ─── Sizes ──────────────────────────────────────────────────── */
 /* bds-lint-ignore — design-spec max-widths */
 
-.bds-modal--sm  { max-width: 400px; }
-.bds-modal--md  { max-width: 600px; }
+.bds-modal--sm  { max-width: 640px; }
+.bds-modal--md  { max-width: 720px; }
 .bds-modal--lg  { max-width: 800px; }
 .bds-modal--xl  { max-width: 1000px; }
 .bds-modal--full { max-width: 95vw; }

--- a/components/ui/Radio/Radio.css
+++ b/components/ui/Radio/Radio.css
@@ -16,18 +16,65 @@
   cursor: not-allowed;
 }
 
-/* ─── Input ───────────────────────────────────────────── */
+/* ─── Hidden native input ────────────────────────────── */
 
 .bds-radio__input {
-  width: 16px; /* bds-lint-ignore — native radio size */
-  height: 16px; /* bds-lint-ignore */
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
   margin: 0;
-  cursor: pointer;
-  flex-shrink: 0;
-  accent-color: var(--background-brand-primary);
+  pointer-events: none;
 }
 
-.bds-radio--disabled .bds-radio__input {
+/* ─── Custom indicator ───────────────────────────────── */
+
+.bds-radio__indicator {
+  width: 22px; /* bds-lint-ignore — fixed radio indicator size */
+  height: 22px; /* bds-lint-ignore */
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: var(--border-width-lg) solid var(--border-primary);
+  background-color: var(--background-input);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  box-sizing: border-box;
+}
+
+/* Inner dot — hidden by default */
+.bds-radio__indicator::after {
+  content: '';
+  width: 10px; /* bds-lint-ignore — fixed inner dot size */
+  height: 10px; /* bds-lint-ignore */
+  border-radius: 50%;
+  background-color: transparent;
+  transition: background-color 0.15s;
+}
+
+/* ── Hover ── */
+.bds-radio:hover:not(.bds-radio--disabled) .bds-radio__indicator {
+  border-color: var(--border-brand-primary);
+}
+
+/* ── Checked ── */
+.bds-radio__input:checked + .bds-radio__indicator {
+  border-color: var(--border-brand-primary);
+}
+
+.bds-radio__input:checked + .bds-radio__indicator::after {
+  background-color: var(--surface-brand-primary);
+}
+
+/* ── Focus-visible ── */
+.bds-radio__input:focus-visible + .bds-radio__indicator {
+  box-shadow: 0 0 0 2px var(--border-brand-primary); /* bds-lint-ignore — focus ring */
+  outline: none;
+}
+
+/* ── Disabled ── */
+.bds-radio--disabled .bds-radio__indicator {
   cursor: not-allowed;
 }
 

--- a/components/ui/Radio/Radio.tsx
+++ b/components/ui/Radio/Radio.tsx
@@ -67,6 +67,7 @@ export function Radio({
         className="bds-radio__input"
         {...props}
       />
+      <span className="bds-radio__indicator" aria-hidden />
       <span className="bds-radio__text">{label}</span>
     </label>
   );


### PR DESCRIPTION
## Summary
- Radio: custom indicator replacing native input — brand ring on hover, brand-filled dot when checked, focus-visible ring
- Modal: 640px min-width on desktop (768px+), sm bumped to 640px, md to 720px

## Test plan
- [ ] Storybook: Radio stories — default, checked, disabled, group
- [ ] Storybook: Modal stories — sm, md, lg sizes on desktop viewport
- [ ] Verify radio focus-visible ring with keyboard nav
- [ ] Check modal on mobile viewport stays fluid (no min-width below 768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)