### PR TITLE
feat(tokens)!: consolidate dark-mode to [data-theme] and bundle brand theme

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -21,7 +21,7 @@ import { FeedbackWidget } from './FeedbackWidget';
 // 5. Storybook overrides (Base mode spacing, UI fixes)
 import '../tokens/figma-tokens.css';
 import '../tokens/gap-fills.css';
-import '../tokens/theme-brik.css';
+import '../tokens/theme-brand-brik.css';
 import '../tokens/font-audit.css';
 import '../css/animations.css';
 import '../css/premium-effects.css';
@@ -79,14 +79,20 @@ const ThemedDocsContainer: typeof DefaultDocsContainer = (props) => {
   // Without this, CSS vars stay stale when the user switches themes.
   useLayoutEffect(() => {
     const body = document.body;
+    const html = document.documentElement;
     body.className = body.className.replace(/\btheme-\S+/g, '');
-    body.classList.remove('dark', 'light');
     if (themeNum === 'brik-dark') {
-      body.classList.add('body', 'theme-brik', 'dark');
+      body.classList.add('body', 'theme-brand-brik');
+      html.setAttribute('data-theme', 'dark');
     } else if (themeNum === 'client-sim') {
-      body.classList.add('body', 'theme-brik', 'theme-client-sim', 'light');
+      body.classList.add('body', 'theme-brand-brik', 'theme-client-sim');
+      html.setAttribute('data-theme', 'light');
+    } else if (themeNum === 'brik') {
+      body.classList.add('body', 'theme-brand-brik');
+      html.setAttribute('data-theme', 'light');
     } else {
-      body.classList.add('body', `theme-${themeNum}`, 'light');
+      body.classList.add('body', `theme-${themeNum}`);
+      html.removeAttribute('data-theme');
     }
     const isDark = storybookThemes[themeNum as ThemeNumber]?.base === 'dark';
     body.setAttribute('data-bds-dark', String(isDark));
@@ -134,20 +140,26 @@ const withTheme: Decorator = (Story, context) => {
   // useLayoutEffect runs synchronously before paint — no flash of old theme.
   useLayoutEffect(() => {
     const body = document.body;
-    // Strip any previous theme and dark/light classes
+    const html = document.documentElement;
+    // Strip any previous theme classes
     body.className = body.className.replace(/\btheme-\S+/g, '');
-    body.classList.remove('dark', 'light');
 
     // Apply theme classes:
-    // - brik-dark: .theme-brik.dark
-    // - client-sim (Font Audit): .theme-brik.theme-client-sim (inherit Brik colors, override fonts)
-    // - all others: .theme-X
+    // - brik + brik-dark: .theme-brand-brik + data-theme attr (light/dark)
+    // - client-sim (Font Audit): .theme-brand-brik.theme-client-sim + data-theme="light"
+    // - all others: .theme-X (no data-theme attribute)
     if (themeNumber === 'brik-dark') {
-      body.classList.add('body', 'theme-brik', 'dark');
+      body.classList.add('body', 'theme-brand-brik');
+      html.setAttribute('data-theme', 'dark');
     } else if (themeNumber === 'client-sim') {
-      body.classList.add('body', 'theme-brik', 'theme-client-sim', 'light');
+      body.classList.add('body', 'theme-brand-brik', 'theme-client-sim');
+      html.setAttribute('data-theme', 'light');
+    } else if (themeNumber === 'brik') {
+      body.classList.add('body', 'theme-brand-brik');
+      html.setAttribute('data-theme', 'light');
     } else {
-      body.classList.add('body', `theme-${themeNumber}`, 'light');
+      body.classList.add('body', `theme-${themeNumber}`);
+      html.removeAttribute('data-theme');
     }
 
     // Set dark mode data attribute for CSS selectors that need light/dark branching

--- a/components/providers/ThemeProvider.tsx
+++ b/components/providers/ThemeProvider.tsx
@@ -92,9 +92,9 @@ export interface ThemeProviderProps {
  * - localStorage persistence (optional)
  * - Automatic body class application (optional)
  *
- * Available Themes:
- * - theme-brik: Brik Light (Default)
- * - theme-brik-dark: Brik Dark
+ * Available Themes (class + data-theme attribute):
+ * - theme-brand-brik + data-theme="light": Brik Light (default)
+ * - theme-brand-brik + data-theme="dark": Brik Dark
  * - theme-1: Peach (Open Sans)
  * - theme-2: Pastel (Source Sans)
  * - theme-3: Luxury (Hind)
@@ -155,10 +155,13 @@ export function ThemeProvider({
       body.classList.add('body');
     }
 
-    // Remove old theme classes
+    // Remove old theme classes (includes legacy 'theme-brik' / 'theme-brik-dark'
+    // names from pre-v0.7 BDS in case a consumer upgrades without a hard reload)
     body.classList.remove(
       'theme-brik',
       'theme-brik-dark',
+      'theme-brand-brik',
+      'theme-client-sim',
       'theme-1',
       'theme-2',
       'theme-3',
@@ -169,8 +172,20 @@ export function ThemeProvider({
       'theme-8'
     );
 
-    // Add theme class (always add it, including theme-1)
-    body.classList.add(`theme-${theme.themeNumber}`);
+    // Brand themes share the 'theme-brand-brik' class and differentiate via
+    // the `data-theme` attribute on <html>. Numbered template themes keep the
+    // 'theme-X' class (no data-theme attribute).
+    const html = document.documentElement;
+    if (theme.themeNumber === 'brik' || theme.themeNumber === 'brik-dark') {
+      body.classList.add('theme-brand-brik');
+      html.setAttribute('data-theme', theme.themeNumber === 'brik-dark' ? 'dark' : 'light');
+    } else if (theme.themeNumber === 'client-sim') {
+      body.classList.add('theme-brand-brik', 'theme-client-sim');
+      html.setAttribute('data-theme', 'light');
+    } else {
+      body.classList.add(`theme-${theme.themeNumber}`);
+      html.removeAttribute('data-theme');
+    }
 
     // Dispatch custom event for other scripts
     document.dispatchEvent(

--- a/design-tokens/metadata.json
+++ b/design-tokens/metadata.json
@@ -12,6 +12,6 @@
     "theme-6",
     "theme-7",
     "theme-8",
-    "theme-brik"
+    "theme-brand-brik"
   ]
 }

--- a/scripts/build-dist-tokens.js
+++ b/scripts/build-dist-tokens.js
@@ -4,7 +4,7 @@
  * Called by: npm run build:lib (as the final step)
  *
  * Produces:
- *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + figma-dark-corrections.css + gap-fills.css concatenated
+ *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + figma-dark-corrections.css + theme-brand-brik.css + gap-fills.css concatenated
  *   dist/bridge.css  — clean name ↔ Webflow internal name aliases
  */
 const fs = require('fs');
@@ -55,7 +55,15 @@ if (fs.existsSync(darkCorrectionsPath)) {
   console.log('  ✓ Including dark-mode corrections');
 }
 
-fs.writeFileSync(path.join(DIST_DIR, 'tokens.css'), header + figmaTokens + darkTokens + darkCorrections + '\n\n' + gapFills);
+// Brik brand theme — applied when consumer sets .theme-brand-brik on <body>
+const themeBrandBrikPath = path.join(TOKENS_DIR, 'theme-brand-brik.css');
+let themeBrandBrik = '';
+if (fs.existsSync(themeBrandBrikPath)) {
+  themeBrandBrik = '\n\n' + fs.readFileSync(themeBrandBrikPath, 'utf8');
+  console.log('  ✓ Including Brik brand theme');
+}
+
+fs.writeFileSync(path.join(DIST_DIR, 'tokens.css'), header + figmaTokens + darkTokens + darkCorrections + themeBrandBrik + '\n\n' + gapFills);
 console.log('  ✓ dist/tokens.css');
 
 // Copy bridge.css

--- a/scripts/validate-themes.js
+++ b/scripts/validate-themes.js
@@ -178,7 +178,7 @@ const rootVars = { ...(figmaBlocks[':root'] || {}), ...(gapBlocks[':root'] || {}
 
 // Determine theme names from CSS
 const themeNames = Object.keys(themeBlocks).filter(k => k.startsWith('theme-'));
-if (!themeNames.includes('theme-brik')) themeNames.unshift('theme-brik');
+if (!themeNames.includes('theme-brand-brik')) themeNames.unshift('theme-brand-brik');
 
 const results = [];
 

--- a/stories/foundation/ClientThemes.mdx
+++ b/stories/foundation/ClientThemes.mdx
@@ -9,26 +9,26 @@ BDS ships 3 built-in themes. Each theme overrides a curated set of semantic colo
 
 ## How themes work
 
-Themes are applied by adding a class to `<body>`. The `ThemeProvider` component manages this automatically.
+Brand themes use a class on `<body>` plus the `data-theme` attribute on `<html>`. The `ThemeProvider` component manages both automatically.
 
 ```tsx
 // In your layout or app root:
-<ThemeProvider theme="brik">
+<ThemeProvider initialTheme={{ themeNumber: 'brik-dark' }}>
   <App />
 </ThemeProvider>
 ```
 
-Internally, `ThemeProvider` sets `document.body.className = 'body theme-{name}'`. The CSS selector `.body.theme-{name} { ... }` then overrides the semantic tokens for that theme. Brik's own blocks live in `tokens/theme-brik.css`; the client-sim block lives in `tokens/font-audit.css`.
+Internally, `ThemeProvider` sets `body.classList.add('theme-brand-brik')` and `html.setAttribute('data-theme', 'dark')`. The CSS selector `.theme-brand-brik[data-theme="dark"] { ... }` then overrides the semantic tokens for that theme. Brik's blocks live in `tokens/theme-brand-brik.css` (bundled into `dist/tokens.css`); the client-sim block lives in `tokens/font-audit.css`. See `tokens/CASCADE.md` for the full load order.
 
 ## Built-in themes
 
 <ThemeOverview />
 
-| Class | Description |
-|-------|-------------|
-| `.body.theme-brik` | Brik brand — poppy red on near-black, Poppins |
-| `.body.theme-brik-dark` | Brik brand, dark mode — poppy red on near-black |
-| `.body.theme-client-sim` | Font audit tool — Georgia/Verdana/Courier New exposes semantic font-family misuse |
+| Selector | Description |
+|----------|-------------|
+| `.theme-brand-brik[data-theme="light"]` (or no `data-theme`) | Brik brand — poppy red, Poppins on white |
+| `.theme-brand-brik[data-theme="dark"]` | Brik brand, dark mode — poppy red on near-black |
+| `.theme-brand-brik.theme-client-sim` | Font audit tool — Georgia/Verdana/Courier New exposes semantic font-family misuse |
 
 Use the paintbrush icon in the Storybook toolbar to switch themes in real time.
 
@@ -64,7 +64,7 @@ Each `.body.theme-{name}` block overrides a fixed set of **semantic color tokens
 
 > **Note:** `--surface-nav` is a deprecated alias for `--surface-navigation`. Both resolve to the same value. Prefer `--surface-navigation` in new client overrides.
 
-**Typography tokens** are not overridden by `theme-brik` or `theme-brik-dark` — both share the Brik font stack. The `theme-client-sim` class demonstrates font family overrides only.
+**Typography tokens** are not overridden by `data-theme="light"` vs `data-theme="dark"` — both share the Brik font stack. The `theme-client-sim` class demonstrates font family overrides only.
 
 **Spacing tokens** are not theme-controlled — spacing comes from the Base/Spacious mode set on `.body`, not from theme classes.
 

--- a/tokens/CASCADE.md
+++ b/tokens/CASCADE.md
@@ -12,21 +12,24 @@ renew-pms, brikdesigns) via `@brikdesigns/bds/tokens.css`. Built by
 1. `figma-tokens.css` — auto-generated light-mode tokens (`:root`)
 2. `figma-tokens-dark.css` — auto-generated dark-mode tokens (`:root[data-theme="dark"]`)
 3. `figma-dark-corrections.css` — manual overrides for known-wrong Figma dark values
-4. `gap-fills.css` — manual tokens not yet in Figma
+4. `theme-brand-brik.css` — Brik brand overrides (scoped to `.theme-brand-brik` class)
+5. `gap-fills.css` — manual tokens not yet in Figma
 
-**Not bundled:** `theme-brik.css`, `bridge.css`, `font-audit.css`, `animations.css`,
-`motion-classes.css`, `storybook-themes.ts`, `index.ts`.
+**Not bundled:** `bridge.css` (opt-in via separate export), `font-audit.css`
+(Storybook-only), `animations.css`, `motion-classes.css`, `storybook-themes.ts`,
+`index.ts`.
 
 ## Dark-mode selector contract
 
-**Consumers: `:root[data-theme="dark"]`** — set via a `data-theme` attribute on
-`<html>` (pattern used by portal). This is the only dark-mode selector that
-ships in `dist/tokens.css`.
+**Single switch across the ecosystem: `[data-theme="dark"]` attribute on `<html>`.**
 
-**Storybook:** uses `.theme-brik.dark` (class-based), declared in
-`theme-brik.css`. This file is Storybook-only. A structural consolidation to
-`[data-theme]` is tracked as a follow-up — until then, dark-mode changes need
-to be made in two places to stay aligned.
+- Figma-generated tokens: `:root[data-theme="dark"]`
+- Brand overrides: `.theme-brand-brik[data-theme="dark"]`
+- Storybook sets the attribute via the theme toolbar (`preview.tsx`)
+- React consumers use `ThemeProvider` (which sets it automatically when `applyToBody` is true)
+- Astro/Webflow/static consumers set it manually on `<html>`
+
+No consumer should toggle a `.dark` class — the attribute is the only switch.
 
 ## Decision tree — where to put a change
 
@@ -34,7 +37,7 @@ to be made in two places to stay aligned.
 |---|---|
 | Fix a value that came out of Figma wrong | `figma-dark-corrections.css` (dark) or a new `figma-corrections.css` (light — doesn't exist yet, add when needed) |
 | Add a semantic token Figma doesn't export | `gap-fills.css` |
-| Adjust Brik's brand colors / fonts | `theme-brik.css` (caveat: Storybook only — consumers need their own theme file) |
+| Adjust Brik's brand colors / fonts | `theme-brand-brik.css` — consumers get these automatically when they apply `.theme-brand-brik` to `<body>` |
 | Add a Webflow-facing alias | `bridge.css` (deprecated layer) |
 | Touch an auto-generated file | Don't. Fix in Figma and re-pull, or add an override in a manual file. |
 
@@ -49,10 +52,10 @@ place for a correction is a manual file bundled AFTER the auto-generated ones.
 ## Manual (safe to edit)
 
 - `figma-dark-corrections.css` — known-wrong dark values
+- `theme-brand-brik.css` — Brik brand overrides (class-scoped, bundled into dist)
 - `gap-fills.css` — tokens Figma doesn't export yet
-- `theme-brik.css` — Storybook-only brand theme (see consolidation followup)
-- `bridge.css` — legacy Webflow aliases (deprecated)
-- `animations.css`, `motion-classes.css`, `font-audit.css` — component-level
+- `bridge.css` — legacy Webflow aliases (deprecated, opt-in only)
+- `font-audit.css`, `animations.css`, `motion-classes.css` — Storybook/component-level
 
 ## Adding a new file to the bundle
 

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -11,13 +11,15 @@
  */
 
 /**
- * Available theme identifiers (maps to .theme-X classes)
+ * Available theme identifiers
  *
- * - theme-brik: Brik Brand — poppy red, Poppins
- * - theme-brik.dark: Brik Brand dark mode — poppy red on near-black
- * - theme-client-sim: Font Audit — intentionally distinct system fonts per family.
- *   heading=Georgia (serif), body=Verdana (sans), label=Courier New (mono).
- *   Any component using the wrong family token becomes immediately visible.
+ * Brand themes share the `.theme-brand-brik` class and differentiate via the
+ * `data-theme` attribute on <html>. Numbered template themes keep the
+ * `.theme-X` class pattern (no data-theme attribute).
+ *
+ * - brik          → `.theme-brand-brik` + `data-theme="light"` (Brik Brand — poppy red, Poppins)
+ * - brik-dark     → `.theme-brand-brik` + `data-theme="dark"` (poppy red on near-black)
+ * - client-sim    → `.theme-brand-brik.theme-client-sim` + `data-theme="light"` (Font Audit tool)
  *
  * Website template themes (1-8) moved to brik/brik-website-themes repo.
  */
@@ -77,12 +79,23 @@ export const themeMetadata: Record<ThemeNumber, { name: string; description: str
 };
 
 /**
- * Generate CSS class string for theme
+ * Generate CSS class string for theme.
+ *
+ * Brand themes (brik, brik-dark, client-sim) return `.theme-brand-brik` — the
+ * light/dark split is expressed via the `data-theme` attribute on <html>, not
+ * the class string. Apply that attribute separately (ThemeProvider does this
+ * automatically when `applyToBody` is true).
+ *
+ * Numbered template themes (theme-1 through theme-8) return their own class.
  */
 export function getThemeClasses(config: Partial<BDSThemeConfig>): string {
   const classes: string[] = ['body'];
 
-  if (config.themeNumber) {
+  if (config.themeNumber === 'brik' || config.themeNumber === 'brik-dark') {
+    classes.push('theme-brand-brik');
+  } else if (config.themeNumber === 'client-sim') {
+    classes.push('theme-brand-brik', 'theme-client-sim');
+  } else if (config.themeNumber) {
     classes.push(`theme-${config.themeNumber}`);
   }
 

--- a/tokens/theme-brand-brik.css
+++ b/tokens/theme-brand-brik.css
@@ -1,23 +1,24 @@
 /**
  * Brik Brand Theme — Light + Dark modes
  *
- * Loaded by: Storybook ONLY (.storybook/preview.tsx). NOT bundled into
- * dist/tokens.css. Consumers that apply Brik brand colors (portal,
- * brikdesigns.com) ship their own brand-theme file until consolidation.
+ * Loaded by: bundled into dist/tokens.css (after figma-dark-corrections.css).
+ * Every consumer with `@import '@brikdesigns/bds/tokens.css'` receives these
+ * brand overrides. Also imported directly in Storybook preview.tsx.
  *
  * See tokens/CASCADE.md for the full load-order + selector contract.
  *
  * Color + typography overrides only; spacing uses Base mode defaults from figma-tokens.css.
  *
- * Dark mode uses `.theme-brik.dark` (class toggle) instead of the consumer
- * `:root[data-theme="dark"]` selector. The values here duplicate what
- * figma-tokens-dark.css declares — kept in sync by convention until the
- * structural followup rescopes this file to `[data-theme="dark"]`.
+ * Selector contract: `.theme-brand-brik` for light mode, scoped with the
+ * consumer-standard `[data-theme="dark"]` attribute for dark mode. Matches
+ * figma-tokens-dark.css's dark-mode mechanism so Storybook and consumers
+ * share one switch. Set by ThemeProvider for React apps; set manually on
+ * html/body for Astro/Webflow/static sites.
  */
 
 /* ─── Light mode ─────────────────────────────────────────────── */
 
-.theme-brik {
+.theme-brand-brik {
   /* Page */
   --page-primary: var(--color-grayscale-white);
   --page-secondary: var(--color-grayscale-lightest);
@@ -65,9 +66,9 @@
   --font-family-display: Poppins, sans-serif;
 }
 
-/* ─── Dark mode (explicit class) ─────────────────────────────── */
+/* ─── Dark mode (data-theme attribute) ───────────────────────── */
 
-.theme-brik.dark {
+.theme-brand-brik[data-theme="dark"] {
   /* Page */
   --page-primary: var(--color-grayscale-black);
   --page-secondary: var(--color-grayscale-darker);
@@ -120,7 +121,7 @@
 /* ─── Dark mode (system preference auto-switch) ──────────────── */
 
 @media (prefers-color-scheme: dark) {
-  .theme-brik:not(.light) {
+  .theme-brand-brik:not([data-theme="light"]) {
     /* Page */
     --page-primary: var(--color-grayscale-black);
     --page-secondary: var(--color-grayscale-darker);


### PR DESCRIPTION
Closes #104.

## Summary
Collapses two parallel dark-mode mechanisms into a single selector across the BDS ecosystem. Before this PR:

| File | Selector | Who loads it |
|---|---|---|
| `figma-tokens-dark.css` (auto) | `:root[data-theme=\"dark\"]` | all consumers via `dist/tokens.css` |
| `theme-brik.css` (manual) | `.theme-brik.dark` + `@media (prefers-color-scheme: dark)` | Storybook only |

The two files duplicated dark-mode values and `theme-brik.css` never reached consumers at all — which is how the recent banner fix got misrouted. After this PR there is **one** dark-mode selector across the ecosystem: the `[data-theme]` attribute on `<html>`.

## What changed

- **Rename** `tokens/theme-brik.css` → `tokens/theme-brand-brik.css` (history preserved via `git mv`). New name signals \"brand overrides\" instead of \"theme switching.\"
- **Rescope selectors** inside the file: `.theme-brik` → `.theme-brand-brik`, `.theme-brik.dark` → `.theme-brand-brik[data-theme=\"dark\"]`, `@media (prefers-color-scheme: dark) .theme-brik:not(.light)` → `@media (prefers-color-scheme: dark) .theme-brand-brik:not([data-theme=\"light\"])`.
- **Bundle it into `dist/tokens.css`** via `scripts/build-dist-tokens.js` (after `figma-dark-corrections.css`, before `gap-fills.css`). Consumers who apply `.theme-brand-brik` to `<body>` now receive Brik brand overrides automatically — no more consumer-local `theme-brik-portal.css` drift (that cleanup is a separate follow-up).
- **Storybook `preview.tsx`**: drop the `.dark` / `.light` body-class toggle. Set `data-theme=\"dark|light\"` on `<html>` instead. Storybook and consumers share the same switch — no more Storybook-vs-production drift.
- **`ThemeProvider.tsx`**: emit `.theme-brand-brik` for brand themes (brik / brik-dark / client-sim) plus the `data-theme` attribute. Legacy class names (`theme-brik`, `theme-brik-dark`) still stripped on re-render so in-flight upgrades don't leave ghost classes.
- **`getThemeClasses()`** signature preserved, but output for brand themes changes (see Breaking Change below).
- Doc updates: `tokens/CASCADE.md`, `stories/foundation/ClientThemes.mdx`, `tokens/index.ts` docstrings, `scripts/validate-themes.js` fallback name, `design-tokens/metadata.json`.

## Breaking change — scoped

`getThemeClasses({ themeNumber: 'brik' })` now returns `'body theme-brand-brik'` instead of `'body theme-brik'`. Light/dark is carried by the `data-theme` attribute on `<html>`, not the body class.

### Consumer audit (done before this PR)
- **Portal** — `BDSProvider` sets `applyToBody={false}`, so no class reaches the DOM. Uses its own `[data-theme=\"dark\"]` for dark mode. **Unaffected.**
- **renew-pms** — does not instantiate `ThemeProvider`. **Unaffected.**
- **brikdesigns.com** — does not instantiate `ThemeProvider`. **Unaffected.**
- **Storybook (internal)** — migrated in this PR.

No external consumer uses the old class names. Semver: minor bump (0.x pre-1.0 allows breaking in minor). A downstream consumer that later adopts `ThemeProvider` with `applyToBody={true}` will get the new class pattern and the new `[data-theme]` attribute automatically — aligned with how Figma-generated tokens already ship.

## Merge order

This PR stacks on top of #102 (v0.6.0 release). Suggested order:
1. Merge #102 first (releases v0.6.0 with the banner + token fix).
2. Merge this PR.
3. A subsequent release PR cuts v0.7.0 with the rebuilt `dist/tokens.css` including this consolidation + the theme-brand-brik.css bundle.

`dist/` intentionally not included here — release PR pattern.

## Test plan
- [ ] Open Storybook [banner Playground dark mode](http://localhost:6006/?path=/story/components-feedback-marketing-banner--playground&globals=themeNumber:brik-dark): banner background is brand-primary orange, title/description white, on-color button still renders white — confirms `[data-theme=\"dark\"]` attribute is applied and tokens cascade correctly
- [ ] Inspect `<html>` element in Storybook dev tools; `data-theme=\"dark\"` should be present when brik-dark is selected, `data-theme=\"light\"` otherwise
- [ ] Inspect `<body>` classes; should include `theme-brand-brik` (not `.theme-brik` or `.dark`)
- [ ] `grep -rn 'theme-brik\\\\b' --include='*.css' --include='*.tsx' --include='*.ts' --include='*.mdx'` returns no results outside primitive token names (`--theme-brik-poppy-red`, etc.)
- [ ] `npm run typecheck` passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)