### PR TITLE
feat(banner+button): marketing banner spec + on-color variant

### DIFF
--- a/components/ui/Banner/Banner.css
+++ b/components/ui/Banner/Banner.css
@@ -9,8 +9,8 @@
   gap: var(--gap-lg);
   background-color: var(--surface-brand-primary);
   color: var(--text-on-color-dark);
-  padding: var(--padding-lg);
-  border-radius: var(--border-radius-sm);
+  padding: var(--padding-md) var(--padding-huge);
+  border-radius: var(--border-radius-100);
   width: 100%;
   box-sizing: border-box;
 }

--- a/components/ui/Banner/Banner.stories.tsx
+++ b/components/ui/Banner/Banner.stories.tsx
@@ -31,9 +31,7 @@ const Stack = ({ children }: { children: React.ReactNode }) => (
 );
 
 const BannerAction = ({ children }: { children: string }) => (
-  <Button variant="secondary" size="sm" style={{ backgroundColor: 'var(--background-on-color-dark)', color: 'var(--text-primary)', border: 'none' }}>
-    {children}
-  </Button>
+  <Button variant="on-color" size="md">{children}</Button>
 );
 
 /* ─── Playground ─────────────────────────────────────────────── */

--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -112,6 +112,11 @@
   color: var(--text-on-color-light);
 }
 
+.bds-button--on-color {
+  background-color: var(--background-on-color-dark);
+  color: var(--text-on-color-light);
+}
+
 .bds-button--danger {
   background-color: var(--background-accent-red);
   color: var(--text-on-color-dark);
@@ -208,6 +213,16 @@
 .bds-button--inverse:active:not(:disabled) {
   background-color: var(--background-brand-primary-pressed);
   color: var(--text-on-color-dark);
+  transform: translateY(var(--button-active-translate-y)); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
+}
+
+/* ── On-color ── Static white button for use on brand-colored surfaces. */
+.bds-button--on-color:hover:not(:disabled):not(.bds-button--loading) {
+  opacity: 0.9;
+}
+
+.bds-button--on-color:active:not(:disabled) {
+  opacity: 0.8;
   transform: translateY(var(--button-active-translate-y)); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
 }
 

--- a/components/ui/Button/Button.stories.tsx
+++ b/components/ui/Button/Button.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['primary', 'outline', 'secondary', 'ghost', 'inverse', 'destructive', 'positive', 'selected'],
+      options: ['primary', 'outline', 'secondary', 'ghost', 'inverse', 'on-color', 'destructive', 'positive', 'selected'],
     },
     size: {
       control: 'select',
@@ -132,18 +132,26 @@ export const Variants: Story = {
   render: () => (
     <Stack>
       <SectionLabel>Brand buttons (UI hierarchy)</SectionLabel>
-      {(['primary', 'secondary', 'outline', 'ghost', 'inverse'] as const).map((variant) => (
-        <div key={variant} style={variant === 'inverse' ? { background: 'var(--surface-inverse)', padding: 'var(--padding-md)', borderRadius: 'var(--border-radius-md)' } : undefined}>
-          <SectionLabel>{variant}</SectionLabel>
-          <Row>
-            <Button variant={variant} size="tiny">Tiny</Button>
-            <Button variant={variant} size="sm">Small</Button>
-            <Button variant={variant} size="md">Medium</Button>
-            <Button variant={variant} size="lg">Large</Button>
-            <Button variant={variant} size="xl">X-Large</Button>
-          </Row>
-        </div>
-      ))}
+      {(['primary', 'secondary', 'outline', 'ghost', 'inverse', 'on-color'] as const).map((variant) => {
+        const surfaceStyle =
+          variant === 'inverse'
+            ? { background: 'var(--surface-inverse)', padding: 'var(--padding-md)', borderRadius: 'var(--border-radius-md)' }
+            : variant === 'on-color'
+              ? { background: 'var(--surface-brand-primary)', padding: 'var(--padding-md)', borderRadius: 'var(--border-radius-md)' }
+              : undefined;
+        return (
+          <div key={variant} style={surfaceStyle}>
+            <SectionLabel>{variant}</SectionLabel>
+            <Row>
+              <Button variant={variant} size="tiny">Tiny</Button>
+              <Button variant={variant} size="sm">Small</Button>
+              <Button variant={variant} size="md">Medium</Button>
+              <Button variant={variant} size="lg">Large</Button>
+              <Button variant={variant} size="xl">X-Large</Button>
+            </Row>
+          </div>
+        );
+      })}
 
       <SectionLabel>System buttons (semantic actions)</SectionLabel>
       {(['selected', 'destructive', 'positive'] as const).map((variant) => (
@@ -218,7 +226,7 @@ export const States: Story = {
         <SectionLabel>Disabled</SectionLabel>
         <SectionLabel>Loading</SectionLabel>
 
-        {(['primary', 'outline', 'secondary', 'ghost', 'inverse', 'destructive', 'positive', 'selected'] as const).map((variant) => (
+        {(['primary', 'outline', 'secondary', 'ghost', 'inverse', 'on-color', 'destructive', 'positive', 'selected'] as const).map((variant) => (
           <React.Fragment key={variant}>
             <SectionLabel>{variant}</SectionLabel>
             <Button variant={variant} size="md">Button</Button>

--- a/components/ui/Button/Button.tsx
+++ b/components/ui/Button/Button.tsx
@@ -10,7 +10,8 @@ import './Button.css';
  * - outline: Secondary emphasis (brand border)
  * - secondary: Tertiary/subtle (surface fill)
  * - ghost: Minimal emphasis (no background)
- * - inverse: For dark backgrounds (white fill)
+ * - inverse: For dark theme surfaces (white in light mode, black in dark mode — flips with theme)
+ * - on-color: For brand-colored surfaces like banner backgrounds (always white fill, black text — does not flip with theme)
  *
  * System variants (semantic actions):
  * - destructive: Destructive action (system red)
@@ -28,6 +29,7 @@ export type ButtonVariant =
   | 'secondary'
   | 'ghost'
   | 'inverse'
+  | 'on-color'
   | 'danger'
   | 'danger-outline'
   | 'danger-ghost'


### PR DESCRIPTION
Depends on #100 (token fix) for correct dark-mode rendering in consumers.

## Summary

Two related changes for the marketing banner:

### (1) Banner padding + radius match Figma
[Figma node 25671-789](https://www.figma.com/design/yhLkzLUnG71UFTgURDvgnv/Brik-Website?node-id=25671-789) specifies:
- Padding: 16px vertical, 48px horizontal (asymmetric)
- Radius: 4px

Previously the Banner used `padding-lg` (24px all sides) and `border-radius-sm` (8px). Updated to `var(--padding-md) var(--padding-huge)` and `var(--border-radius-100)`.

### (2) New `Button variant="on-color"`
The Figma spec for the Banner's action button uses `--background-on-color-dark` (static white) and `--text-on-color-light` (static black). `Button variant="inverse"` was the closest existing fit, but it maps to `--background-inverse` which is theme-flipping — wrong semantics for a button sitting on a brand-colored (non-flipping) surface.

- Added `'on-color'` to `ButtonVariant` union
- New class `.bds-button--on-color` using the on-color tokens
- Hover: `opacity: 0.9`; active: `opacity: 0.8` + `translate-y` (matches existing variant patterns)
- Banner stories now use `variant="on-color"` for the action slot (was an inline-styled `secondary` workaround)
- Button stories' Variants grid renders the new variant on a `--surface-brand-primary` preview so you can see it in context

## Dependency chain
1. **Merge #100 first** — fixes `--background-on-color-dark` dark-mode token value in `dist/tokens.css`. Without it, consumers in dark mode get a black on-color button on an orange banner (still legible, but not the Figma intent).
2. **Merge this PR second** — Button variant + Banner spec match.
3. **Release PR** — version bump + rebuilt `dist/` (separate, per BDS convention).
4. **Portal update** — `npm update @brikdesigns/bds`, switch `LinkButton variant="inverse"` → `variant="on-color"` in `admin/page.tsx`, drop the inline `borderRadius` override.

## Storybook preview
- [Banner / Playground](http://localhost:6006/?path=/story/components-feedback-marketing-banner--playground)
- [Banner / Variants](http://localhost:6006/?path=/story/components-feedback-marketing-banner--variants)
- [Button / Variants](http://localhost:6006/?path=/story/components-action-button--variants)
- [Button / States](http://localhost:6006/?path=/story/components-action-button--states)

## Test plan
- [ ] Banner renders with 16/48 padding and 4px radius in Storybook
- [ ] Button `variant="on-color"` renders white-on-orange in the Variants grid
- [ ] Typecheck passes (confirmed locally)
- [ ] After #100 merges + this rebases, dark-mode Storybook Banner still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)