### PR TITLE
refactor(spacing): tighten ButtonGroup + Sheet footer gap to gap-md

### DIFF
--- a/components/ui/ButtonGroup/ButtonGroup.css
+++ b/components/ui/ButtonGroup/ButtonGroup.css
@@ -6,7 +6,7 @@
 .bds-button-group {
   display: inline-flex;
   align-items: center;
-  gap: var(--gap-lg);
+  gap: var(--gap-md);
   flex-wrap: wrap;
   box-sizing: border-box;
 }

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -184,7 +184,7 @@
 .bds-sheet__footer {
   padding: var(--padding-lg);
   display: flex;
-  gap: var(--gap-lg);
+  gap: var(--gap-md);
   justify-content: flex-end;
   flex-wrap: wrap;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

Drops the gap between buttons in both primitives from \`--gap-lg\` (16px) to \`--gap-md\` (8px). Button groupings now read as a single unit rather than spaced peers.

- [ButtonGroup.css:9](components/ui/ButtonGroup/ButtonGroup.css#L9) — \`gap-lg\` → \`gap-md\`
- [Sheet.css:163](components/ui/Sheet/Sheet.css#L163) \`.bds-sheet__footer\` — \`gap-lg\` → \`gap-md\`

Kept in lockstep so mixing them inside a shared footer row produces consistent spacing.

## Test plan

- [x] Full validation suite — all 5 pass
- [ ] Visual check on Sheet footer stories + ButtonGroup stories after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)