### PR TITLE
fix: SheetStack headless config, z-index layering, Chip + Button

### DIFF
--- a/components/providers/SheetStackProvider.tsx
+++ b/components/providers/SheetStackProvider.tsx
@@ -108,6 +108,7 @@ export function SheetStackProvider({ children }: SheetStackProviderProps) {
     clearExitTimer();
     setIsExiting(false);
     setDirection('forward');
+    setSheetConfig({});
     setStack([{
       key: nextKey(type),
       type,
@@ -125,6 +126,7 @@ export function SheetStackProvider({ children }: SheetStackProviderProps) {
     clearExitTimer();
     setIsExiting(false);
     setDirection('forward');
+    setSheetConfig({});
     setStack((prev) => [...prev, {
       key: nextKey(type),
       type,
@@ -146,6 +148,7 @@ export function SheetStackProvider({ children }: SheetStackProviderProps) {
     clearExitTimer();
     exitTimer.current = setTimeout(() => {
       setIsExiting(false);
+      setSheetConfig({});
       setStack((prev) => prev.slice(0, -1));
     }, 150);
   }, [stack.length, clearExitTimer]);

--- a/components/providers/SheetStackRenderer.tsx
+++ b/components/providers/SheetStackRenderer.tsx
@@ -3,7 +3,7 @@
 import { type ReactNode, type CSSProperties } from 'react';
 import { Icon } from '@iconify/react';
 import { Sheet } from '../ui/Sheet';
-import { useSheetStack, type SheetFrame } from './SheetStackProvider';
+import { useSheetStack, useSheetConfig, type SheetFrame } from './SheetStackProvider';
 import { bdsClass } from '../utils';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -75,6 +75,7 @@ const headerRowStyle: CSSProperties = {
  */
 export function SheetStackRenderer({ renderFrame, width = '600px', globalFrameProps = {} }: SheetStackRendererProps) {
   const { stack, isOpen, isExiting, direction, back, closeAll, pushSheet } = useSheetStack();
+  const config = useSheetConfig();
 
   if (!isOpen) return null;
 
@@ -89,6 +90,9 @@ export function SheetStackRenderer({ renderFrame, width = '600px', globalFramePr
     globalFrameProps,
   };
 
+  // Resolve title: prefer headless config title, fall back to frame title
+  const baseTitle = config.title ?? topFrame.title ?? topFrame.type;
+
   // Build the title — includes back arrow when stack is deep
   const titleContent = isDeep ? (
     <span style={headerRowStyle}>
@@ -101,10 +105,10 @@ export function SheetStackRenderer({ renderFrame, width = '600px', globalFramePr
       >
         <Icon icon="ph:arrow-left-bold" />
       </button>
-      {topFrame.title ?? topFrame.type}
+      {baseTitle}
     </span>
   ) : (
-    topFrame.title ?? topFrame.type
+    baseTitle
   );
 
   // Animation class for frame content
@@ -114,19 +118,31 @@ export function SheetStackRenderer({ renderFrame, width = '600px', globalFramePr
     !isExiting && direction === 'back' ? 'bds-sheet-stack__frame--back' : '',
   );
 
+  // Headless components return null but must stay mounted for effects (data fetching,
+  // configureSheet calls). Render them in a hidden container outside the Sheet body
+  // so they survive the tabs/body swap inside the Sheet.
+  const frameContent = renderFrame(topFrame, ctx);
+
   return (
-    <Sheet
-      isOpen
-      onClose={closeAll}
-      title={titleContent}
-      width={width}
-      variant={topFrame.variant}
-      closeOnEscape
-    >
-      <div className={frameClass} key={topFrame.key}>
-        {renderFrame(topFrame, ctx)}
-      </div>
-    </Sheet>
+    <>
+      <div style={{ display: 'none' }}>{frameContent}</div>
+      <Sheet
+        isOpen
+        onClose={closeAll}
+        title={titleContent}
+        width={width}
+        variant={topFrame.variant}
+        closeOnEscape
+        tabs={config.tabs}
+        activeTab={config.activeTab}
+        onTabChange={config.onTabChange}
+        footer={config.footer}
+      >
+        <div className={frameClass} key={topFrame.key}>
+          {config.body}
+        </div>
+      </Sheet>
+    </>
   );
 }
 

--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -48,6 +48,7 @@
   padding: var(--padding-tiny);
   font-size: var(--label-xs);
   gap: var(--gap-xs);
+  border-radius: var(--border-radius-sm);
 }
 
 .bds-button--sm {

--- a/components/ui/Chip/Chip.css
+++ b/components/ui/Chip/Chip.css
@@ -18,9 +18,8 @@
   border-radius: var(--border-radius-pill);
   font-family: var(--font-family-label);
   font-weight: var(--font-weight-semi-bold);
-  line-height: var(--font-line-height-tight);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  line-height: var(--font-line-height-normal);
+  text-transform: capitalize;
   cursor: pointer;
   user-select: none;
   border: none;

--- a/components/ui/Dialog/Dialog.css
+++ b/components/ui/Dialog/Dialog.css
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 1100;
 }
 
 .bds-dialog {

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -9,7 +9,7 @@
   right: 0;
   bottom: 0;
   background-color: var(--background-overlay);
-  z-index: 1000;
+  z-index: 900;
 }
 
 .bds-sheet {
@@ -18,7 +18,7 @@
   box-shadow: var(--shadow-overlay);
   display: flex;
   flex-direction: column;
-  z-index: 1001;
+  z-index: 901;
   overflow: hidden;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- **SheetStackRenderer** consumes `useSheetConfig()` — headless components' tabs/footer/title now reach the Sheet. Headless component rendered in hidden container to stay mounted during tab/body swap.
- **SheetStackProvider** resets config on `openSheet`/`pushSheet`/`back` to prevent stale content between frame transitions.
- **z-index layering**: Sheet 900 < Modal 1000 < Dialog 1100 (modals render above sheets, dialogs above modals)
- **Button tiny**: `border-radius-sm` so 24px icon buttons aren't circular
- **Chip**: `text-transform: uppercase` → `capitalize`, removed `letter-spacing`, `line-height: tight` → `normal` (matches Button label treatment)

## Test plan
- [ ] Open a request from the board → sheet loads with tabs and data
- [ ] Drill into a related record (vendor, room) → back button appears, data loads
- [ ] Open Manage modal from sheet → modal renders above sheet, lightbox between them
- [ ] Open Reject dialog from Manage → dialog renders above modal
- [ ] Verify Chip filters (requests, contacts) show capitalize instead of ALL CAPS
- [ ] Verify tiny IconButtons in tables have rounded-rectangle corners, not circular

🤖 Generated with [Claude Code](https://claude.com/claude-code)