### PR TITLE
feat(input): add AddableTextList component (v0.1.5)

### DIFF
--- a/components/ui/AddableTextList/AddableTextList.css
+++ b/components/ui/AddableTextList/AddableTextList.css
@@ -1,0 +1,46 @@
+.bds-addable-text-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  width: 100%;
+}
+
+.bds-addable-text-list__label {
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+.bds-addable-text-list__items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  align-items: center;
+}
+
+.bds-addable-text-list__empty {
+  font-family: var(--font-family-body);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.bds-addable-text-list__input-row {
+  display: flex;
+  gap: var(--gap-sm);
+  align-items: flex-start;
+  width: 100%;
+}
+
+.bds-addable-text-list__input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.bds-addable-text-list__helper {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+}

--- a/components/ui/AddableTextList/AddableTextList.mdx
+++ b/components/ui/AddableTextList/AddableTextList.mdx
@@ -1,0 +1,39 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './AddableTextList.stories';
+
+<Meta of={Stories} />
+
+# Addable text list
+
+A list of text values with a reveal-on-click add pattern. The input is hidden until the user clicks the "Add New" button; pressing **Enter** commits the value and re-focuses the input for rapid entry, **Escape** cancels. Existing values render as removable tags.
+
+Use for lightweight list capture where a full multi-select is overkill (e.g. services offered, payment types, back-office tools). Designed to be swapped for a MultiSelect later without changing data shape.
+
+---
+
+## Playground
+
+<Canvas of={Stories.Playground} />
+
+## Empty state
+
+<Canvas of={Stories.Empty} />
+
+## Variants
+
+Sizes, empty/helper/disabled states, and item limit.
+
+<Canvas of={Stories.Variants} />
+
+---
+
+## Behavior
+
+- **Enter** commits the trimmed value and keeps the input open for the next entry.
+- **Escape** or **blur on empty** cancels and hides the input.
+- Duplicates are blocked case-insensitively unless `allowDuplicates` is set.
+- When `maxItems` is reached, the Add button is hidden.
+
+## Props
+
+<ArgTypes of={Stories} />

--- a/components/ui/AddableTextList/AddableTextList.stories.tsx
+++ b/components/ui/AddableTextList/AddableTextList.stories.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { AddableTextList } from './AddableTextList';
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <div
+    style={{
+      fontFamily: 'var(--font-family-label)',
+      fontSize: 'var(--body-xs)', // bds-lint-ignore
+      textTransform: 'uppercase' as const,
+      letterSpacing: '0.05em',
+      marginBottom: 'var(--gap-md)',
+      color: 'var(--text-muted)',
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
+);
+
+const meta: Meta<typeof AddableTextList> = {
+  title: 'Components/Form/addable-text-list',
+  component: AddableTextList,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    label: { control: 'text' },
+    addLabel: { control: 'text' },
+    placeholder: { control: 'text' },
+    helperText: { control: 'text' },
+    emptyLabel: { control: 'text' },
+    disabled: { control: 'boolean' },
+    allowDuplicates: { control: 'boolean' },
+    maxItems: { control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AddableTextList>;
+
+const Controlled = (args: React.ComponentProps<typeof AddableTextList>) => {
+  const [values, setValues] = useState<string[]>(args.values ?? []);
+  return (
+    <div style={{ width: 420 }}>
+      <AddableTextList
+        {...args}
+        values={values}
+        onChange={(next) => {
+          setValues(next);
+          args.onChange?.(next);
+        }}
+      />
+    </div>
+  );
+};
+
+export const Playground: Story = {
+  args: {
+    label: 'Services Offered',
+    placeholder: 'e.g. Dental cleaning',
+    addLabel: 'Add Service',
+    values: ['Dental cleaning', 'Whitening'],
+    size: 'md',
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+export const Empty: Story = {
+  args: {
+    label: 'Back-Office Tools',
+    placeholder: 'e.g. QuickBooks',
+    addLabel: 'Add Tool',
+    emptyLabel: 'No tools added yet.',
+    values: [],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+export const AddAnEntry: Story = {
+  name: 'Interaction — add an entry',
+  args: {
+    label: 'Payment Types',
+    placeholder: 'e.g. Aetna',
+    addLabel: 'Add Payment Type',
+    values: ['Cash', 'Visa'],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    const addButton = canvas.getByRole('button', { name: /add payment type/i });
+    await userEvent.click(addButton);
+
+    const input = await canvas.findByLabelText(/add payment types/i);
+    await userEvent.type(input, 'Medicare');
+
+    await userEvent.click(canvas.getByRole('button', { name: /^add$/i }));
+
+    await expect(args.onChange).toHaveBeenCalledWith(['Cash', 'Visa', 'Medicare']);
+  },
+};
+
+export const RemoveAnEntry: Story = {
+  name: 'Interaction — remove an entry',
+  args: {
+    label: 'Services Offered',
+    values: ['Cleaning', 'Whitening', 'Braces'],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const removeButtons = canvas.getAllByRole('button', { name: /remove/i });
+    await userEvent.click(removeButtons[1]);
+    await expect(args.onChange).toHaveBeenCalledWith(['Cleaning', 'Braces']);
+  },
+};
+
+export const DuplicateBlocked: Story = {
+  name: 'Interaction — duplicates blocked (case-insensitive)',
+  args: {
+    label: 'Services Offered',
+    values: ['Cleaning'],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /add new/i }));
+    const input = await canvas.findByLabelText(/add services offered/i);
+    await userEvent.type(input, 'cleaning{Enter}');
+    await expect(args.onChange).not.toHaveBeenCalled();
+  },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ width: 480 }}>
+      <Stack>
+        <div>
+          <SectionLabel>Sizes</SectionLabel>
+          <Stack gap="var(--gap-lg)">
+            <Controlled
+              label="Small"
+              size="sm"
+              placeholder="Enter service"
+              values={['Cleaning']}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="Medium (default)"
+              size="md"
+              placeholder="Enter service"
+              values={['Cleaning', 'Whitening']}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="Large"
+              size="lg"
+              placeholder="Enter service"
+              values={['Cleaning']}
+              onChange={() => {}}
+            />
+          </Stack>
+        </div>
+
+        <div>
+          <SectionLabel>States</SectionLabel>
+          <Stack gap="var(--gap-lg)">
+            <Controlled
+              label="Empty"
+              emptyLabel="No services added yet."
+              placeholder="Enter service"
+              values={[]}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="With helper text"
+              helperText="Press Enter to add; Escape to cancel."
+              placeholder="Enter service"
+              values={['Cleaning']}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="Disabled"
+              disabled
+              values={['Cleaning', 'Whitening']}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="Max 3 items"
+              maxItems={3}
+              values={['A', 'B', 'C']}
+              onChange={() => {}}
+              helperText="Add button hides when limit is reached."
+            />
+          </Stack>
+        </div>
+      </Stack>
+    </div>
+  ),
+};

--- a/components/ui/AddableTextList/AddableTextList.tsx
+++ b/components/ui/AddableTextList/AddableTextList.tsx
@@ -1,0 +1,196 @@
+import { useRef, useState, type KeyboardEvent } from 'react';
+import { Icon } from '@iconify/react';
+import { bdsClass } from '../../utils';
+import { Button, type ButtonSize } from '../Button';
+import { Tag, type TagSize } from '../Tag';
+import { TextInput, type TextInputSize } from '../TextInput';
+import './AddableTextList.css';
+
+export type AddableTextListSize = 'sm' | 'md' | 'lg';
+
+export interface AddableTextListProps {
+  /** Current list of values */
+  values: string[];
+  /** Called when values change (add / remove) */
+  onChange: (next: string[]) => void;
+  /** Optional field label */
+  label?: string;
+  /** Helper text below the list */
+  helperText?: string;
+  /** Placeholder shown in the reveal input */
+  placeholder?: string;
+  /** Text on the reveal button */
+  addLabel?: string;
+  /** Text shown when list is empty (and input is not revealed) */
+  emptyLabel?: string;
+  /** Size for input, button, and tags */
+  size?: AddableTextListSize;
+  /** Hide all controls */
+  disabled?: boolean;
+  /** Maximum number of entries */
+  maxItems?: number;
+  /** Additional className applied to root */
+  className?: string;
+  /** Block duplicate values (case-insensitive) */
+  allowDuplicates?: boolean;
+}
+
+const TAG_SIZE: Record<AddableTextListSize, TagSize> = { sm: 'sm', md: 'md', lg: 'md' };
+const BUTTON_SIZE: Record<AddableTextListSize, ButtonSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+const INPUT_SIZE: Record<AddableTextListSize, TextInputSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+
+/**
+ * AddableTextList — list of text values with a reveal-on-click add pattern.
+ *
+ * The input is hidden until the user clicks the "Add new" button. Pressing
+ * Enter commits the value, Escape cancels. Existing values render as
+ * removable Tags.
+ *
+ * @example
+ * ```tsx
+ * <AddableTextList
+ *   label="Services Offered"
+ *   values={services}
+ *   onChange={setServices}
+ *   placeholder="e.g. Dental cleaning"
+ * />
+ * ```
+ */
+export function AddableTextList({
+  values,
+  onChange,
+  label,
+  helperText,
+  placeholder,
+  addLabel = 'Add New',
+  emptyLabel,
+  size = 'md',
+  disabled = false,
+  maxItems,
+  className,
+  allowDuplicates = false,
+}: AddableTextListProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const atLimit = typeof maxItems === 'number' && values.length >= maxItems;
+
+  const reveal = () => {
+    setDraft('');
+    setIsEditing(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const cancel = () => {
+    setDraft('');
+    setIsEditing(false);
+  };
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      cancel();
+      return;
+    }
+    if (!allowDuplicates && values.some((v) => v.toLowerCase() === trimmed.toLowerCase())) {
+      cancel();
+      return;
+    }
+    onChange([...values, trimmed]);
+    setDraft('');
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const remove = (index: number) => {
+    onChange(values.filter((_, i) => i !== index));
+  };
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
+
+  const showEmpty = values.length === 0 && !isEditing && emptyLabel;
+
+  return (
+    <div className={bdsClass('bds-addable-text-list', className)}>
+      {label && <span className="bds-addable-text-list__label">{label}</span>}
+
+      {values.length > 0 && (
+        <div className="bds-addable-text-list__items" role="list">
+          {values.map((value, index) => (
+            <Tag
+              key={`${index}-${value}`}
+              size={TAG_SIZE[size]}
+              onRemove={disabled ? undefined : () => remove(index)}
+              role="listitem"
+            >
+              {value}
+            </Tag>
+          ))}
+        </div>
+      )}
+
+      {showEmpty && <span className="bds-addable-text-list__empty">{emptyLabel}</span>}
+
+      {!disabled && isEditing && !atLimit && (
+        <div className="bds-addable-text-list__input-row">
+          <div className="bds-addable-text-list__input">
+            <TextInput
+              ref={inputRef}
+              size={INPUT_SIZE[size]}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={handleKey}
+              onBlur={() => {
+                if (!draft.trim()) cancel();
+              }}
+              placeholder={placeholder}
+              aria-label={label ? `Add ${label}` : 'Add item'}
+              fullWidth
+            />
+          </div>
+          <Button
+            size={BUTTON_SIZE[size]}
+            variant="primary"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={commit}
+          >
+            Add
+          </Button>
+          <Button
+            size={BUTTON_SIZE[size]}
+            variant="ghost"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={cancel}
+          >
+            Cancel
+          </Button>
+        </div>
+      )}
+
+      {!disabled && !isEditing && !atLimit && (
+        <div>
+          <Button
+            size={BUTTON_SIZE[size]}
+            variant="outline"
+            onClick={reveal}
+          >
+            <Icon icon="ph:plus" />
+            {addLabel}
+          </Button>
+        </div>
+      )}
+
+      {helperText && <span className="bds-addable-text-list__helper">{helperText}</span>}
+    </div>
+  );
+}
+
+export default AddableTextList;

--- a/components/ui/AddableTextList/index.ts
+++ b/components/ui/AddableTextList/index.ts
@@ -1,0 +1,2 @@
+export { AddableTextList } from './AddableTextList';
+export type { AddableTextListProps, AddableTextListSize } from './AddableTextList';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,6 +1,7 @@
 // UI Components
 export * from './Accordion';
 export * from './ActivityTimeline';
+export * from './AddableTextList';
 export * from './AddressInput';
 export * from './AnimatedIcon';
 export * from './AlertBanner';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Brik Design System - React component library with Webflow-synced design tokens",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- New `AddableTextList` component — reveal-on-click text entry pattern for lightweight list capture.
- Composes existing primitives (TextInput + Button + Tag) — no new visual tokens.
- Release bump to **v0.1.5** included.

## Why
Portal Intel tab is adding Billing & Services + Software cards that need a simple \"Add new → text input → Enter\" UX. Future-compatible with MultiSelect (same `string[]` data shape) once vertical-specific taxonomies exist.

## Behavior
- **Enter** commits the trimmed value and keeps the input open for rapid entry.
- **Escape** / blur-on-empty cancels.
- Duplicates blocked case-insensitively (override with `allowDuplicates`).
- `maxItems` hides the Add button at the limit.

## Stories
- Playground, Empty, Variants (sizes/states/limit), and three interaction tests (add, remove, duplicate-blocked).

## Test plan
- [ ] Visual: Storybook → Components/Form/addable-text-list → check all sizes render on token grid
- [ ] Interaction: add → enter → adds tag, clears input, keeps focus
- [ ] Interaction: Escape cancels, blur-on-empty cancels
- [ ] Interaction: duplicate (case-insensitive) rejected silently
- [ ] Chromatic diff clean (run `npm run chromatic` after merge)
- [ ] After merge: `npm publish` from main → portal updates to `@brikdesigns/bds@0.1.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)