### PR TITLE
chore(release): v0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Brik Design System - React component library with Webflow-synced design tokens",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- Version bump to 0.1.4 after PR #79 merge (brand intermediate layer)
- Package already published to GitHub Packages

## Test plan
- [x] `npm publish` succeeded — `@brikdesigns/bds@0.1.4` live on registry
- [x] Full validation suite passed (token lint, grid audit, theme compliance, TypeScript, Storybook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)