### PR TITLE
fix(storybook): scope .sbdocs typography to exclude story canvas

### DIFF
--- a/.storybook/storybook-overrides.css
+++ b/.storybook/storybook-overrides.css
@@ -356,30 +356,40 @@ body[data-bds-dark="true"] #storybook-docs#storybook-docs .sbdocs-preview {
    theming experience.
    ============================================ */
 
-/* Docs headings — theme heading font + color */
-.sbdocs h1,
-.sbdocs h2,
-.sbdocs h3,
-.sbdocs h4 {
+/* Docs-chrome typography — MDX body content only.
+ *
+ * Story canvases render inside .sbdocs-preview > .docs-story. Those subtrees
+ * must NOT inherit docs-chrome colors/fonts, or any component using <p>, <li>,
+ * <h*>, or <a> with a custom color inside a Docs preview gets silently
+ * overridden (incl. !important). The :not() exclusions below keep the docs
+ * chrome themed without bleeding into rendered components.
+ *
+ * Regression covered by: Displays/Card/card-testimonial — Variants.
+ */
+
+.sbdocs h1:not(.sbdocs-preview *),
+.sbdocs h2:not(.sbdocs-preview *),
+.sbdocs h3:not(.sbdocs-preview *),
+.sbdocs h4:not(.sbdocs-preview *) {
   color: var(--text-primary) !important;
   font-family: var(--font-family-heading, inherit) !important;
 }
 
-/* Docs body text */
-.sbdocs p,
-.sbdocs li {
+.sbdocs p:not(.sbdocs-preview *),
+.sbdocs li:not(.sbdocs-preview *) {
   color: var(--text-secondary) !important;
   font-family: var(--font-family-body, inherit) !important;
 }
 
-/* Docs links — brand color (exclude code blocks, anchors, and button components) */
-.sbdocs a:not([class*="docblock"]):not([class*="anchor"]):not([class*="bds-button"]) {
+.sbdocs a:not([class*="docblock"]):not([class*="anchor"]):not([class*="bds-button"]):not(.sbdocs-preview *) {
   color: var(--text-brand-primary) !important;
 }
 
-/* Description / subtitle blocks */
-div[class*="Description"],
-div[class*="Subtitle"] {
+/* Description / subtitle blocks — scope to docs chrome only.
+ * Unscoped this would match any <div class="...Description..."> anywhere,
+ * including consumer components. */
+.sbdocs div[class*="Description"]:not(.sbdocs-preview *),
+.sbdocs div[class*="Subtitle"]:not(.sbdocs-preview *) {
   color: var(--text-secondary) !important;
 }
 


### PR DESCRIPTION
## Summary

The `.sbdocs p / li / h1–h4 / a` rules in `.storybook/storybook-overrides.css` applied to every descendant of `.sbdocs`, including components rendered inside `.sbdocs-preview > .docs-story`. This silently hijacked text colors on any component using `<p>`, `<h*>`, or `<a>` with a custom color in a Docs canvas — even across `!important`.

Two offending unscoped selectors — `div[class*="Description"]` and `div[class*="Subtitle"]` — could also match any consumer component whose class name happened to contain those substrings.

### What broke

Concrete example caught this: `CardTestimonial` on the brand variant uses `<p className="bds-card-testimonial__name">` with `color: var(--text-on-color-dark)` (white on brand surface). The docs-chrome rule `.sbdocs p { color: var(--text-secondary) !important }` won on specificity and the author name rendered near-invisible against the brand orange — only in the Docs view, not in Canvas.

### Fix

- Added `:not(.sbdocs-preview *)` to every docs-chrome typography selector so MDX body content stays themed but story previews keep their own component CSS.
- Scoped the `div[class*="Description"|Subtitle]` selectors under `.sbdocs` so they can't match consumer components globally.

### Scope

One file, one concern. No component or token changes. No behavior change in Canvas mode. Docs chrome typography is visually identical to before — the only diff is that story previews no longer inherit it.

## Test plan

- [ ] `npm run storybook` → open `Displays / Card / card-testimonial` in **Docs view** — verify the author name and role on brand-variant cards render white (was dim/invisible before this PR)
- [ ] Same story in **Canvas view** — unchanged (was already correct)
- [ ] `npm run storybook` → open `Components / *` docs pages — verify MDX body text (`<p>`, `<li>`), headings (`<h1>–<h4>`), and links still read themed (docs-chrome intent preserved)
- [ ] `npm run typecheck` — passes
- [ ] `npm run lint-tokens:grid` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)