### PR TITLE
fix(button): hover states, LinkButton text, loading color

### DIFF
--- a/.storybook/storybook-overrides.css
+++ b/.storybook/storybook-overrides.css
@@ -372,8 +372,8 @@ body[data-bds-dark="true"] #storybook-docs#storybook-docs .sbdocs-preview {
   font-family: var(--font-family-body, inherit) !important;
 }
 
-/* Docs links — brand color (exclude code block and anchor links) */
-.sbdocs a:not([class*="docblock"]):not([class*="anchor"]) {
+/* Docs links — brand color (exclude code blocks, anchors, and button components) */
+.sbdocs a:not([class*="docblock"]):not([class*="anchor"]):not([class*="bds-button"]) {
   color: var(--text-brand-primary) !important;
 }
 

--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -211,6 +211,26 @@
   transform: translateY(var(--button-active-translate-y)); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
 }
 
+/* ── Destructive ── */
+.bds-button--destructive:hover:not(:disabled):not(.bds-button--loading) {
+  background-color: var(--background-negative-hover);
+}
+
+.bds-button--destructive:active:not(:disabled) {
+  background-color: var(--background-negative-pressed);
+  transform: translateY(var(--button-active-translate-y)); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
+}
+
+/* ── Positive ── */
+.bds-button--positive:hover:not(:disabled):not(.bds-button--loading) {
+  background-color: var(--background-positive-hover);
+}
+
+.bds-button--positive:active:not(:disabled) {
+  background-color: var(--background-positive-pressed);
+  transform: translateY(var(--button-active-translate-y)); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
+}
+
 /* ── Danger variants ── */
 .bds-button--danger-outline:hover:not(:disabled):not(.bds-button--loading) {
   background-color: var(--background-accent-red);
@@ -222,8 +242,8 @@
   color: var(--text-on-color-dark);
 }
 
-/* ── Disabled (all variants) ── */
-.bds-button:disabled {
+/* ── Disabled (all variants, except loading) ── */
+.bds-button:disabled:not(.bds-button--loading) {
   background-color: var(--background-disabled);
   color: var(--text-disabled);
   border-color: var(--border-disabled);

--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -128,6 +128,14 @@
   --text-status-neutral:              var(--color-system-neutral);
   --surface-status-info:              var(--color-system-blue-light);
 
+  /* ── System color hover/pressed states ──
+     Darken system colors for interactive feedback on destructive/positive buttons.
+     TODO: promote to Figma variables once interaction states are modeled for system colors. */
+  --background-negative-hover:   color-mix(in srgb, var(--color-system-red) 85%, black);
+  --background-negative-pressed: color-mix(in srgb, var(--color-system-red) 70%, black);
+  --background-positive-hover:   color-mix(in srgb, var(--color-system-green) 85%, black);
+  --background-positive-pressed: color-mix(in srgb, var(--color-system-green) 70%, black);
+
   /* Presence (for Avatar online/away/busy/offline indicators) */
   --background-presence-online:  var(--color-system-green);
   --background-presence-away:    var(--color-system-yellow);

--- a/tokens/theme-brik.css
+++ b/tokens/theme-brik.css
@@ -32,6 +32,7 @@
   --background-brand-secondary: #f1f0ec;
   --background-primary: var(--color-grayscale-white);
   --background-secondary: var(--color-grayscale-lightest);
+  --background-secondary-hover: var(--color-grayscale-lighter);
   --background-inverse: var(--color-grayscale-darkest);
   --background-input: var(--color-grayscale-white);
   --background-image: #17171799;


### PR DESCRIPTION
## Summary
- **Destructive + Positive hover/active states** — new gap-fill tokens (`--background-negative-hover/pressed`, `--background-positive-hover/pressed`) using `color-mix()` to darken system red/green
- **Primary LinkButton text visibility** — exclude `.bds-button` from Storybook docs link color override so `--text-on-color-dark` (white) applies correctly
- **Loading state preserves variant color** — disabled rule now skips `.bds-button--loading` so loading buttons keep their variant background instead of going gray
- **Secondary hover (theme-brik)** — add `--background-secondary-hover: var(--color-grayscale-lighter)` to light mode (one step darker from lightest)

## Test plan
- [ ] Hover destructive/positive buttons in Storybook — should darken subtly
- [ ] Check primary LinkButton shows white text on red background
- [ ] Trigger loading state on each variant — should keep variant color, not gray
- [ ] Verify secondary button hover is a subtle one-step darken in light mode
- [ ] Check dark mode still works correctly for all variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)