### PR TITLE
feat(sheet): plumb headless mode + subtitle + onBack through SheetConfig

### DIFF
--- a/components/providers/SheetStackProvider.tsx
+++ b/components/providers/SheetStackProvider.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   type ReactNode,
 } from 'react';
-import type { SheetVariant, SheetTab } from '../ui/Sheet';
+import type { SheetVariant, SheetTab, SheetMode } from '../ui/Sheet';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -51,12 +51,32 @@ const SheetStackContext = createContext<SheetStackContextValue | undefined>(unde
 /** Configuration set by headless sheet components via useConfigureSheet */
 export interface SheetConfig {
   title?: ReactNode;
+  /** Subtitle rendered under the title */
+  subtitle?: ReactNode;
   tabs?: SheetTab[];
   activeTab?: string;
   onTabChange?: (id: string) => void;
+  /**
+   * Custom footer. When provided, overrides the mode-driven auto-footer.
+   */
   footer?: ReactNode;
   /** Override body content (e.g. skeleton while loading) */
   body?: ReactNode;
+  /**
+   * Sheet mode — drives auto-footer when no custom `footer` is set.
+   * - `read` with `onEdit` → `[Close] [Edit]`
+   * - `edit` with `onSave` → `[Cancel] [Save]`
+   */
+  mode?: SheetMode;
+  onEdit?: () => void;
+  onSave?: () => void;
+  onCancel?: () => void;
+  editLabel?: string;
+  saveLabel?: string;
+  cancelLabel?: string;
+  closeLabel?: string;
+  saveDisabled?: boolean;
+  saveLoading?: boolean;
 }
 
 interface SheetConfigContextValue {

--- a/components/providers/SheetStackRenderer.tsx
+++ b/components/providers/SheetStackRenderer.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { type ReactNode, type CSSProperties } from 'react';
-import { Icon } from '@iconify/react';
+import { type ReactNode } from 'react';
 import { Sheet } from '../ui/Sheet';
 import { useSheetStack, useSheetConfig, type SheetFrame } from './SheetStackProvider';
 import { bdsClass } from '../utils';
@@ -33,25 +32,6 @@ export interface SheetStackRendererProps {
   globalFrameProps?: Record<string, unknown>;
 }
 
-// ─── Styles ─────────────────────────────────────────────────────────────────
-
-const backBtnStyle: CSSProperties = {
-  background: 'none',
-  border: 'none',
-  cursor: 'pointer',
-  padding: 0,
-  display: 'flex',
-  alignItems: 'center',
-  opacity: 0.6,
-  transition: 'opacity 0.2s',
-};
-
-const headerRowStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 'var(--gap-sm)',
-};
-
 // ─── Component ──────────────────────────────────────────────────────────────
 
 /**
@@ -63,12 +43,17 @@ const headerRowStyle: CSSProperties = {
  * The `renderFrame` callback maps frame types to your app's sheet components.
  * BDS doesn't know about your entity types — the app defines the mapping.
  *
+ * Headless sheet components call `useConfigureSheet()` to push their
+ * body, title, subtitle, tabs, footer, or read/edit mode up to this
+ * renderer. When the stack is deep (>1 frame), a back button auto-renders
+ * in the header to pop back to the previous frame.
+ *
  * @example
  * ```tsx
  * <SheetStackRenderer
  *   renderFrame={(frame, ctx) => {
  *     const Component = sheetComponents[frame.type];
- *     return <Component {...frame.props} onClose={ctx.closeAll} onNavigate={ctx.pushSheet} />;
+ *     return <Component {...frame.props} onNavigate={ctx.pushSheet} />;
  *   }}
  * />
  * ```
@@ -91,25 +76,7 @@ export function SheetStackRenderer({ renderFrame, width = '600px', globalFramePr
   };
 
   // Resolve title: prefer headless config title, fall back to frame title
-  const baseTitle = config.title ?? topFrame.title ?? topFrame.type;
-
-  // Build the title — includes back arrow when stack is deep
-  const titleContent = isDeep ? (
-    <span style={headerRowStyle}>
-      <button
-        type="button"
-        style={backBtnStyle}
-        onClick={back}
-        aria-label="Back"
-        className="bds-sheet__back-btn"
-      >
-        <Icon icon="ph:arrow-left-bold" />
-      </button>
-      {baseTitle}
-    </span>
-  ) : (
-    baseTitle
-  );
+  const resolvedTitle = config.title ?? topFrame.title ?? topFrame.type;
 
   // Animation class for frame content
   const frameClass = bdsClass(
@@ -129,7 +96,9 @@ export function SheetStackRenderer({ renderFrame, width = '600px', globalFramePr
       <Sheet
         isOpen
         onClose={closeAll}
-        title={titleContent}
+        title={resolvedTitle}
+        subtitle={config.subtitle}
+        onBack={isDeep ? back : undefined}
         width={width}
         variant={topFrame.variant}
         closeOnEscape
@@ -137,6 +106,16 @@ export function SheetStackRenderer({ renderFrame, width = '600px', globalFramePr
         activeTab={config.activeTab}
         onTabChange={config.onTabChange}
         footer={config.footer}
+        mode={config.mode}
+        onEdit={config.onEdit}
+        onSave={config.onSave}
+        onCancel={config.onCancel}
+        editLabel={config.editLabel}
+        saveLabel={config.saveLabel}
+        cancelLabel={config.cancelLabel}
+        closeLabel={config.closeLabel}
+        saveDisabled={config.saveDisabled}
+        saveLoading={config.saveLoading}
       >
         <div className={frameClass} key={topFrame.key}>
           {config.body}

--- a/components/ui/Sheet/index.ts
+++ b/components/ui/Sheet/index.ts
@@ -1,1 +1,1 @@
-export { Sheet, type SheetProps, type SheetSide, type SheetTab, type SheetVariant } from './Sheet';
+export { Sheet, type SheetProps, type SheetSide, type SheetTab, type SheetVariant, type SheetMode } from './Sheet';


### PR DESCRIPTION
## Summary

Extends \`SheetConfig\` (used by \`useConfigureSheet\`) so headless consumers get the full Sheet API — not just \`title\` / \`tabs\` / \`footer\` / \`body\`.

**New \`SheetConfig\` fields (all optional):** \`subtitle\`, \`mode\`, \`onEdit\`, \`onSave\`, \`onCancel\`, \`editLabel\`, \`saveLabel\`, \`cancelLabel\`, \`closeLabel\`, \`saveDisabled\`, \`saveLoading\`.

\`SheetStackRenderer\` forwards all of those to \`<Sheet>\` and delegates back-button rendering to \`Sheet\`'s \`onBack\` prop (removes the inline back button it used to render in the title).

## Why

Portal (#138) had to compose its own \`[Close][Edit]\` / \`[Cancel][Save]\` footer Button JSX in a helper hook because \`useConfigureSheet\` only accepted \`footer: ReactNode\`. With this change, consumers can drop the manual JSX:

\`\`\`tsx
// Before — manual footer composition
configureSheet({ body, footer: editing ? <CancelSave/> : <CloseEdit/> });

// After — mode-driven auto-footer
configureSheet({ body, mode: editing ? 'edit' : 'read',
                 onEdit: startEdit, onSave: commit, onCancel: cancelEdit,
                 saveLoading: saving });
\`\`\`

Custom \`footer\` still wins when supplied, so this is fully additive.

## Test plan

- [x] Typecheck — pass
- [x] Token lint — pass
- [x] Full validation suite (token, grid, theme, typecheck, Storybook build) — all 5 pass
- [ ] Consumer simplification lands in brik-client-portal next

🤖 Generated with [Claude Code](https://claude.com/claude-code)