### PR TITLE
feat(sheet): header composition + read/edit mode footers

### DIFF
--- a/components/icons.ts
+++ b/components/icons.ts
@@ -3,6 +3,7 @@
 // Render: <Icon icon={X} />
 
 export const X = 'ph:x';
+export const XBold = 'ph:x-bold';
 export const Plus = 'ph:plus';
 export const Minus = 'ph:minus';
 export const CaretDown = 'ph:caret-down';
@@ -20,6 +21,7 @@ export const Spinner = 'ph:spinner';
 export const CircleX = 'ph:x-circle';
 // Navigation / general
 export const ArrowLeft = 'ph:arrow-left';
+export const ArrowLeftBold = 'ph:arrow-left-bold';
 export const ArrowRight = 'ph:arrow-right';
 export const ArrowUp = 'ph:arrow-up';
 export const ArrowDown = 'ph:arrow-down';

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -69,9 +69,25 @@
 
 .bds-sheet__header-top {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   width: 100%;
+  gap: var(--gap-md);
+}
+
+.bds-sheet__header-lead {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--gap-md);
+  min-width: 0;
+  flex: 1;
+}
+
+.bds-sheet__titles {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  min-width: 0;
 }
 
 /* ─── Title (matches Modal) ─────────────────────────────────── */
@@ -85,16 +101,24 @@
   margin: 0;
 }
 
+.bds-sheet__subtitle {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
 /* ─── Close button (matches Modal) ──────────────────────────── */
 
 .bds-sheet__close {
   background: none;
   border: none;
   font-size: var(--icon-md);
-  line-height: var(--font-line-height-tight);
+  line-height: 1;
   cursor: pointer;
-  padding: 0 var(--padding-md) var(--padding-md);
-  margin-right: calc(-1 * var(--padding-md));
+  padding: var(--padding-xs);
+  margin: calc(-1 * var(--padding-xs));
   color: var(--text-primary);
   opacity: 0.6;
   transition: opacity 0.2s;
@@ -102,6 +126,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 .bds-sheet__close:hover {
@@ -201,15 +226,27 @@
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: var(--padding-xs);
+  margin: calc(-1 * var(--padding-xs));
   display: flex;
   align-items: center;
+  justify-content: center;
   color: var(--text-primary);
+  font-size: var(--icon-md);
+  line-height: 1;
+  border-radius: var(--border-radius-md);
   opacity: 0.6;
   transition: opacity 0.2s;
+  flex-shrink: 0;
 }
 
 .bds-sheet__back-btn:hover {
+  opacity: 1;
+}
+
+.bds-sheet__back-btn:focus-visible {
+  outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
+  outline-offset: 2px;
   opacity: 1;
 }
 

--- a/components/ui/Sheet/Sheet.mdx
+++ b/components/ui/Sheet/Sheet.mdx
@@ -7,6 +7,11 @@ import * as Stories from './Sheet.stories';
 
 Sliding panel overlay anchored to a screen edge. Use for detail views, forms, and secondary content that shouldn't replace the current page.
 
+Sheets support two modes that map to the most common UX pattern across the product suite:
+
+- **`read`** — view-only display. Footer (if shown) renders `[Close] [Edit]`.
+- **`edit`** — active form state. Footer renders `[Cancel] [Save]`.
+
 ---
 
 ## Playground
@@ -25,11 +30,68 @@ Right, left, bottom, wide, and no-title configurations.
 - **`left`** — Navigation or sidebar panels
 - **`bottom`** — Mobile-friendly bottom sheet
 
+## Header
+
+The header composes `title`, `subtitle`, and an optional `onBack` button for nested flows.
+
+<Canvas of={Stories.Header} />
+
+- Use **`subtitle`** for record state, timestamps, or short context.
+- Use **`onBack`** when a sheet is pushed on top of another sheet (e.g. a related-entity drilldown). Pair with your sheet stack controller.
+- The close icon uses the Phosphor **bold** weight so it reads at a glance.
+
+## Read mode
+
+Read mode displays data. When `onEdit` is supplied, the footer auto-renders a primary **Edit** action alongside a secondary **Close**.
+
+<Canvas of={Stories.ReadMode} />
+
+Don't put the Edit button in the body. It belongs in the footer where the user expects primary actions.
+
+## Edit mode
+
+Edit mode is the active form state. The footer auto-renders `[Cancel] [Save]`. Pass `saveLoading` while the save promise is in flight and `saveDisabled` when the form is invalid.
+
+<Canvas of={Stories.EditMode} />
+
+## Read ↔ Edit toggle
+
+The canonical pattern: open in `read`, let the user click Edit to switch to `edit`, then Save / Cancel returns to `read`.
+
+<Canvas of={Stories.ReadEditToggle} />
+
+This mirrors the renew-pms convention. `brik-client-portal` should adopt the same pattern — no more edit buttons floating inside the sheet body.
+
+## Read-only floating
+
+Pure read content that doesn't require an action can skip the backdrop and render as a floating popover with `variant="floating"`. Skip the footer entirely.
+
+<Canvas of={Stories.ReadOnlyFloating} />
+
 ## Patterns
 
-Detail panel with actions and mobile bottom sheet.
+Custom footer (overrides mode) and mobile bottom sheet.
 
 <Canvas of={Stories.Patterns} />
+
+A custom `footer` always wins over mode-driven auto-footer. Use it for non-standard action sets (e.g. Archive / Cancel / Save).
+
+---
+
+## When to use which treatment
+
+| Scenario | Variant | Footer |
+|---|---|---|
+| Read-only metadata, no CTA | `floating` | none |
+| Read detail with edit capability | `default`, `mode="read"` + `onEdit` | `[Close] [Edit]` (auto) |
+| Active form / edit workflow | `default`, `mode="edit"` + `onSave` | `[Cancel] [Save]` (auto) |
+| Non-standard action set | any | custom `footer` |
+
+Rules:
+
+- Don't render Edit as a button in the body. Use `mode="read"` + `onEdit`.
+- Read-only sheets without any action don't need a footer — and often don't need a backdrop; prefer `variant="floating"`.
+- Edit mode always has a footer.
 
 ---
 
@@ -42,16 +104,26 @@ Detail panel with actions and mobile bottom sheet.
 ## Usage
 
 ```tsx
-import { Sheet } from '@brik/bds';
+import { Sheet } from '@brikdesigns/bds';
 import { useState } from 'react';
 
-const [isOpen, setIsOpen] = useState(false);
+function CompanySheet() {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<'read' | 'edit'>('read');
 
-<Sheet
-  isOpen={isOpen}
-  onClose={() => setIsOpen(false)}
-  title="Company details"
->
-  <p>Detail content here...</p>
-</Sheet>
+  return (
+    <Sheet
+      isOpen={open}
+      onClose={() => setOpen(false)}
+      title="Brik Designs"
+      subtitle="Active · Updated 2 days ago"
+      mode={mode}
+      onEdit={() => setMode('edit')}
+      onSave={async () => { await save(); setMode('read'); }}
+      onCancel={() => setMode('read')}
+    >
+      {mode === 'read' ? <ReadOnlyFields /> : <EditFormFields />}
+    </Sheet>
+  );
+}
 ```

--- a/components/ui/Sheet/Sheet.stories.tsx
+++ b/components/ui/Sheet/Sheet.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Sheet } from './Sheet';
 import { Button } from '../Button';
+import { TextInput } from '../TextInput';
 
 const meta: Meta<typeof Sheet> = {
   title: 'Displays/Overlay/sheet',
@@ -9,7 +10,10 @@ const meta: Meta<typeof Sheet> = {
   parameters: { layout: 'centered' },
   argTypes: {
     side: { control: 'select', options: ['right', 'left', 'bottom'] },
+    variant: { control: 'select', options: ['default', 'floating'] },
+    mode: { control: 'select', options: [undefined, 'read', 'edit'] },
     title: { control: 'text' },
+    subtitle: { control: 'text' },
     width: { control: 'text' },
     closeOnBackdrop: { control: 'boolean' },
     closeOnEscape: { control: 'boolean' },
@@ -47,6 +51,37 @@ const SampleContent = () => (
   </div>
 );
 
+/* ─── Read-only detail view (faux) ───────────────────────────── */
+
+const ReadOnlyFields = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
+    {[
+      { label: 'Company', value: 'Brik Designs' },
+      { label: 'Owner', value: 'Nick Stanerson' },
+      { label: 'Industry', value: 'Design & Engineering' },
+      { label: 'Status', value: 'Active' },
+    ].map((field) => (
+      <div key={field.label} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xs)' }}>
+        <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          {field.label}
+        </span>
+        <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)', color: 'var(--text-primary)' }}>
+          {field.value}
+        </span>
+      </div>
+    ))}
+  </div>
+);
+
+const EditFormFields = ({ onChange }: { onChange?: (k: string, v: string) => void }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
+    <TextInput label="Company" defaultValue="Brik Designs" onChange={(e) => onChange?.('company', e.target.value)} />
+    <TextInput label="Owner" defaultValue="Nick Stanerson" onChange={(e) => onChange?.('owner', e.target.value)} />
+    <TextInput label="Industry" defaultValue="Design & Engineering" onChange={(e) => onChange?.('industry', e.target.value)} />
+    <TextInput label="Status" defaultValue="Active" onChange={(e) => onChange?.('status', e.target.value)} />
+  </div>
+);
+
 /* ─── Playground ─────────────────────────────────────────────── */
 
 export const Playground: Story = {
@@ -66,6 +101,7 @@ export const Playground: Story = {
     onClose: () => {},
     children: null,
     title: 'Details',
+    subtitle: 'Metadata for this company record',
     side: 'right',
     width: '400px',
   },
@@ -135,6 +171,179 @@ export const Variants: Story = {
   },
 };
 
+/* ─── Header (title, subtitle, back button) ──────────────────── */
+
+export const Header: Story = {
+  render: () => {
+    const [openId, setOpenId] = useState<string | null>(null);
+    const open = (id: string) => setOpenId(id);
+    const close = () => setOpenId(null);
+
+    return (
+      <Stack>
+        <SectionLabel>Title only</SectionLabel>
+        <Row>
+          <div>
+            <Button onClick={() => open('title')}>Open</Button>
+            <Sheet isOpen={openId === 'title'} onClose={close} title="Company details">
+              <SampleContent />
+            </Sheet>
+          </div>
+        </Row>
+
+        <SectionLabel>Title + subtitle</SectionLabel>
+        <Row>
+          <div>
+            <Button onClick={() => open('subtitle')}>Open</Button>
+            <Sheet
+              isOpen={openId === 'subtitle'}
+              onClose={close}
+              title="Company details"
+              subtitle="Metadata for this company record"
+            >
+              <SampleContent />
+            </Sheet>
+          </div>
+        </Row>
+
+        <SectionLabel>With back button (nested flow)</SectionLabel>
+        <Row>
+          <div>
+            <Button onClick={() => open('back')}>Open nested</Button>
+            <Sheet
+              isOpen={openId === 'back'}
+              onClose={close}
+              title="Contact"
+              subtitle="Opened from Company details"
+              onBack={close}
+            >
+              <SampleContent />
+            </Sheet>
+          </div>
+        </Row>
+      </Stack>
+    );
+  },
+};
+
+/* ─── Read mode — footer renders [Close] [Edit] ──────────────── */
+
+export const ReadMode: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>View company</Button>
+        <Sheet
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          title="Brik Designs"
+          subtitle="Active · Updated 2 days ago"
+          mode="read"
+          onEdit={() => alert('Switch to edit mode')}
+        >
+          <ReadOnlyFields />
+        </Sheet>
+      </>
+    );
+  },
+};
+
+/* ─── Edit mode — footer renders [Cancel] [Save] ─────────────── */
+
+export const EditMode: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const handleSave = () => {
+      setSaving(true);
+      setTimeout(() => {
+        setSaving(false);
+        setOpen(false);
+      }, 900);
+    };
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Edit company</Button>
+        <Sheet
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          title="Edit company"
+          subtitle="Update record details"
+          mode="edit"
+          onSave={handleSave}
+          saveLoading={saving}
+        >
+          <EditFormFields />
+        </Sheet>
+      </>
+    );
+  },
+};
+
+/* ─── Read ↔ Edit toggle — the canonical pattern ─────────────── */
+
+export const ReadEditToggle: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const [mode, setMode] = useState<'read' | 'edit'>('read');
+    const [saving, setSaving] = useState(false);
+
+    const handleOpen = () => {
+      setMode('read');
+      setOpen(true);
+    };
+    const handleSave = () => {
+      setSaving(true);
+      setTimeout(() => {
+        setSaving(false);
+        setMode('read');
+      }, 700);
+    };
+
+    return (
+      <>
+        <Button onClick={handleOpen}>Open company</Button>
+        <Sheet
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          title="Brik Designs"
+          subtitle={mode === 'read' ? 'Active · Updated 2 days ago' : 'Editing record'}
+          mode={mode}
+          onEdit={() => setMode('edit')}
+          onSave={handleSave}
+          onCancel={() => setMode('read')}
+          saveLoading={saving}
+        >
+          {mode === 'read' ? <ReadOnlyFields /> : <EditFormFields />}
+        </Sheet>
+      </>
+    );
+  },
+};
+
+/* ─── Read-only floating (popover, no footer) ────────────────── */
+
+export const ReadOnlyFloating: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Show info</Button>
+        <Sheet
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          title="Quick info"
+          subtitle="Read-only — no CTA needed"
+          variant="floating"
+        >
+          <SampleContent />
+        </Sheet>
+      </>
+    );
+  },
+};
+
 /* ─── Patterns ───────────────────────────────────────────────── */
 
 export const Patterns: Story = {
@@ -145,18 +354,23 @@ export const Patterns: Story = {
 
     return (
       <Stack>
-        <SectionLabel>Detail panel with actions</SectionLabel>
+        <SectionLabel>Custom footer (overrides mode)</SectionLabel>
         <Row>
           <div>
-            <Button onClick={() => open('detail')}>View details</Button>
-            <Sheet isOpen={openId === 'detail'} onClose={close} title="Company details">
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
-                <SampleContent />
-                <div style={{ display: 'flex', gap: 'var(--gap-md)', justifyContent: 'flex-end' }}>
+            <Button onClick={() => open('custom')}>View details</Button>
+            <Sheet
+              isOpen={openId === 'custom'}
+              onClose={close}
+              title="Company details"
+              footer={(
+                <>
+                  <Button variant="danger-ghost" onClick={close}>Archive</Button>
                   <Button variant="ghost" onClick={close}>Cancel</Button>
                   <Button variant="primary" onClick={close}>Save</Button>
-                </div>
-              </div>
+                </>
+              )}
+            >
+              <SampleContent />
             </Sheet>
           </div>
         </Row>

--- a/components/ui/Sheet/Sheet.tsx
+++ b/components/ui/Sheet/Sheet.tsx
@@ -1,7 +1,8 @@
 import { type ReactNode, type CSSProperties, useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Icon } from '@iconify/react';
-import { X } from '../../icons';
+import { XBold, ArrowLeftBold, Pen } from '../../icons';
+import { Button } from '../Button';
 import { bdsClass } from '../../utils';
 import './Sheet.css';
 
@@ -14,6 +15,7 @@ export interface SheetTab {
 }
 
 export type SheetVariant = 'default' | 'floating';
+export type SheetMode = 'read' | 'edit';
 
 export interface SheetProps {
   isOpen: boolean;
@@ -21,6 +23,8 @@ export interface SheetProps {
   children?: ReactNode;
   side?: SheetSide;
   title?: ReactNode;
+  /** Optional subtitle rendered under the title */
+  subtitle?: ReactNode;
   /** Width for left/right sheets (default: 400px) */
   width?: string;
   /**
@@ -32,7 +36,35 @@ export interface SheetProps {
   closeOnBackdrop?: boolean;
   closeOnEscape?: boolean;
   showCloseButton?: boolean;
-  /** Optional footer pinned to bottom of sheet */
+  /**
+   * When set, renders a back button in the header for nested sheet navigation.
+   */
+  onBack?: () => void;
+  /**
+   * Sheet mode. When set, the footer auto-renders mode-appropriate actions
+   * unless a custom `footer` is provided.
+   * - `read` with `onEdit` → renders `[Close] [Edit]` (primary Edit)
+   * - `edit` → renders `[Cancel] [Save]` (primary Save)
+   */
+  mode?: SheetMode;
+  /** Triggered from the primary action in read mode (switch to edit) */
+  onEdit?: () => void;
+  /** Triggered from the primary action in edit mode (commit changes) */
+  onSave?: () => void;
+  /** Triggered from the secondary action in edit mode. Falls back to `onClose`. */
+  onCancel?: () => void;
+  editLabel?: string;
+  saveLabel?: string;
+  cancelLabel?: string;
+  closeLabel?: string;
+  /** Disable the save button (e.g. while form is invalid) */
+  saveDisabled?: boolean;
+  /** Show loading state on the save button */
+  saveLoading?: boolean;
+  /**
+   * Custom footer. When provided, overrides mode-driven auto-footer.
+   * Use this for non-standard action sets.
+   */
   footer?: ReactNode;
   /** Optional tabs rendered below the header. When provided, children is ignored. */
   tabs?: SheetTab[];
@@ -45,11 +77,10 @@ export interface SheetProps {
 /**
  * Sheet — sliding panel overlay for contextual content.
  *
- * Width is a runtime value passed via inline style since it's user-configurable.
- * Close icon matches Modal dismiss treatment (FontAwesome xmark).
- *
- * Tab variant: pass `tabs` array to render a tab bar below the header.
- * Each tab's content replaces `children` in the body area.
+ * Read / edit mode: pass `mode="read"` with `onEdit` for a view-only sheet that
+ * exposes a primary Edit action in the footer. Pass `mode="edit"` with `onSave`
+ * to switch into form state with Cancel / Save actions. Custom `footer` always
+ * wins when supplied.
  */
 export function Sheet({
   isOpen,
@@ -57,11 +88,23 @@ export function Sheet({
   children,
   side = 'right',
   title,
+  subtitle,
   width = '400px',
   variant = 'default',
   closeOnBackdrop = true,
   closeOnEscape = true,
   showCloseButton = true,
+  onBack,
+  mode,
+  onEdit,
+  onSave,
+  onCancel,
+  editLabel = 'Edit',
+  saveLabel = 'Save',
+  cancelLabel = 'Cancel',
+  closeLabel = 'Close',
+  saveDisabled,
+  saveLoading,
   footer,
   tabs,
   activeTab: controlledTab,
@@ -108,11 +151,46 @@ export function Sheet({
     }
   };
 
-  // Width is runtime-configurable, so it stays as inline style
   const widthStyle: CSSProperties | undefined =
     side !== 'bottom' ? { width } : undefined;
 
   const activeTabContent = tabs?.find((t) => t.id === activeTab)?.content;
+
+  const resolvedFooter = (() => {
+    if (footer !== undefined) return footer;
+    if (mode === 'edit' && onSave) {
+      return (
+        <>
+          <Button variant="ghost" onClick={onCancel ?? onClose}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant="primary"
+            onClick={onSave}
+            disabled={saveDisabled}
+            loading={saveLoading}
+          >
+            {saveLabel}
+          </Button>
+        </>
+      );
+    }
+    if (mode === 'read' && onEdit) {
+      return (
+        <>
+          <Button variant="ghost" onClick={onClose}>
+            {closeLabel}
+          </Button>
+          <Button variant="primary" onClick={onEdit} iconBefore={<Icon icon={Pen} />}>
+            {editLabel}
+          </Button>
+        </>
+      );
+    }
+    return null;
+  })();
+
+  const hasHeaderContent = title || subtitle || onBack || showCloseButton;
 
   const sheet = (
     <>
@@ -123,10 +201,25 @@ export function Sheet({
         aria-modal={!isFloating}
         style={widthStyle}
       >
-        {(title || showCloseButton) && (
+        {hasHeaderContent && (
           <div className={bdsClass('bds-sheet__header', tabs ? 'bds-sheet__header--has-tabs' : '')}>
             <div className="bds-sheet__header-top">
-              {title && <h2 className="bds-sheet__title">{title}</h2>}
+              <div className="bds-sheet__header-lead">
+                {onBack && (
+                  <button
+                    type="button"
+                    onClick={onBack}
+                    className="bds-sheet__back-btn"
+                    aria-label="Back"
+                  >
+                    <Icon icon={ArrowLeftBold} />
+                  </button>
+                )}
+                <div className="bds-sheet__titles">
+                  {title && <h2 className="bds-sheet__title">{title}</h2>}
+                  {subtitle && <p className="bds-sheet__subtitle">{subtitle}</p>}
+                </div>
+              </div>
               {showCloseButton && (
                 <button
                   type="button"
@@ -134,7 +227,7 @@ export function Sheet({
                   className="bds-sheet__close"
                   aria-label="Close"
                 >
-                  <Icon icon={X} />
+                  <Icon icon={XBold} />
                 </button>
               )}
             </div>
@@ -162,7 +255,7 @@ export function Sheet({
         <div className="bds-sheet__body">
           {tabs ? activeTabContent : children}
         </div>
-        {footer && <div className="bds-sheet__footer">{footer}</div>}
+        {resolvedFooter && <div className="bds-sheet__footer">{resolvedFooter}</div>}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

- **Header**: adds `subtitle`, `onBack` (back button for nested flows), and thicker dismiss icon (`ph:x-bold`). Back button uses `ph:arrow-left-bold` with matching container to the close button.
- **Mode**: `mode="read"` + `onEdit` auto-renders `[Close] [Edit]` footer; `mode="edit"` + `onSave` auto-renders `[Cancel] [Save]` with `saveLoading` / `saveDisabled`. Custom `footer` still wins.
- **Stories + MDX**: `Header`, `ReadMode`, `EditMode`, `ReadEditToggle` (canonical), `ReadOnlyFloating`; MDX documents the pattern and calls out the body-level edit button antipattern.

Aligns Sheet with the read/edit pattern already used in renew-pms so brik-client-portal can standardize against it in a follow-up sweep.

## Test plan

- [x] Typecheck (`tsc --noEmit`) — pass
- [x] Token lint — pass (0 errors, 0 warnings in Sheet files)
- [x] Full validation suite (grid, theme, typecheck, Storybook build) — all 5 pass
- [ ] Visual check — [Header](http://localhost:6006/?path=/story/displays-overlay-sheet--header), [ReadEditToggle](http://localhost:6006/?path=/story/displays-overlay-sheet--read-edit-toggle), [ReadMode](http://localhost:6006/?path=/story/displays-overlay-sheet--read-mode), [EditMode](http://localhost:6006/?path=/story/displays-overlay-sheet--edit-mode), [ReadOnlyFloating](http://localhost:6006/?path=/story/displays-overlay-sheet--read-only-floating)

## Follow-up (out of scope)

1. Version bump + dist rebuild (release chore PR)
2. brik-client-portal sweep: move body-level edit buttons into `mode="read"` + `onEdit`, flag read-only sheets for `variant="floating"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)