### PR TITLE
feat(card)!: surface-primary default, new CardList, CardControl action align, semantic testimonial

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -12,15 +12,15 @@
 
 /* ─── Variants ───────────────────────────────────────────────── */
 
-.bds-card--default {
+.bds-card--outlined {
   background-color: var(--surface-primary);
-  border: none;
+  border: var(--border-width-md) solid var(--border-secondary);
   box-shadow: var(--box-shadow-none);
 }
 
-.bds-card--outlined {
-  background-color: var(--surface-secondary);
-  border: var(--border-width-md) solid var(--border-secondary);
+.bds-card--brand {
+  background-color: var(--surface-primary);
+  border: var(--border-width-md) solid var(--border-brand-primary);
   box-shadow: var(--box-shadow-none);
 }
 

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -21,8 +21,8 @@ All visual variants, padding sizes, interactive, and link modes.
 
 <Canvas of={Stories.Variants} />
 
-- **`default`** — No border or shadow
-- **`outlined`** — Subtle border, most common
+- **`outlined`** — Subtle secondary border (default)
+- **`brand`** — Primary-color border for emphasis
 - **`elevated`** — Shadow for visual prominence
 
 ## Patterns

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Card> = {
   component: Card,
   parameters: { layout: 'centered' },
   argTypes: {
-    variant: { control: 'select', options: ['default', 'outlined', 'elevated'] },
+    variant: { control: 'select', options: ['outlined', 'brand', 'elevated'] },
     padding: { control: 'select', options: ['none', 'sm', 'md', 'lg'] },
     interactive: { control: 'boolean' },
   },
@@ -63,9 +63,9 @@ export const Playground: Story = {
 export const Variants: Story = {
   render: () => (
     <Stack>
-      <SectionLabel>Variant: default / outlined / elevated</SectionLabel>
+      <SectionLabel>Variant: outlined / brand / elevated</SectionLabel>
       <Row>
-        {(['default', 'outlined', 'elevated'] as const).map((v) => (
+        {(['outlined', 'brand', 'elevated'] as const).map((v) => (
           <Card key={v} variant={v} padding="md" style={{ width: 220 }}>
             <CardTitle as="h4">{v}</CardTitle>
             <CardDescription>Card variant preview</CardDescription>

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -2,7 +2,7 @@ import { type HTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
 import './Card.css';
 
-export type CardVariant = 'default' | 'outlined' | 'elevated';
+export type CardVariant = 'outlined' | 'brand' | 'elevated';
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
 
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {

--- a/components/ui/CardControl/CardControl.css
+++ b/components/ui/CardControl/CardControl.css
@@ -3,7 +3,6 @@
 
 .bds-card-control {
   display: flex;
-  align-items: center;
   gap: var(--padding-xl);
   padding: var(--padding-xl);
   background-color: var(--surface-primary);
@@ -14,6 +13,11 @@
   box-sizing: border-box;
   flex-wrap: wrap;
 }
+
+/* ─── Action alignment ───────────────────────────────────────── */
+
+.bds-card-control--action-center { align-items: center; }
+.bds-card-control--action-top    { align-items: flex-start; }
 
 /* ─── Content — badge + text ─────────────────────────────────── */
 

--- a/components/ui/CardControl/CardControl.mdx
+++ b/components/ui/CardControl/CardControl.mdx
@@ -21,11 +21,23 @@ Switch actions, button actions, status badges, and minimal layout.
 
 <Canvas of={Stories.Variants} />
 
+## Action alignment
+
+Use `actionAlign="top"` when the description wraps to multiple lines — the CTA anchors to the upper-right corner instead of drifting to the vertical center of the card.
+
+<Canvas of={Stories.ActionAlignment} />
+
 ## Patterns
 
 Settings panel with mixed action types.
 
 <Canvas of={Stories.Patterns} />
+
+## Toggle switch panel
+
+Multi-row notification panel using switches with top-aligned actions — a common settings-page layout.
+
+<Canvas of={Stories.ToggleSwitchPanel} />
 
 ---
 

--- a/components/ui/CardControl/CardControl.stories.tsx
+++ b/components/ui/CardControl/CardControl.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof CardControl> = {
   argTypes: {
     title: { control: 'text' },
     description: { control: 'text' },
+    actionAlign: { control: 'inline-radio', options: ['center', 'top'] },
   },
 };
 
@@ -49,7 +50,42 @@ export const Playground: Story = {
   args: {
     title: 'Notifications',
     description: 'Receive email notifications for updates',
+    actionAlign: 'center',
   },
+};
+
+/* ─── Action alignment ───────────────────────────────────────── */
+
+export const ActionAlignment: Story = {
+  render: () => (
+    <Stack>
+      <SectionLabel>actionAlign = "center" (default)</SectionLabel>
+      <CardControl
+        title="Push notifications"
+        description="Get alerts for replies, mentions, and direct messages across all of your connected devices."
+        badge={<Badge size="xs" status="info" icon={<Icon icon="ph:bell" />} />}
+        action={<Button variant="outline" size="sm">Configure</Button>}
+      />
+
+      <SectionLabel>actionAlign = "top" — CTA anchored to upper-right</SectionLabel>
+      <CardControl
+        actionAlign="top"
+        title="Push notifications"
+        description="Get alerts for replies, mentions, and direct messages across all of your connected devices."
+        badge={<Badge size="xs" status="info" icon={<Icon icon="ph:bell" />} />}
+        action={<Button variant="outline" size="sm">Configure</Button>}
+      />
+
+      <SectionLabel>actionAlign = "top" — with switch toggle</SectionLabel>
+      <CardControl
+        actionAlign="top"
+        title="Two-factor authentication"
+        description="Require a verification code from your authenticator app in addition to your password on every sign-in."
+        badge={<Badge size="xs" status="positive" icon={<Icon icon="ph:shield-check" />} />}
+        action={<Switch checked onChange={() => {}} />}
+      />
+    </Stack>
+  ),
 };
 
 /* ─── Variants ───────────────────────────────────────────────── */
@@ -125,6 +161,51 @@ export const Patterns: Story = {
           description="Configure two-factor authentication"
           badge={<Badge size="xs" status="info" icon={<Icon icon="ph:shield-check" />} />}
           action={<Button variant="outline" size="sm">Configure</Button>}
+        />
+      </Stack>
+    );
+  },
+};
+
+/* ─── Toggle switch panel ────────────────────────────────────── */
+
+export const ToggleSwitchPanel: Story = {
+  render: () => {
+    const [email, setEmail] = useState(true);
+    const [sms, setSms] = useState(false);
+    const [product, setProduct] = useState(true);
+    const [marketing, setMarketing] = useState(false);
+
+    return (
+      <Stack>
+        <SectionLabel>Notification preferences — multi-row toggle panel</SectionLabel>
+        <CardControl
+          actionAlign="top"
+          title="Email updates"
+          description="Product announcements, billing receipts, and security alerts delivered to your inbox."
+          badge={<Badge size="xs" status="positive" icon={<Icon icon="ph:envelope" />} />}
+          action={<Switch checked={email} onChange={(e) => setEmail(e.target.checked)} />}
+        />
+        <CardControl
+          actionAlign="top"
+          title="SMS alerts"
+          description="Critical security alerts sent to your verified phone number. Carrier rates may apply."
+          badge={<Badge size="xs" status="info" icon={<Icon icon="ph:device-mobile" />} />}
+          action={<Switch checked={sms} onChange={(e) => setSms(e.target.checked)} />}
+        />
+        <CardControl
+          actionAlign="top"
+          title="Product updates"
+          description="New features, product news, and the occasional deep-dive on what the team is shipping."
+          badge={<Badge size="xs" status="info" icon={<Icon icon="ph:sparkle" />} />}
+          action={<Switch checked={product} onChange={(e) => setProduct(e.target.checked)} />}
+        />
+        <CardControl
+          actionAlign="top"
+          title="Marketing emails"
+          description="Seasonal promotions and partner offers. You can unsubscribe at any time from the footer of any email."
+          badge={<Badge size="xs" status="warning" icon={<Icon icon="ph:megaphone" />} />}
+          action={<Switch checked={marketing} onChange={(e) => setMarketing(e.target.checked)} />}
         />
       </Stack>
     );

--- a/components/ui/CardControl/CardControl.tsx
+++ b/components/ui/CardControl/CardControl.tsx
@@ -2,11 +2,15 @@ import { type HTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
 import './CardControl.css';
 
+export type CardControlActionAlign = 'center' | 'top';
+
 export interface CardControlProps extends HTMLAttributes<HTMLDivElement> {
   title: string;
   description?: string;
   badge?: ReactNode;
   action?: ReactNode;
+  /** Vertical alignment of the action slot. `top` anchors the CTA to the upper-right corner. */
+  actionAlign?: CardControlActionAlign;
 }
 
 /**
@@ -17,12 +21,21 @@ export function CardControl({
   description,
   badge,
   action,
+  actionAlign = 'center',
   className,
   style,
   ...props
 }: CardControlProps) {
   return (
-    <div className={bdsClass('bds-card-control', className)} style={style} {...props}>
+    <div
+      className={bdsClass(
+        'bds-card-control',
+        `bds-card-control--action-${actionAlign}`,
+        className,
+      )}
+      style={style}
+      {...props}
+    >
       <div className="bds-card-control__content">
         {badge}
         <div className="bds-card-control__text">

--- a/components/ui/CardControl/index.ts
+++ b/components/ui/CardControl/index.ts
@@ -1,2 +1,2 @@
-export { CardControl, type CardControlProps } from './CardControl';
+export { CardControl, type CardControlProps, type CardControlActionAlign } from './CardControl';
 export { default } from './CardControl';

--- a/components/ui/CardList/CardList.css
+++ b/components/ui/CardList/CardList.css
@@ -1,0 +1,59 @@
+@layer bds-components {
+/* ─── CardList ───────────────────────────────────────────────── */
+
+.bds-card-list {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* ─── Orientation ────────────────────────────────────────────── */
+
+.bds-card-list--vertical {
+  flex-direction: column;
+}
+
+.bds-card-list--horizontal {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+/* ─── Gap ────────────────────────────────────────────────────── */
+
+.bds-card-list--gap-sm { gap: var(--gap-sm); }
+.bds-card-list--gap-md { gap: var(--gap-md); }
+.bds-card-list--gap-lg { gap: var(--gap-lg); }
+.bds-card-list--gap-xl { gap: var(--gap-xl); }
+
+/* ─── Items ──────────────────────────────────────────────────── */
+
+.bds-card-list__item {
+  display: flex;
+  min-width: 0;
+}
+
+.bds-card-list--vertical > .bds-card-list__item {
+  flex-direction: column;
+  width: 100%;
+}
+
+.bds-card-list--horizontal > .bds-card-list__item {
+  flex: 1 1 0;
+  flex-direction: column;
+}
+
+.bds-card-list--horizontal.bds-card-list--fit > .bds-card-list__item {
+  flex: 0 0 auto;
+}
+
+/* Ensure direct card children stretch to fill the item cell */
+.bds-card-list__item > * {
+  width: 100%;
+  height: 100%;
+}
+}

--- a/components/ui/CardList/CardList.mdx
+++ b/components/ui/CardList/CardList.mdx
@@ -1,0 +1,65 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './CardList.stories';
+
+<Meta of={Stories} />
+
+# CardList
+
+Layout wrapper that stacks any card component (`Card`, `CardDisplay`, `CardFeature`, `CardTestimonial`, etc.) in a vertical column or horizontal row. Handles gap, equal column distribution, and wrapping so the card components themselves stay layout-agnostic.
+
+---
+
+## Playground
+
+<Canvas of={Stories.Playground} />
+
+## Vertical
+
+Stacks cards top-to-bottom at full width. Use for feeds, settings lists, or any full-width content column.
+
+<Canvas of={Stories.Vertical} />
+
+## Horizontal
+
+Lays cards out in a row with equal-width columns by default. Wraps to a new line on narrow viewports.
+
+<Canvas of={Stories.Horizontal} />
+
+## Horizontal — fit content
+
+Set `fitContent` when each card declares its own width (e.g. a scrollable product carousel). Items won't stretch to fill the row.
+
+<Canvas of={Stories.HorizontalFitContent} />
+
+## Gap scale
+
+<Canvas of={Stories.GapScale} />
+
+---
+
+## Props
+
+<ArgTypes of={Stories} />
+
+---
+
+## Usage
+
+```tsx
+import { CardList, Card, CardTitle, CardDescription } from '@brik/bds';
+
+<CardList orientation="horizontal" gap="lg">
+  <Card variant="outlined" padding="lg">
+    <CardTitle>Design</CardTitle>
+    <CardDescription>Brand and identity.</CardDescription>
+  </Card>
+  <Card variant="outlined" padding="lg">
+    <CardTitle>Development</CardTitle>
+    <CardDescription>Product engineering.</CardDescription>
+  </Card>
+</CardList>
+```
+
+- `orientation` — `'vertical'` (default) or `'horizontal'`
+- `gap` — `'sm' | 'md' | 'lg' | 'xl'` (default `'md'`)
+- `fitContent` — horizontal only; when `true`, items size to their children instead of filling equal columns

--- a/components/ui/CardList/CardList.stories.tsx
+++ b/components/ui/CardList/CardList.stories.tsx
@@ -1,0 +1,254 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CardList } from './CardList';
+import { Card, CardTitle, CardDescription, CardFooter } from '../Card/Card';
+import { CardDisplay } from '../CardDisplay';
+import { CardFeature } from '../CardFeature';
+import { CardTestimonial } from '../CardTestimonial';
+import { Button } from '../Button';
+import { Badge } from '../Badge';
+
+const meta: Meta<typeof CardList> = {
+  title: 'Displays/Card/card-list',
+  component: CardList,
+  parameters: { layout: 'padded' },
+  argTypes: {
+    orientation: { control: 'inline-radio', options: ['vertical', 'horizontal'] },
+    gap: { control: 'select', options: ['sm', 'md', 'lg', 'xl'] },
+    fitContent: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CardList>;
+
+/* ─── Layout helpers ─────────────────────────────────────────── */
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+    {children}
+  </span>
+);
+
+const Stack = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%', maxWidth: 1100 }}>
+    {children}
+  </div>
+);
+
+/* ─── Playground ─────────────────────────────────────────────── */
+
+export const Playground: Story = {
+  args: {
+    orientation: 'vertical',
+    gap: 'md',
+    fitContent: false,
+  },
+  render: (args) => (
+    <div style={{ width: 720 }}>
+      <CardList {...args}>
+        <Card variant="outlined" padding="md">
+          <CardTitle as="h4">Card one</CardTitle>
+          <CardDescription>Short description for the first card in the list.</CardDescription>
+        </Card>
+        <Card variant="outlined" padding="md">
+          <CardTitle as="h4">Card two</CardTitle>
+          <CardDescription>Short description for the second card in the list.</CardDescription>
+        </Card>
+        <Card variant="outlined" padding="md">
+          <CardTitle as="h4">Card three</CardTitle>
+          <CardDescription>Short description for the third card in the list.</CardDescription>
+        </Card>
+      </CardList>
+    </div>
+  ),
+};
+
+/* ─── Vertical layout ────────────────────────────────────────── */
+
+export const Vertical: Story = {
+  render: () => (
+    <Stack>
+      <SectionLabel>Vertical — generic Card</SectionLabel>
+      <div style={{ width: 480 }}>
+        <CardList orientation="vertical" gap="md">
+          <Card variant="outlined" padding="md">
+            <CardTitle as="h4">Quarterly report</CardTitle>
+            <CardDescription>Summary of Q1 performance across all channels.</CardDescription>
+            <CardFooter>
+              <Button variant="outline" size="sm">View</Button>
+            </CardFooter>
+          </Card>
+          <Card variant="outlined" padding="md">
+            <CardTitle as="h4">Team update</CardTitle>
+            <CardDescription>New hires, role changes, and milestones this month.</CardDescription>
+            <CardFooter>
+              <Button variant="outline" size="sm">View</Button>
+            </CardFooter>
+          </Card>
+          <Card variant="outlined" padding="md">
+            <CardTitle as="h4">Product roadmap</CardTitle>
+            <CardDescription>Upcoming features planned for the next two quarters.</CardDescription>
+            <CardFooter>
+              <Button variant="outline" size="sm">View</Button>
+            </CardFooter>
+          </Card>
+        </CardList>
+      </div>
+
+      <SectionLabel>Vertical — CardFeature</SectionLabel>
+      <div style={{ width: 480 }}>
+        <CardList orientation="vertical" gap="md">
+          <CardFeature
+            icon="★"
+            title="Token-driven design"
+            description="Every color, spacing, and type value references a single source of truth."
+            align="left"
+          />
+          <CardFeature
+            icon="◆"
+            title="Accessible by default"
+            description="Radix primitives and ARIA patterns are built into every interactive component."
+            align="left"
+          />
+          <CardFeature
+            icon="●"
+            title="Themeable"
+            description="Swap a single theme file to rebrand without touching components."
+            align="left"
+          />
+        </CardList>
+      </div>
+    </Stack>
+  ),
+};
+
+/* ─── Horizontal layout ──────────────────────────────────────── */
+
+export const Horizontal: Story = {
+  render: () => (
+    <Stack>
+      <SectionLabel>Horizontal — equal columns (default)</SectionLabel>
+      <CardList orientation="horizontal" gap="lg">
+        <Card variant="outlined" padding="lg">
+          <Badge>Design</Badge>
+          <CardTitle>Design</CardTitle>
+          <CardDescription>Brand, identity, and design systems.</CardDescription>
+          <CardFooter>
+            <Button variant="outline" size="sm">Learn more</Button>
+          </CardFooter>
+        </Card>
+        <Card variant="outlined" padding="lg">
+          <Badge>Development</Badge>
+          <CardTitle>Development</CardTitle>
+          <CardDescription>Full-stack product engineering.</CardDescription>
+          <CardFooter>
+            <Button variant="outline" size="sm">Learn more</Button>
+          </CardFooter>
+        </Card>
+        <Card variant="outlined" padding="lg">
+          <Badge>Strategy</Badge>
+          <CardTitle>Strategy</CardTitle>
+          <CardDescription>Roadmapping and growth operations.</CardDescription>
+          <CardFooter>
+            <Button variant="outline" size="sm">Learn more</Button>
+          </CardFooter>
+        </Card>
+      </CardList>
+
+      <SectionLabel>Horizontal — CardDisplay</SectionLabel>
+      <CardList orientation="horizontal" gap="lg">
+        <CardDisplay
+          title="Bloom Cafe"
+          description="Full rebrand and e-commerce launch for a specialty coffee shop."
+          imageSrc="https://placehold.co/640x360/EEEEEE/111111?text=Bloom+Cafe"
+          imageAlt="Bloom Cafe case study"
+          action={<Button variant="outline" size="sm">View case study</Button>}
+        />
+        <CardDisplay
+          title="Apex Corp"
+          description="Conversion-focused marketing site that tripled qualified leads."
+          imageSrc="https://placehold.co/640x360/EEEEEE/111111?text=Apex+Corp"
+          imageAlt="Apex Corp case study"
+          action={<Button variant="outline" size="sm">View case study</Button>}
+        />
+        <CardDisplay
+          title="Greenfield"
+          description="Internal ops portal that replaced five spreadsheets."
+          imageSrc="https://placehold.co/640x360/EEEEEE/111111?text=Greenfield"
+          imageAlt="Greenfield case study"
+          action={<Button variant="outline" size="sm">View case study</Button>}
+        />
+      </CardList>
+
+      <SectionLabel>Horizontal — CardTestimonial (brand + outlined)</SectionLabel>
+      <CardList orientation="horizontal" gap="lg">
+        <CardTestimonial
+          variant="brand"
+          quote="Square has completely transformed how we handle payments. The analytics alone have helped us grow 40% this year."
+          authorName="Sarah Chen"
+          authorRole="Owner, Bloom Cafe"
+          rating={5}
+        />
+        <CardTestimonial
+          variant="outlined"
+          quote="Professional, responsive, and creative. Our new site has driven 3x more leads."
+          authorName="Marcus Johnson"
+          authorRole="Marketing Director, Apex Corp"
+          rating={5}
+        />
+        <CardTestimonial
+          variant="brand"
+          quote="Working with this team felt like an extension of our own company."
+          authorName="Emily Rodriguez"
+          authorRole="CEO, Greenfield Digital"
+          rating={4}
+        />
+      </CardList>
+    </Stack>
+  ),
+};
+
+/* ─── Fit content ────────────────────────────────────────────── */
+
+export const HorizontalFitContent: Story = {
+  render: () => (
+    <Stack>
+      <SectionLabel>Horizontal — fitContent (items size to own width)</SectionLabel>
+      <CardList orientation="horizontal" gap="md" fitContent>
+        <Card variant="outlined" padding="md" style={{ width: 200 }}>
+          <CardTitle as="h4">200px</CardTitle>
+          <CardDescription>Fixed width card.</CardDescription>
+        </Card>
+        <Card variant="outlined" padding="md" style={{ width: 280 }}>
+          <CardTitle as="h4">280px</CardTitle>
+          <CardDescription>Different fixed width.</CardDescription>
+        </Card>
+        <Card variant="outlined" padding="md" style={{ width: 160 }}>
+          <CardTitle as="h4">160px</CardTitle>
+          <CardDescription>Narrowest card.</CardDescription>
+        </Card>
+      </CardList>
+    </Stack>
+  ),
+};
+
+/* ─── Gap scale ──────────────────────────────────────────────── */
+
+export const GapScale: Story = {
+  render: () => (
+    <Stack>
+      {(['sm', 'md', 'lg', 'xl'] as const).map((g) => (
+        <div key={g}>
+          <SectionLabel>{`gap = ${g}`}</SectionLabel>
+          <CardList orientation="horizontal" gap={g}>
+            {[1, 2, 3, 4].map((n) => (
+              <Card key={n} variant="outlined" padding="md">
+                <CardTitle as="h4">{`Card ${n}`}</CardTitle>
+              </Card>
+            ))}
+          </CardList>
+        </div>
+      ))}
+    </Stack>
+  ),
+};

--- a/components/ui/CardList/CardList.tsx
+++ b/components/ui/CardList/CardList.tsx
@@ -1,0 +1,51 @@
+import { Children, type HTMLAttributes, type ReactNode, isValidElement } from 'react';
+import { bdsClass } from '../../utils';
+import './CardList.css';
+
+export type CardListOrientation = 'vertical' | 'horizontal';
+export type CardListGap = 'sm' | 'md' | 'lg' | 'xl';
+
+export interface CardListProps extends HTMLAttributes<HTMLUListElement> {
+  orientation?: CardListOrientation;
+  gap?: CardListGap;
+  /** Horizontal only — when true, items size to their content instead of filling equal columns */
+  fitContent?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * CardList — layout wrapper that stacks card components vertically or horizontally.
+ */
+export function CardList({
+  orientation = 'vertical',
+  gap = 'md',
+  fitContent = false,
+  children,
+  className,
+  style,
+  ...props
+}: CardListProps) {
+  const classes = bdsClass(
+    'bds-card-list',
+    `bds-card-list--${orientation}`,
+    `bds-card-list--gap-${gap}`,
+    orientation === 'horizontal' && fitContent && 'bds-card-list--fit',
+    className,
+  );
+
+  return (
+    <ul className={classes} style={style} {...props}>
+      {Children.map(children, (child, index) => {
+        if (!isValidElement(child)) return null;
+        const key = (child as { key?: string | number }).key ?? index;
+        return (
+          <li key={key} className="bds-card-list__item">
+            {child}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default CardList;

--- a/components/ui/CardList/index.ts
+++ b/components/ui/CardList/index.ts
@@ -1,0 +1,7 @@
+export {
+  CardList,
+  type CardListProps,
+  type CardListOrientation,
+  type CardListGap,
+} from './CardList';
+export { default } from './CardList';

--- a/components/ui/CardTestimonial/CardTestimonial.css
+++ b/components/ui/CardTestimonial/CardTestimonial.css
@@ -10,6 +10,7 @@
   width: 100%;
   min-width: 0;
   box-sizing: border-box;
+  margin: 0;
 }
 
 /* ─── Variants ───────────────────────────────────────────────── */
@@ -34,7 +35,7 @@
   user-select: none;
 }
 
-.bds-card-testimonial--brand .bds-card-testimonial__quote-mark { color: var(--text-inverse); }
+.bds-card-testimonial--brand .bds-card-testimonial__quote-mark { color: var(--text-on-color-dark); }
 .bds-card-testimonial--outlined .bds-card-testimonial__quote-mark { color: var(--text-brand-primary); }
 
 /* ─── Quote body ─────────────────────────────────────────────── */
@@ -47,7 +48,7 @@
   margin: 0;
 }
 
-.bds-card-testimonial--brand .bds-card-testimonial__body { color: var(--text-inverse); }
+.bds-card-testimonial--brand .bds-card-testimonial__body { color: var(--text-on-color-dark); }
 .bds-card-testimonial--outlined .bds-card-testimonial__body { color: var(--text-primary); }
 
 /* ─── Attribution ────────────────────────────────────────────── */
@@ -65,10 +66,11 @@
   font-size: var(--label-md);
   font-weight: var(--font-weight-semi-bold);
   line-height: var(--font-line-height-snug);
+  font-style: normal;
   margin: 0;
 }
 
-.bds-card-testimonial--brand .bds-card-testimonial__name { color: var(--text-inverse); }
+.bds-card-testimonial--brand .bds-card-testimonial__name { color: var(--text-on-color-dark); }
 .bds-card-testimonial--outlined .bds-card-testimonial__name { color: var(--text-primary); }
 
 /* ─── Author role ────────────────────────────────────────────── */
@@ -81,7 +83,7 @@
   margin: 0;
 }
 
-.bds-card-testimonial--brand .bds-card-testimonial__role { color: var(--text-inverse); }
+.bds-card-testimonial--brand .bds-card-testimonial__role { color: var(--text-on-color-dark); }
 .bds-card-testimonial--outlined .bds-card-testimonial__role { color: var(--text-secondary); }
 
 /* ─── Star rating ────────────────────────────────────────────── */

--- a/components/ui/CardTestimonial/CardTestimonial.tsx
+++ b/components/ui/CardTestimonial/CardTestimonial.tsx
@@ -5,7 +5,7 @@ import './CardTestimonial.css';
 
 export type CardTestimonialVariant = 'brand' | 'outlined';
 
-export interface CardTestimonialProps extends HTMLAttributes<HTMLDivElement> {
+export interface CardTestimonialProps extends HTMLAttributes<HTMLElement> {
   quote: string;
   authorName: string;
   authorRole?: string;
@@ -27,7 +27,7 @@ export function CardTestimonial({
   ...props
 }: CardTestimonialProps) {
   return (
-    <div
+    <figure
       className={bdsClass('bds-card-testimonial', `bds-card-testimonial--${variant}`, className)}
       style={style}
       {...props}
@@ -40,10 +40,10 @@ export function CardTestimonial({
         {quote}
       </blockquote>
 
-      <div className="bds-card-testimonial__attribution">
-        <p className="bds-card-testimonial__name">{authorName}</p>
-        {authorRole && <p className="bds-card-testimonial__role">{authorRole}</p>}
-      </div>
+      <figcaption className="bds-card-testimonial__attribution">
+        <cite className="bds-card-testimonial__name">{authorName}</cite>
+        {authorRole && <span className="bds-card-testimonial__role">{authorRole}</span>}
+      </figcaption>
 
       {rating != null && rating > 0 && (
         <div className="bds-card-testimonial__stars" role="img" aria-label={`${rating} out of 5 stars`}>
@@ -52,7 +52,7 @@ export function CardTestimonial({
           ))}
         </div>
       )}
-    </div>
+    </figure>
   );
 }
 

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -17,6 +17,7 @@ export * from './Card';
 export * from './CardControl';
 export * from './CardDisplay';
 export * from './CardFeature';
+export * from './CardList';
 export * from './CardTestimonial';
 export * from './Checkbox';
 export * from './Chip';


### PR DESCRIPTION
## Summary

- **Card**: drop blank `default` variant; `outlined` is the explicit default; add `brand` variant with primary border for emphasis.
- **CardList** (new): layout wrapper for any card family component — `orientation` (`vertical` | `horizontal`), `gap` (`sm|md|lg|xl`), and `fitContent` for non-equal-column horizontal rows.
- **CardControl**: add `actionAlign` (`center` default | `top`). `top` anchors the CTA to the upper-right — needed when the description wraps or when stacking multiple switch rows.
- **CardTestimonial**: refactor attribution to `<figure>` / `<figcaption>` / `<cite>` / `<span>` (was `<div>`/`<p>`/`<p>`) — proper WHATWG quotation structure, and defense against future global `<p>` collisions. Swap `--text-inverse` → `--text-on-color-dark` on brand variant to match established BDS pattern.

Rebased onto main after #88 landed, which independently fixed the `.sbdocs p` bleed that was hiding the testimonial author name in Docs view.

## Breaking change

`Card` `variant="default"` removed. Migrate to `variant="outlined"` (new default) or `variant="brand"`. No existing consumer usage was found in the codebase.

## Test plan

- [ ] `npm run storybook` → **Displays / Card / card** — verify `outlined` / `brand` / `elevated` all render correctly; no blank default tile
- [ ] **Displays / Card / card-list** — verify `Playground`, `Vertical`, `Horizontal`, `HorizontalFitContent`, `GapScale` stories
- [ ] **Displays / Card / card-control** — verify `ActionAlignment` (center vs top) and `ToggleSwitchPanel` (multi-row switches with top-aligned CTAs)
- [ ] **Displays / Card / card-testimonial** — verify brand variant renders author name and role in white on brand surface in both Canvas and Docs views
- [ ] `npm run typecheck` — passes
- [ ] `npm run lint-tokens:grid` — passes (0 errors)
- [ ] After merge: propagate BDS to `brik-client-portal`, `renew-pms`, and `brikdesigns` so the CardList export and Card variant types land in consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)