### PR TITLE
chore(release): v0.1.8 — tighten ButtonGroup + Sheet footer gap to gap-md

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -573,7 +573,7 @@
 .bds-sheet__footer {
   padding: var(--padding-lg);
   display: flex;
-  gap: var(--gap-lg);
+  gap: var(--gap-md);
   justify-content: flex-end;
   flex-wrap: wrap;
   flex-shrink: 0;
@@ -1833,7 +1833,7 @@
 .bds-button-group {
   display: inline-flex;
   align-items: center;
-  gap: var(--gap-lg);
+  gap: var(--gap-md);
   flex-wrap: wrap;
   box-sizing: border-box;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Brik Design System - React component library with Webflow-synced design tokens",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

- Bumps \`package.json\` to **0.1.8**
- Rebuilds \`dist/styles.css\` to ship the gap change from [bds#86](https://github.com/brikdesigns/brik-bds/pull/86)
- No API surface changes — visual only

Consumers run \`npm update @brikdesigns/bds\` after merge.

## Test plan

- [x] \`npm run build:lib\` — clean (only dist/styles.css rewrites, JS bundles identical since it's a pure CSS token swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)