### PR TITLE
fix(inputs): suppress 1Password/LastPass on non-password fields

### DIFF
--- a/components/ui/AddressInput/AddressInput.tsx
+++ b/components/ui/AddressInput/AddressInput.tsx
@@ -360,6 +360,8 @@ export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
             <Icon icon={MapPin} />
           </span>
           <input
+            data-1p-ignore=""
+            data-lpignore="true"
             ref={ref}
             id={inputId}
             type="text"

--- a/components/ui/PasswordInput/PasswordInput.tsx
+++ b/components/ui/PasswordInput/PasswordInput.tsx
@@ -112,6 +112,8 @@ export const PasswordInput = ({
       id={inputId}
       type={showPassword ? 'text' : 'password'}
       iconAfter={toggleButton}
+      data-1p-ignore={undefined}
+      data-lpignore={undefined}
       {...props}
     />
   );

--- a/components/ui/SearchInput/SearchInput.tsx
+++ b/components/ui/SearchInput/SearchInput.tsx
@@ -188,6 +188,8 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             <Icon icon={MagnifyingGlass} />
           </span>
           <input
+            data-1p-ignore=""
+            data-lpignore="true"
             ref={ref}
             id={inputId}
             type="search"

--- a/components/ui/TextArea/TextArea.tsx
+++ b/components/ui/TextArea/TextArea.tsx
@@ -206,6 +206,8 @@ export function TextArea({
         </label>
       )}
       <textarea
+        data-1p-ignore=""
+        data-lpignore="true"
         id={inputId}
         placeholder={placeholder}
         rows={rows}

--- a/components/ui/TextInput/TextInput.tsx
+++ b/components/ui/TextInput/TextInput.tsx
@@ -219,6 +219,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           )}
 
           <input
+            data-1p-ignore=""
+            data-lpignore="true"
             ref={ref}
             id={inputId}
             className="bds-text-input-field"


### PR DESCRIPTION
## Summary
- Add `data-1p-ignore` and `data-lpignore` attributes to **TextInput**, **TextArea**, **SearchInput**, and **AddressInput** to prevent password manager overlays on standard form fields
- **PasswordInput** explicitly overrides these back to `undefined` so 1Password remains active on password fields (including during show/hide toggle)
- No new props, no API surface change — 5 files, 10 lines added

## Test plan
- [ ] TextInput, SearchInput, AddressInput, TextArea no longer show 1Password icon
- [ ] PasswordInput still shows 1Password autofill prompt
- [ ] PasswordInput show/hide toggle does not re-trigger 1Password on the revealed text field

🤖 Generated with [Claude Code](https://claude.com/claude-code)