### PR TITLE
feat: ActivityTimeline + NotificationList display components

### DIFF
--- a/components/ui/ActivityTimeline/ActivityTimeline.css
+++ b/components/ui/ActivityTimeline/ActivityTimeline.css
@@ -1,0 +1,108 @@
+@layer bds-components {
+/**
+ * BDS ActivityTimeline — Vertical event timeline display
+ *
+ * Token-based. Matches BDS display component conventions.
+ * Naming: BEM-lite — .bds-activity-timeline, .bds-activity-timeline__dot
+ */
+
+/* ─── Container ──────────────────────────────────────────────── */
+
+.bds-activity-timeline {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ─── Event row ──────────────────────────────────────────────── */
+
+.bds-activity-timeline__event {
+  display: flex;
+  gap: var(--gap-md);
+}
+
+/* ─── Rail (dot + line) ──────────────────────────────────────── */
+
+.bds-activity-timeline__rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 28px; /* bds-lint-ignore — fixed rail width matching dot size */
+  flex-shrink: 0;
+}
+
+/* Dot */
+.bds-activity-timeline__dot {
+  width: 28px; /* bds-lint-ignore — fixed dot size */
+  height: 28px; /* bds-lint-ignore */
+  border-radius: var(--border-radius-pill);
+  background-color: var(--surface-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* Origin dot — brand colored */
+.bds-activity-timeline__dot--origin {
+  background-color: var(--background-brand-primary);
+}
+
+/* Icon inside dot */
+.bds-activity-timeline__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--body-sm);
+  color: var(--text-secondary);
+  line-height: 1;
+}
+
+.bds-activity-timeline__dot--origin .bds-activity-timeline__icon {
+  color: var(--text-on-color-dark);
+}
+
+/* Connector line */
+.bds-activity-timeline__line {
+  width: 2px; /* bds-lint-ignore — hairline connector */
+  flex: 1;
+  min-height: 20px; /* bds-lint-ignore — minimum connector height */
+  background-color: var(--border-muted);
+}
+
+/* ─── Content ────────────────────────────────────────────────── */
+
+.bds-activity-timeline__content {
+  padding-top: var(--padding-tiny);
+  padding-bottom: var(--padding-lg);
+}
+
+.bds-activity-timeline__content--last {
+  padding-bottom: 0;
+}
+
+/* Label — primary event text */
+.bds-activity-timeline__label {
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  font-weight: var(--font-weight-semi-bold);
+  color: var(--text-primary);
+  line-height: var(--font-line-height-tight);
+}
+
+/* Detail — secondary info */
+.bds-activity-timeline__detail {
+  font-family: var(--font-family-body);
+  font-size: var(--body-xs);
+  color: var(--text-secondary);
+  margin-top: 2px; /* bds-lint-ignore — tight detail spacing */
+}
+
+/* Timestamp */
+.bds-activity-timeline__timestamp {
+  font-family: var(--font-family-body);
+  font-size: var(--body-xs);
+  color: var(--text-muted);
+  margin-top: 2px; /* bds-lint-ignore — tight timestamp spacing */
+}
+
+} /* end @layer bds-components */

--- a/components/ui/ActivityTimeline/ActivityTimeline.stories.tsx
+++ b/components/ui/ActivityTimeline/ActivityTimeline.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Icon } from '@iconify/react';
+import { ActivityTimeline } from './ActivityTimeline';
+
+const meta: Meta<typeof ActivityTimeline> = {
+  title: 'Components/Display/activity-timeline',
+  component: ActivityTimeline,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActivityTimeline>;
+
+/* ═══════════════════════════════════════════════════════════════ */
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ width: 380 }}>
+      <ActivityTimeline events={[
+        { icon: <Icon icon="ph:plus" />, label: 'Request submitted', detail: 'by Emily Rivera', timestamp: 'Apr 12, 2026, 1:04 PM', isOrigin: true },
+        { icon: <Icon icon="ph:user" />, label: 'Assigned', detail: 'to Nick Stanerson', timestamp: 'Apr 12, 2026, 3:15 PM' },
+        { icon: <Icon icon="ph:check-circle" />, label: 'Status changed to In Progress', timestamp: 'Apr 12, 2026, 3:15 PM' },
+      ]} />
+    </div>
+  ),
+};
+
+export const TaskLifecycle: Story = {
+  render: () => (
+    <div style={{ width: 380 }}>
+      <ActivityTimeline events={[
+        { icon: <Icon icon="ph:plus-circle" />, label: 'Task created', detail: 'from template: Daily Opening Checklist', timestamp: 'Apr 10, 2026, 8:00 AM', isOrigin: true },
+        { icon: <Icon icon="ph:user-circle" />, label: 'Assigned', detail: 'to Sarah Mitchell', timestamp: 'Apr 10, 2026, 8:05 AM' },
+        { icon: <Icon icon="ph:play-circle" />, label: 'Status changed to In Progress', timestamp: 'Apr 10, 2026, 8:30 AM' },
+        { icon: <Icon icon="ph:warning-circle" />, label: 'Marked as Blocked', detail: 'Missing supplies — waiting on reorder', timestamp: 'Apr 10, 2026, 9:15 AM' },
+        { icon: <Icon icon="ph:check-circle" />, label: 'Completed', timestamp: 'Apr 10, 2026, 11:00 AM' },
+      ]} />
+    </div>
+  ),
+};
+
+export const SingleEvent: Story = {
+  render: () => (
+    <div style={{ width: 380 }}>
+      <ActivityTimeline events={[
+        { icon: <Icon icon="ph:plus" />, label: 'Created', detail: 'by System', timestamp: 'Just now', isOrigin: true },
+      ]} />
+    </div>
+  ),
+};
+
+export const Resolved: Story = {
+  render: () => (
+    <div style={{ width: 380 }}>
+      <ActivityTimeline events={[
+        { icon: <Icon icon="ph:plus" />, label: 'Request submitted', detail: 'by Tyler Nguyen', timestamp: 'Apr 8, 2026, 2:00 PM', isOrigin: true },
+        { icon: <Icon icon="ph:user" />, label: 'Assigned', detail: 'to Amanda Chen', timestamp: 'Apr 8, 2026, 2:30 PM' },
+        { icon: <Icon icon="ph:truck" />, label: 'Status: Waiting on Vendor', detail: 'Patterson Dental contacted', timestamp: 'Apr 9, 2026, 10:00 AM' },
+        { icon: <Icon icon="ph:check-circle" />, label: 'Resolved', detail: 'Replacement part installed and tested', timestamp: 'Apr 11, 2026, 3:45 PM' },
+      ]} />
+    </div>
+  ),
+};

--- a/components/ui/ActivityTimeline/ActivityTimeline.tsx
+++ b/components/ui/ActivityTimeline/ActivityTimeline.tsx
@@ -1,0 +1,86 @@
+import { type ReactNode } from 'react';
+import { bdsClass } from '../../utils';
+import './ActivityTimeline.css';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export interface TimelineEvent {
+  /** Icon element rendered inside the event dot */
+  icon: ReactNode;
+  /** Primary label (e.g. "Request submitted") */
+  label: string;
+  /** Secondary detail line (e.g. "by Emily Rivera") */
+  detail?: string | null;
+  /** Timestamp string (pre-formatted by consumer) */
+  timestamp: string;
+  /** Whether this is the "origin" event — uses brand-colored dot */
+  isOrigin?: boolean;
+}
+
+export interface ActivityTimelineProps {
+  /** Array of timeline events to render (top → bottom, chronological) */
+  events: TimelineEvent[];
+  /** Additional className */
+  className?: string;
+}
+
+/**
+ * ActivityTimeline — vertical timeline display component.
+ *
+ * Renders a list of chronological events with a connecting rail,
+ * icon dots, labels, detail text, and timestamps. The first event
+ * (or any event with `isOrigin`) uses the brand-colored dot;
+ * all others use a muted surface dot.
+ *
+ * This is a pure display component — no internal state, no data fetching.
+ * The consumer provides pre-formatted events.
+ *
+ * @example
+ * ```tsx
+ * <ActivityTimeline events={[
+ *   { icon: <Icon icon="ph:plus" />, label: 'Created', detail: 'by Jane', timestamp: 'Apr 12, 2026', isOrigin: true },
+ *   { icon: <Icon icon="ph:user" />, label: 'Assigned', detail: 'to Nick', timestamp: 'Apr 12, 2026' },
+ *   { icon: <Icon icon="ph:check-circle" />, label: 'Completed', timestamp: 'Apr 13, 2026' },
+ * ]} />
+ * ```
+ */
+export function ActivityTimeline({ events, className = '' }: ActivityTimelineProps) {
+  if (events.length === 0) return null;
+
+  return (
+    <div className={bdsClass('bds-activity-timeline', className)}>
+      {events.map((event, idx) => {
+        const isLast = idx === events.length - 1;
+        const isOrigin = event.isOrigin ?? idx === 0;
+
+        return (
+          <div key={idx} className="bds-activity-timeline__event">
+            {/* Rail column: dot + connector line */}
+            <div className="bds-activity-timeline__rail">
+              <div
+                className={bdsClass(
+                  'bds-activity-timeline__dot',
+                  isOrigin && 'bds-activity-timeline__dot--origin',
+                )}
+              >
+                <span className="bds-activity-timeline__icon">{event.icon}</span>
+              </div>
+              {!isLast && <div className="bds-activity-timeline__line" />}
+            </div>
+
+            {/* Content column */}
+            <div className={bdsClass('bds-activity-timeline__content', isLast && 'bds-activity-timeline__content--last')}>
+              <div className="bds-activity-timeline__label">{event.label}</div>
+              {event.detail && (
+                <div className="bds-activity-timeline__detail">{event.detail}</div>
+              )}
+              <div className="bds-activity-timeline__timestamp">{event.timestamp}</div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default ActivityTimeline;

--- a/components/ui/ActivityTimeline/index.ts
+++ b/components/ui/ActivityTimeline/index.ts
@@ -1,0 +1,2 @@
+export { ActivityTimeline, type ActivityTimelineProps, type TimelineEvent } from './ActivityTimeline';
+export { default } from './ActivityTimeline';

--- a/components/ui/NotificationList/NotificationList.css
+++ b/components/ui/NotificationList/NotificationList.css
@@ -1,0 +1,143 @@
+@layer bds-components {
+/**
+ * BDS NotificationList — Notification presentation components
+ *
+ * Covers: NotificationItem, NotificationList, NotificationPopover.
+ * All token-based. Presentation only — no data/behavior logic.
+ *
+ * Naming: BEM-lite — .bds-notification-item, .bds-notification-popover
+ */
+
+/* ═══════════════════════════════════════════════════════════════
+   NotificationItem
+   ═══════════════════════════════════════════════════════════════ */
+
+.bds-notification-item {
+  display: flex;
+  gap: var(--gap-md);
+  padding: var(--padding-sm) var(--padding-md);
+  cursor: pointer;
+  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  transition: background-color 0.15s;
+}
+
+.bds-notification-item:hover {
+  background-color: var(--surface-secondary);
+}
+
+/* Unread highlight */
+.bds-notification-item--unread {
+  background-color: var(--surface-secondary);
+}
+
+/* Unread dot */
+.bds-notification-item__dot {
+  width: 8px; /* bds-lint-ignore — fixed unread dot size */
+  height: 8px; /* bds-lint-ignore */
+  border-radius: var(--border-radius-pill);
+  background-color: var(--surface-brand-primary);
+  flex-shrink: 0;
+  margin-top: 6px; /* bds-lint-ignore — optical alignment with title baseline */
+}
+
+/* Content */
+.bds-notification-item__content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Title */
+.bds-notification-item__title {
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  line-height: var(--font-line-height-snug);
+}
+
+/* Body */
+.bds-notification-item__body {
+  font-family: var(--font-family-body);
+  font-size: var(--body-xs);
+  color: var(--text-secondary);
+  line-height: var(--font-line-height-normal);
+  margin-top: var(--gap-xs);
+}
+
+/* Timestamp */
+.bds-notification-item__time {
+  font-family: var(--font-family-label);
+  font-size: var(--body-tiny);
+  color: var(--text-muted);
+  margin-top: var(--gap-xs);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   NotificationList
+   ═══════════════════════════════════════════════════════════════ */
+
+.bds-notification-list {
+  overflow-y: auto;
+}
+
+/* Empty state */
+.bds-notification-list__empty {
+  padding: var(--padding-xl);
+  text-align: center;
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  color: var(--text-muted);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   NotificationPopover (presentation shell)
+   ═══════════════════════════════════════════════════════════════ */
+
+.bds-notification-popover {
+  width: 360px; /* bds-lint-ignore — design-spec popover width */
+  max-height: 480px; /* bds-lint-ignore — design-spec max scroll height */
+  background-color: var(--surface-primary);
+  border: var(--border-width-sm) solid var(--border-muted);
+  border-radius: var(--border-radius-md);
+  box-shadow: var(--box-shadow-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Header */
+.bds-notification-popover__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--padding-sm) var(--padding-md);
+  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  flex-shrink: 0;
+}
+
+/* Title */
+.bds-notification-popover__title {
+  font-family: var(--font-family-label);
+  font-size: var(--label-md);
+  font-weight: var(--font-weight-semi-bold);
+  color: var(--text-primary);
+}
+
+/* Header action (Mark all read) */
+.bds-notification-popover__action {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family-label);
+  font-size: var(--body-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-brand-primary);
+  padding: 0;
+  transition: opacity 0.15s;
+}
+
+.bds-notification-popover__action:hover {
+  opacity: 0.8;
+}
+
+} /* end @layer bds-components */

--- a/components/ui/NotificationList/NotificationList.stories.tsx
+++ b/components/ui/NotificationList/NotificationList.stories.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { NotificationItem, NotificationList, NotificationPopover } from './NotificationList';
+import type { NotificationItemData } from './NotificationList';
+
+const meta: Meta<typeof NotificationList> = {
+  title: 'Components/Display/notification-list',
+  component: NotificationList,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof NotificationList>;
+
+/* ─── Sample data ─────────────────────────────────────────────── */
+
+const SAMPLE_NOTIFICATIONS: NotificationItemData[] = [
+  { id: '1', title: 'New Request: Broken iPad', body: 'Emily Rivera submitted a Medium priority Device Issue request', time: '2h ago' },
+  { id: '2', title: 'Task Assigned: Daily Opening Checklist', body: 'You have been assigned a new task', time: '3h ago' },
+  { id: '3', title: 'Request Resolved', body: 'Autoclave repair has been completed', time: '1d ago', isRead: true },
+  { id: '4', title: 'Training Due: OSHA Safety', body: 'Complete by end of Q2', time: '2d ago', isRead: true },
+  { id: '5', title: 'New Request: Leaking Faucet', body: 'Facilities maintenance requested for Room 3', time: '3d ago', isRead: true },
+];
+
+/* ═══════════════════════════════════════════════════════════════ */
+
+export const Item: Story = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <NotificationItem
+        notification={SAMPLE_NOTIFICATIONS[0]}
+        onClick={(n) => console.log('Clicked:', n.id)}
+      />
+    </div>
+  ),
+};
+
+export const ItemRead: Story = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <NotificationItem
+        notification={SAMPLE_NOTIFICATIONS[2]}
+        onClick={(n) => console.log('Clicked:', n.id)}
+      />
+    </div>
+  ),
+};
+
+export const List: Story = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <NotificationList
+        notifications={SAMPLE_NOTIFICATIONS}
+        onItemClick={(n) => console.log('Clicked:', n.id)}
+      />
+    </div>
+  ),
+};
+
+export const ListEmpty: Story = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <NotificationList notifications={[]} />
+    </div>
+  ),
+};
+
+export const Popover: Story = {
+  render: () => {
+    const [notifications, setNotifications] = useState(SAMPLE_NOTIFICATIONS);
+    const unreadCount = notifications.filter(n => !n.isRead).length;
+
+    const handleMarkAllRead = () => {
+      setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
+    };
+
+    const handleClick = (n: NotificationItemData) => {
+      setNotifications(prev => prev.map(item =>
+        item.id === n.id ? { ...item, isRead: true } : item
+      ));
+    };
+
+    return (
+      <NotificationPopover
+        notifications={notifications}
+        onItemClick={handleClick}
+        onMarkAllRead={handleMarkAllRead}
+        showMarkAllRead={unreadCount > 0}
+      />
+    );
+  },
+};
+
+export const PopoverEmpty: Story = {
+  render: () => (
+    <NotificationPopover
+      notifications={[]}
+      emptyMessage="You're all caught up!"
+    />
+  ),
+};

--- a/components/ui/NotificationList/NotificationList.tsx
+++ b/components/ui/NotificationList/NotificationList.tsx
@@ -1,0 +1,197 @@
+import { type ReactNode, type KeyboardEvent } from 'react';
+import { bdsClass } from '../../utils';
+import './NotificationList.css';
+
+// ─── NotificationItem ───────────────────────────────────────────────
+
+export interface NotificationItemData {
+  /** Unique identifier */
+  id: string;
+  /** Primary title text */
+  title: string;
+  /** Optional body/description */
+  body?: string | null;
+  /** Formatted time string (e.g. "2h ago") — consumer formats this */
+  time: string;
+  /** Whether the notification has been read */
+  isRead?: boolean;
+}
+
+export interface NotificationItemProps {
+  /** Notification data */
+  notification: NotificationItemData;
+  /** Click handler */
+  onClick?: (notification: NotificationItemData) => void;
+}
+
+/**
+ * NotificationItem — single notification row.
+ *
+ * Pure display component. Shows unread dot, title, body, and timestamp.
+ * Unread items get a highlighted background.
+ */
+export function NotificationItem({ notification, onClick }: NotificationItemProps) {
+  const isRead = notification.isRead ?? false;
+
+  const handleClick = () => onClick?.(notification);
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick?.(notification);
+    }
+  };
+
+  return (
+    <div
+      className={bdsClass('bds-notification-item', !isRead && 'bds-notification-item--unread')}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+    >
+      {!isRead && <div className="bds-notification-item__dot" />}
+      <div className="bds-notification-item__content">
+        <div className="bds-notification-item__title">{notification.title}</div>
+        {notification.body && (
+          <div className="bds-notification-item__body">{notification.body}</div>
+        )}
+        <div className="bds-notification-item__time">{notification.time}</div>
+      </div>
+    </div>
+  );
+}
+
+// ─── NotificationList ───────────────────────────────────────────────
+
+export interface NotificationListProps {
+  /** Array of notifications to display */
+  notifications: NotificationItemData[];
+  /** Click handler for individual items */
+  onItemClick?: (notification: NotificationItemData) => void;
+  /** Empty state message */
+  emptyMessage?: string;
+  /** Additional className */
+  className?: string;
+}
+
+/**
+ * NotificationList — scrollable list of notification items.
+ *
+ * Pure display component. Renders NotificationItems with an empty state.
+ * Does not manage data fetching, real-time subscriptions, or read state —
+ * the consumer provides pre-processed notification data.
+ *
+ * @example
+ * ```tsx
+ * <NotificationList
+ *   notifications={[
+ *     { id: '1', title: 'New Request', body: 'Emily submitted a request', time: '2h ago' },
+ *     { id: '2', title: 'Task Assigned', time: '5h ago', isRead: true },
+ *   ]}
+ *   onItemClick={(n) => console.log(n.id)}
+ * />
+ * ```
+ */
+export function NotificationList({
+  notifications,
+  onItemClick,
+  emptyMessage = 'No notifications yet',
+  className = '',
+}: NotificationListProps) {
+  return (
+    <div className={bdsClass('bds-notification-list', className)}>
+      {notifications.length === 0 ? (
+        <div className="bds-notification-list__empty">{emptyMessage}</div>
+      ) : (
+        notifications.map((n) => (
+          <NotificationItem key={n.id} notification={n} onClick={onItemClick} />
+        ))
+      )}
+    </div>
+  );
+}
+
+// ─── NotificationPopover ────────────────────────────────────────────
+
+export interface NotificationPopoverProps {
+  /** Title displayed in the header */
+  title?: string;
+  /** Notification data */
+  notifications: NotificationItemData[];
+  /** Click handler for individual items */
+  onItemClick?: (notification: NotificationItemData) => void;
+  /** "Mark all read" handler — hidden when null/undefined */
+  onMarkAllRead?: () => void;
+  /** Whether to show the "Mark all read" button */
+  showMarkAllRead?: boolean;
+  /** Empty state message */
+  emptyMessage?: string;
+  /** Header action slot (replaces default "Mark all read" button) */
+  headerAction?: ReactNode;
+  /** Additional className */
+  className?: string;
+}
+
+/**
+ * NotificationPopover — presentation shell for a notification dropdown.
+ *
+ * Renders the popover frame (header, list, empty state) but does NOT handle
+ * positioning, open/close state, or portal rendering. The consumer wraps
+ * this in their own popover/dropdown mechanism (Radix, BDS Popover, etc.)
+ * and controls visibility.
+ *
+ * This separation keeps BDS free of product-specific notification logic
+ * (real-time subscriptions, routing, mark-as-read APIs) while providing
+ * a consistent, themeable notification UI across products.
+ *
+ * @example
+ * ```tsx
+ * // Consumer controls open state + positioning
+ * {isOpen && (
+ *   <div className="my-dropdown-position">
+ *     <NotificationPopover
+ *       notifications={notifications}
+ *       onItemClick={handleClick}
+ *       onMarkAllRead={handleMarkAllRead}
+ *       showMarkAllRead={unreadCount > 0}
+ *     />
+ *   </div>
+ * )}
+ * ```
+ */
+export function NotificationPopover({
+  title = 'Notifications',
+  notifications,
+  onItemClick,
+  onMarkAllRead,
+  showMarkAllRead = false,
+  emptyMessage,
+  headerAction,
+  className = '',
+}: NotificationPopoverProps) {
+  return (
+    <div className={bdsClass('bds-notification-popover', className)}>
+      <div className="bds-notification-popover__header">
+        <span className="bds-notification-popover__title">{title}</span>
+        {headerAction ?? (
+          showMarkAllRead && onMarkAllRead && (
+            <button
+              type="button"
+              className="bds-notification-popover__action"
+              onClick={onMarkAllRead}
+            >
+              Mark all read
+            </button>
+          )
+        )}
+      </div>
+      <NotificationList
+        notifications={notifications}
+        onItemClick={onItemClick}
+        emptyMessage={emptyMessage}
+      />
+    </div>
+  );
+}
+
+export default NotificationList;

--- a/components/ui/NotificationList/index.ts
+++ b/components/ui/NotificationList/index.ts
@@ -1,0 +1,10 @@
+export {
+  NotificationItem,
+  NotificationList,
+  NotificationPopover,
+  type NotificationItemData,
+  type NotificationItemProps,
+  type NotificationListProps,
+  type NotificationPopoverProps,
+} from './NotificationList';
+export { default } from './NotificationList';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,5 +1,6 @@
 // UI Components
 export * from './Accordion';
+export * from './ActivityTimeline';
 export * from './AddressInput';
 export * from './AnimatedIcon';
 export * from './AlertBanner';
@@ -35,6 +36,7 @@ export * from './Meter';
 export * from './Modal';
 export * from './MultiSelect';
 export * from './NavBar';
+export * from './NotificationList';
 export * from './PageHeader';
 export * from './Pagination';
 export * from './PasswordInput';


### PR DESCRIPTION
## Summary
- **ActivityTimeline** — vertical event timeline display (icon dots, connecting rail, labels, detail, timestamps). Pure display component, consumer provides `TimelineEvent[]`.
- **NotificationList** — micro-experience presentation layer:
  - `NotificationItem` — single row with unread dot, title, body, time
  - `NotificationList` — scrollable list with empty state
  - `NotificationPopover` — presentation shell (header + mark-all-read + list). Does NOT handle positioning/portals — consumer wraps in their own mechanism.

## Architecture decision
Notifications are a micro-experience (mux). Only the **presentation layer** is promoted to BDS. Data fetching, real-time subscriptions, mark-as-read APIs, and routing logic stay in each product.

## Test plan
- [ ] Storybook: ActivityTimeline — Default, TaskLifecycle, SingleEvent, Resolved
- [ ] Storybook: NotificationList — Item, ItemRead, List, ListEmpty, Popover, PopoverEmpty
- [ ] Verify brand-colored origin dot in ActivityTimeline
- [ ] Verify unread highlight + dot in NotificationItem
- [ ] Test NotificationPopover "Mark all read" interaction in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)