### PR TITLE
fix: standardize component heights to 4px grid

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -35,7 +35,7 @@ const config: StorybookConfig = {
     wip: { excludeFromSidebar: true },
   },
   features: {
-    experimentalComponentsManifest: true,
+    experimentalCodeExamples: true,
   },
   docs: {
     defaultName: 'Overview',

--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -19,6 +19,7 @@
   white-space: nowrap;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  box-sizing: border-box;
 }
 
 /* ─── Sizes (shared scale with Tag) ──────────────────────────── */

--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -44,39 +44,44 @@
 
 /* ─── Sizes ───────────────────────────────────────────────────── */
 
+/*
+ * Height scale shares the same 4px grid as IconButton:
+ *   tiny=24  sm=32  md=40  lg=48  xl=56  (8px steps)
+ *
+ * Vertical centering is handled by the base flexbox (align-items: center).
+ * Only padding-inline remains for horizontal spacing.
+ */
+
 .bds-button--tiny {
-  padding: var(--padding-tiny);
+  height: 24px;
+  padding-inline: var(--padding-tiny);
   font-size: var(--label-xs);
   gap: var(--gap-xs);
   border-radius: var(--border-radius-sm);
-  min-height: 36px;
 }
 
 .bds-button--sm {
-  /* Block padding aligned with TextInput sm (--padding-xs = 10px) so both
-   * components share the same natural height. min-height: 44px snaps to 4px grid. */
-  padding-block: var(--padding-xs);
+  height: 32px;
   padding-inline: var(--padding-sm);
   font-size: var(--label-sm);
-  min-height: 44px;
 }
 
 .bds-button--md {
-  padding: var(--padding-md);
+  height: 40px;
+  padding-inline: var(--padding-md);
   font-size: var(--label-md);
-  min-height: 56px;
 }
 
 .bds-button--lg {
-  padding: var(--padding-md);
+  height: 48px;
+  padding-inline: var(--padding-md);
   font-size: var(--label-lg);
-  min-height: 64px;
 }
 
 .bds-button--xl {
-  padding: var(--padding-lg);
+  height: 56px;
+  padding-inline: var(--padding-lg);
   font-size: var(--label-xl);
-  min-height: 80px;
 }
 
 /* ─── Variants ────────────────────────────────────────────────── */

--- a/components/ui/FilterButton/FilterButton.css
+++ b/components/ui/FilterButton/FilterButton.css
@@ -33,23 +33,26 @@
   color: var(--text-on-color-dark);
 }
 
-/* Size variants */
+/* Size variants — height scale matches Button/IconButton (4px grid, 8px steps) */
 
 .bds-filter-button__trigger--sm {
-  padding: var(--padding-sm) var(--padding-md);
+  height: 32px;
+  padding-inline: var(--padding-md);
   font-size: var(--label-sm);
   gap: var(--gap-sm);
 }
 
 .bds-filter-button__trigger--md {
-  padding: var(--padding-md) var(--padding-lg);
+  height: 40px;
+  padding-inline: var(--padding-lg);
   font-size: var(--label-md);
   gap: var(--gap-md);
 }
 
 .bds-filter-button__trigger--lg {
-  padding: var(--padding-lg) var(--padding-xl);
-  font-size: var(--label-md);
+  height: 48px;
+  padding-inline: var(--padding-xl);
+  font-size: var(--label-lg);
   gap: var(--gap-lg);
 }
 

--- a/components/ui/ServiceBadge/ServiceTag.css
+++ b/components/ui/ServiceBadge/ServiceTag.css
@@ -11,6 +11,7 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   border-radius: var(--border-radius-sm);
+  box-sizing: border-box;
 }
 
 .bds-service-tag--has-icon {
@@ -20,17 +21,20 @@
 /* ─── Sizes ──────────────────────────────────────────────────── */
 
 .bds-service-tag--sm {
-  padding: var(--padding-tiny) var(--padding-sm);
+  height: 28px;
+  padding-inline: var(--padding-sm);
   font-size: var(--label-tiny);
 }
 
 .bds-service-tag--md {
-  padding: var(--padding-tiny) var(--padding-sm);
+  height: 32px;
+  padding-inline: var(--padding-sm);
   font-size: var(--label-sm);
 }
 
 .bds-service-tag--lg {
-  padding: var(--padding-sm) var(--padding-md);
+  height: 40px;
+  padding-inline: var(--padding-md);
   font-size: var(--label-md);
 }
 

--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -26,6 +26,7 @@
   user-select: none;
   overflow: clip;
   transition: background-color var(--duration-normal) var(--ease-out);
+  box-sizing: border-box;
 }
 
 /* ─── Sizes (shared scale with Badge) ────────────────────────── */


### PR DESCRIPTION
## Summary

- **Unify Button/FilterButton heights to match IconButton's 4px grid** — replace `min-height` + `padding-block` with explicit `height` at all tiers: tiny=24, sm=32, md=40, lg=48, xl=56 (8px steps)
- **Fix missing `box-sizing: border-box`** on Badge, Tag, and ServiceTag — padding was stacking on top of explicit heights (Badge sm rendered 44px instead of 28px)
- **Add explicit heights to ServiceTag** — was padding-driven, producing fractional values (26.26px)
- **Fix FilterButton lg** using `--label-md` instead of `--label-lg`
- **Fix pre-existing SB10 typecheck** (`experimentalComponentsManifest` → `experimentalCodeExamples`)

### Height scale (all component families)

| Size | Button | IconButton | FilterButton | Badge/Tag | ServiceTag | Chip |
|------|--------|------------|--------------|-----------|------------|------|
| xs   | —      | —          | —            | 24px      | —          | —    |
| sm   | 32px   | 32px       | 32px         | 28px      | 28px       | 28px |
| md   | 40px   | 40px       | 40px         | 32px      | 32px       | 32px |
| lg   | 48px   | 48px       | 48px         | 40px      | 40px       | 40px |

## Test plan

- [ ] Storybook: verify Button, IconButton, FilterButton stories at all sizes
- [ ] Storybook: verify Badge, Tag, ServiceTag, Chip stories at all sizes
- [ ] Chromatic: run `npm run chromatic` and review visual diffs
- [ ] Portal smoke test after submodule sync: sidebar nav, filter tables, form buttons, page header actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)