### PR TITLE
fix: enforce 4px grid heights on Button + indicator components

### DIFF
--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -37,18 +37,21 @@
   padding: var(--padding-tiny) var(--padding-sm);
   gap: var(--gap-xs);
   font-size: var(--label-tiny);
+  height: 28px;
 }
 
 .bds-badge--md {
   padding: var(--padding-sm) var(--padding-md);
   gap: var(--gap-sm);
   font-size: var(--label-sm);
+  height: 32px;
 }
 
 .bds-badge--lg {
   padding: var(--padding-sm) var(--padding-md);
   gap: var(--gap-md);
   font-size: var(--label-md);
+  height: 40px;
 }
 
 /* ─── Icon Wrapper (shared sizing with Tag) ──────────────────── */

--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -49,6 +49,7 @@
   font-size: var(--label-xs);
   gap: var(--gap-xs);
   border-radius: var(--border-radius-sm);
+  min-height: 36px;
 }
 
 .bds-button--sm {
@@ -63,16 +64,19 @@
 .bds-button--md {
   padding: var(--padding-md);
   font-size: var(--label-md);
+  min-height: 56px;
 }
 
 .bds-button--lg {
   padding: var(--padding-md);
   font-size: var(--label-lg);
+  min-height: 64px;
 }
 
 .bds-button--xl {
   padding: var(--padding-lg);
   font-size: var(--label-xl);
+  min-height: 80px;
 }
 
 /* ─── Variants ────────────────────────────────────────────────── */

--- a/components/ui/Chip/Chip.css
+++ b/components/ui/Chip/Chip.css
@@ -47,18 +47,21 @@
   padding: var(--space-150) var(--padding-sm);
   font-size: var(--label-tiny);
   gap: var(--gap-xs);
+  height: 28px;
 }
 
 .bds-chip--md {
   padding: var(--padding-sm) var(--padding-md);
   font-size: var(--label-sm);
   gap: var(--gap-sm);
+  height: 32px;
 }
 
 .bds-chip--lg {
   padding: var(--padding-sm) var(--padding-md);
   font-size: var(--label-md);
   gap: var(--gap-md);
+  height: 40px;
 }
 
 /* ─── Variant + Appearance ────────────────────────────────────── */

--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -44,6 +44,7 @@
   padding: var(--padding-tiny) var(--padding-sm);
   gap: var(--gap-xs);
   font-size: var(--label-tiny);
+  height: 28px;
   border-radius: var(--border-radius-sm);
 }
 
@@ -51,6 +52,7 @@
   padding: var(--padding-sm) var(--padding-md);
   gap: var(--gap-sm);
   font-size: var(--label-sm);
+  height: 32px;
   border-radius: var(--border-radius-md);
 }
 
@@ -58,6 +60,7 @@
   padding: var(--padding-sm) var(--padding-md);
   gap: var(--gap-md);
   font-size: var(--label-md);
+  height: 40px;
   border-radius: var(--border-radius-md);
 }
 


### PR DESCRIPTION
## Summary

Closes #65 — adds `min-height` to all Button size tiers:

| Size | min-height | Grid |
|------|-----------|------|
| tiny | 36px | 9×4 |
| sm | 44px (unchanged) | 11×4 |
| md | 56px | 14×4 |
| lg | 64px | 16×4 |
| xl | 80px | 20×4 |

Closes #64 — adds explicit `height` to Badge, Tag, and Chip sm/md/lg:

| Size | height | Grid |
|------|--------|------|
| xs | 24px (unchanged) | 6×4 |
| sm | 28px | 7×4 |
| md | 32px | 8×4 |
| lg | 40px | 10×4 |

## Why

Heights were previously derived from `padding + font-size × line-height + border`, producing fractional values (26.26px, ~35px, etc.) that broke 4px grid alignment. Indicators rendered at different heights side-by-side.

## Test plan

- [ ] All 5 validation checks pass
- [ ] Storybook: Button at all sizes visually inspected
- [ ] Storybook: Badge, Tag, Chip at sm/md/lg — consistent heights
- [ ] After merge: remove renew-pms `@layer client-overrides` height workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)