### PR TITLE
feat(infra): shared ensure-storybook.sh helper for consumers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,14 @@ The MCP addon (`@storybook/addon-mcp`) exposes the full BDS component library as
 
 **MCP unreachable?** If `get-storybook-story-instructions` fails (Storybook not running, connection refused), read the cached fallback at [`docs/STORYBOOK-WRITING-GUIDE.md`](docs/STORYBOOK-WRITING-GUIDE.md). This mirrors the MCP output and is kept in sync — if you call the MCP later and its content differs, update the cached file in the same PR.
 
+### Shared autostart helper
+
+[`scripts/ensure-storybook.sh`](scripts/ensure-storybook.sh) is the source of truth for the Storybook autostart logic used by every BDS-consumer's `session-guard.sh` hook (portal, renew-pms, brikdesigns). Each consumer pipes its Claude Code `tool_input` JSON into this helper on stdin; if the edit targets a UI file and Storybook isn't listening on `:6006`, the helper launches it in the background.
+
+**Why shared:** before this helper existed, each consumer carried a ~35-line copy of the autostart logic. Now the consumers have a 3-line invocation; changes to the autostart behavior happen here and propagate on next consumer commit.
+
+**Marker keying:** the helper reads `SESSION_GUARD_PARENT_PID` (exported by the caller) so all consumer hooks share one "already-fired" marker per Claude Code session. Without it, each hook would fire independently.
+
 **Addon vitest** (`@storybook/addon-vitest`) is also installed for the test feedback loop.
 
 ### Chromatic (visual testing + hosted Storybook)

--- a/scripts/ensure-storybook.sh
+++ b/scripts/ensure-storybook.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ensure-storybook.sh — shared helper for BDS-consumer session guards.
+#
+# Each consumer's scripts/session-guard.sh (portal, renew-pms, brikdesigns)
+# pipes its Claude Code hook `tool_input` JSON into this script on stdin.
+# If the edit targets a UI file and Storybook isn't already running on
+# port 6006, this helper launches `npm run storybook` in the BDS repo in
+# the background so the storybook-mcp server becomes reachable.
+#
+# Input  : JSON on stdin (Claude Code PreToolUse hook payload).
+# Env    : SESSION_GUARD_PARENT_PID — set by the calling session-guard so
+#          all repo hooks share a single "already-fired this session" marker.
+# Side   : Writes /tmp/.brik-storybook-autostart-${PID} to key the once-
+#          per-session behavior. Launches a detached `npm run storybook`
+#          if the port is free.
+# Exit   : 0 always — the helper never blocks the calling hook.
+#
+# Behavior is silent on success. Prints a single info line when it
+# actually starts the dev server.
+
+set -euo pipefail
+
+# Compute the marker key. Prefer the caller's parent PID so multiple repos
+# sharing a single Claude Code session don't each re-spawn Storybook.
+if [[ -n "${SESSION_GUARD_PARENT_PID:-}" ]]; then
+  MARKER_KEY="$SESSION_GUARD_PARENT_PID"
+else
+  MARKER_KEY=$(ps -o ppid= -p $$ 2>/dev/null | tr -d ' ')
+  MARKER_KEY="${MARKER_KEY:-unknown}"
+fi
+MARKER="/tmp/.brik-storybook-autostart-${MARKER_KEY}"
+
+# Already fired this session? Nothing to do.
+[[ -f "$MARKER" ]] && exit 0
+
+# Pull the target file path out of the hook payload.
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' 2>/dev/null || echo "")
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Only act on UI-relevant extensions.
+case "$FILE_PATH" in
+  *.tsx|*.jsx|*.css|*.scss|*.stories.ts|*.stories.tsx|*.stories.js|*.stories.jsx) ;;
+  *) exit 0 ;;
+esac
+
+touch "$MARKER"
+
+# Storybook already up? Done.
+if curl -s -o /dev/null --max-time 1 http://localhost:6006/ 2>/dev/null; then
+  exit 0
+fi
+
+# BDS repo missing? Nothing to start. (Consumers with an npm-only install
+# won't have this path — silently skip.)
+BDS_DIR="$HOME/Documents/GitHub/brik/brik-bds"
+[[ -d "$BDS_DIR" && -f "$BDS_DIR/package.json" ]] || exit 0
+
+echo ""
+echo "🔧  Storybook not running on :6006 — starting in background for the BDS MCP."
+echo "    Logs: /tmp/brik-storybook.log"
+echo ""
+
+(
+  cd "$BDS_DIR"
+  nohup npm run storybook > /tmp/brik-storybook.log 2>&1 &
+  disown
+) >/dev/null 2>&1 || true
+
+exit 0


### PR DESCRIPTION
## Summary
- New [`scripts/ensure-storybook.sh`](scripts/ensure-storybook.sh) — single source of truth for the Storybook autostart logic used by every BDS consumer's `session-guard.sh` hook.
- CLAUDE.md now documents the helper, the `SESSION_GUARD_PARENT_PID` marker-keying convention, and how consumers invoke it.

## Why
Before this PR the autostart logic was duplicated ~35 lines across three repos (brik-client-portal, renew-pms, brikdesigns). Any change to the behavior — a new excluded extension, a different port, a timeout tweak — had to be made in three places. This helper collapses that to one.

## Consumer refactors (follow-up PRs)
Each consumer's `session-guard.sh` will shrink to a 3-line invocation that pipes its `tool_input` JSON into this helper:
- [ ] brik-client-portal
- [ ] renew-pms
- [ ] brikdesigns

## Test plan
- [ ] Simulate a `.tsx` edit with port 6006 free → helper starts Storybook, prints one info line.
- [ ] Simulate a non-UI edit → helper exits silently, no marker created.
- [ ] Simulate a `.tsx` edit with port 6006 already up → silent exit 0.
- [ ] Simulate a `.tsx` edit after the marker exists → silent exit 0 (no double-start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)