### PR TITLE
feat(filter-bar): add FilterBar component

### DIFF
--- a/components/ui/FilterBar/FilterBar.css
+++ b/components/ui/FilterBar/FilterBar.css
@@ -1,0 +1,33 @@
+@layer bds-components {
+/* FilterBar — heading + counter + filter-controls row for list/table views */
+
+.bds-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  margin-bottom: var(--padding-lg);
+  flex-wrap: wrap;
+}
+
+/* ─── Title (heading-sm) ───────────────────────────────── */
+
+.bds-filter-bar__title {
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-sm);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-snug);
+  color: var(--text-primary);
+  margin: 0;
+  text-transform: capitalize;
+}
+
+/* ─── Controls (filter buttons + clear button) ─────────── */
+
+.bds-filter-bar__controls {
+  display: flex;
+  gap: var(--gap-xs);
+  margin-left: auto;
+  flex-wrap: wrap;
+  align-items: center;
+}
+}

--- a/components/ui/FilterBar/FilterBar.mdx
+++ b/components/ui/FilterBar/FilterBar.mdx
@@ -1,0 +1,94 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './FilterBar.stories';
+
+<Meta of={Stories} />
+
+# Filter bar
+
+Shared heading + counter + filter-controls row for list/table views. Renders a `heading-sm` title and a `Counter` on the left, filter children on the right, and an optional ghost "Clear filters" button that appears when any filter is active.
+
+Pairs naturally with [FilterButton](/?path=/docs/components-action-filter-button--docs) and [FilterToggle](/?path=/docs/components-action-filter-toggle--docs) for the control children.
+
+---
+
+## Default
+
+No filter applied — counter stays neutral and the Clear button is hidden.
+
+<Canvas of={Stories.Default} />
+
+## Filtered
+
+When `filtered < total`, the counter switches to `brand` (configurable via `activeStatus`) and, if `onClear` is provided, a ghost Clear button appears after the controls.
+
+<Canvas of={Stories.Filtered} />
+
+## No title
+
+The title is optional. When omitted the counter leads the row.
+
+<Canvas of={Stories.NoTitle} />
+
+## No clear callback
+
+Omit `onClear` to suppress the Clear button entirely — useful for table views that don't support bulk-clearing all filters at once.
+
+<Canvas of={Stories.NoClear} />
+
+## Interactive
+
+Real-world wiring: local state holds filter values, `filtered.length` feeds the counter, and `onClear` resets all filters.
+
+<Canvas of={Stories.Interactive} />
+
+---
+
+## Props
+
+<ArgTypes of={Stories} />
+
+---
+
+## Usage
+
+```tsx
+import { FilterBar, FilterButton } from '@brikdesigns/bds';
+import { useState, useMemo } from 'react';
+
+function EngagementsTable({ rows }) {
+  const [status, setStatus] = useState<string | undefined>();
+
+  const filtered = useMemo(
+    () => (status ? rows.filter((r) => r.status === status) : rows),
+    [rows, status],
+  );
+
+  return (
+    <FilterBar
+      title="Engagements"
+      total={rows.length}
+      filtered={filtered.length}
+      label="engagements"
+      onClear={() => setStatus(undefined)}
+    >
+      <FilterButton
+        label="Status"
+        value={status}
+        onChange={setStatus}
+        options={[
+          { id: 'active', label: 'Active' },
+          { id: 'pending', label: 'Pending' },
+        ]}
+      />
+    </FilterBar>
+  );
+}
+```
+
+---
+
+## Accessibility
+
+- The title renders as an `<h2>` — ensure the surrounding page uses a sensible heading hierarchy (typically an `<h1>` on the page and `<h2>` per table).
+- The container carries an `aria-label` (falls back to `"{title} filter bar"` or `"{label} filter bar"`).
+- Counter announces `"Count: {n}"` via `aria-label`.

--- a/components/ui/FilterBar/FilterBar.stories.tsx
+++ b/components/ui/FilterBar/FilterBar.stories.tsx
@@ -1,0 +1,215 @@
+import { useState, useMemo } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn, expect } from 'storybook/test';
+import { FilterBar } from './FilterBar';
+import { FilterButton } from '../FilterButton';
+import { FilterToggle } from '../FilterToggle';
+
+/* ─── Shared Fixtures ─────────────────────────────────── */
+
+type Row = { id: string; name: string; industry: string; status: 'active' | 'inactive' };
+
+const rows: Row[] = [
+  { id: '1', name: 'Acme Co', industry: 'saas', status: 'active' },
+  { id: '2', name: 'Beacon Health', industry: 'healthcare', status: 'active' },
+  { id: '3', name: 'Cedar Finance', industry: 'finance', status: 'active' },
+  { id: '4', name: 'Dawn Labs', industry: 'saas', status: 'inactive' },
+  { id: '5', name: 'Evergreen Legal', industry: 'legal', status: 'active' },
+  { id: '6', name: 'Fig Studio', industry: 'creative', status: 'inactive' },
+  { id: '7', name: 'Gridline', industry: 'saas', status: 'active' },
+  { id: '8', name: 'Harbor & Co', industry: 'legal', status: 'active' },
+];
+
+const industryOptions = [
+  { id: 'saas', label: 'SaaS' },
+  { id: 'healthcare', label: 'Healthcare' },
+  { id: 'finance', label: 'Finance' },
+  { id: 'legal', label: 'Legal' },
+  { id: 'creative', label: 'Creative' },
+];
+
+const statusOptions = [
+  { id: 'active', label: 'Active' },
+  { id: 'inactive', label: 'Inactive' },
+];
+
+/* ─── Meta ────────────────────────────────────────────── */
+
+const meta = {
+  title: 'Components/Action/filter-bar',
+  component: FilterBar,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', minHeight: 200, padding: 'var(--padding-lg)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof FilterBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ═══════════════════════════════════════════════════════════════
+   1. DEFAULT — No filter applied; counter in neutral state
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Default: Story = {
+  args: {
+    title: 'Companies',
+    total: rows.length,
+    filtered: rows.length,
+    label: 'companies',
+    children: (
+      <>
+        <FilterButton label="Industry" options={industryOptions} />
+        <FilterButton label="Status" options={statusOptions} />
+      </>
+    ),
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   2. FILTERED — Filter active; counter switches to brand + Clear button
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Filtered: Story = {
+  args: {
+    title: 'Companies',
+    total: rows.length,
+    filtered: 3,
+    label: 'companies',
+    onClear: fn(),
+    children: (
+      <>
+        <FilterButton label="Industry" options={industryOptions} value="saas" />
+        <FilterButton label="Status" options={statusOptions} />
+      </>
+    ),
+  },
+  play: async ({ canvas, args }) => {
+    const clearBtn = await canvas.findByRole('button', { name: /clear filters/i });
+    await clearBtn.click();
+    await expect(args.onClear).toHaveBeenCalled();
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   3. NO TITLE — Counter leads when title is omitted
+   ═══════════════════════════════════════════════════════════════ */
+
+export const NoTitle: Story = {
+  args: {
+    total: rows.length,
+    filtered: rows.length,
+    label: 'companies',
+    children: (
+      <>
+        <FilterButton label="Industry" options={industryOptions} />
+        <FilterButton label="Status" options={statusOptions} />
+      </>
+    ),
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   4. NO CLEAR — onClear omitted so no button appears when filtered
+   ═══════════════════════════════════════════════════════════════ */
+
+export const NoClear: Story = {
+  args: {
+    title: 'Companies',
+    total: rows.length,
+    filtered: 2,
+    label: 'companies',
+    children: (
+      <>
+        <FilterButton label="Industry" options={industryOptions} value="legal" />
+      </>
+    ),
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   5. INTERACTIVE — Full table + filter wiring
+   ═══════════════════════════════════════════════════════════════ */
+
+export const Interactive: Story = {
+  args: {
+    title: 'Companies',
+    total: rows.length,
+    filtered: rows.length,
+    label: 'companies',
+    children: null,
+  },
+  render: () => {
+    function Demo() {
+      const [industry, setIndustry] = useState<string | undefined>();
+      const [status, setStatus] = useState<string | undefined>();
+
+      const filtered = useMemo(() => {
+        return rows.filter((r) => {
+          if (industry && r.industry !== industry) return false;
+          if (status && r.status !== status) return false;
+          return true;
+        });
+      }, [industry, status]);
+
+      const clearFilters = () => {
+        setIndustry(undefined);
+        setStatus(undefined);
+      };
+
+      return (
+        <div>
+          <FilterBar
+            title="Companies"
+            total={rows.length}
+            filtered={filtered.length}
+            label="companies"
+            onClear={clearFilters}
+          >
+            <FilterButton
+              label="Industry"
+              options={industryOptions}
+              value={industry}
+              onChange={setIndustry}
+            />
+            <FilterButton
+              label="Status"
+              options={statusOptions}
+              value={status}
+              onChange={setStatus}
+            />
+            <FilterToggle
+              label="Active only"
+              active={status === 'active'}
+              onToggle={() => setStatus(status === 'active' ? undefined : 'active')}
+            />
+          </FilterBar>
+
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left', padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)' }}>Name</th>
+                <th style={{ textAlign: 'left', padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)' }}>Industry</th>
+                <th style={{ textAlign: 'left', padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)' }}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((r) => (
+                <tr key={r.id}>
+                  <td style={{ padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)' }}>{r.name}</td>
+                  <td style={{ padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)', textTransform: 'capitalize' }}>{r.industry}</td>
+                  <td style={{ padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)', textTransform: 'capitalize' }}>{r.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};

--- a/components/ui/FilterBar/FilterBar.tsx
+++ b/components/ui/FilterBar/FilterBar.tsx
@@ -1,0 +1,94 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { Button } from '../Button';
+import { Counter, type CounterStatus } from '../Counter';
+import { bdsClass } from '../../utils';
+import './FilterBar.css';
+
+export interface FilterBarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  /** Total count before filtering */
+  total: number;
+  /** Count after filtering (pass same value as total when no filter is active) */
+  filtered: number;
+  /** Plural entity label, used in the aria-label fallback ("companies", "tasks") */
+  label: string;
+  /** Optional section heading rendered at heading-sm inline with the counter */
+  title?: ReactNode;
+  /** Override the counter's status when a filter is active (default: 'brand') */
+  activeStatus?: CounterStatus;
+  /** Callback to clear all filters. When provided, a "Clear filters" button appears while filtered < total. */
+  onClear?: () => void;
+  /** Label for the Clear button (default: "Clear filters") */
+  clearLabel?: string;
+  /** FilterButton / FilterToggle children rendered on the right */
+  children: ReactNode;
+}
+
+/**
+ * FilterBar — shared heading + counter + filter-controls row for list views.
+ *
+ * Layout: `[title] [counter]          [filter children] [clear?]`
+ *
+ * The counter shows the current filtered count. When `filtered < total` the
+ * counter switches to `activeStatus` (default `brand`) and, if `onClear` is
+ * provided, a ghost "Clear filters" button appears after the filter controls.
+ *
+ * @example
+ * ```tsx
+ * const [statusFilter, setStatusFilter] = useState<string | undefined>();
+ *
+ * <FilterBar
+ *   title="Engagements"
+ *   total={rows.length}
+ *   filtered={filtered.length}
+ *   label="engagements"
+ *   onClear={() => setStatusFilter(undefined)}
+ * >
+ *   <FilterButton label="Status" value={statusFilter} onChange={setStatusFilter} options={...} />
+ * </FilterBar>
+ * ```
+ */
+export function FilterBar({
+  total,
+  filtered,
+  label,
+  title,
+  activeStatus = 'brand',
+  onClear,
+  clearLabel = 'Clear filters',
+  children,
+  className,
+  style,
+  ...props
+}: FilterBarProps) {
+  const isFiltered = filtered < total;
+  const ariaLabel =
+    (props['aria-label'] as string | undefined) ??
+    (typeof title === 'string' ? `${title} filter bar` : `${label} filter bar`);
+
+  return (
+    <div
+      className={bdsClass('bds-filter-bar', className)}
+      style={style}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      {title && <h2 className="bds-filter-bar__title">{title}</h2>}
+      <Counter
+        count={filtered}
+        status={isFiltered ? activeStatus : 'neutral'}
+        size="sm"
+      />
+
+      <div className="bds-filter-bar__controls">
+        {children}
+        {onClear && isFiltered && (
+          <Button variant="ghost" size="md" onClick={onClear}>
+            {clearLabel}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FilterBar;

--- a/components/ui/FilterBar/index.ts
+++ b/components/ui/FilterBar/index.ts
@@ -1,0 +1,2 @@
+export { FilterBar } from './FilterBar';
+export type { FilterBarProps } from './FilterBar';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -31,6 +31,7 @@ export * from './Dot';
 export * from './EmailInput';
 export * from './EmptyState';
 export * from './FileUploader';
+export * from './FilterBar';
 export * from './FilterButton';
 export * from './FilterToggle';
 export * from './Footer';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Brik Design System - React component library with Webflow-synced design tokens",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

- New `FilterBar` BDS component composing heading + BDS `Counter` + filter-control children + optional ghost "Clear filters" button
- Promotes a pattern already duplicated in 11 portal admin tables (and likely renew-pms soon) into BDS
- Story coverage: default, filtered (with interaction test), no-title, no-clear, fully interactive demo with filter-button wiring
- Dedicated MDX docs page with API, usage snippet, and a11y notes
- Version bump 0.3.0 → 0.4.0 (minor — new component)

## API

| Prop | Type | Notes |
|---|---|---|
| `title` | `ReactNode` | Optional heading-sm label |
| `total` / `filtered` / `label` | `number` / `number` / `string` | Drive the Counter + aria-label fallback |
| `activeStatus` | `CounterStatus` | Counter color when filtered (default `'brand'`) |
| `onClear` | `() => void` | Renders Clear button when `filtered < total` |
| `clearLabel` | `string` | Default `"Clear filters"` |
| `children` | `ReactNode` | `FilterButton` / `FilterToggle` |

## Follow-up (not in this PR)

After this merges and `@brikdesigns/bds` publishes:
- Swap portal's local `src/components/filter-bar.tsx` for the BDS import
- Delete the local component (11 consumers already using the same API)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint-tokens` — 0 errors (1 pre-existing warning in Icons.stories)
- [x] `npm run build-storybook` — passes (pre-push hook)
- [ ] Visually verify all 5 stories in Storybook preview
- [ ] Confirm Counter status flip (neutral → brand) when filter applied
- [ ] Confirm Clear button only appears with `onClear` AND `filtered < total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)