### PR TITLE
feat(addable-entry-list): text + textarea sibling of AddableTextList

### DIFF
--- a/components/ui/AddableEntryList/AddableEntryList.css
+++ b/components/ui/AddableEntryList/AddableEntryList.css
@@ -1,0 +1,109 @@
+.bds-addable-entry-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  width: 100%;
+}
+
+.bds-addable-entry-list__label {
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+.bds-addable-entry-list__items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+
+.bds-addable-entry-list__item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--gap-sm);
+  padding: var(--padding-md);
+  border: var(--border-width-md) solid var(--border-muted);
+  border-radius: var(--border-radius-md);
+}
+
+.bds-addable-entry-list__item-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-tiny);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.bds-addable-entry-list__item-primary {
+  font-family: var(--font-family-body);
+  font-weight: var(--font-weight-semi-bold);
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.bds-addable-entry-list__item-secondary {
+  font-family: var(--font-family-body);
+  color: var(--text-secondary);
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.bds-addable-entry-list__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--border-radius-sm);
+  flex-shrink: 0;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.bds-addable-entry-list__remove:hover {
+  background: var(--background-muted);
+  color: var(--text-primary);
+}
+
+.bds-addable-entry-list__remove:focus-visible {
+  outline: var(--border-width-md) solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+.bds-addable-entry-list__remove svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.bds-addable-entry-list__empty {
+  font-family: var(--font-family-body);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.bds-addable-entry-list__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  padding: var(--padding-md);
+  border: var(--border-width-md) solid var(--border-muted);
+  border-radius: var(--border-radius-md);
+}
+
+.bds-addable-entry-list__form-actions {
+  display: flex;
+  gap: var(--gap-sm);
+  justify-content: flex-end;
+}
+
+.bds-addable-entry-list__helper {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+}

--- a/components/ui/AddableEntryList/AddableEntryList.mdx
+++ b/components/ui/AddableEntryList/AddableEntryList.mdx
@@ -1,0 +1,54 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './AddableEntryList.stories';
+
+<Meta of={Stories} />
+
+# Addable entry list
+
+The text + textarea sibling of [`AddableTextList`](?path=/docs/components-form-addable-text-list--overview). Existing entries render as read-only cards with a remove button. Clicking "Add" reveals a form with a text input (primary) and textarea (secondary). **Save** commits the entry and keeps the form open for rapid entry; **Escape** cancels.
+
+Use for lists where each row needs a headline value + context (competitor URL + notes, reference site + why, line item + description, team member + role). The entry shape is intentionally generic so a single BDS component serves all of these — map your domain shape to `{ primary, secondary }` at the boundary.
+
+---
+
+## Playground
+
+<Canvas of={Stories.Playground} />
+
+## Empty state
+
+<Canvas of={Stories.Empty} />
+
+## Secondary is optional
+
+The `secondary` field can be left blank — the rendered card only shows it when present.
+
+<Canvas of={Stories.PrimaryOnly} />
+
+## Variants
+
+Sizes, empty/helper/disabled states, and item limit.
+
+<Canvas of={Stories.Variants} />
+
+---
+
+## Behavior
+
+- **Save** commits the entry (primary trimmed, secondary trimmed) and keeps the form open for rapid entry.
+- **Escape** cancels and hides the form.
+- **Primary is required**; empty-primary submissions are silently dropped.
+- Duplicates are blocked case-insensitively on the primary value unless `allowDuplicates` is set.
+- When `maxItems` is reached, the Add button is hidden.
+- Entries are read-only once added — remove to replace.
+
+## When to use this vs. `AddableTextList`
+
+| Pick | When |
+| ---- | ---- |
+| `AddableTextList` | Each row is a single short value (service name, payment type, tag). |
+| `AddableEntryList` | Each row needs a primary value **and** a secondary note or description. |
+
+## Props
+
+<ArgTypes of={Stories} />

--- a/components/ui/AddableEntryList/AddableEntryList.stories.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.stories.tsx
@@ -1,0 +1,301 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { AddableEntryList, type AddableEntry } from './AddableEntryList';
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <div
+    style={{
+      fontFamily: 'var(--font-family-label)',
+      fontSize: 'var(--body-xs)', // bds-lint-ignore
+      textTransform: 'uppercase' as const,
+      letterSpacing: '0.05em',
+      marginBottom: 'var(--gap-md)',
+      color: 'var(--text-muted)',
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
+);
+
+const meta: Meta<typeof AddableEntryList> = {
+  title: 'Components/Form/addable-entry-list',
+  component: AddableEntryList,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    label: { control: 'text' },
+    addLabel: { control: 'text' },
+    primaryPlaceholder: { control: 'text' },
+    secondaryPlaceholder: { control: 'text' },
+    primaryLabel: { control: 'text' },
+    secondaryLabel: { control: 'text' },
+    helperText: { control: 'text' },
+    emptyLabel: { control: 'text' },
+    disabled: { control: 'boolean' },
+    allowDuplicates: { control: 'boolean' },
+    maxItems: { control: 'number' },
+    secondaryRows: { control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AddableEntryList>;
+
+const Controlled = (args: React.ComponentProps<typeof AddableEntryList>) => {
+  const [entries, setEntries] = useState<AddableEntry[]>(args.entries ?? []);
+  return (
+    <div style={{ width: 480 }}>
+      <AddableEntryList
+        {...args}
+        entries={entries}
+        onChange={(next) => {
+          setEntries(next);
+          args.onChange?.(next);
+        }}
+      />
+    </div>
+  );
+};
+
+export const Playground: Story = {
+  args: {
+    label: 'Competitors',
+    primaryLabel: 'URL',
+    primaryPlaceholder: 'https://competitor.com',
+    secondaryLabel: 'Notes',
+    secondaryPlaceholder: 'Competitive positioning, strengths, relevance...',
+    addLabel: 'Add Competitor',
+    removeLabel: 'Remove competitor',
+    entries: [
+      { primary: 'https://acme.com', secondary: 'Direct competitor — stronger brand, weaker product pipeline.' },
+      { primary: 'https://widgets.io', secondary: 'Adjacent market; watch for vertical expansion.' },
+    ],
+    size: 'md',
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+export const Empty: Story = {
+  args: {
+    label: 'Reference Sites',
+    primaryLabel: 'URL',
+    primaryPlaceholder: 'https://example.com',
+    secondaryLabel: 'Notes',
+    secondaryPlaceholder: 'Why this site is a reference',
+    addLabel: 'Add Reference',
+    removeLabel: 'Remove reference',
+    emptyLabel: 'No reference sites added yet.',
+    entries: [],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+export const AddAnEntry: Story = {
+  name: 'Interaction — add an entry',
+  args: {
+    label: 'Competitors',
+    primaryLabel: 'URL',
+    primaryPlaceholder: 'https://competitor.com',
+    secondaryLabel: 'Notes',
+    secondaryPlaceholder: 'Competitive positioning',
+    addLabel: 'Add Competitor',
+    removeLabel: 'Remove competitor',
+    entries: [{ primary: 'https://acme.com', secondary: 'Direct competitor' }],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    const addButton = canvas.getByRole('button', { name: /add competitor/i });
+    await userEvent.click(addButton);
+
+    const urlInput = await canvas.findByLabelText('URL');
+    await userEvent.type(urlInput, 'https://newrival.com');
+
+    const notesInput = await canvas.findByLabelText('Notes');
+    await userEvent.type(notesInput, 'Newly funded, aggressive go-to-market');
+
+    await userEvent.click(canvas.getByRole('button', { name: /^add$/i }));
+
+    await expect(args.onChange).toHaveBeenCalledWith([
+      { primary: 'https://acme.com', secondary: 'Direct competitor' },
+      { primary: 'https://newrival.com', secondary: 'Newly funded, aggressive go-to-market' },
+    ]);
+  },
+};
+
+export const RemoveAnEntry: Story = {
+  name: 'Interaction — remove an entry',
+  args: {
+    label: 'Competitors',
+    addLabel: 'Add Competitor',
+    removeLabel: 'Remove competitor',
+    entries: [
+      { primary: 'https://acme.com', secondary: 'Direct competitor' },
+      { primary: 'https://widgets.io', secondary: 'Adjacent market' },
+      { primary: 'https://rival.co', secondary: 'Emerging threat' },
+    ],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const removeButtons = canvas.getAllByRole('button', { name: /remove competitor/i });
+    await userEvent.click(removeButtons[1]);
+    await expect(args.onChange).toHaveBeenCalledWith([
+      { primary: 'https://acme.com', secondary: 'Direct competitor' },
+      { primary: 'https://rival.co', secondary: 'Emerging threat' },
+    ]);
+  },
+};
+
+export const DuplicateBlocked: Story = {
+  name: 'Interaction — duplicates blocked (case-insensitive)',
+  args: {
+    label: 'Competitors',
+    primaryLabel: 'URL',
+    secondaryLabel: 'Notes',
+    addLabel: 'Add Competitor',
+    removeLabel: 'Remove competitor',
+    entries: [{ primary: 'https://acme.com', secondary: 'Direct competitor' }],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /add competitor/i }));
+
+    const urlInput = await canvas.findByLabelText('URL');
+    await userEvent.type(urlInput, 'HTTPS://ACME.COM');
+
+    await userEvent.click(canvas.getByRole('button', { name: /^add$/i }));
+    await expect(args.onChange).not.toHaveBeenCalled();
+  },
+};
+
+export const PrimaryOnly: Story = {
+  name: 'Secondary optional',
+  args: {
+    label: 'Line Items',
+    primaryLabel: 'Item',
+    secondaryLabel: 'Description',
+    primaryPlaceholder: 'e.g. Logo design',
+    secondaryPlaceholder: 'Optional description',
+    addLabel: 'Add Line Item',
+    removeLabel: 'Remove line item',
+    entries: [
+      { primary: 'Logo design', secondary: '' },
+      { primary: 'Brand guidelines', secondary: '12-page PDF including color, typography, and voice.' },
+    ],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ width: 520 }}>
+      <Stack>
+        <div>
+          <SectionLabel>Sizes</SectionLabel>
+          <Stack gap="var(--gap-lg)">
+            <Controlled
+              label="Small"
+              size="sm"
+              primaryLabel="URL"
+              secondaryLabel="Notes"
+              primaryPlaceholder="https://example.com"
+              secondaryPlaceholder="Notes"
+              addLabel="Add"
+              removeLabel="Remove entry"
+              entries={[{ primary: 'https://acme.com', secondary: 'Direct competitor' }]}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="Medium (default)"
+              size="md"
+              primaryLabel="URL"
+              secondaryLabel="Notes"
+              primaryPlaceholder="https://example.com"
+              secondaryPlaceholder="Notes"
+              addLabel="Add"
+              removeLabel="Remove entry"
+              entries={[
+                { primary: 'https://acme.com', secondary: 'Direct competitor' },
+                { primary: 'https://widgets.io', secondary: 'Adjacent market' },
+              ]}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="Large"
+              size="lg"
+              primaryLabel="URL"
+              secondaryLabel="Notes"
+              primaryPlaceholder="https://example.com"
+              secondaryPlaceholder="Notes"
+              addLabel="Add"
+              removeLabel="Remove entry"
+              entries={[{ primary: 'https://acme.com', secondary: 'Direct competitor' }]}
+              onChange={() => {}}
+            />
+          </Stack>
+        </div>
+
+        <div>
+          <SectionLabel>States</SectionLabel>
+          <Stack gap="var(--gap-lg)">
+            <Controlled
+              label="Empty"
+              emptyLabel="No competitors added yet."
+              addLabel="Add Competitor"
+              entries={[]}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="With helper text"
+              helperText="Escape cancels the form; Save keeps it open for rapid entry."
+              primaryLabel="URL"
+              secondaryLabel="Notes"
+              addLabel="Add Competitor"
+              removeLabel="Remove competitor"
+              entries={[{ primary: 'https://acme.com', secondary: 'Direct competitor' }]}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="Disabled"
+              disabled
+              addLabel="Add Competitor"
+              removeLabel="Remove competitor"
+              entries={[
+                { primary: 'https://acme.com', secondary: 'Direct competitor' },
+                { primary: 'https://widgets.io', secondary: 'Adjacent market' },
+              ]}
+              onChange={() => {}}
+            />
+            <Controlled
+              label="Max 3 entries"
+              maxItems={3}
+              addLabel="Add"
+              removeLabel="Remove entry"
+              helperText="Add button hides when limit is reached."
+              entries={[
+                { primary: 'A', secondary: 'First' },
+                { primary: 'B', secondary: 'Second' },
+                { primary: 'C', secondary: 'Third' },
+              ]}
+              onChange={() => {}}
+            />
+          </Stack>
+        </div>
+      </Stack>
+    </div>
+  ),
+};

--- a/components/ui/AddableEntryList/AddableEntryList.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.tsx
@@ -1,0 +1,261 @@
+import { useRef, useState, type KeyboardEvent } from 'react';
+import { Icon } from '@iconify/react';
+import { bdsClass } from '../../utils';
+import { Button, type ButtonSize } from '../Button';
+import { TextInput, type TextInputSize } from '../TextInput';
+import { TextArea, type TextAreaSize } from '../TextArea';
+import './AddableEntryList.css';
+
+export type AddableEntryListSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Generic entry shape. Consumers map their domain types
+ * (competitor URL + notes, reference site + note, line item + description, etc.)
+ * to / from this shape at the boundary.
+ */
+export interface AddableEntry {
+  primary: string;
+  secondary: string;
+}
+
+export interface AddableEntryListProps {
+  /** Current list of entries */
+  entries: AddableEntry[];
+  /** Called when entries change (add / remove) */
+  onChange: (next: AddableEntry[]) => void;
+  /** Optional field label */
+  label?: string;
+  /** Helper text below the list */
+  helperText?: string;
+  /** Label shown above the primary input (defaults to none) */
+  primaryLabel?: string;
+  /** Label shown above the secondary textarea (defaults to none) */
+  secondaryLabel?: string;
+  /** Placeholder for the primary input */
+  primaryPlaceholder?: string;
+  /** Placeholder for the secondary textarea */
+  secondaryPlaceholder?: string;
+  /** Text on the reveal button */
+  addLabel?: string;
+  /** Accessible label for the remove button on each entry */
+  removeLabel?: string;
+  /** Text shown when list is empty (and form is not revealed) */
+  emptyLabel?: string;
+  /** Size for input, textarea, and buttons */
+  size?: AddableEntryListSize;
+  /** Hide all controls */
+  disabled?: boolean;
+  /** Maximum number of entries */
+  maxItems?: number;
+  /** Number of rows on the secondary textarea */
+  secondaryRows?: number;
+  /** Additional className applied to root */
+  className?: string;
+  /** Block duplicates by primary value (case-insensitive) */
+  allowDuplicates?: boolean;
+}
+
+const BUTTON_SIZE: Record<AddableEntryListSize, ButtonSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+const INPUT_SIZE: Record<AddableEntryListSize, TextInputSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+const TEXTAREA_SIZE: Record<AddableEntryListSize, TextAreaSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+
+/**
+ * AddableEntryList — the text + textarea sibling of `AddableTextList`.
+ *
+ * Existing entries render as read-only cards with a remove button.
+ * Clicking "Add New" reveals a form with a TextInput (primary) and
+ * TextArea (secondary). Save commits the entry and keeps the form open
+ * for rapid entry; Cancel closes it.
+ *
+ * The entry shape is deliberately generic (`{ primary, secondary }`) so
+ * a single BDS component serves competitor URLs + notes, reference sites
+ * + notes, line item + description, team member + role, and so on.
+ * Consumers map their domain shape at the boundary.
+ *
+ * @example
+ * ```tsx
+ * <AddableEntryList
+ *   label="Competitors"
+ *   entries={competitors}
+ *   onChange={setCompetitors}
+ *   primaryPlaceholder="https://competitor.com"
+ *   secondaryPlaceholder="Competitive positioning, strengths, relevance..."
+ *   addLabel="Add Competitor"
+ *   removeLabel="Remove competitor"
+ * />
+ * ```
+ */
+export function AddableEntryList({
+  entries,
+  onChange,
+  label,
+  helperText,
+  primaryLabel,
+  secondaryLabel,
+  primaryPlaceholder,
+  secondaryPlaceholder,
+  addLabel = 'Add New',
+  removeLabel = 'Remove entry',
+  emptyLabel,
+  size = 'md',
+  disabled = false,
+  maxItems,
+  secondaryRows = 2,
+  className,
+  allowDuplicates = false,
+}: AddableEntryListProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [primaryDraft, setPrimaryDraft] = useState('');
+  const [secondaryDraft, setSecondaryDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const atLimit = typeof maxItems === 'number' && entries.length >= maxItems;
+
+  const reveal = () => {
+    setPrimaryDraft('');
+    setSecondaryDraft('');
+    setIsEditing(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const cancel = () => {
+    setPrimaryDraft('');
+    setSecondaryDraft('');
+    setIsEditing(false);
+  };
+
+  const commit = () => {
+    const trimmedPrimary = primaryDraft.trim();
+    const trimmedSecondary = secondaryDraft.trim();
+    if (!trimmedPrimary) {
+      cancel();
+      return;
+    }
+    if (!allowDuplicates && entries.some((e) => e.primary.toLowerCase() === trimmedPrimary.toLowerCase())) {
+      cancel();
+      return;
+    }
+    onChange([...entries, { primary: trimmedPrimary, secondary: trimmedSecondary }]);
+    setPrimaryDraft('');
+    setSecondaryDraft('');
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const remove = (index: number) => {
+    onChange(entries.filter((_, i) => i !== index));
+  };
+
+  const handlePrimaryKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
+
+  const handleSecondaryKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
+
+  const showEmpty = entries.length === 0 && !isEditing && emptyLabel;
+
+  return (
+    <div className={bdsClass('bds-addable-entry-list', className)}>
+      {label && <span className="bds-addable-entry-list__label">{label}</span>}
+
+      {entries.length > 0 && (
+        <div className="bds-addable-entry-list__items" role="list">
+          {entries.map((entry, index) => (
+            <div
+              key={`${index}-${entry.primary}`}
+              className="bds-addable-entry-list__item"
+              role="listitem"
+            >
+              <div className="bds-addable-entry-list__item-content">
+                <span className="bds-addable-entry-list__item-primary">{entry.primary}</span>
+                {entry.secondary && (
+                  <span className="bds-addable-entry-list__item-secondary">{entry.secondary}</span>
+                )}
+              </div>
+              {!disabled && (
+                <button
+                  type="button"
+                  className="bds-addable-entry-list__remove"
+                  onClick={() => remove(index)}
+                  aria-label={removeLabel}
+                >
+                  <Icon icon="ph:x" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showEmpty && <span className="bds-addable-entry-list__empty">{emptyLabel}</span>}
+
+      {!disabled && isEditing && !atLimit && (
+        <div className="bds-addable-entry-list__form">
+          <TextInput
+            ref={inputRef}
+            size={INPUT_SIZE[size]}
+            label={primaryLabel}
+            value={primaryDraft}
+            onChange={(e) => setPrimaryDraft(e.target.value)}
+            onKeyDown={handlePrimaryKey}
+            placeholder={primaryPlaceholder}
+            aria-label={primaryLabel ?? (label ? `Add ${label}` : 'New entry')}
+            fullWidth
+          />
+          <TextArea
+            size={TEXTAREA_SIZE[size]}
+            label={secondaryLabel}
+            value={secondaryDraft}
+            onChange={(e) => setSecondaryDraft(e.target.value)}
+            onKeyDown={handleSecondaryKey}
+            placeholder={secondaryPlaceholder}
+            rows={secondaryRows}
+            fullWidth
+          />
+          <div className="bds-addable-entry-list__form-actions">
+            <Button
+              size={BUTTON_SIZE[size]}
+              variant="primary"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={commit}
+            >
+              Add
+            </Button>
+            <Button
+              size={BUTTON_SIZE[size]}
+              variant="ghost"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={cancel}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {!disabled && !isEditing && !atLimit && (
+        <div>
+          <Button
+            size={BUTTON_SIZE[size]}
+            variant="outline"
+            onClick={reveal}
+          >
+            <Icon icon="ph:plus" />
+            {addLabel}
+          </Button>
+        </div>
+      )}
+
+      {helperText && <span className="bds-addable-entry-list__helper">{helperText}</span>}
+    </div>
+  );
+}
+
+export default AddableEntryList;

--- a/components/ui/AddableEntryList/index.ts
+++ b/components/ui/AddableEntryList/index.ts
@@ -1,0 +1,2 @@
+export { AddableEntryList } from './AddableEntryList';
+export type { AddableEntryListProps, AddableEntryListSize, AddableEntry } from './AddableEntryList';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,6 +1,7 @@
 // UI Components
 export * from './Accordion';
 export * from './ActivityTimeline';
+export * from './AddableEntryList';
 export * from './AddableTextList';
 export * from './AddressInput';
 export * from './AnimatedIcon';


### PR DESCRIPTION
## Summary

Adds **`AddableEntryList`** — the text + textarea sibling of `AddableTextList`. Companion Storybook docs + story, wired into `components/ui/index.ts`.

Pattern: existing entries render as read-only cards with a remove button; clicking **Add** reveals a `TextInput` (primary) + `TextArea` (secondary) form. **Save** commits and keeps the form open for rapid entry; **Escape** cancels.

## Why

Flagged by Nick on 2026-04-16 — portal's `EditableEntryList` (local, in `onboarding-shared.tsx`) implements this pattern ad-hoc for Competitors. Promoting to BDS so portal, renew-pms, and brikdesigns can share one component for:

- Competitor URL + notes
- Reference site + why
- Line item + description
- Team member + role

Entry shape is intentionally generic `{ primary: string; secondary: string }` so consumers map their domain shape at the boundary.

## What's included

- `components/ui/AddableEntryList/` — `.tsx`, `.css`, `.stories.tsx`, `.mdx`, `index.ts`
- 7 stories: Playground, Empty, PrimaryOnly, Variants + 3 play-function interaction tests (add, remove, duplicate-blocked)
- Exported from `components/ui/index.ts`

## Follow-up (separate PR, after this merges + npm publish)

- [ ] Bump `@brikdesigns/bds` in `brik-client-portal`
- [ ] Replace portal's local `EditableEntryList` in `src/components/sheets/onboarding-shared.tsx` + update Competitors sheet to import from BDS
- [ ] Audit `renew-pms` for the same pattern

## Test plan

- [ ] Playground renders with two seeded competitors, matches AddableTextList visual language
- [ ] Clicking "Add Competitor" reveals the form; Save commits; form stays open for rapid entry
- [ ] Escape cancels cleanly
- [ ] Play functions pass in Storybook test runner: add, remove, duplicate-blocked
- [ ] `npm run typecheck` passes (confirmed locally)
- [ ] Secondary field is optional — `PrimaryOnly` story demonstrates

🤖 Generated with [Claude Code](https://claude.com/claude-code)