### PR TITLE
fix(tokens): keep --background-on-color-* static across dark mode

### DIFF
--- a/scripts/build-dist-tokens.js
+++ b/scripts/build-dist-tokens.js
@@ -4,7 +4,7 @@
  * Called by: npm run build:lib (as the final step)
  *
  * Produces:
- *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + gap-fills.css concatenated
+ *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + figma-dark-corrections.css + gap-fills.css concatenated
  *   dist/bridge.css  — clean name ↔ Webflow internal name aliases
  */
 const fs = require('fs');
@@ -47,7 +47,15 @@ if (fs.existsSync(darkTokensPath)) {
   console.log('  ⚠ No figma-tokens-dark.css found — run npm run build:sd-dark to generate');
 }
 
-fs.writeFileSync(path.join(DIST_DIR, 'tokens.css'), header + figmaTokens + darkTokens + '\n\n' + gapFills);
+// Post-Figma dark-mode corrections — overrides for values the Figma export gets wrong
+const darkCorrectionsPath = path.join(TOKENS_DIR, 'figma-dark-corrections.css');
+let darkCorrections = '';
+if (fs.existsSync(darkCorrectionsPath)) {
+  darkCorrections = '\n\n' + fs.readFileSync(darkCorrectionsPath, 'utf8');
+  console.log('  ✓ Including dark-mode corrections');
+}
+
+fs.writeFileSync(path.join(DIST_DIR, 'tokens.css'), header + figmaTokens + darkTokens + darkCorrections + '\n\n' + gapFills);
 console.log('  ✓ dist/tokens.css');
 
 // Copy bridge.css

--- a/tokens/figma-dark-corrections.css
+++ b/tokens/figma-dark-corrections.css
@@ -1,0 +1,22 @@
+/**
+ * figma-dark-corrections.css — post-Figma dark-mode overrides
+ *
+ * Figma's dark-mode export (figma-tokens-dark.css) flips values that
+ * shouldn't flip. This file re-asserts the correct values and is
+ * concatenated into dist/tokens.css AFTER figma-tokens-dark.css, so
+ * these overrides survive the next Figma pull.
+ *
+ * Keep edits here minimal — prefer fixing the source in Figma and
+ * removing the correction when the sync confirms the fix.
+ */
+
+:root[data-theme="dark"] {
+  /**
+   * `--background-on-color-*` describes contrast for non-neutral
+   * (brand-colored) surfaces, which don't flip with theme. The sibling
+   * `--text-on-color-*` tokens already stay static in both modes — the
+   * backgrounds must behave the same.
+   */
+  --background-on-color-dark: var(--color-grayscale-white);
+  --background-on-color-light: var(--color-grayscale-black);
+}


### PR DESCRIPTION
## Summary
- `--background-on-color-dark` and `--background-on-color-light` were flipping in dark mode (white ↔ black) in Figma's export, while their sibling `--text-on-color-*` tokens correctly stay static across modes.
- These tokens describe contrast for non-neutral (brand-colored) surfaces like `--surface-brand-primary` — those surfaces don't flip with theme, so neither should their contrast pairs.
- Introduces `tokens/figma-dark-corrections.css` as a post-Figma override layer. `build-dist-tokens.js` concatenates it into `dist/tokens.css` after `figma-tokens-dark.css`, so the correction survives the next Figma pull.

## Why a corrections file (not patching figma-tokens-dark.css)
`figma-tokens-dark.css` is auto-generated by `scripts/figma-pull-tokens.sh` and will be overwritten. Upstream the fix belongs in the Figma variable itself — until that happens, the corrections file keeps the dist output correct.

## Impact
- Any consumer loading `@brikdesigns/bds/tokens.css` with `:root[data-theme="dark"]` (portal, renew-pms, brikdesigns) will now get the correct white/black values.
- No Storybook impact — Storybook loads `figma-tokens.css` directly (no dark block) and uses `.theme-brik.dark`, which never set these tokens.
- `dist/tokens.css` rebuild left to the release PR (current PR commits source only).

## Test plan
- [ ] After merge, next release PR includes the rebuilt `dist/tokens.css` (lines near 536–537 re-assert the white/black values)
- [ ] In a consumer on `data-theme="dark"`, confirm `getComputedStyle(':root').getPropertyValue('--background-on-color-dark')` resolves to `#ffffff`
- [ ] Confirm no unrelated token values changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)