### PR TITLE
fix: align TimePicker trigger height to 4px grid

### DIFF
--- a/components/ui/TimePicker/TimePicker.css
+++ b/components/ui/TimePicker/TimePicker.css
@@ -43,7 +43,7 @@
 
 .bds-time-picker__trigger {
   width: 100%;
-  padding: var(--padding-xs);
+  padding: 0 var(--padding-xs);
   font-family: var(--font-family-body);
   font-weight: var(--font-weight-regular);
   line-height: var(--font-line-height-normal);
@@ -84,10 +84,10 @@
   box-shadow: 0 0 0 1px var(--border-brand-primary);
 }
 
-/* Trigger sizes */
-.bds-time-picker--sm .bds-time-picker__trigger { font-size: var(--body-sm); }
-.bds-time-picker--md .bds-time-picker__trigger { font-size: var(--body-md); }
-.bds-time-picker--lg .bds-time-picker__trigger { font-size: var(--body-lg); }
+/* Trigger sizes — heights match Button scale (8px steps, 4px grid) */
+.bds-time-picker--sm .bds-time-picker__trigger { font-size: var(--body-sm); height: 32px; }
+.bds-time-picker--md .bds-time-picker__trigger { font-size: var(--body-md); height: 40px; }
+.bds-time-picker--lg .bds-time-picker__trigger { font-size: var(--body-lg); height: 48px; }
 
 /* ─── Trigger placeholder & icon ─────────────────────────────── */
 


### PR DESCRIPTION
## Summary

- TimePicker trigger used padding-derived heights (43/46/49px) — same issue fixed for other inputs in #68
- Switched to horizontal-only padding + explicit heights matching the Button scale (sm=32, md=40, lg=48)
- Completes the input height alignment started in #66–#68

### Unified height scale (all components, 4px grid)

| Size | Button | Inputs | Badge/Tag |
|------|--------|--------|-----------|
| tiny | 24px | — | — |
| sm | 32px | 32px | 28px |
| md | 40px | 40px | 32px |
| lg | 48px | 48px | 40px |
| xl | 56px | — | — |

## Test plan

- [ ] Verify TimePicker trigger text is vertically centered at all 3 sizes
- [ ] Check TimePicker dropdown popover still opens/positions correctly
- [ ] Confirm no visual regression in Form composite stories (inputs + buttons side-by-side)
- [ ] Run `npm run lint-tokens:grid` — passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)