### PR TITLE
feat(filter-toggle): add FilterToggle component

### DIFF
--- a/components/ui/FilterToggle/FilterToggle.css
+++ b/components/ui/FilterToggle/FilterToggle.css
@@ -1,0 +1,49 @@
+@layer bds-components {
+/* FilterToggle — binary on/off filter pill for filter bars */
+
+/* ─── Base ────────────────────────────────────────────── */
+
+.bds-filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--background-secondary);
+  border-radius: var(--border-radius-md);
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+  white-space: nowrap;
+  box-sizing: border-box;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+/* ─── Active state ────────────────────────────────────── */
+
+.bds-filter-toggle--active {
+  background-color: var(--background-brand-primary);
+  color: var(--text-on-color-dark);
+}
+
+/* ─── Size variants — matches FilterButton/Button height scale (4px grid, 8px steps) ─── */
+
+.bds-filter-toggle--sm {
+  height: 32px;
+  padding-inline: var(--padding-md);
+  font-size: var(--label-sm);
+}
+
+.bds-filter-toggle--md {
+  height: 40px;
+  padding-inline: var(--padding-lg);
+  font-size: var(--label-md);
+}
+
+.bds-filter-toggle--lg {
+  height: 48px;
+  padding-inline: var(--padding-xl);
+  font-size: var(--label-lg);
+}
+}

--- a/components/ui/FilterToggle/FilterToggle.stories.tsx
+++ b/components/ui/FilterToggle/FilterToggle.stories.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { FilterToggle } from './FilterToggle';
+import { FilterButton } from '../FilterButton/FilterButton';
+
+/* ─── Layout Helpers (story-only) ─────────────────────────────── */
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <div style={{
+    fontFamily: 'var(--font-family-label)',
+    fontSize: 'var(--body-xs)', // bds-lint-ignore
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginBottom: 'var(--gap-md)',
+    color: 'var(--text-muted)',
+  }}>
+    {children}
+  </div>
+);
+
+const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
+);
+
+const Row = ({ children, gap = 'var(--gap-lg)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap, alignItems: 'flex-start' }}>{children}</div>
+);
+
+/* ─── Meta ────────────────────────────────────────────── */
+
+const meta = {
+  title: 'Components/Action/filter-toggle',
+  component: FilterToggle,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div style={{ minHeight: 120, padding: 'var(--padding-lg)', display: 'flex', justifyContent: 'center', alignItems: 'flex-start' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof FilterToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ═══════════════════════════════════════════════════════════════
+   1. PLAYGROUND — Args-based, use Controls panel to explore
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Playground: Story = {
+  args: {
+    label: 'Show Archived',
+    active: false,
+    onToggle: () => {},
+    size: 'md',
+  },
+  render: (args) => {
+    function Toggle() {
+      const [active, setActive] = useState(args.active);
+      return (
+        <FilterToggle
+          {...args}
+          active={active}
+          onToggle={() => setActive((prev) => !prev)}
+        />
+      );
+    }
+    return <Toggle />;
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   2. VARIANTS — Sizes, states
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Variants: Story = {
+  args: { label: 'Toggle', active: false, onToggle: () => {} },
+  render: () => (
+    <Stack>
+      <div>
+        <SectionLabel>Sizes — inactive</SectionLabel>
+        <Row>
+          <FilterToggle label="Small" active={false} onToggle={() => {}} size="sm" />
+          <FilterToggle label="Medium" active={false} onToggle={() => {}} size="md" />
+          <FilterToggle label="Large" active={false} onToggle={() => {}} size="lg" />
+        </Row>
+      </div>
+
+      <div>
+        <SectionLabel>Sizes — active</SectionLabel>
+        <Row>
+          <FilterToggle label="Small" active onToggle={() => {}} size="sm" />
+          <FilterToggle label="Medium" active onToggle={() => {}} size="md" />
+          <FilterToggle label="Large" active onToggle={() => {}} size="lg" />
+        </Row>
+      </div>
+    </Stack>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   3. PATTERNS — Mixed filter bar with FilterButton + FilterToggle
+   ═══════════════════════════════════════════════════════════════ */
+
+const statusOptions = [
+  { id: 'active', label: 'Active' },
+  { id: 'inactive', label: 'Inactive' },
+  { id: 'pending', label: 'Pending' },
+];
+
+const roleOptions = [
+  { id: 'admin', label: 'Admin' },
+  { id: 'editor', label: 'Editor' },
+  { id: 'viewer', label: 'Viewer' },
+];
+
+export const Patterns: Story = {
+  args: { label: 'Toggle', active: false, onToggle: () => {} },
+  render: () => {
+    function FilterBar() {
+      const [status, setStatus] = useState<string | undefined>();
+      const [role, setRole] = useState<string | undefined>();
+      const [primaryOnly, setPrimaryOnly] = useState(false);
+
+      return (
+        <Stack>
+          <div>
+            <SectionLabel>Filter bar — FilterButton + FilterToggle</SectionLabel>
+            <Row>
+              <FilterButton label="Status" options={statusOptions} value={status} onChange={setStatus} size="sm" />
+              <FilterToggle
+                label="Show Primary Contacts"
+                active={primaryOnly}
+                onToggle={() => setPrimaryOnly((prev) => !prev)}
+                size="sm"
+              />
+              <FilterButton label="Role" options={roleOptions} value={role} onChange={setRole} size="sm" />
+            </Row>
+          </div>
+        </Stack>
+      );
+    }
+    return <FilterBar />;
+  },
+};

--- a/components/ui/FilterToggle/FilterToggle.tsx
+++ b/components/ui/FilterToggle/FilterToggle.tsx
@@ -1,0 +1,68 @@
+import type { ButtonHTMLAttributes } from 'react';
+import { bdsClass } from '../../utils';
+import './FilterToggle.css';
+
+/**
+ * FilterToggle sizes (matches FilterButton/Button size scale)
+ */
+export type FilterToggleSize = 'sm' | 'md' | 'lg';
+
+/**
+ * FilterToggle component props
+ */
+export interface FilterToggleProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
+  /** Button label */
+  label: string;
+  /** Whether the filter is active */
+  active: boolean;
+  /** Toggle callback */
+  onToggle: () => void;
+  /** Size variant (default: 'md') */
+  size?: FilterToggleSize;
+}
+
+/**
+ * FilterToggle — A binary on/off filter pill for filter bars
+ *
+ * Visually cohesive with FilterButton but without a dropdown.
+ * Click toggles between active (brand) and inactive (secondary) states.
+ *
+ * @example
+ * ```tsx
+ * const [showArchived, setShowArchived] = useState(false);
+ *
+ * <FilterToggle
+ *   label="Show Archived"
+ *   active={showArchived}
+ *   onToggle={() => setShowArchived((prev) => !prev)}
+ * />
+ * ```
+ */
+export function FilterToggle({
+  label,
+  active,
+  onToggle,
+  size = 'md',
+  className = '',
+  ...props
+}: FilterToggleProps) {
+  return (
+    <button
+      type="button"
+      className={bdsClass(
+        'bds-filter-toggle',
+        `bds-filter-toggle--${size}`,
+        active && 'bds-filter-toggle--active',
+        className,
+      )}
+      aria-pressed={active}
+      onClick={onToggle}
+      {...props}
+    >
+      {label}
+    </button>
+  );
+}
+
+export default FilterToggle;

--- a/components/ui/FilterToggle/index.ts
+++ b/components/ui/FilterToggle/index.ts
@@ -1,0 +1,2 @@
+export { FilterToggle } from './FilterToggle';
+export type { FilterToggleProps, FilterToggleSize } from './FilterToggle';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -28,6 +28,7 @@ export * from './Dot';
 export * from './EmptyState';
 export * from './FileUploader';
 export * from './FilterButton';
+export * from './FilterToggle';
 export * from './Footer';
 export * from './Form';
 export * from './Icons';


### PR DESCRIPTION
## Summary
- Adds `FilterToggle` — a binary on/off filter pill for filter bars
- Same visual language as `FilterButton` (height scale, tokens, active-state colors) but no dropdown
- Props: `label`, `active`, `onToggle`, `size` (sm/md/lg)
- Includes Storybook stories: playground, size variants, and mixed filter bar pattern with FilterButton

## Motivation
The portal has a one-off `FilterToggle` component using inline styles and JS token imports instead of BDS CSS classes. This formalizes the pattern in BDS so consumers can import it properly.

## Test plan
- [ ] Storybook: verify all three stories render correctly (`filter-toggle`)
- [ ] Visual: confirm size variants match FilterButton trigger heights (32/40/48px)
- [ ] Visual: confirm active state uses brand primary background
- [ ] Mixed bar: FilterToggle sits flush alongside FilterButton in the Patterns story

🤖 Generated with [Claude Code](https://claude.com/claude-code)