### PR TITLE
feat(content-system): add BCS scaffold with industry packs + voice patterns

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,6 +7,8 @@ const config: StorybookConfig = {
     '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../components/**/*.mdx',
     '../components/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../content-system/**/*.mdx',
+    '../content-system/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
   addons: [
     '@storybook/addon-a11y',

--- a/content-system/Overview.mdx
+++ b/content-system/Overview.mdx
@@ -1,0 +1,152 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { PERSONALITY_VALUES, VOICE_VALUES, VISUAL_STYLE_VALUES, INDUSTRY_SLUGS } from './vocabularies';
+import { industryPacks } from './industries';
+import { voicePatterns } from './voices';
+
+<Meta title="Content System/Overview" />
+
+# Brik Content System (BCS)
+
+BCS is the **content vocabulary** that pairs with BDS's visual vocabulary. Together they form the two halves of the resolver in the client portal: signal in → design + copy out, with consistent constraints and shared taxonomy.
+
+BDS answers *"what does the site look like?"* — tokens, components, blueprints, themes.
+BCS answers *"what does the site sound like, and for whom?"* — voice patterns, industry packs, service catalogs, regulatory constraints.
+
+Both live in this repo because they're the same kind of artifact: a versioned vocabulary that many consumers depend on. Portal, mockup generators, content automations, and strategy workers all import from here.
+
+## Architecture
+
+```
+content-system/
+├── vocabularies/          Locked enums — single source of truth for the 3 portal axes
+│   ├── personality.ts     11 traits
+│   ├── voice.ts           8 traits
+│   ├── visual-style.ts    11 traits
+│   └── industry.ts        slug registry
+├── schema/                TypeScript types for pack authoring
+│   └── industry-pack.ts
+├── industries/            Industry packs — data + narrative
+│   ├── dental.ts  + .mdx
+│   └── small-business.ts  + .mdx
+└── voices/                Voice patterns — 8 VoicePattern files + blender spec
+```
+
+Each industry pack is two co-located files: a `.ts` file exporting the typed `IndustryPack` data, and an `.mdx` narrative that renders in this Storybook. Both describe the same industry — keep them in sync.
+
+Voice patterns are lighter weight — one `.ts` file per voice trait, plus a single [Voices Overview](?path=/docs/content-system-voices-overview--docs) page that renders all 8 side-by-side for comparison.
+
+## The three axes
+
+Captured in the client portal; imported from here so nothing drifts.
+
+| Axis | Count | Values |
+|---|---|---|
+| **Personality** | {PERSONALITY_VALUES.length} | {PERSONALITY_VALUES.join(' · ')} |
+| **Voice** | {VOICE_VALUES.length} | {VOICE_VALUES.join(' · ')} |
+| **Visual Style** | {VISUAL_STYLE_VALUES.length} | {VISUAL_STYLE_VALUES.join(' · ')} |
+
+Clients pick up to 3 in each axis. Overlap across axes (e.g. "Approachable" in Personality + Voice) is a strength signal the resolver should weight higher.
+
+## Voice patterns
+
+{VOICE_VALUES.length} canonical voices, {Object.keys(voicePatterns).length} patterns authored. Browse the [Voices Overview](?path=/docs/content-system-voices-overview--docs) to see all 8 side-by-side with examples.
+
+<table>
+  <thead><tr><th>Voice</th><th>Summary</th></tr></thead>
+  <tbody>
+    {VOICE_VALUES.map(v => (
+      <tr key={v}><td><strong>{v}</strong></td><td>{voicePatterns[v].summary}</td></tr>
+    ))}
+  </tbody>
+</table>
+
+## Industry packs
+
+{INDUSTRY_SLUGS.length} registered slugs, {Object.keys(industryPacks).length} with full packs ported.
+
+<table>
+  <thead><tr><th>Slug</th><th>Display Name</th><th>Version</th><th>Last Reviewed</th></tr></thead>
+  <tbody>
+    {INDUSTRY_SLUGS.map(s => {
+      const p = industryPacks[s];
+      return p ? (
+        <tr key={s}>
+          <td><code>{s}</code></td>
+          <td>{p.displayName}</td>
+          <td>{p.version}</td>
+          <td>{p.lastReviewed}</td>
+        </tr>
+      ) : (
+        <tr key={s}>
+          <td><code>{s}</code></td>
+          <td><em>(pending port)</em></td>
+          <td>—</td>
+          <td>—</td>
+        </tr>
+      );
+    })}
+  </tbody>
+</table>
+
+## How the portal uses BCS
+
+```ts
+// In the portal resolver:
+import {
+  industryPacks,
+  DEFAULT_INDUSTRY_SLUG,
+  type IndustrySlug,
+} from '@brikdesigns/bds/content-system';
+
+function resolveBrandLanguage(profile: CompanyProfile) {
+  const slug = (profile.industry_slug ?? DEFAULT_INDUSTRY_SLUG) as IndustrySlug;
+  const pack = industryPacks[slug];
+
+  return {
+    ctaLanguage: {
+      approved: dedupe([
+        ...profile.cta_language?.approved ?? [],  // client override wins
+        ...pack.ctaDefaults.approved,              // industry default fills gaps
+      ]),
+      rejected: dedupe([
+        ...profile.cta_language?.rejected ?? [],
+        ...pack.ctaDefaults.rejected,
+      ]),
+    },
+    vocabulary: {
+      preferred: pack.vocabulary.preferred,
+      avoid: [
+        ...pack.vocabulary.avoid,
+        ...profile.anti_messages.map(m => ({ term: m, reason: 'client-specified' })),
+      ],
+    },
+    // ...page archetypes, services, regulatory, seasonality...
+  };
+}
+```
+
+Same cascade pattern as token theming: **client > industry > baseline**.
+
+## Authoring an industry pack
+
+1. Add the slug to [`vocabularies/industry.ts`](?path=/docs/content-system-vocabularies--docs).
+2. Create `industries/{slug}.ts` — typed `IndustryPack` data. Use dental.ts as a model for structure depth.
+3. Create `industries/{slug}.mdx` — narrative companion. Use dental.mdx as a model for sections.
+4. Add to the registry in `industries/index.ts`.
+5. Bump `version` and set `lastReviewed` to today.
+6. Review cadence is quarterly by default. CI should flag packs past their review date (future enhancement).
+
+## Phase roadmap
+
+- ✓ Phase 1 — Vocabulary lock + schema + first 3 industry packs
+- ✓ Phase 2 — 8 voice pattern files + blender spec
+- ☐ Phase 3 — Resolver in portal (`resolveBrandLanguage`, `resolveTheme`, `composeBlueprints`)
+- ☐ Phase 4 — Blueprint library materialized with Personality/Voice/VisualStyle tags
+- ☐ Phase 5 — Claude Design in Paper consuming resolved output
+- ☐ Phase 6 — Build script: `content-system.json` emit for non-TS consumers
+
+## Related
+
+- [Industries index](?path=/docs/content-system-industries-dental--docs)
+- [Design Tokens overview](?path=/docs/foundations-design-tokens-overview--docs)
+- [Client Themes](?path=/docs/foundations-design-tokens-client-themes--docs)

--- a/content-system/README.md
+++ b/content-system/README.md
@@ -1,0 +1,75 @@
+# Content System (BCS)
+
+The content vocabulary that pairs with BDS's visual vocabulary.
+
+Browse the full docs in Storybook under **Content System / Overview**. This README is for contributors authoring packs.
+
+## Structure
+
+```
+content-system/
+├── vocabularies/    Locked enums — portal imports these directly
+├── schema/          TypeScript types for pack authoring
+├── industries/      Industry packs ({slug}.ts + {slug}.mdx pairs)
+└── voices/          Voice patterns (phase 2)
+```
+
+## Locked enums
+
+The three portal axes are defined once, here, and imported everywhere:
+
+- `vocabularies/personality.ts` — 11 Brand Personality traits
+- `vocabularies/voice.ts` — 8 Brand Voice traits
+- `vocabularies/visual-style.ts` — 11 Visual Style directions
+- `vocabularies/industry.ts` — canonical industry slug registry
+
+**Do not drift these.** The portal's `company_profiles.brand_personality[]`, `voice_tone[]`, `style_preferences[]`, and `industry_slug` columns are validated against these exports. Adding values requires a coordinated change across BDS + portal.
+
+## Adding an industry pack
+
+1. **Add the slug** to `vocabularies/industry.ts` in the `INDUSTRY_SLUGS` array.
+2. **Create the data file** `industries/{slug}.ts`:
+   - Export a const satisfying `IndustryPack` (see `schema/industry-pack.ts`).
+   - Use `dental.ts` as a structural reference — it's the most complete pack.
+3. **Create the narrative** `industries/{slug}.mdx`:
+   - Include `<Meta title="Content System/Industries/{DisplayName}" />`.
+   - Import the data file and reference structured values inline for a single source of truth.
+   - Use `dental.mdx` as a reference.
+4. **Register the pack** in `industries/index.ts`.
+5. **Set metadata:**
+   - `version: '1.0.0'` for a new pack.
+   - `lastReviewed: 'YYYY-MM-DD'` to today's date.
+   - `reviewCadence: 'quarterly'` unless there's reason to deviate.
+
+## Editing an existing pack
+
+1. Bump `version` (semver — minor for additions, major for schema breaks).
+2. Update `lastReviewed` when you've confirmed the content is still accurate (even without changes).
+3. Keep `.ts` and `.mdx` in sync — if you change structured values, update the narrative, and vice versa.
+4. If you rename or remove a value that consumers depend on (e.g. a service slug), treat it as a major version bump and coordinate with the portal team.
+
+## Promotion — graduating a vertical out of `small-business`
+
+`small-business` is the catch-all. Graduate to a dedicated pack when **any** of:
+
+1. Brik has **3+ active clients** in the vertical, OR
+2. Seasonality, regulation, or terminology diverges meaningfully from the catch-all, OR
+3. Strategy docs for that vertical repeat **60%+ of the time**.
+
+Promotion steps are in `industries/small-business.mdx` §9.
+
+## Type safety
+
+`industries/index.ts` exports a `Record<IndustrySlug, IndustryPack>`. When you add a new slug to `INDUSTRY_SLUGS` but forget to add the pack to the registry, TypeScript will flag it. Run `tsc --noEmit` in CI to catch drift.
+
+## Consumers
+
+- **Brik Client Portal** — imports `industryPacks`, `DEFAULT_INDUSTRY_SLUG`, and the three axis enums for the resolver. See portal `src/lib/profiles/resolve-brand-language.ts` (not yet built).
+- **brand-strategy-worker** — seeds generated CTAs and naming conventions from the active pack before client-specific synthesis.
+- **Mockup generator (Claude Design in Paper)** — reads page archetypes and blueprint defaults to scaffold section layouts.
+
+## Related
+
+- `../tokens/` — BDS design tokens (visual vocabulary)
+- `../blueprints/` — blueprint library (page/section layout patterns — to be populated)
+- Portal: `company_profiles` schema at `supabase/migrations/` and types at `src/lib/profiles/types.ts`

--- a/content-system/index.ts
+++ b/content-system/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Brik Content System (BCS) — public surface.
+ *
+ * The content vocabulary that pairs with the BDS visual vocabulary.
+ * Consumed by the portal resolver, brand-strategy workers, and mockup
+ * generation pipelines.
+ *
+ * Organization mirrors BDS:
+ *   - vocabularies/ — locked enums (Personality, Voice, Visual Style, Industry)
+ *   - schema/       — TypeScript types for pack authoring
+ *   - industries/   — industry packs (data + narrative)
+ *   - voices/       — voice patterns (rules, examples, pairings)
+ */
+
+export * from './vocabularies';
+export * from './schema';
+export { industryPacks, dental, realEstateRvMhc, smallBusiness } from './industries';
+export {
+  voicePatterns,
+  approachable,
+  authoritative,
+  conversational,
+  direct,
+  empathetic,
+  expert,
+  poetic,
+  witty,
+} from './voices';

--- a/content-system/industries/dental.mdx
+++ b/content-system/industries/dental.mdx
@@ -1,0 +1,115 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { dental } from './dental';
+
+<Meta title="Content System/Industries/Dental" />
+
+# Dental
+
+**Version:** {dental.version}  •  **Last reviewed:** {dental.lastReviewed}  •  **Review cadence:** {dental.reviewCadence}
+
+Static reference. Automations reference this when generating strategy documents. Never injected into client briefs as client-specific fact — always layer through the resolver so client overrides win.
+
+Structured data lives in [`dental.ts`](?path=/docs/content-system-industries-dental--docs). This page is the narrative companion. Keep them in sync.
+
+---
+
+## 1. Industry Overview
+
+Dental is a high-trust, local-first professional healthcare category. Patients choose providers based on proximity, insurance acceptance, and reputation signals more than price. The market is bifurcating between independent and small-group practices competing on patient experience, and DSO-backed practices competing on scale, convenience, and marketing spend.
+
+Patient acquisition is expensive and slow. Lifetime value is high — a single retained family can generate **$15K–$40K+** over a decade. This asymmetry is why retention nearly always outperforms acquisition spend for established practices.
+
+## 2. Default Affinities
+
+When a client hasn't yet picked traits in the portal, these are the pack's starting affinities. Clients always override.
+
+| Axis | Affinities (first = strongest) |
+|---|---|
+| **Personality** | {dental.affinities.personality.join(' · ')} |
+| **Voice** | {dental.affinities.voice.join(' · ')} |
+| **Visual Style** | {dental.affinities.visualStyle.join(' · ')} |
+
+Independent practices skew warmer and more conversational; cosmetic boutiques skew more Refined + Modern; pediatric practices skew Playful + Approachable. The pack defaults aim at the median general-practice independent.
+
+## 3. Common Patient Pain Points
+
+- **Cost anxiety** — surprise bills, unclear coverage, sticker shock on crowns/implants/ortho
+- **Dental anxiety** — ~36% of adults report moderate-to-severe dental fear; top reason for avoidance
+- **Insurance confusion** — PPO vs HMO vs FFS, in-network vs out, annual maximums
+- **Trust deficit** — suspicion of over-treatment ("do I really need this crown?")
+- **Scheduling friction** — long new-patient waits, inflexible hours for working parents
+- **Continuity of care** — patients stay for years; hygienist/dentist turnover triggers churn
+- **Cosmetic hesitation** — 3–12 month shopping cycles for veneers, Invisalign, implants
+
+## 4. Seasonality
+
+| Quarter | Intent | Focus |
+|---|---|---|
+| **Q1 (Jan–Mar)** | high | Insurance reset surge. Highest-intent window. New-patient calls peak. |
+| **Q2 (Apr–Jun)** | medium | Tax refunds drive cosmetic/elective inquiries. Long shopping cycles start. |
+| **Q3 (Jul–Aug)** | high | Pediatric + ortho surge during summer break. Adult cosmetic dips. |
+| **Q4 (Nov–Dec)** | high | Use-it-or-lose-it benefits push. Best campaign ROI of year for insurance practices. |
+
+## 5. Competitive Landscape
+
+- **Independent solo/small-group** — relationship, community ties, owner-dentist continuity
+- **DSO-backed** (Heartland, Pacific Dental, Aspen, Smile Brands, MB2) — ad spend, extended hours, standardized experience
+- **Specialty** (ortho, endo, perio, oral surgery, pediatric, prosthodontics) — referral-driven, board-certified authority
+- **Cosmetic / boutique** — design-forward, concierge, premium pricing, Instagram-native
+- **Budget / insurance-heavy** — high-volume, Medicaid/HMO, compete on access
+- **DTC aligner disruptors** — Invisalign, ClearCorrect (SmileDirectClub's collapse slowed but didn't stop this)
+
+## 6. Listings Requirements
+
+**Required:** Google Business Profile (primary category "Dentist" or specialty variant), Bing Places, Apple Business Connect, Facebook, Yelp, Healthgrades, Zocdoc.
+
+**Conditional (insurance-accepting practices only):** Delta Dental, MetLife, Cigna, Aetna, Humana provider finders — verify annually.
+
+**NPI** must match across all listings. Mismatch hurts trust and insurance routing.
+
+## 7. Regulatory Summary
+
+- **HIPAA** — patient photos, reviews, testimonials require written authorization; responses to reviews cannot confirm patient status
+- **State dental boards** — vary by state; common restrictions on "best," "#1," "specialist" (unless board-certified), "painless"
+- **Before/after photos** — require signed release; most states require "individual results vary" disclaimer
+- **ADA specialty recognition** — only 12 specialties are ADA-recognized; "cosmetic dentist" and "implant dentist" are NOT specialties
+- **ADA/WCAG 2.1 AA** — healthcare sites are frequent ADA-lawsuit targets; compliance is non-negotiable
+
+## 8. Vocabulary — Avoid
+
+<table>
+  <thead><tr><th>Term</th><th>Why</th></tr></thead>
+  <tbody>
+    {dental.vocabulary.avoid.map((v, i) => (
+      <tr key={i}><td><strong>{v.term}</strong></td><td>{v.reason}</td></tr>
+    ))}
+  </tbody>
+</table>
+
+## 9. Brik Strategic POV
+
+Three considerations that differentiate Brik's dental strategy. These are not generic industry facts — they reflect Brik's POV and should surface in briefs where applicable.
+
+### Retention Economics
+New-patient CAC ($200–$500+) vastly exceeds reactivation/case-close cost (under $10). A 1% hygiene reappt improvement on a ~2,000 active-patient practice produces $40–60K+/yr. A 5% case-acceptance gain can match 75–150 new patients in revenue. **Stabilize retention before recommending acquisition.**
+
+Brik audits: Total Active Patients, Unscheduled Active, New Patients (Last Month), Total Lost (Last Month), Hygiene Reappt %, Case Acceptance %, Production/Visit, No-Show Rate, Hyg/Dr Visit ratio, Email/Cell capture, ASAP List.
+
+### Independent vs DSO
+Independents should not out-spend DSOs. Structural moats: continuity of care, clinical autonomy, slower more personal experience, community embeddedness, owner-dentist visibility, decision speed, referral velocity.
+
+**Messaging posture:** continuity, ownership, community, clinical integrity. Avoid corporate gloss. "Your dentist. Not a corporation." — the emotional posture, not the literal words.
+
+### FFS Transition
+PPO write-offs commonly consume 20–40% of potential production. Transitioning toward FFS is typically the single highest-leverage long-term business decision for an established independent.
+
+**Prerequisites:** ~1,500+ active patients, hygiene reappt >90%, case acceptance >50%, healthy review presence, membership plan ready ($350–$500/yr covering 2 cleanings + exams + X-rays + 15–20% off treatment), owner-dentist with 3+ years of runway.
+
+Three transition patterns: **selective drop** (lowest-paying PPOs first), **full FFS**, **hybrid/grandfather** (honor existing; FFS for new patients only).
+
+---
+
+## Related
+
+- [Blueprint library](?path=/docs/content-system-blueprints--docs) — page layout patterns tagged with industry affinities
+- [Vocabularies](?path=/docs/content-system-vocabularies--docs) — locked enums for Personality, Voice, Visual Style

--- a/content-system/industries/dental.ts
+++ b/content-system/industries/dental.ts
@@ -1,0 +1,315 @@
+import type { IndustryPack } from '../schema';
+
+/**
+ * Dental industry pack.
+ *
+ * Ported from industry-reference-dental.md v1.1 (2026-04-01).
+ * Narrative body lives in ./dental.mdx.
+ *
+ * Brik POV: retention over acquisition, independent over DSO,
+ * long-term insurance de-risking (FFS transition). These are encoded
+ * in `strategicConsiderations` and should surface in generated briefs
+ * for established independent practices.
+ */
+export const dental: IndustryPack = {
+  slug: 'dental',
+  displayName: 'Dental',
+  version: '1.1.0',
+  reviewCadence: 'quarterly',
+  lastReviewed: '2026-04-01',
+
+  affinities: {
+    personality: ['Professional', 'Warm', 'Approachable', 'Refined', 'Modern'],
+    voice: ['Empathetic', 'Expert', 'Conversational'],
+    visualStyle: ['Light', 'Classic', 'Minimal'],
+  },
+
+  pageArchetypes: [
+    {
+      slug: 'home',
+      displayName: 'Home',
+      required: true,
+      blueprintDefaults: ['hero_split_60_40', 'services_detail_two_column', 'stats_centered_light', 'testimonials_3col_cards', 'cta_split_contact'],
+    },
+    {
+      slug: 'meet-the-doctor',
+      displayName: 'Meet the Doctor',
+      required: true,
+      blueprintDefaults: ['hero_interior_minimal', 'about_story_split', 'team_bio_grid'],
+      description: 'Owner-dentist visibility is a structural moat vs DSOs. Lead with the doctor\'s face, story, and community tie-in.',
+    },
+    {
+      slug: 'services-overview',
+      displayName: 'Services',
+      required: true,
+      blueprintDefaults: ['hero_interior_minimal', 'services_detail_two_column', 'faq_accordion_grouped'],
+    },
+    {
+      slug: 'insurance-accepted',
+      displayName: 'Insurance & Financing',
+      required: true,
+      description: 'Only for insurance-accepting practices. Remove if the practice is FFS or during a transition.',
+    },
+    {
+      slug: 'membership-plan',
+      displayName: 'Membership Plan',
+      required: false,
+      description: 'Required for FFS practices and strongly recommended as a third option (alongside PPO/cash) for insurance-accepting practices.',
+    },
+    {
+      slug: 'new-patient',
+      displayName: 'New Patient Info',
+      required: true,
+      blueprintDefaults: ['hero_interior_minimal', 'features_alternating_split', 'faq_accordion_grouped'],
+    },
+    {
+      slug: 'before-after',
+      displayName: 'Smile Gallery',
+      required: false,
+      blueprintDefaults: ['gallery_masonry_3col'],
+      description: 'HIPAA-sensitive. Requires signed patient release. Include "individual results vary" disclaimer per state board rules.',
+    },
+    {
+      slug: 'contact',
+      displayName: 'Contact',
+      required: true,
+      blueprintDefaults: ['contact_form_split', 'cta_split_contact'],
+    },
+  ],
+
+  servicesCatalog: [
+    { slug: 'preventive', displayName: 'Preventive Care', category: 'preventive', aliases: ['cleaning', 'prophy', 'prophylaxis', 'exam', 'checkup', 'hygiene'] },
+    { slug: 'deep-cleaning', displayName: 'Deep Cleaning (SRP)', category: 'preventive', aliases: ['scaling and root planing', 'srp', 'periodontal maintenance'] },
+    { slug: 'restorative', displayName: 'Fillings & Crowns', category: 'restorative', aliases: ['filling', 'composite', 'amalgam', 'crown', 'bridge', 'onlay', 'inlay'] },
+    { slug: 'endodontics', displayName: 'Root Canal', category: 'restorative', aliases: ['endo', 'root canal therapy'] },
+    { slug: 'cosmetic', displayName: 'Cosmetic Dentistry', category: 'cosmetic', aliases: ['whitening', 'veneers', 'bonding', 'smile makeover'], regulatoryNote: 'Not an ADA-recognized specialty — do not market as "cosmetic specialist" unless board-certified in a recognized specialty.' },
+    { slug: 'orthodontics', displayName: 'Orthodontics', category: 'orthodontics', aliases: ['braces', 'invisalign', 'clearcorrect', 'aligners'], regulatoryNote: 'Only orthodontists may advertise as "orthodontic specialists."' },
+    { slug: 'implants', displayName: 'Dental Implants', category: 'surgical', aliases: ['implant', 'all-on-4', 'all on four'], regulatoryNote: 'Not an ADA-recognized specialty — avoid "implant specialist" without board certification.' },
+    { slug: 'extractions', displayName: 'Extractions & Oral Surgery', category: 'surgical', aliases: ['extraction', 'wisdom teeth', 'tooth removal', 'oral surgery'] },
+    { slug: 'pediatric', displayName: 'Pediatric Dentistry', category: 'pediatric', aliases: ['pedo', 'children\'s dentistry', 'kids dentist'] },
+    { slug: 'sedation', displayName: 'Sedation Dentistry', category: 'anxiety', aliases: ['nitrous', 'oral sedation', 'iv sedation', 'laughing gas'] },
+    { slug: 'emergency', displayName: 'Emergency Dental Care', category: 'emergency', aliases: ['dental emergency', 'urgent care', 'same-day'] },
+    { slug: 'tmj', displayName: 'TMJ & Bite Therapy', category: 'specialty', aliases: ['tmj', 'tmd', 'bruxism', 'nightguard'] },
+  ],
+
+  vocabulary: {
+    preferred: [
+      // Clinical + operations (from §7)
+      'operatory', 'hygienist', 'treatment coordinator', 'recall', 'recare', 'case acceptance',
+      'prophy', 'scaling and root planing', 'perio maintenance', 'crown', 'veneer', 'implant', 'aligner',
+      // Insurance / finance
+      'PPO', 'FFS', 'in-network', 'out-of-network', 'annual maximum', 'pre-authorization',
+      'membership plan', 'CareCredit', 'third-party financing',
+      // Retention / communications
+      'treatment plan', 'reactivation', 'ASAP list', 'expiring benefits', 'post-op', 'welcome packet',
+    ],
+    avoid: [
+      { term: 'specialist', reason: 'Only the 12 ADA-recognized specialties may use this term unless the dentist is board-certified in that specialty.' },
+      { term: 'painless', reason: 'Creates unreasonable expectations; regulated or prohibited in most state dental board advertising rules.' },
+      { term: 'best dentist', reason: 'Dental board violation in most states; unsubstantiated superiority claim.' },
+      { term: '#1 dentist', reason: 'Same as "best" — unsubstantiated, board-violating.' },
+      { term: 'cheap', reason: 'Price-race positioning; undermines brand and profitability.' },
+      { term: 'discount', reason: 'Same as "cheap" in premium-positioned copy; attracts low-LTV patients.' },
+      { term: 'guaranteed results', reason: 'Prohibited in healthcare advertising in most states.' },
+      { term: 'cosmetic specialist', reason: 'Cosmetic dentistry is not an ADA-recognized specialty.' },
+      { term: 'implant specialist', reason: 'Implant dentistry is not an ADA-recognized specialty.' },
+    ],
+  },
+
+  ctaDefaults: {
+    approved: [
+      'Request Your Consultation',
+      'Meet Your Dentist',
+      'Schedule a Visit',
+      'New Patient Special',
+      'See If We Take Your Insurance',
+      'Reserve Your Appointment',
+    ],
+    rejected: [
+      'Book Now',
+      'Click Here',
+      'Submit',
+      'Learn More',
+    ],
+  },
+
+  seasonality: {
+    Q1: {
+      intent: 'high',
+      focus: ['insurance-reset', 'new-patient', 'preventive-schedule'],
+      notes: 'Jan–Feb insurance benefits reset drives the highest-intent window of the year. Surge in new-patient calls. Prioritize GBP, Ads, and recall/reactivation.',
+    },
+    Q2: {
+      intent: 'medium',
+      focus: ['cosmetic', 'tax-refund', 'invisalign', 'whitening'],
+      notes: 'Tax-refund season (Mar–Apr) drives elective/cosmetic inquiries. Longer shopping cycles (3–12 mo) for veneers, implants, ortho.',
+    },
+    Q3: {
+      intent: 'high',
+      focus: ['pediatric', 'orthodontics', 'back-to-school'],
+      notes: 'Kids on summer break = pediatric + ortho surge. Adult cosmetic dips. Pre-back-to-school exam push.',
+    },
+    Q4: {
+      intent: 'high',
+      focus: ['expiring-benefits', 'membership-renewal', 'case-acceptance'],
+      notes: 'Nov–Dec "use-it-or-lose-it" push. Strongest ROI automation is expiring-benefits for insurance-accepting practices. FFS/membership practices pivot to annual renewal + case close.',
+    },
+  },
+
+  keywordBank: {
+    primary: [
+      'dentist near me',
+      'family dentist',
+      'cosmetic dentist',
+      'new patient dentist',
+      'dental office',
+      'emergency dentist',
+      'pediatric dentist',
+    ],
+    serviceLevel: [
+      'teeth whitening',
+      'dental implants',
+      'Invisalign provider',
+      'same day crowns',
+      'sedation dentistry',
+      'root canal',
+      'veneers',
+      'full mouth reconstruction',
+    ],
+  },
+
+  directories: {
+    required: [
+      'Google Business Profile',
+      'Bing Places',
+      'Apple Business Connect',
+      'Facebook Business Page',
+      'Yelp',
+      'Healthgrades',
+      'Zocdoc',
+    ],
+    optional: ['Vitals', 'WebMD Care', 'RateMDs', '1-800-DENTIST', 'Nextdoor'],
+    conditional: {
+      // Insurance-accepting practices should verify these annually
+      'insurance-network': [
+        'Delta Dental provider finder',
+        'MetLife provider finder',
+        'Cigna provider finder',
+        'Aetna provider finder',
+        'Humana provider finder',
+      ],
+    },
+  },
+
+  regulatory: [
+    {
+      topic: 'HIPAA',
+      summary: 'Federal health privacy law covering patient-identifiable information.',
+      implication: 'Before/after photos, reviews, testimonials, and case studies require signed patient authorization. Responses to reviews cannot confirm patient status.',
+      scope: 'federal',
+    },
+    {
+      topic: 'State Dental Board Advertising Rules',
+      summary: 'Each state board regulates dental advertising with varying strictness.',
+      implication: 'Common prohibitions: "best," "#1," "specialist" (unless board-certified), "painless," unsubstantiated superiority claims. Cosmetic/implant dentistry are not ADA-recognized specialties in most states. Verify rules per state before publishing.',
+      scope: 'state',
+    },
+    {
+      topic: 'Before/After Photos',
+      summary: 'Photos showing treatment results have state-specific disclosure requirements.',
+      implication: 'Require signed patient release. Most states require "individual results vary" disclaimer. Some states restrict or prohibit use entirely for certain procedures.',
+      scope: 'state',
+    },
+    {
+      topic: 'Pricing Claims',
+      summary: 'Free exam / discounted service offers may be regulated under state insurance laws.',
+      implication: 'Offers of "free" exams, cleanings, or consultations may require disclaimers. Some states prohibit inducements for patients with insurance. Verify per state.',
+      scope: 'state',
+    },
+    {
+      topic: 'ADA Specialty Recognition',
+      summary: 'Only 12 dental specialties are recognized by the American Dental Association.',
+      implication: 'Cosmetic and implant dentistry are NOT ADA-recognized specialties. Marketing must reflect this — never describe a general dentist as a "cosmetic specialist" or "implant specialist."',
+      scope: 'federal',
+    },
+    {
+      topic: 'ADA / WCAG 2.1 AA Accessibility',
+      summary: 'Healthcare websites are frequent ADA lawsuit targets.',
+      implication: 'Minimum WCAG 2.1 AA compliance is non-negotiable. Color contrast, alt text, keyboard navigation, semantic markup all required.',
+      scope: 'federal',
+    },
+    {
+      topic: 'Telehealth Rules',
+      summary: 'Virtual dental consultations are regulated state-by-state.',
+      implication: 'If offering virtual consults, verify state-specific licensure and scope-of-practice rules before advertising.',
+      scope: 'state',
+    },
+  ],
+
+  customerPainPoints: [
+    { summary: 'Cost anxiety — fear of surprise bills, sticker shock on crowns/implants/ortho.', detail: 'Pricing opacity drives bounce; transparent price ranges and financing options reduce friction.' },
+    { summary: 'Dental anxiety — ~36% of adults report moderate-to-severe dental fear.', detail: 'Top reason for avoidance. Sedation availability, "gentle dentistry" framing, and anxiety-friendly office imagery all move the needle.' },
+    { summary: 'Insurance confusion — PPO/HMO/FFS, in-network vs out-of-network, annual maximums.', detail: 'Practices that clearly list accepted carriers and explain coverage convert better.' },
+    { summary: 'Trust deficit — suspicion of over-treatment ("do I really need this crown?").', detail: 'Second-opinion language, conservative-treatment positioning, and owner-dentist visibility reduce this.' },
+    { summary: 'Scheduling friction — long new-patient waits, limited hours for working parents.', detail: 'Online booking, extended hours, and ASAP lists directly affect conversion.' },
+    { summary: 'Continuity of care — patients stay loyal for years; provider turnover triggers churn.', detail: 'Owner-dentist visibility and team stability are marketing assets for independents.' },
+    { summary: 'Cosmetic hesitation — 3–12 month shopping cycles for veneers, Invisalign, implants.', detail: 'Long nurture sequences (email, retargeting) and financing options drive case acceptance.' },
+  ],
+
+  competitiveLandscape: [
+    {
+      name: 'Independent solo/small-group practices',
+      moat: 'Relationship, community ties, owner-dentist continuity, clinical autonomy, faster decision speed.',
+      weakness: 'Cannot out-spend on ads; limited hours without burnout; fewer carriers listed.',
+    },
+    {
+      name: 'DSO-backed practices',
+      examples: ['Heartland Dental', 'Pacific Dental Services', 'Aspen Dental', 'Smile Brands', 'MB2 Dental'],
+      moat: 'Ad spend, extended hours, cross-location flexibility, standardized experience, aggressive SEO.',
+      weakness: 'Provider turnover, corporate production quotas, slow marketing pivots, inauthentic owner content.',
+    },
+    {
+      name: 'Specialty practices',
+      examples: ['Orthodontics', 'Endodontics', 'Periodontics', 'Oral Surgery', 'Pediatric', 'Prosthodontics'],
+      moat: 'Referral-driven; board certification; niche authority.',
+      weakness: 'Dependent on GP referral relationships; narrower service mix limits one-stop-shop positioning.',
+    },
+    {
+      name: 'Cosmetic / boutique practices',
+      moat: 'Design-forward, concierge positioning, premium pricing, Instagram-native content.',
+      weakness: 'Smaller addressable market; depends on affluent local demographics.',
+    },
+    {
+      name: 'Budget / insurance-heavy practices',
+      moat: 'High volume, Medicaid/HMO access, compete on accessibility.',
+      weakness: 'Low LTV patients, margin compression, reputation pressure.',
+    },
+    {
+      name: 'Direct-to-consumer aligner disruptors',
+      examples: ['Invisalign', 'ClearCorrect', 'Byte (defunct)'],
+      moat: 'Convenience, price, at-home experience.',
+      weakness: 'No in-office oversight; SmileDirectClub collapse showed limits of unsupervised care.',
+    },
+  ],
+
+  strategicConsiderations: [
+    {
+      slug: 'retention-economics',
+      title: 'Internal Marketing & Retention Economics',
+      summary: 'New-patient CAC ($200–$500+) vastly exceeds reactivation/case-close cost (<$10). A 1% hygiene reappt gain on a 2,000-patient practice ≈ $40–60K/yr. Stabilize retention metrics before recommending acquisition spend.',
+      appliesWhen: ['established-practice', 'has-active-patient-base', 'retention-metrics-below-benchmark'],
+    },
+    {
+      slug: 'independent-vs-dso',
+      title: 'Independent vs DSO Positioning',
+      summary: 'Independents should not out-spend DSOs. Compete on continuity, autonomy, community, and owner visibility. Avoid price wars and insurance-heavy positioning — DSOs will always win that search.',
+      appliesWhen: ['independent-practice', 'dso-competition-local'],
+    },
+    {
+      slug: 'ffs-transition',
+      title: 'Fee-for-Service (FFS) Transition Strategy',
+      summary: 'PPO write-offs commonly consume 20–40% of potential production. FFS transition is the single highest-leverage long-term business decision for established independents. Prerequisites: 1500+ active patients, 90%+ hygiene reappt, 50%+ case acceptance, membership plan ready, 12–24 month owner runway.',
+      appliesWhen: ['established-independent', 'ppo-heavy', 'owner-has-long-runway'],
+    },
+  ],
+};

--- a/content-system/industries/index.ts
+++ b/content-system/industries/index.ts
@@ -1,0 +1,25 @@
+import type { IndustryPack } from '../schema';
+import type { IndustrySlug } from '../vocabularies';
+import { dental } from './dental';
+import { realEstateRvMhc } from './real-estate-rv-mhc';
+import { smallBusiness } from './small-business';
+
+/**
+ * Industry pack registry — maps every slug in INDUSTRY_SLUGS to its IndustryPack.
+ *
+ * When adding a new pack:
+ *   1. Add the slug to `vocabularies/industry.ts`
+ *   2. Create `{slug}.ts` and `{slug}.mdx` in this folder
+ *   3. Import and add to the registry below
+ *
+ * Type-level guarantee: the record is constrained to IndustrySlug keys, so
+ * TypeScript will flag any missing entry when new slugs are added to the
+ * vocabulary.
+ */
+export const industryPacks: Record<IndustrySlug, IndustryPack> = {
+  'dental': dental,
+  'real-estate-rv-mhc': realEstateRvMhc,
+  'small-business': smallBusiness,
+};
+
+export { dental, realEstateRvMhc, smallBusiness };

--- a/content-system/industries/real-estate-rv-mhc.mdx
+++ b/content-system/industries/real-estate-rv-mhc.mdx
@@ -1,0 +1,142 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { realEstateRvMhc } from './real-estate-rv-mhc';
+
+<Meta title="Content System/Industries/Real Estate — RV Parks & MHC" />
+
+# Real Estate — RV Parks & Manufactured Housing Communities (MHC)
+
+**Version:** {realEstateRvMhc.version}  •  **Last reviewed:** {realEstateRvMhc.lastReviewed}  •  **Review cadence:** {realEstateRvMhc.reviewCadence}
+
+Structured data lives in [`real-estate-rv-mhc.ts`](?path=/docs/content-system-industries-real-estate-rv-mhc--docs). This page is the narrative companion.
+
+This pack covers **two distinct segments that typically share an operator and website:**
+- **RV Parks** — transient + extended-stay guests
+- **MHC** — long-term residents who own their manufactured home and lease the lot
+
+Many pain points, seasons, and regulatory burdens differ between segments — data entries are tagged with `segment` where applicable.
+
+---
+
+## 1. Industry Overview
+
+RV parks and MHCs are a specialized segment of residential/hospitality real estate built on a **land-lease model**: operators own the land and amenities; residents or guests own their unit (RV, park model, or manufactured home) and pay lot rent or site rent.
+
+The asset class is attractive to investors because of **sticky tenancy** (MHC), **recurring revenue**, and **limited new supply** — but it sits at the intersection of real estate, hospitality, affordable housing policy, and local tourism, which makes marketing uniquely complex.
+
+## 2. Default Affinities
+
+| Axis | Affinities |
+|---|---|
+| **Personality** | {realEstateRvMhc.affinities.personality.join(' · ')} |
+| **Voice** | {realEstateRvMhc.affinities.voice.join(' · ')} |
+| **Visual Style** | {realEstateRvMhc.affinities.visualStyle.join(' · ')} |
+
+Luxury RV resorts will lean Refined + Luxurious; family-focused campgrounds lean Playful + Warm; 55+ MHCs lean Classic + Professional. The pack defaults target the median well-run independent property.
+
+## 3. Customer Pain Points by Segment
+
+**RV Parks (transient & extended-stay guests):**
+- Availability and reservation confusion — is the site open? can I book online?
+- Hookup details — 30 vs 50 amp, water/sewer, full hookup vs partial, pull-through vs back-in
+- Rig size limits — big rigs (40'+) filtered out of many parks
+- Pet policies, quiet hours, community rules clarity
+- Amenities reality vs photos (pool open? Wi-Fi usable? bathhouse clean?)
+- Seasonal closures and rate transparency
+
+**MHC (long-term residents):**
+- Lot rent increases and predictability
+- Community rules, pet policies, age restrictions (55+)
+- Home placement / move-in logistics and costs
+- Management responsiveness and reputation
+- Home ownership vs renting a park-owned home confusion
+- Financing barriers — chattel loans have higher rates than site-built
+- Resale restrictions and community approval of buyers
+
+**Both:** natural disaster season (hurricane, wildfire, flood) directly affects reputation management and occupancy.
+
+## 4. Seasonality
+
+| Quarter | Intent | Focus |
+|---|---|---|
+| **Q1 (Jan–Mar)** | high | Snowbird season in Sun Belt (AZ, FL, TX, Southern CA, Gulf Coast). RV extended-stay dominates. MHC slowest move-in season; tax-refund inquiries late Q1. |
+| **Q2 (Apr–Jun)** | high | RV shoulder season; spring travelers, workcampers arriving. MHC peak move-in season. |
+| **Q3 (Jul–Aug)** | high | Peak family/vacation RV season in northern and mountain markets. MHC move-in continues. |
+| **Q4 (Oct–Dec)** | medium | Fall foliage short window → holiday lull. Sun Belt RV parks fill back up late Q4. MHC slow leasing; internal rate-planning season. |
+
+## 5. Competitive Landscape
+
+- **National REITs / large RV operators:** Sun Communities (Sun Outdoors), Equity LifeStyle Properties (Thousand Trails / Encore), Roberts Resorts, Blue Water
+- **RV franchise networks:** KOA, Jellystone Park, Yogi Bear's
+- **National MHC operators:** Sun, Equity LifeStyle, RHP Properties, YES! Communities, Inspire, Flagship, Cal-Am
+- **Mid-size and family-owned MHC operators:** majority of U.S. MHC inventory; under acquisition pressure
+- **Public-land RV competition:** state parks, National Forest, Corps of Engineers — cheaper, fewer amenities
+- **Apartments & SFR (MHC competition):** compete for the affordable housing tenant dollar
+- **Boondocking / alternative platforms:** Harvest Hosts, Hipcamp, Boondockers Welcome — bottom-of-market pressure
+
+Industry consolidation is steady; independents increasingly face acquisition pressure.
+
+## 6. Listings Requirements
+
+**Foundational (all):** Google Business Profile (primary category "RV Park" or "Mobile home park"), NAP consistency, Bing, Apple Business Connect, Facebook, optionally Yelp.
+
+**RV-specific directories (critical for RV operators):**
+
+- **Good Sam** — trusted by older RVers
+- **Campendium** — review-driven, large reach
+- **RV Life / RV Parky** — trip-planning integration
+- **The Dyrt** — growing, younger audience
+- **Hipcamp** — unique/boutique parks
+- **AllStays** — widely used reference app
+- **Roadtrippers** — influences route planning
+
+**MHC-specific directories:**
+
+- **MHVillage** — dominant MHC listing platform
+- **Datacomp / JLT Reports** — rent comp data (not consumer-facing but shapes perception)
+- **Apartments.com / Zillow Rentals** — increasingly list MHC lots
+- **Facebook Marketplace & local community groups** — significant lead source for both home resale and lot availability
+- **MHP Home Source / MobileHome.net** — secondary consumer directories
+
+NAP consistency across all platforms is critical given these directories cross-reference one another.
+
+## 7. Regulatory Summary
+
+| Topic | Scope | Implication |
+|---|---|---|
+| **Fair Housing Act (FHA)** | federal | Affects advertising copy. "Adult community" and "no children" restricted. "Private" / "exclusive" can imply protected-class exclusion. |
+| **Truth-in-advertising (FTC)** | federal | Amenity photos must reflect current reality. Occupancy claims must be current. |
+| **State MHP Acts / Landlord-Tenant Law** | state | Highly variable. CA/FL/OR/MI/NY have strong tenant protections. Rate-change messaging must comply. |
+| **HOPA (55+)** | federal | 55+ community status legal only with HOPA compliance. |
+| **Lot lease agreements** | state | Most states require written leases. Some require specific disclosures. |
+| **Chattel vs real-property financing** | federal | CFPB oversight on chattel loans. Affordability messaging must be accurate. |
+| **Rent control** | local | Rate-change communications must comply with notice periods. |
+| **Local zoning (RV parks)** | local | Length-of-stay caps (14–30 days common) restrict "permanent residence" messaging. |
+| **Transient Occupancy Tax** | local | Rate communications must include applicable TOT disclosures. |
+| **ADA accessibility** | federal | Amenity-building compliance + WCAG 2.1 AA for the website. |
+
+## 8. Vocabulary — Avoid
+
+<table>
+  <thead><tr><th>Term</th><th>Why</th></tr></thead>
+  <tbody>
+    {realEstateRvMhc.vocabulary.avoid.map((v, i) => (
+      <tr key={i}><td><strong>{v.term}</strong></td><td>{v.reason}</td></tr>
+    ))}
+  </tbody>
+</table>
+
+## 9. Future — Brik Strategic POV
+
+Not yet populated. This pack has no `strategicConsiderations` entries because Brik does not yet have a defensible POV backed by client outcomes in this vertical. As the client portfolio grows, add sections for topics like:
+
+- **Lot-fill strategy for value-add acquisitions** — marketing a newly-acquired property with low physical occupancy
+- **55+ vs open-community positioning** — when HOPA certification is worth the operational cost
+- **Reputation recovery after natural disaster** — Gulf Coast hurricane season playbook
+- **MHC-to-manufactured-home-sales funnel** — cross-selling within a community
+
+---
+
+## Related
+
+- [Dental pack](?path=/docs/content-system-industries-dental--docs) — reference for pack structure maturity
+- [Small Business baseline](?path=/docs/content-system-industries-small-business-general---docs) — catch-all pack

--- a/content-system/industries/real-estate-rv-mhc.ts
+++ b/content-system/industries/real-estate-rv-mhc.ts
@@ -1,0 +1,360 @@
+import type { IndustryPack } from '../schema';
+
+/**
+ * Real Estate — RV Parks & Manufactured Housing Communities (MHC).
+ *
+ * Ported from industry-reference-real-estate-rv-mhc.md v1.0 (2026-04-01).
+ * Narrative body lives in ./real-estate-rv-mhc.mdx.
+ *
+ * This pack covers two distinct-but-related segments that typically share
+ * an operator and website: RV parks (transient + extended-stay guests) and
+ * MHCs (long-term residents). Pain points, seasonality, and regulatory
+ * burden differ meaningfully between the two — many entries use the
+ * `segment` field to flag which customer type they apply to.
+ *
+ * No Brik-specific strategic POV section yet — add `strategicConsiderations`
+ * once Brik has a defensible perspective backed by client outcomes.
+ */
+export const realEstateRvMhc: IndustryPack = {
+  slug: 'real-estate-rv-mhc',
+  displayName: 'Real Estate — RV Parks & MHC',
+  version: '1.0.0',
+  reviewCadence: 'quarterly',
+  lastReviewed: '2026-04-01',
+
+  affinities: {
+    personality: ['Approachable', 'Warm', 'Professional', 'Modern', 'Bold'],
+    voice: ['Direct', 'Expert', 'Conversational'],
+    visualStyle: ['Light', 'Modern', 'Classic'],
+  },
+
+  pageArchetypes: [
+    {
+      slug: 'home',
+      displayName: 'Home',
+      required: true,
+      blueprintDefaults: ['hero_fullbleed_photo', 'services_detail_two_column', 'stats_dark_bar', 'cta_split_contact'],
+      description: 'Lead with a hero photo of the property — drone/aerial or amenity-forward. Trust signals (years in operation, number of sites, rating) pair well here.',
+    },
+    {
+      slug: 'sites-availability',
+      displayName: 'Sites & Availability',
+      required: true,
+      blueprintDefaults: ['hero_interior_minimal', 'features_bento_asymmetric', 'gallery_masonry_3col'],
+      description: 'The #1 bounce-prevention page. Clear hookup info (30/50 amp, full hookup, pull-through vs back-in), rig-size limits, pricing, and direct online booking or reservation link.',
+    },
+    {
+      slug: 'amenities',
+      displayName: 'Amenities',
+      required: true,
+      blueprintDefaults: ['features_3col_icon_grid', 'gallery_masonry_3col'],
+      description: 'Photo-heavy. Reality must match photos — customer pain point is "amenities look nothing like the listing."',
+    },
+    {
+      slug: 'rules-policies',
+      displayName: 'Rules & Policies',
+      required: true,
+      description: 'Pet policies, quiet hours, community rules, age restrictions (55+ must be HOPA-compliant), check-in/check-out times.',
+    },
+    {
+      slug: 'reservations',
+      displayName: 'Book a Stay',
+      required: false,
+      description: 'RV parks only. Direct online booking reduces phone friction. Integration with Campspot, Newbook, or RMS.',
+    },
+    {
+      slug: 'homes-for-sale',
+      displayName: 'Homes for Sale',
+      required: false,
+      description: 'MHC only. Park-owned home inventory or listings of resident-owned homes available for resale.',
+    },
+    {
+      slug: 'lease-info',
+      displayName: 'Lot Rental Info',
+      required: false,
+      description: 'MHC only. Lot rent pricing, utilities pass-through structure, lease terms, application process.',
+    },
+    {
+      slug: 'community',
+      displayName: 'Our Community',
+      required: false,
+      description: 'MHC only. About the community, events calendar, resident testimonials, neighborhood feel.',
+    },
+    {
+      slug: 'contact',
+      displayName: 'Contact',
+      required: true,
+      blueprintDefaults: ['contact_form_split', 'cta_split_contact'],
+    },
+  ],
+
+  servicesCatalog: [
+    { slug: 'nightly-sites', displayName: 'Nightly RV Sites', category: 'rv-transient', aliases: ['overnight', 'short stay', 'nightly rate'] },
+    { slug: 'weekly-sites', displayName: 'Weekly RV Sites', category: 'rv-extended', aliases: ['weekly rate'] },
+    { slug: 'monthly-sites', displayName: 'Monthly RV Sites', category: 'rv-extended', aliases: ['monthly rate', 'long-term'] },
+    { slug: 'seasonal-sites', displayName: 'Seasonal Sites', category: 'rv-extended', aliases: ['snowbird', 'winter site', 'summer site'] },
+    { slug: 'full-hookup', displayName: 'Full-Hookup Sites (FHU)', category: 'rv-site-type', aliases: ['FHU', 'full hookup', 'water sewer electric'] },
+    { slug: 'big-rig-sites', displayName: 'Big-Rig Friendly Sites', category: 'rv-site-type', aliases: ['40 foot', 'big rig', 'class A'] },
+    { slug: 'pull-through', displayName: 'Pull-Through Sites', category: 'rv-site-type', aliases: ['pull through'] },
+    { slug: 'cabins', displayName: 'Cabins / Park Models', category: 'rv-lodging', aliases: ['park model', 'cabin rental', 'tiny home'] },
+    { slug: 'lot-rental', displayName: 'Manufactured Home Lot Rental', category: 'mhc-core', aliases: ['lot rent', 'pad rent', 'space rent', 'site rent'] },
+    { slug: 'home-sales', displayName: 'Manufactured Home Sales', category: 'mhc-core', aliases: ['park-owned home', 'POH', 'home for sale', 'resale'] },
+    { slug: 'home-placement', displayName: 'Home Placement Services', category: 'mhc-ops', aliases: ['move-in', 'setup', 'placement'] },
+    { slug: 'clubhouse-events', displayName: 'Clubhouse & Community Events', category: 'amenity', aliases: ['clubhouse', 'events', 'activities'] },
+  ],
+
+  vocabulary: {
+    preferred: [
+      // Site & infrastructure
+      'pad', 'site', 'lot', 'space', 'full hookup', 'FHU', '30 amp', '50 amp', 'pedestal',
+      'pull-through', 'back-in', 'big rig', 'Class A', 'Class B', 'Class C', 'fifth wheel',
+      'travel trailer', 'toy hauler', 'park model', 'tiny home', 'manufactured home', 'modular home',
+      // Operations
+      'lot rent', 'site rent', 'space rent', 'pad rent', 'nightly rate', 'weekly rate',
+      'monthly rate', 'seasonal rate', 'snowbird rate', 'transient guest', 'extended-stay',
+      'workcamper', 'camp host', 'park-owned home', 'POH', 'tenant-owned home', 'TOH',
+      'bathhouse', 'clubhouse', 'amenity',
+      // Business & investment
+      'cap rate', 'NOI', 'economic occupancy', 'physical occupancy', 'lot fill',
+      'infill', 'value-add', 'repositioning', 'MHC',
+      // Legal & tenancy
+      'lot lease', 'residency agreement', 'community rules', 'house rules', 'HOPA',
+      '55+ community', 'Fair Housing Act', 'chattel loan', 'real property loan',
+    ],
+    avoid: [
+      { term: 'trailer park', reason: 'Dated, pejorative. Use "manufactured housing community" or "MHC."' },
+      { term: 'mobile home', reason: 'Historically accurate for pre-1976 units; current term is "manufactured home."' },
+      { term: 'permanent residence', reason: 'Used in RV park marketing creates legal and zoning risk — most jurisdictions cap length of stay.' },
+      { term: 'affordable housing', reason: 'Restricts brand positioning and can trigger stigma. Use as one attribute among many, not sole positioning.' },
+      { term: 'senior', reason: 'In 55+ community messaging, must be HOPA-compliant. Casual use without the HOPA framing creates FHA risk.' },
+      { term: 'private community', reason: 'Language implying exclusivity can be read as protected-class exclusion under FHA.' },
+      { term: 'exclusive community', reason: 'Same as "private" — FHA discrimination risk in how exclusivity is phrased.' },
+      { term: 'adult community', reason: 'Only compliant if HOPA requirements are met AND copy frames it properly. Default to avoiding without legal review.' },
+      { term: 'no children', reason: 'Direct FHA familial-status violation unless HOPA-compliant 55+ certification is in place.' },
+    ],
+  },
+
+  ctaDefaults: {
+    approved: [
+      'Reserve Your Site',
+      'Check Availability',
+      'Book Your Stay',
+      'Schedule a Tour',
+      'View Homes for Sale',
+      'Apply for Residency',
+      'Request Info',
+    ],
+    rejected: [
+      'Book Now',
+      'Buy Now',
+      'Click Here',
+      'Sign Up',
+    ],
+  },
+
+  seasonality: {
+    Q1: {
+      intent: 'high',
+      focus: ['snowbird-season', 'sun-belt-rv-peak', 'mhc-slow'],
+      notes: 'Jan–Mar: snowbird season in Sun Belt (AZ, FL, TX, Southern CA, Gulf Coast) for RV. Extended-stay bookings dominate. MHC move-ins are at annual low; tax refund inquiries late Q1.',
+    },
+    Q2: {
+      intent: 'high',
+      focus: ['rv-shoulder', 'mhc-move-in-peak', 'workcamper-arrivals'],
+      notes: 'Apr–Jun: RV shoulder season with spring travelers, workcampers arriving for summer. MHC peak move-in season (weather, school calendar).',
+    },
+    Q3: {
+      intent: 'high',
+      focus: ['family-vacation', 'weekend-warriors', 'mhc-move-in-continued'],
+      notes: 'Jul–Aug: peak family/vacation season in northern and mountain RV markets. MHC continues peak move-in season.',
+    },
+    Q4: {
+      intent: 'medium',
+      focus: ['fall-foliage', 'holiday-lull', 'sun-belt-rv-rebuild', 'mhc-rate-planning'],
+      notes: 'Oct–Dec: fall foliage short window for northern RV markets → rapid drop-off → holiday lull. Sun Belt parks fill back up late Q4. MHC: slow leasing; internal budget/rate-increase planning.',
+    },
+  },
+
+  keywordBank: {
+    primary: [
+      'RV park {city}',
+      'RV resort {region}',
+      'manufactured home community {city}',
+      'MHC {city}',
+      'mobile home park {city}',
+      '55+ community {city}',
+      'snowbird park {region}',
+      'monthly RV site {city}',
+    ],
+    serviceLevel: [
+      'full hookup RV sites',
+      'pull-through RV sites',
+      'big rig RV park',
+      'park model home',
+      'homes for sale manufactured',
+      'lot rent {city}',
+      'RV park with pool',
+      'pet-friendly RV park',
+    ],
+  },
+
+  directories: {
+    required: [
+      'Google Business Profile',
+      'Bing Places',
+      'Apple Business Connect',
+      'Facebook Business Page',
+    ],
+    optional: [
+      'Yelp',
+      'Nextdoor',
+    ],
+    conditional: {
+      'rv-parks': [
+        'Good Sam',
+        'Campendium',
+        'RV Life',
+        'RV Parky',
+        'The Dyrt',
+        'Hipcamp',
+        'AllStays',
+        'Roadtrippers',
+      ],
+      'mhc': [
+        'MHVillage',
+        'Datacomp / JLT Reports',
+        'Apartments.com',
+        'Zillow Rentals',
+        'Facebook Marketplace',
+        'MHP Home Source',
+        'MobileHome.net',
+      ],
+    },
+  },
+
+  regulatory: [
+    {
+      topic: 'Fair Housing Act (FHA)',
+      summary: 'Federal prohibition on discrimination based on race, color, national origin, religion, sex, familial status, disability.',
+      implication: 'Affects advertising copy. "Adult community" and "no children" are restricted. Imagery must not imply exclusion of protected classes. Language like "private" or "exclusive" can trigger scrutiny if it implies protected-class exclusion.',
+      scope: 'federal',
+    },
+    {
+      topic: 'Truth-in-advertising (FTC)',
+      summary: 'Amenity and availability claims must be accurate and substantiated.',
+      implication: 'Pool/Wi-Fi/bathhouse photos must reflect current reality. Occupancy and availability claims must be current. "Luxury," "resort," "five-star" require substantiation.',
+      scope: 'federal',
+    },
+    {
+      topic: 'State Mobile Home Park Acts / Landlord-Tenant Law',
+      summary: 'State-by-state tenant protections for MHC residents — highly variable.',
+      implication: 'CA, FL, OR, MI, NY have strong protections: rent increase notice periods, lease renewal rights, resident right-to-purchase on sale. Marketing about rates, leases, and community changes must comply with the applicable state law.',
+      scope: 'state',
+    },
+    {
+      topic: 'HOPA (Housing for Older Persons Act)',
+      summary: 'Federal exemption allowing age-restricted (55+) housing if specific occupancy and intent requirements are met.',
+      implication: 'A 55+ community can legally restrict by age ONLY if HOPA-compliant. Marketing must reflect HOPA framing. Non-compliant communities using "55+" language face FHA risk.',
+      scope: 'federal',
+    },
+    {
+      topic: 'Lot Lease Agreements',
+      summary: 'Most states require written lot leases for MHC residents; some require specific disclosures.',
+      implication: 'Website should clarify lease terms, utility pass-through, community rules, sale procedures. Some states require specific disclosures be accessible to prospective residents.',
+      scope: 'state',
+    },
+    {
+      topic: 'Chattel vs Real Property Financing',
+      summary: 'Manufactured homes often titled like vehicles (DMV) rather than real estate — affects financing and messaging.',
+      implication: 'Financing disclosures under CFPB oversight. Marketing about home affordability must distinguish between chattel loans (higher rates) and real-property-titled homes.',
+      scope: 'federal',
+    },
+    {
+      topic: 'Rent Control',
+      summary: 'Local to specific cities/states; affects rent increase communications.',
+      implication: 'Rate-change messaging must comply with applicable rent control and notice-period laws.',
+      scope: 'local',
+    },
+    {
+      topic: 'Local Land-Use / Zoning (RV parks)',
+      summary: 'Length-of-stay caps (often 14–30 days) exist in many jurisdictions.',
+      implication: 'RV park marketing cannot promote "permanent" or "live here full-time" in jurisdictions with stay caps. Extended-stay messaging must align with zoning.',
+      scope: 'local',
+    },
+    {
+      topic: 'Transient Occupancy Tax (TOT / bed tax)',
+      summary: 'Applies to short-stay RV guests in many counties.',
+      implication: 'Rate communications and booking confirmations must include applicable TOT disclosures.',
+      scope: 'local',
+    },
+    {
+      topic: 'ADA Accessibility',
+      summary: 'Required for amenity buildings; site-level accessibility varies.',
+      implication: 'Accessibility info (ADA-compliant sites, accessible bathhouse, accessible clubhouse) should be surfaced on the site. WCAG 2.1 AA for the website itself.',
+      scope: 'federal',
+    },
+  ],
+
+  customerPainPoints: [
+    // RV Parks
+    { summary: 'Availability and reservation confusion — is the site open? can I book online?', segment: 'rv-transient' },
+    { summary: 'Hookup details unclear — 30 vs 50 amp, water/sewer, full hookup vs partial, pull-through vs back-in.', segment: 'rv-transient' },
+    { summary: 'Rig size limits — big rigs (40\'+) get filtered out of many parks.', segment: 'rv-transient' },
+    { summary: 'Pet policies, quiet hours, community rules need to be clear upfront.', segment: 'rv-transient' },
+    { summary: 'Amenities reality vs photos — is the pool open? is Wi-Fi usable? is the bathhouse clean?', segment: 'rv-transient' },
+    { summary: 'Seasonal closures and rate transparency.', segment: 'rv-transient' },
+    // MHC
+    { summary: 'Lot rent increases and predictability.', segment: 'mhc-resident' },
+    { summary: 'Community rules, pet policies, age restrictions (55+) need clarity.', segment: 'mhc-resident' },
+    { summary: 'Home placement / move-in logistics and costs.', segment: 'mhc-resident' },
+    { summary: 'Management responsiveness and reputation.', segment: 'mhc-resident' },
+    { summary: 'Home ownership vs renting a park-owned home confusion.', segment: 'mhc-resident' },
+    { summary: 'Financing barriers — "chattel" loans on the home itself carry higher rates than site-built.', segment: 'mhc-resident' },
+    { summary: 'Resale restrictions and community approval of buyers.', segment: 'mhc-resident' },
+    // Shared
+    { summary: 'Natural disaster season (hurricane, wildfire, flood) directly affects reputation and occupancy.' },
+  ],
+
+  competitiveLandscape: [
+    {
+      name: 'National REITs / large RV operators',
+      examples: ['Sun Communities (Sun Outdoors)', 'Equity LifeStyle Properties (ELS / Thousand Trails / Encore RV Resorts)', 'Roberts Resorts', 'Blue Water'],
+      moat: 'Scale, portfolio booking, brand trust, member networks.',
+      weakness: 'Commoditized experience; independents can differentiate on character, niche audiences, and location-specific appeal.',
+    },
+    {
+      name: 'RV franchise / brand networks',
+      examples: ['KOA (Kampgrounds of America)', 'Jellystone Park', 'Yogi Bear\'s franchises'],
+      moat: 'Brand recognition, family-friendly standardization, national ad spend.',
+      weakness: 'Less unique character; locked into franchise fees and standards.',
+    },
+    {
+      name: 'National MHC operators',
+      examples: ['Sun Communities', 'Equity LifeStyle', 'RHP Properties', 'YES! Communities', 'Inspire Communities', 'Flagship', 'Cal-Am'],
+      moat: 'Capital, operational scale, resident services.',
+      weakness: 'Perceived as corporate landlords — local operators can win on relationship and responsiveness.',
+    },
+    {
+      name: 'Mid-size and family-owned MHC operators',
+      moat: 'Personal relationships, community stewardship, long-time residents.',
+      weakness: 'Susceptible to acquisition pressure; smaller ad budgets.',
+    },
+    {
+      name: 'Public-land RV competition',
+      examples: ['State parks', 'National Forest dispersed camping', 'Corps of Engineers sites'],
+      moat: 'Cheaper, natural settings.',
+      weakness: 'Fewer amenities, limited reservations, no hookups.',
+    },
+    {
+      name: 'Apartments & SFR (for MHC)',
+      moat: 'Newer inventory, more financing options for renters.',
+      weakness: 'Higher monthly cost; no path to home ownership.',
+    },
+    {
+      name: 'Boondocking / alternative platforms',
+      examples: ['Harvest Hosts', 'Hipcamp', 'Boondockers Welcome'],
+      moat: 'Price, unique experiences.',
+      weakness: 'Bottom-of-market positioning; not a substitute for full-service parks.',
+    },
+  ],
+};

--- a/content-system/industries/small-business.mdx
+++ b/content-system/industries/small-business.mdx
@@ -1,0 +1,127 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { smallBusiness } from './small-business';
+
+<Meta title="Content System/Industries/Small Business (General)" />
+
+# Small Business (General)
+
+**Version:** {smallBusiness.version}  •  **Last reviewed:** {smallBusiness.lastReviewed}  •  **Review cadence:** {smallBusiness.reviewCadence}
+
+Catch-all baseline for clients who don't yet fit a defined Brik sub-industry. Used as `DEFAULT_INDUSTRY_SLUG` by the resolver when no dedicated pack matches.
+
+Structured data lives in [`small-business.ts`](?path=/docs/content-system-industries-small-business--docs). Promotion rules at the bottom of this page govern when to graduate a vertical out of this pack.
+
+---
+
+## 1. What belongs here
+
+Local service and retail operators who don't fit a defined Brik sub-industry yet — boutique fitness, home services (HVAC, plumbing, electrical, landscaping), local legal/financial advisors, specialty retail, restaurants, pet services, and similar.
+
+These businesses share a common playbook — local-search dominance, reputation management, service clarity, conversion-focused sites — but vary widely in sales cycle, seasonality, and regulatory detail.
+
+**Treat this pack as the shared foundation; layer client-specific nuance into the brief.** Flag any finding that would materially change the playbook for the vertical so we know when to promote.
+
+## 2. Default Affinities
+
+| Axis | Affinities (first = strongest) |
+|---|---|
+| **Personality** | {smallBusiness.affinities.personality.join(' · ')} |
+| **Voice** | {smallBusiness.affinities.voice.join(' · ')} |
+| **Visual Style** | {smallBusiness.affinities.visualStyle.join(' · ')} |
+
+Intentionally balanced and conservative — the catch-all should not push clients toward a specific aesthetic. Client intake should always override.
+
+## 3. Common Customer Pain Points
+
+- **Trust and legitimacy** — is this business real, licensed, reviewed by people like me?
+- **Pricing opacity** — "call for quote" friction; customers increasingly expect ranges or transparent pricing
+- **Scheduling friction** — phone-only booking, slow response to web inquiries
+- **Service-area confusion** — do they come to me? do I come to them?
+- **Comparison shopping** — customers routinely get 2–3 quotes and read 3+ review platforms before choosing
+- **Response time** — leads go cold within hours; slow replies kill conversion
+- **Quality anxiety** — will the work be done right, on time, for the quoted price?
+- **Decision fatigue** — too many options, inconsistent credentials, unclear differentiation
+
+## 4. Seasonality (variable by vertical)
+
+| Quarter | Intent | Focus |
+|---|---|---|
+| **Q1** | medium | Tax-refund boost for discretionary (late Feb–Apr). January fitness/wellness surge. Home services quiet. |
+| **Q2** | high | Spring/summer ramp for home services, outdoor services, event/wedding-adjacent. |
+| **Q3** | medium | Back-to-school affects family-oriented services. Peak for most outdoor/seasonal verticals. |
+| **Q4** | high | Holiday retail push (Oct–Dec). Professional services slow late December. Year-end deductible spend. |
+
+**Flag during intake:** always identify the client's actual seasonal curve in onboarding — assumptions from one vertical rarely transfer to another.
+
+## 5. Competitive Landscape Patterns
+
+- **Direct local competitors** — 3–10 businesses in the same ZIP competing for the same queries
+- **Franchise / chain encroachment** — national brands with bigger ad budgets (Mosquito Joe, Mr. Handyman, Anytime Fitness, Massage Envy, H&R Block)
+- **Marketplace aggregators** — Yelp, Thumbtack, Angi, HomeAdvisor, Houzz, TaskRabbit, Bark — intercept bottom-of-funnel searches and resell leads
+- **Platform disruptors** — DoorDash/UberEats (restaurants), Airbnb (lodging), ClassPass (fitness), Rover (pet services)
+- **Solopreneur informal competition** — Nextdoor/Facebook groups competing on price; positioning opportunity for licensed businesses
+- **DIY / self-service alternatives** — YouTube, AI tools, big-box retail
+
+## 6. Listings Requirements
+
+**Foundational (all small businesses):** Google Business Profile (primary category is the #1 local-SEO lever), NAP consistency, Bing Places, Apple Business Connect, Facebook Business Page, Yelp, optional BBB.
+
+**Vertical-specific directory families** (conditional, evaluated during intake):
+
+| Vertical | Directories |
+|---|---|
+| Home services | Angi, Thumbtack, HomeAdvisor, Porch, Nextdoor |
+| Restaurants | Yelp, TripAdvisor, OpenTable, Resy, DoorDash, Uber Eats, Google Food Menu |
+| Legal / financial | Avvo, Justia, FindLaw, Super Lawyers, NAPFA |
+| Medical / wellness | Healthgrades, Zocdoc, Vitals |
+| Beauty | Vagaro, Booksy, StyleSeat, Fresha |
+| Fitness | ClassPass, Mindbody |
+| Real estate | Zillow, Realtor.com, Redfin, Trulia |
+
+## 7. Regulatory Summary
+
+| Topic | Scope | Implication |
+|---|---|---|
+| **Business licensing** | state | Surface license numbers in footer / About where required |
+| **FTC truth-in-advertising** | federal | Never use "best/#1/leading" without substantiation |
+| **FTC Endorsement Guides (2023)** | federal | Paid/incentivized reviews must be disclosed; fake reviews carry civil penalties |
+| **CAN-SPAM** | federal | Email templates need physical address + unsubscribe + 10-day honor |
+| **TCPA** | federal | SMS requires express opt-in; heavy per-message fines |
+| **ADA / WCAG 2.1 AA** | federal | Non-negotiable; small businesses are frequent lawsuit targets |
+| **CCPA / state privacy laws** | state | Privacy policy, cookie consent, right-to-delete mechanisms |
+| **Industry-specific** | industry | HIPAA, GLBA, state bar, licensing boards — cross-check during intake |
+
+## 8. Vocabulary — Avoid (catch-all baseline)
+
+<table>
+  <thead><tr><th>Term</th><th>Why</th></tr></thead>
+  <tbody>
+    {smallBusiness.vocabulary.avoid.map((v, i) => (
+      <tr key={i}><td><strong>{v.term}</strong></td><td>{v.reason}</td></tr>
+    ))}
+  </tbody>
+</table>
+
+**Do not use without client confirmation:** industry-specific jargon — always mirror the client's own language from intake and existing marketing.
+
+## 9. Promotion Criteria — Graduating Out of This Pack
+
+Graduate a sub-industry to its own reference pack when **any** of the following is true:
+
+1. Brik has **3 or more active clients** in that vertical, OR
+2. The vertical has meaningfully different **seasonality, regulation, or terminology** from this catch-all, OR
+3. Strategy documents for that vertical are **materially the same 60%+ of the time**, signaling a repeatable pattern worth codifying.
+
+When graduating:
+
+1. Add the new slug to [`vocabularies/industry.ts`](?path=/docs/content-system-vocabularies--docs).
+2. Create `{new-slug}.ts` (IndustryPack) + `{new-slug}.mdx` (narrative) in `content-system/industries/`.
+3. Backfill existing clients in the portal by updating `company_profiles.industry_slug`.
+4. Bump this pack's `version` and log the graduation in the changelog section of this file.
+
+---
+
+## Related
+
+- [Dental pack](?path=/docs/content-system-industries-dental--docs) — first graduated vertical, reference for pack structure
+- [Vocabularies](?path=/docs/content-system-vocabularies--docs) — locked enums

--- a/content-system/industries/small-business.ts
+++ b/content-system/industries/small-business.ts
@@ -1,0 +1,278 @@
+import type { IndustryPack } from '../schema';
+
+/**
+ * Small Business industry pack — the catch-all baseline.
+ *
+ * Ported from industry-reference-small-business.md v1.0 (2026-04-01).
+ * Narrative body lives in ./small-business.mdx.
+ *
+ * This pack is the DEFAULT_INDUSTRY_SLUG used when a client's vertical
+ * has not yet been matched to a dedicated pack. Promote a vertical out of
+ * this pack when Brik has 3+ clients in it OR seasonality/regulation/
+ * terminology diverges meaningfully OR strategy docs repeat 60%+.
+ */
+export const smallBusiness: IndustryPack = {
+  slug: 'small-business',
+  displayName: 'Small Business (General)',
+  version: '1.0.0',
+  reviewCadence: 'quarterly',
+  lastReviewed: '2026-04-01',
+
+  affinities: {
+    personality: ['Professional', 'Approachable', 'Warm', 'Modern'],
+    voice: ['Direct', 'Conversational', 'Expert'],
+    visualStyle: ['Light', 'Modern', 'Minimal'],
+  },
+
+  pageArchetypes: [
+    {
+      slug: 'home',
+      displayName: 'Home',
+      required: true,
+      blueprintDefaults: ['hero_split_60_40', 'services_detail_two_column', 'testimonials_3col_cards', 'cta_split_contact'],
+    },
+    {
+      slug: 'about',
+      displayName: 'About',
+      required: true,
+      blueprintDefaults: ['hero_interior_minimal', 'about_story_split'],
+    },
+    {
+      slug: 'services',
+      displayName: 'Services',
+      required: true,
+      blueprintDefaults: ['hero_interior_minimal', 'services_detail_two_column', 'faq_accordion_grouped'],
+    },
+    {
+      slug: 'contact',
+      displayName: 'Contact',
+      required: true,
+      blueprintDefaults: ['contact_form_split', 'cta_split_contact'],
+    },
+    {
+      slug: 'testimonials',
+      displayName: 'Testimonials',
+      required: false,
+      blueprintDefaults: ['testimonials_3col_cards', 'testimonials_featured_large'],
+    },
+    {
+      slug: 'pricing',
+      displayName: 'Pricing',
+      required: false,
+      description: 'Include when the vertical benefits from transparent pricing (increasingly most). Omit only when "call for quote" is the dominant model in the sub-vertical.',
+    },
+    {
+      slug: 'service-areas',
+      displayName: 'Service Areas',
+      required: false,
+      description: 'Required for service-area businesses (SABs) operating across multiple cities/neighborhoods. Skip for brick-and-mortar single-location businesses.',
+    },
+  ],
+
+  servicesCatalog: [
+    // Intentionally empty. The catch-all pack cannot enumerate services for
+    // every vertical. The resolver should fall back to free-text service
+    // capture from onboarding and flag for industry promotion when 3+
+    // clients share a pattern.
+  ],
+
+  vocabulary: {
+    preferred: [
+      // Marketing + measurement
+      'CAC', 'LTV', 'LTV:CAC', 'CPL', 'CPA', 'lead-to-close rate', 'show rate',
+      'average ticket', 'repeat rate', 'NPS',
+      // Local SEO
+      'NAP', 'GBP', 'SAB', 'citation', 'local pack', 'map pack', 'schema markup',
+      // Website + conversion
+      'landing page', 'lead magnet', 'CTA', 'above-the-fold', 'hero',
+      // Reputation
+      'reputation management', 'review velocity', 'response rate', 'review diversity',
+    ],
+    avoid: [
+      { term: 'best', reason: 'FTC requires substantiation for superiority claims. Unqualified "best" is legally risky and rarely earns trust.' },
+      { term: '#1', reason: 'Same as "best" — unsubstantiated superiority claim.' },
+      { term: 'leading', reason: 'Same as "best" unless specific market-share data backs it.' },
+      { term: 'expert', reason: 'Requires credentials/licensure backing; misleading without them in regulated verticals.' },
+      { term: 'guaranteed results', reason: 'Prohibited in most regulated verticals (health, legal, finance). Creates legal exposure in unregulated ones.' },
+      { term: 'review gating', reason: 'Now largely prohibited on Google — do not design systems that filter reviews by sentiment before publishing.' },
+    ],
+  },
+
+  ctaDefaults: {
+    approved: [
+      'Get a Free Quote',
+      'Request a Consultation',
+      'Schedule a Visit',
+      'Contact Us',
+      'See Pricing',
+      'Get Started',
+    ],
+    rejected: [
+      'Click Here',
+      'Submit',
+      'Buy Now',
+    ],
+  },
+
+  seasonality: {
+    Q1: {
+      intent: 'medium',
+      focus: ['tax-refund-services', 'new-year-fitness', 'professional-services-slow'],
+      notes: 'Tax refund season (late Feb–Apr) boosts discretionary services. January surges fitness/wellness. Home services quiet until spring.',
+    },
+    Q2: {
+      intent: 'high',
+      focus: ['home-services', 'outdoor-services', 'event-services'],
+      notes: 'Spring/summer ramp for home services, landscaping, events, wedding-adjacent businesses.',
+    },
+    Q3: {
+      intent: 'medium',
+      focus: ['back-to-school', 'family-services', 'seasonal-peak'],
+      notes: 'Back-to-school affects family services. Peak for most outdoor/seasonal verticals.',
+    },
+    Q4: {
+      intent: 'high',
+      focus: ['holiday-retail', 'year-end-deductible-spend', 'december-slowdown'],
+      notes: 'Holiday retail push Oct–Dec. Professional services slow in late December. Year-end deductible-driven spend on services.',
+    },
+  },
+
+  keywordBank: {
+    primary: [
+      '{service} near me',
+      'best {service} {city}',
+      '{service} {neighborhood}',
+      'local {service}',
+      'affordable {service}',
+      'trusted {service}',
+    ],
+    serviceLevel: [
+      '{specific service} cost',
+      '{specific service} reviews',
+      'how to choose a {service}',
+      '{service} consultation',
+    ],
+  },
+
+  directories: {
+    required: [
+      'Google Business Profile',
+      'Bing Places',
+      'Apple Business Connect',
+      'Facebook Business Page',
+    ],
+    optional: [
+      'Yelp',
+      'Better Business Bureau',
+      'Nextdoor',
+    ],
+    conditional: {
+      'home-services': ['Angi', 'Thumbtack', 'HomeAdvisor', 'Porch', 'Nextdoor'],
+      'restaurants': ['Yelp', 'TripAdvisor', 'OpenTable', 'Resy', 'DoorDash', 'Uber Eats', 'Google Food Menu'],
+      'legal-financial': ['Avvo', 'Justia', 'FindLaw', 'Super Lawyers', 'NAPFA'],
+      'medical-wellness': ['Healthgrades', 'Zocdoc', 'Vitals'],
+      'beauty': ['Vagaro', 'Booksy', 'StyleSeat', 'Fresha'],
+      'fitness': ['ClassPass', 'Mindbody'],
+      'real-estate': ['Zillow', 'Realtor.com', 'Redfin', 'Trulia'],
+    },
+  },
+
+  regulatory: [
+    {
+      topic: 'Business Licensing',
+      summary: 'State and local business licenses must be current and displayed correctly on the website.',
+      implication: 'Site footer and About pages should surface license numbers where required by industry or state.',
+      scope: 'state',
+    },
+    {
+      topic: 'FTC Advertising Rules',
+      summary: 'Truthful claims, substantiation for "best/#1/leading" language, clear and conspicuous disclosures.',
+      implication: 'Never use superiority claims without data. Disclose paid relationships, affiliate links, sponsored content.',
+      scope: 'federal',
+    },
+    {
+      topic: 'FTC Endorsement Guides (2023 update)',
+      summary: 'Testimonials must reflect typical results. Paid/incentivized reviews must be disclosed. Fake reviews carry civil penalties.',
+      implication: 'Testimonial pages need "individual results vary" disclaimers where applicable. Any compensated reviews must be flagged.',
+      scope: 'federal',
+    },
+    {
+      topic: 'CAN-SPAM Act',
+      summary: 'Email marketing must include physical address, unsubscribe link, honored within 10 days.',
+      implication: 'All transactional and marketing email templates must meet these requirements out of the box.',
+      scope: 'federal',
+    },
+    {
+      topic: 'TCPA',
+      summary: 'SMS/call marketing requires express consent. Violations carry heavy per-message fines.',
+      implication: 'Any SMS automation must collect explicit opt-in before send. Document consent capture.',
+      scope: 'federal',
+    },
+    {
+      topic: 'ADA / WCAG 2.1 AA Accessibility',
+      summary: 'Small businesses are frequent ADA-lawsuit targets.',
+      implication: 'Minimum WCAG 2.1 AA compliance is non-negotiable across all Brik-delivered sites.',
+      scope: 'federal',
+    },
+    {
+      topic: 'CCPA / State Privacy Laws',
+      summary: 'California, Virginia, Colorado, Connecticut, Utah, Texas, and growing list require privacy disclosures.',
+      implication: 'Privacy policy and cookie consent required. Right-to-delete and opt-out mechanisms must be implemented.',
+      scope: 'state',
+    },
+    {
+      topic: 'Industry-specific licensing',
+      summary: 'HIPAA (health), Gramm-Leach-Bliley (financial), state bar (legal), licensing boards (RE, contractors, cosmetology) all add requirements.',
+      implication: 'Always cross-check regulatory scope during intake. Graduate client to a dedicated industry pack once vertical is identified.',
+      scope: 'industry',
+    },
+  ],
+
+  customerPainPoints: [
+    { summary: 'Trust and legitimacy — is this business real, licensed, and reviewed?' },
+    { summary: 'Pricing opacity — "call for quote" friction; customers want ranges or transparent pricing.' },
+    { summary: 'Scheduling friction — phone-only booking, slow web response.' },
+    { summary: 'Service-area confusion — do they come to me or do I come to them?' },
+    { summary: 'Comparison shopping — customers typically get 2–3 quotes and read 3+ review platforms before choosing.' },
+    { summary: 'Response time — leads go cold within hours; slow replies kill conversion.' },
+    { summary: 'Quality anxiety — will the work be done right, on time, for the quoted price?' },
+    { summary: 'Decision fatigue — too many options, inconsistent credentials, unclear differentiation.' },
+  ],
+
+  competitiveLandscape: [
+    {
+      name: 'Direct local competitors',
+      moat: 'Proximity, word-of-mouth, local reviews.',
+      weakness: 'Similar offerings create commoditization pressure.',
+    },
+    {
+      name: 'Franchise / chain encroachment',
+      examples: ['Mosquito Joe', 'Mr. Handyman', 'Anytime Fitness', 'Massage Envy', 'H&R Block'],
+      moat: 'Bigger ad budgets, brand trust, convenience.',
+      weakness: 'Lower personalization, less community embeddedness, slower local decision-making.',
+    },
+    {
+      name: 'Marketplace aggregators',
+      examples: ['Yelp', 'Thumbtack', 'Angi', 'HomeAdvisor', 'Houzz', 'TaskRabbit', 'Bark'],
+      moat: 'Intercept bottom-of-funnel searches. Sell leads.',
+      weakness: 'Race-to-bottom pricing; eroding lead quality; customer loyalty stays with the platform, not the business.',
+    },
+    {
+      name: 'Platform disruptors',
+      examples: ['DoorDash', 'UberEats', 'Airbnb', 'ClassPass', 'Rover'],
+      moat: 'Change how customers discover and compare.',
+      weakness: 'Take a significant cut; commoditize the experience.',
+    },
+    {
+      name: 'Solopreneur informal competition',
+      moat: 'Nextdoor/Facebook groups; price.',
+      weakness: 'Unlicensed, uninsured, inconsistent quality — positioning opportunity for licensed businesses.',
+    },
+    {
+      name: 'DIY / self-service alternatives',
+      examples: ['YouTube tutorials', 'AI tools', 'Big-box retail'],
+      moat: 'Free or near-free; customer self-sufficiency.',
+      weakness: 'Doesn\'t work for complex, urgent, or high-stakes needs.',
+    },
+  ],
+};

--- a/content-system/schema/index.ts
+++ b/content-system/schema/index.ts
@@ -1,0 +1,19 @@
+export type {
+  IndustryPack,
+  PageArchetype,
+  ServiceEntry,
+  VocabularyAvoid,
+  SeasonalWindow,
+  RegulatoryNote,
+  CustomerPainPoint,
+  CompetitorArchetype,
+  StrategicConsideration,
+  Quarter,
+} from './industry-pack';
+
+export type {
+  VoicePattern,
+  VoiceRules,
+  VoiceExamples,
+  VoiceExample,
+} from './voice-pattern';

--- a/content-system/schema/industry-pack.ts
+++ b/content-system/schema/industry-pack.ts
@@ -1,0 +1,167 @@
+import type {
+  IndustrySlug,
+  Personality,
+  Voice,
+  VisualStyle,
+} from '../vocabularies';
+
+/**
+ * IndustryPack — the structured data half of an industry reference.
+ *
+ * Each industry in BCS has two files:
+ *   - `{slug}.ts`  — this shape, imported by automations and the portal resolver
+ *   - `{slug}.mdx` — the human-readable narrative (Overview, Pain Points, etc.)
+ *
+ * The narrative explains the industry; the pack lets automations act on it.
+ * Keep them in sync — changes to `.ts` values should be reflected in the
+ * `.mdx` body and vice versa.
+ *
+ * Review cadence is quarterly. Bump `version` on content changes; update
+ * `lastReviewed` on confirmed-still-accurate passes.
+ */
+export interface IndustryPack {
+  /** Canonical slug — must appear in INDUSTRY_SLUGS registry. */
+  slug: IndustrySlug;
+  /** Human-readable name used in portal UI and generated briefs. */
+  displayName: string;
+  /** Semver. Bump on material content change; minor for additions, major for schema breaks. */
+  version: string;
+  reviewCadence: 'quarterly' | 'biannual' | 'annual';
+  /** ISO date YYYY-MM-DD. */
+  lastReviewed: string;
+
+  /**
+   * Affinity defaults — used by the resolver when a client hasn't picked
+   * traits in the portal, or when the pack wants to nudge a balanced default.
+   * Not prescriptive: clients always override. Order matters — first entry
+   * is the strongest affinity.
+   */
+  affinities: {
+    personality: readonly Personality[];
+    voice: readonly Voice[];
+    visualStyle: readonly VisualStyle[];
+  };
+
+  /** Industry-specific information architecture. */
+  pageArchetypes: readonly PageArchetype[];
+
+  /** Canonical service taxonomy used to seed the portal services picker and copy. */
+  servicesCatalog: readonly ServiceEntry[];
+
+  /** Preferred terminology and terms to avoid (regulatory, positioning, or style). */
+  vocabulary: {
+    preferred: readonly string[];
+    avoid: readonly VocabularyAvoid[];
+  };
+
+  /** Default CTA phrasing — seeds company_profile.cta_language when empty. */
+  ctaDefaults: {
+    approved: readonly string[];
+    rejected: readonly string[];
+  };
+
+  /** Quarterly seasonality for campaign timing and copy calendar. */
+  seasonality: Record<Quarter, SeasonalWindow>;
+
+  /** SEO + copy keyword banks. */
+  keywordBank: {
+    primary: readonly string[];
+    serviceLevel: readonly string[];
+  };
+
+  /** Directories and listings required for local SEO and citations. */
+  directories: {
+    required: readonly string[];
+    optional?: readonly string[];
+    /** Industry-specific conditional directories (e.g. dental insurance directories). */
+    conditional?: Record<string, readonly string[]>;
+  };
+
+  /** Regulatory notes that shape copy and design decisions. */
+  regulatory: readonly RegulatoryNote[];
+
+  /** Pain points of the end customer/patient/tenant — informs empathy in copy. */
+  customerPainPoints: readonly CustomerPainPoint[];
+
+  /** Competitor archetypes — shape positioning and differentiation. */
+  competitiveLandscape: readonly CompetitorArchetype[];
+
+  /**
+   * Optional industry-specific strategic considerations that go beyond
+   * generic reference material (e.g. dental's retention economics,
+   * independent-vs-DSO positioning, FFS transition). Populated only when
+   * Brik has a defensible POV that should surface in briefs.
+   */
+  strategicConsiderations?: readonly StrategicConsideration[];
+}
+
+export type Quarter = 'Q1' | 'Q2' | 'Q3' | 'Q4';
+
+export interface PageArchetype {
+  /** Canonical slug used across portal, CMS seeds, and generated sitemaps. */
+  slug: string;
+  displayName: string;
+  /** True if every site in this industry should include this page. */
+  required: boolean;
+  /**
+   * Preferred blueprint keys from the BDS blueprint library (tagged by
+   * personality/voice/visualStyle). The resolver uses these as starting
+   * picks before client traits refine the shortlist.
+   */
+  blueprintDefaults?: readonly string[];
+  description?: string;
+}
+
+export interface ServiceEntry {
+  slug: string;
+  displayName: string;
+  /** Synonyms used when matching free-text service lists from intake. */
+  aliases: readonly string[];
+  /** Optional grouping, e.g. "preventive", "cosmetic", "restorative". */
+  category?: string;
+  regulatoryNote?: string;
+}
+
+export interface VocabularyAvoid {
+  term: string;
+  reason: string;
+}
+
+export interface SeasonalWindow {
+  intent: 'low' | 'medium' | 'high';
+  /** Short keywords describing what the window is about. */
+  focus: readonly string[];
+  notes?: string;
+}
+
+export interface RegulatoryNote {
+  topic: string;
+  summary: string;
+  /** How this regulation constrains copy, design, or collateral. */
+  implication: string;
+  scope?: 'federal' | 'state' | 'local' | 'industry';
+}
+
+export interface CustomerPainPoint {
+  summary: string;
+  /** Optional segment — e.g. "long-term residents" vs "transient guests" for MHC/RV. */
+  segment?: string;
+  detail?: string;
+}
+
+export interface CompetitorArchetype {
+  name: string;
+  examples?: readonly string[];
+  moat?: string;
+  weakness?: string;
+}
+
+export interface StrategicConsideration {
+  /** Short identifier — e.g. "retention-economics", "ffs-transition". */
+  slug: string;
+  title: string;
+  /** Short summary of the POV. The full narrative lives in the .mdx file. */
+  summary: string;
+  /** When generating briefs, these conditions trigger surfacing this consideration. */
+  appliesWhen?: readonly string[];
+}

--- a/content-system/schema/voice-pattern.ts
+++ b/content-system/schema/voice-pattern.ts
@@ -1,0 +1,74 @@
+import type { Voice } from '../vocabularies';
+
+/**
+ * VoicePattern — the writing rules + examples for one canonical voice trait.
+ *
+ * Each voice in `VOICE_VALUES` has a matching `voices/{slug}.ts` file and an
+ * `{slug}.mdx` narrative. The resolver's voice blender reads `rules` and
+ * merges up to 3 voice patterns with first-pick weighted highest.
+ *
+ * Rules are *directional*, not strict — sentence-length ranges are targets
+ * that compose, not hard limits. The blender reconciles conflicts (e.g.
+ * Direct's short-sentence rule vs Poetic's long-cadence rule) by weighting
+ * toward the first pick but allowing the second and third picks to soften.
+ */
+export interface VoicePattern {
+  slug: Voice;
+  displayName: string;
+  version: string;
+  lastReviewed: string;
+
+  /** One-sentence summary shown in portal UI tooltips. */
+  summary: string;
+
+  /** Structured rules the blender consumes. */
+  rules: VoiceRules;
+
+  /** Recognizable tics that mark this voice. */
+  signaturePatterns: readonly string[];
+
+  /** Patterns this voice avoids. */
+  avoid: readonly string[];
+
+  /** Concrete copy examples showing how this voice writes specific surfaces. */
+  examples: VoiceExamples;
+
+  /** How this voice behaves when blended with others. */
+  pairings: {
+    /** Voices that amplify this one when paired. */
+    reinforces: readonly Voice[];
+    /** Voices that create productive tension — notable but not forbidden. */
+    tensions: readonly Voice[];
+  };
+}
+
+export interface VoiceRules {
+  /** Target sentence length in words (avg + min/max range). */
+  sentenceLength: {
+    avg: number;
+    range: readonly [number, number];
+  };
+  contractions: 'encouraged' | 'neutral' | 'avoid';
+  perspective: 'first-person-plural' | 'second-person' | 'third-person' | 'flexible';
+  hedging: 'avoid' | 'neutral' | 'encouraged';
+  imperatives: 'soften' | 'neutral' | 'direct';
+  rhetoricalQuestions: 'avoid' | 'neutral' | 'encouraged';
+  figurativeLanguage: 'avoid' | 'neutral' | 'encouraged';
+}
+
+export interface VoiceExamples {
+  /** Hero headline + optional subhead. */
+  hero: VoiceExample;
+  /** CTA button label or short phrase. */
+  cta: VoiceExample;
+  /** A single paragraph (2–4 sentences). */
+  paragraph: VoiceExample;
+  /** Optional: microcopy — error states, form labels, tooltips. */
+  microcopy?: VoiceExample;
+}
+
+export interface VoiceExample {
+  copy: string;
+  /** Optional author note explaining what the example demonstrates. */
+  notes?: string;
+}

--- a/content-system/vocabularies/index.ts
+++ b/content-system/vocabularies/index.ts
@@ -1,0 +1,24 @@
+export {
+  PERSONALITY_VALUES,
+  isPersonality,
+  type Personality,
+} from './personality';
+
+export {
+  VOICE_VALUES,
+  isVoice,
+  type Voice,
+} from './voice';
+
+export {
+  VISUAL_STYLE_VALUES,
+  isVisualStyle,
+  type VisualStyle,
+} from './visual-style';
+
+export {
+  INDUSTRY_SLUGS,
+  DEFAULT_INDUSTRY_SLUG,
+  isIndustrySlug,
+  type IndustrySlug,
+} from './industry';

--- a/content-system/vocabularies/industry.ts
+++ b/content-system/vocabularies/industry.ts
@@ -1,0 +1,30 @@
+/**
+ * Industry slug registry — canonical keys for every industry pack in BCS.
+ *
+ * Each slug here must have a matching `{slug}.ts` data file and `{slug}.mdx`
+ * narrative in `content-system/industries/`. The portal's
+ * `company_profiles.industry_slug` column is a FK to this list.
+ *
+ * Promotion policy (from industry-reference-small-business.md §Promotion):
+ *   Graduate a vertical out of `small-business` to its own slug when:
+ *     1. Brik has 3+ active clients in that vertical, OR
+ *     2. Seasonality/regulation/terminology diverges meaningfully, OR
+ *     3. Strategy docs repeat 60%+ in that vertical.
+ */
+export const INDUSTRY_SLUGS = [
+  'dental',
+  'real-estate-rv-mhc',
+  'small-business',
+] as const;
+
+export type IndustrySlug = (typeof INDUSTRY_SLUGS)[number];
+
+export const isIndustrySlug = (value: string): value is IndustrySlug =>
+  (INDUSTRY_SLUGS as readonly string[]).includes(value);
+
+/**
+ * Fallback slug used when a client's industry has not yet been matched
+ * to a dedicated pack. The `small-business` pack is designed as a
+ * catch-all baseline.
+ */
+export const DEFAULT_INDUSTRY_SLUG: IndustrySlug = 'small-business';

--- a/content-system/vocabularies/personality.ts
+++ b/content-system/vocabularies/personality.ts
@@ -1,0 +1,28 @@
+/**
+ * Brand Personality — the 11 canonical traits captured in the client portal.
+ *
+ * Single source of truth. The portal enum and BDS blueprint/theme tags
+ * must reference these values. Drift here causes silent resolver failures.
+ *
+ * Clients pick up to 3. Repeated traits across Personality + Voice +
+ * Visual Style indicate reinforced intent and should be weighted higher
+ * by the resolver.
+ */
+export const PERSONALITY_VALUES = [
+  'Warm',
+  'Approachable',
+  'Playful',
+  'Bold',
+  'Professional',
+  'Modern',
+  'Minimal',
+  'Luxury',
+  'Corporate',
+  'Authoritative',
+  'Refined',
+] as const;
+
+export type Personality = (typeof PERSONALITY_VALUES)[number];
+
+export const isPersonality = (value: string): value is Personality =>
+  (PERSONALITY_VALUES as readonly string[]).includes(value);

--- a/content-system/vocabularies/visual-style.ts
+++ b/content-system/vocabularies/visual-style.ts
@@ -1,0 +1,30 @@
+/**
+ * Visual Style — the 11 canonical style directions captured in the client portal.
+ *
+ * Drives theme token selection (palette density, typography, spacing),
+ * imagery treatment, and blueprint shortlist trimming. Distinct from
+ * Personality — a "Playful" personality can be expressed in a "Minimal"
+ * visual style, and those tradeoffs are where craftwork lives.
+ *
+ * Clients pick up to 3. "Minimal" and "Playful" also appear in Personality;
+ * "Luxurious" overlaps with Personality's "Luxury" (intentional — singular
+ * adjective form in Personality, adverbial form here).
+ */
+export const VISUAL_STYLE_VALUES = [
+  'Minimal',
+  'Playful',
+  'Luxurious',
+  'Modern',
+  'Classic',
+  'Dark',
+  'Light',
+  'Colorful',
+  'Monochrome',
+  'Textural',
+  'Brutalist',
+] as const;
+
+export type VisualStyle = (typeof VISUAL_STYLE_VALUES)[number];
+
+export const isVisualStyle = (value: string): value is VisualStyle =>
+  (VISUAL_STYLE_VALUES as readonly string[]).includes(value);

--- a/content-system/vocabularies/voice.ts
+++ b/content-system/vocabularies/voice.ts
@@ -1,0 +1,28 @@
+/**
+ * Brand Voice — the 8 canonical voice traits captured in the client portal.
+ *
+ * Drives copy register, headline cadence, CTA phrasing, and body sentence
+ * structure. Distinct from Personality (which drives visual/structural feel).
+ *
+ * Clients pick up to 3. The resolver blends picks with first-pick weighted
+ * highest; voice patterns (phase 2) define per-trait writing rules.
+ *
+ * Note: "Approachable" and "Authoritative" also appear in Personality.
+ * That overlap is a feature — reinforcement across axes indicates stronger
+ * intent and should increase weight in the resolver.
+ */
+export const VOICE_VALUES = [
+  'Direct',
+  'Empathetic',
+  'Witty',
+  'Expert',
+  'Conversational',
+  'Authoritative',
+  'Poetic',
+  'Approachable',
+] as const;
+
+export type Voice = (typeof VOICE_VALUES)[number];
+
+export const isVoice = (value: string): value is Voice =>
+  (VOICE_VALUES as readonly string[]).includes(value);

--- a/content-system/voices/Overview.mdx
+++ b/content-system/voices/Overview.mdx
@@ -1,0 +1,140 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { VOICE_VALUES } from '../vocabularies';
+import { voicePatterns } from './index';
+
+<Meta title="Content System/Voices/Overview" />
+
+# Voice Patterns
+
+The 8 canonical voice traits captured in the client portal. Each pattern defines structured writing rules the resolver blends at runtime when a client picks multiple voices.
+
+Clients pick up to 3. The blender weights the first pick highest, second in the middle, third as a softening influence. Rules compose — e.g. Direct + Empathetic produces shorter sentences than pure Empathetic but warmer framing than pure Direct.
+
+---
+
+## Rule Summary
+
+How each voice behaves on the structural axes. Use this to predict what a blend will feel like before rendering copy.
+
+<table>
+  <thead>
+    <tr>
+      <th>Voice</th>
+      <th>Avg sentence</th>
+      <th>Contractions</th>
+      <th>Perspective</th>
+      <th>Hedging</th>
+      <th>Imperatives</th>
+      <th>Rhetorical Q</th>
+      <th>Figurative</th>
+    </tr>
+  </thead>
+  <tbody>
+    {VOICE_VALUES.map(v => {
+      const p = voicePatterns[v];
+      const r = p.rules;
+      return (
+        <tr key={v}>
+          <td><strong>{v}</strong></td>
+          <td>{r.sentenceLength.avg} words ({r.sentenceLength.range[0]}–{r.sentenceLength.range[1]})</td>
+          <td>{r.contractions}</td>
+          <td>{r.perspective}</td>
+          <td>{r.hedging}</td>
+          <td>{r.imperatives}</td>
+          <td>{r.rhetoricalQuestions}</td>
+          <td>{r.figurativeLanguage}</td>
+        </tr>
+      );
+    })}
+  </tbody>
+</table>
+
+---
+
+## Pairings
+
+Which voices reinforce each other vs create productive tension. Tensions aren't forbidden — they're where craft lives. A Direct + Empathetic blend produces copy that is both brief and warm (think: "We know this is hard. Here's what to do next.").
+
+<table>
+  <thead>
+    <tr><th>Voice</th><th>Reinforces</th><th>Tensions</th></tr>
+  </thead>
+  <tbody>
+    {VOICE_VALUES.map(v => {
+      const p = voicePatterns[v];
+      return (
+        <tr key={v}>
+          <td><strong>{v}</strong></td>
+          <td>{p.pairings.reinforces.join(', ') || '—'}</td>
+          <td>{p.pairings.tensions.join(', ') || '—'}</td>
+        </tr>
+      );
+    })}
+  </tbody>
+</table>
+
+---
+
+## Examples by Voice
+
+Each voice renders the same four surface types differently. Read across surfaces to feel how the voice expresses itself; read across voices to feel the same surface shift register.
+
+{VOICE_VALUES.map(v => {
+  const p = voicePatterns[v];
+  return (
+    <section key={v} style={{ marginTop: '2rem', paddingTop: '1rem', borderTop: '1px solid var(--border-muted, #ddd)' }}>
+      <h3>{v}</h3>
+      <p><em>{p.summary}</em></p>
+
+      <h4>Hero</h4>
+      <blockquote style={{ fontSize: '1.1em', margin: '0.5rem 0' }}>{p.examples.hero.copy}</blockquote>
+      {p.examples.hero.notes && <p style={{ fontSize: '0.9em', color: 'var(--text-muted, #666)' }}>→ {p.examples.hero.notes}</p>}
+
+      <h4>CTA</h4>
+      <p><code>{p.examples.cta.copy}</code></p>
+      {p.examples.cta.notes && <p style={{ fontSize: '0.9em', color: 'var(--text-muted, #666)' }}>→ {p.examples.cta.notes}</p>}
+
+      <h4>Paragraph</h4>
+      <blockquote style={{ margin: '0.5rem 0' }}>{p.examples.paragraph.copy}</blockquote>
+      {p.examples.paragraph.notes && <p style={{ fontSize: '0.9em', color: 'var(--text-muted, #666)' }}>→ {p.examples.paragraph.notes}</p>}
+
+      {p.examples.microcopy && (
+        <>
+          <h4>Microcopy</h4>
+          <p><code>{p.examples.microcopy.copy}</code></p>
+          {p.examples.microcopy.notes && <p style={{ fontSize: '0.9em', color: 'var(--text-muted, #666)' }}>→ {p.examples.microcopy.notes}</p>}
+        </>
+      )}
+
+      <h4>Signature patterns</h4>
+      <ul>
+        {p.signaturePatterns.map((s, i) => <li key={i}>{s}</li>)}
+      </ul>
+
+      <h4>Avoid</h4>
+      <ul>
+        {p.avoid.map((s, i) => <li key={i}>{s}</li>)}
+      </ul>
+    </section>
+  );
+})}
+
+---
+
+## Blender rules (resolver-side)
+
+The blender isn't built yet — it belongs in the portal resolver. But here's the spec it should follow:
+
+1. **First pick carries 60% weight, second 30%, third 10%** when rules conflict.
+2. **Numeric rules (sentence length) average with weights.** Direct(10) + Empathetic(14) + Poetic(18), weighted 60/30/10, resolves to ~12 words avg.
+3. **Categorical rules resolve by majority vote** with the first pick breaking ties. Direct("avoid" hedging) + Empathetic("neutral") + Poetic("neutral") → hedging stays "avoid" because Direct holds.
+4. **Perspective is first-pick-wins** unless blended voices all agree on another.
+5. **Signature patterns and avoids are unioned, not averaged** — you inherit every voice's guardrails.
+6. **Pairing tensions are surfaced, not filtered.** The resolver notes "Direct × Poetic is a tension blend" in the output so downstream generators know to handle it carefully.
+
+---
+
+## Related
+
+- [Vocabularies](?path=/docs/content-system-vocabularies--docs)
+- [Industries](?path=/docs/content-system-industries-dental--docs)

--- a/content-system/voices/approachable.ts
+++ b/content-system/voices/approachable.ts
@@ -1,0 +1,58 @@
+import type { VoicePattern } from '../schema';
+
+export const approachable: VoicePattern = {
+  slug: 'Approachable',
+  displayName: 'Approachable',
+  version: '1.0.0',
+  lastReviewed: '2026-04-18',
+
+  summary: 'Warm, inclusive, encouraging. Uses first-person-plural (we/us) to signal partnership. Lowers the reader\'s barrier to action.',
+
+  rules: {
+    sentenceLength: { avg: 12, range: [6, 18] },
+    contractions: 'encouraged',
+    perspective: 'first-person-plural',
+    hedging: 'neutral',
+    imperatives: 'soften',
+    rhetoricalQuestions: 'neutral',
+    figurativeLanguage: 'neutral',
+  },
+
+  signaturePatterns: [
+    'First-person-plural as default ("We work with you," "Our team," "Let\'s").',
+    'Inclusive language — "everyone," "all of us," "you and your family."',
+    'Low-barrier CTAs — "say hi," "drop us a line," "come by."',
+    'Permission-giving phrases ("no commitment," "at your own pace," "when you\'re ready").',
+  ],
+
+  avoid: [
+    'Formal distance — third-person institutional voice reads as cold here.',
+    'Over-promising familiarity — "Welcome home!" when the reader has never been here.',
+    'Euphemisms that hide real concerns instead of addressing them warmly.',
+    'Condescension dressed as friendliness.',
+  ],
+
+  examples: {
+    hero: {
+      copy: 'Dental care for your whole family — without the dental-office feeling.',
+      notes: 'Inclusive ("whole family") + specific pain name ("the dental-office feeling") + friendly tone.',
+    },
+    cta: {
+      copy: 'Say hi',
+      notes: 'Low-barrier, low-commitment, friendly register. Pairs well with a subhead like "We\'ll get right back to you."',
+    },
+    paragraph: {
+      copy: 'We\'re a small team, and we like it that way. You\'ll see the same dentist and the same hygienist every time you come in. We\'ll know your kids\' names. We\'ll remember that you like mint over cinnamon. It\'s not complicated — it\'s just how we think dental care should feel.',
+      notes: 'First-person-plural throughout, specific warm details (mint over cinnamon), explicit positioning ("small team").',
+    },
+    microcopy: {
+      copy: 'Any questions? We\'re around.',
+      notes: 'Permission + availability + casual register.',
+    },
+  },
+
+  pairings: {
+    reinforces: ['Empathetic', 'Conversational'],
+    tensions: ['Authoritative'],
+  },
+};

--- a/content-system/voices/authoritative.ts
+++ b/content-system/voices/authoritative.ts
@@ -1,0 +1,58 @@
+import type { VoicePattern } from '../schema';
+
+export const authoritative: VoicePattern = {
+  slug: 'Authoritative',
+  displayName: 'Authoritative',
+  version: '1.0.0',
+  lastReviewed: '2026-04-18',
+
+  summary: 'Declarative, confident, consequential. States things as fact without softening. Earns trust through certainty, not warmth.',
+
+  rules: {
+    sentenceLength: { avg: 14, range: [8, 22] },
+    contractions: 'avoid',
+    perspective: 'flexible',
+    hedging: 'avoid',
+    imperatives: 'direct',
+    rhetoricalQuestions: 'avoid',
+    figurativeLanguage: 'avoid',
+  },
+
+  signaturePatterns: [
+    'Declarative statements without qualifiers ("This is the standard of care.").',
+    'Third-person institutional voice when appropriate ("The practice maintains...").',
+    'Consequence language ("Delay shortens your options. We recommend scheduling within 30 days.").',
+    'Structural parallelism for weight ("We diagnose. We treat. We stand behind the work.").',
+  ],
+
+  avoid: [
+    'Contractions when gravity is called for.',
+    'Apologetic framing of necessary information.',
+    'Over-explaining — authority implies the reader can handle the point.',
+    'Condescension — there is a line between authoritative and paternalistic.',
+  ],
+
+  examples: {
+    hero: {
+      copy: 'Clinical excellence. Uncompromised.',
+      notes: 'Two-word headline + one-word reinforcement. Weight through brevity.',
+    },
+    cta: {
+      copy: 'Schedule a Consultation',
+      notes: 'Proper capitalization, full phrase, appropriate gravity.',
+    },
+    paragraph: {
+      copy: 'The diagnosis is clear. The treatment path is well-established. We will present three options, each with its own tradeoff, and recommend the one we believe serves you best. The decision is yours.',
+      notes: 'Four declarative sentences, no hedging, closes with reader agency — authoritative without being paternalistic.',
+    },
+    microcopy: {
+      copy: 'This action cannot be undone.',
+      notes: 'Direct consequence, no softening, no "please confirm."',
+    },
+  },
+
+  pairings: {
+    reinforces: ['Expert', 'Direct'],
+    tensions: ['Empathetic', 'Witty', 'Poetic'],
+  },
+};

--- a/content-system/voices/conversational.ts
+++ b/content-system/voices/conversational.ts
@@ -1,0 +1,58 @@
+import type { VoicePattern } from '../schema';
+
+export const conversational: VoicePattern = {
+  slug: 'Conversational',
+  displayName: 'Conversational',
+  version: '1.0.0',
+  lastReviewed: '2026-04-18',
+
+  summary: 'Writes the way a thoughtful expert talks to a friend. Contractions, second-person, moderate rhythm.',
+
+  rules: {
+    sentenceLength: { avg: 13, range: [6, 20] },
+    contractions: 'encouraged',
+    perspective: 'second-person',
+    hedging: 'neutral',
+    imperatives: 'neutral',
+    rhetoricalQuestions: 'encouraged',
+    figurativeLanguage: 'neutral',
+  },
+
+  signaturePatterns: [
+    'Rhetorical questions that set up the next point ("So what actually changes? Two things.").',
+    'Sentence openings with "And," "But," "So" — conjunctions used the way people speak.',
+    'Asides in dashes — small clarifications mid-thought.',
+    'Second-person direct address as the default.',
+  ],
+
+  avoid: [
+    'Formality for its own sake.',
+    'Corporate voice ("We are pleased to announce...").',
+    'Overwrought metaphors.',
+    'Bullet lists for things that should be sentences.',
+  ],
+
+  examples: {
+    hero: {
+      copy: 'Your smile, your call — we\'ll just make sure you have the right information to decide.',
+      notes: 'Direct address, em-dash aside, implicit partnership.',
+    },
+    cta: {
+      copy: 'Let\'s talk',
+      notes: 'Invitation, low commitment, conversational register.',
+    },
+    paragraph: {
+      copy: 'So here\'s the thing about dental implants: the surgery itself is straightforward. What takes time is the healing — three to six months before the final crown goes on. That\'s the part most people don\'t hear about up front, and we think you should.',
+      notes: 'Opens with "So," uses a colon like speech, explicit "we think" of opinion.',
+    },
+    microcopy: {
+      copy: 'Quick question — how\'d you hear about us?',
+      notes: 'Casual framing, em-dash, genuine curiosity tone.',
+    },
+  },
+
+  pairings: {
+    reinforces: ['Empathetic', 'Approachable', 'Witty'],
+    tensions: ['Authoritative', 'Poetic'],
+  },
+};

--- a/content-system/voices/direct.ts
+++ b/content-system/voices/direct.ts
@@ -1,0 +1,58 @@
+import type { VoicePattern } from '../schema';
+
+export const direct: VoicePattern = {
+  slug: 'Direct',
+  displayName: 'Direct',
+  version: '1.0.0',
+  lastReviewed: '2026-04-18',
+
+  summary: 'Short, declarative, imperative. Gets to the point and trusts the reader to keep up.',
+
+  rules: {
+    sentenceLength: { avg: 10, range: [4, 16] },
+    contractions: 'neutral',
+    perspective: 'second-person',
+    hedging: 'avoid',
+    imperatives: 'direct',
+    rhetoricalQuestions: 'avoid',
+    figurativeLanguage: 'avoid',
+  },
+
+  signaturePatterns: [
+    'Opens with the verb or the value, not a warm-up.',
+    'Fragments used for emphasis ("Fast. Reliable. Done.").',
+    'Single-clause sentences with active voice.',
+    'Claims stated without softeners ("You save 30%." not "You could save up to 30%.").',
+  ],
+
+  avoid: [
+    'Corporate hedging ("please be advised," "kindly note").',
+    'Passive voice when active is natural.',
+    'Throat-clearing openers ("In today\'s fast-paced world...").',
+    'Qualifying every claim to the point of meaninglessness.',
+  ],
+
+  examples: {
+    hero: {
+      copy: 'Book a visit. Get a plan. Move forward.',
+      notes: 'Three imperatives, no adjectives, complete information.',
+    },
+    cta: {
+      copy: 'Start',
+      notes: 'Single-verb CTAs are peak-Direct. Works when context makes the action obvious.',
+    },
+    paragraph: {
+      copy: 'You need a new website. We build them. Fixed price, four weeks, no surprises. See pricing below.',
+      notes: 'Four sentences, 25 words total. Information-dense, zero ornament.',
+    },
+    microcopy: {
+      copy: 'Required.',
+      notes: 'Not "This field is required" — just "Required."',
+    },
+  },
+
+  pairings: {
+    reinforces: ['Expert', 'Authoritative'],
+    tensions: ['Poetic', 'Empathetic'],
+  },
+};

--- a/content-system/voices/empathetic.ts
+++ b/content-system/voices/empathetic.ts
@@ -1,0 +1,58 @@
+import type { VoicePattern } from '../schema';
+
+export const empathetic: VoicePattern = {
+  slug: 'Empathetic',
+  displayName: 'Empathetic',
+  version: '1.0.0',
+  lastReviewed: '2026-04-18',
+
+  summary: 'Acknowledges the reader\'s situation first. Gentle imperatives, warm tone, second-person perspective.',
+
+  rules: {
+    sentenceLength: { avg: 14, range: [6, 22] },
+    contractions: 'encouraged',
+    perspective: 'second-person',
+    hedging: 'neutral',
+    imperatives: 'soften',
+    rhetoricalQuestions: 'neutral',
+    figurativeLanguage: 'neutral',
+  },
+
+  signaturePatterns: [
+    'Acknowledge-then-assure openings ("We know this can feel overwhelming — here\'s what comes next.").',
+    'Em-dashes for emotional pivots rather than commas.',
+    'Invitation language over command ("Let\'s figure this out together" vs "Book now").',
+    'Named feelings — anxiety, uncertainty, hope — surfaced directly rather than avoided.',
+  ],
+
+  avoid: [
+    'Imperatives without softening ("Do this now" reads as bossy).',
+    'Dismissive language about the reader\'s concern ("It\'s easy! Just...").',
+    'Corporate hedging that masks instead of softens.',
+    'Over-promising emotional outcomes ("You\'ll feel amazing!").',
+  ],
+
+  examples: {
+    hero: {
+      copy: 'When you\'re ready to talk about your smile, we\'ll listen first.',
+      notes: 'Acknowledges readiness as reader\'s choice; promises listening, not selling.',
+    },
+    cta: {
+      copy: 'Take the first step',
+      notes: 'Invitation, not command. Pairs with a subhead like "No pressure, no commitment."',
+    },
+    paragraph: {
+      copy: 'We know dental visits can feel stressful — and cost anxiety doesn\'t help. Before anything else, we\'ll sit down with you, look at your coverage, and walk through what\'s actually needed. No upselling. No surprise bills.',
+      notes: 'Acknowledges feelings, names the pain (cost anxiety), commits to specific behavior.',
+    },
+    microcopy: {
+      copy: 'Not sure what to pick? We can help.',
+      notes: 'Treats uncertainty as normal, not a failure.',
+    },
+  },
+
+  pairings: {
+    reinforces: ['Approachable', 'Conversational'],
+    tensions: ['Direct', 'Authoritative'],
+  },
+};

--- a/content-system/voices/expert.ts
+++ b/content-system/voices/expert.ts
@@ -1,0 +1,58 @@
+import type { VoicePattern } from '../schema';
+
+export const expert: VoicePattern = {
+  slug: 'Expert',
+  displayName: 'Expert',
+  version: '1.0.0',
+  lastReviewed: '2026-04-18',
+
+  summary: 'Credibility through specificity. Uses correct terminology without over-explaining; references data, method, experience.',
+
+  rules: {
+    sentenceLength: { avg: 16, range: [10, 24] },
+    contractions: 'neutral',
+    perspective: 'flexible',
+    hedging: 'neutral',
+    imperatives: 'neutral',
+    rhetoricalQuestions: 'avoid',
+    figurativeLanguage: 'avoid',
+  },
+
+  signaturePatterns: [
+    'Specific numbers over vague quantifiers ("8.2 million cases" not "lots of cases").',
+    'Methodological language — how the work gets done, not just what gets done.',
+    'Industry-specific terminology used correctly (hygiene reappointment, case acceptance, not "customer retention").',
+    'Qualified claims — confident where backed, precise where not.',
+  ],
+
+  avoid: [
+    'Jargon as status signaling (using complex words where simple ones work).',
+    'Undefined acronyms — define on first use.',
+    'Hedging everything into meaninglessness ("generally," "often," "in many cases").',
+    'Patronizing explanations of obvious concepts.',
+  ],
+
+  examples: {
+    hero: {
+      copy: 'Independent dentistry, backed by 22 years of clinical experience and 3,400 active families.',
+      notes: 'Specific years, specific patient count, specific positioning (independent).',
+    },
+    cta: {
+      copy: 'Review our case studies',
+      notes: 'Assumes the reader is discerning enough to want evidence.',
+    },
+    paragraph: {
+      copy: 'A same-day crown starts with a CBCT scan and an iTero digital impression. No temporary crown, no second visit — the ceramic is milled in-office on a CEREC unit while you wait. The process takes about two hours from scan to seat.',
+      notes: 'Names the tools, explains the method, quantifies the time. Technical but accessible.',
+    },
+    microcopy: {
+      copy: 'Enter your NPI to continue',
+      notes: 'Assumes the reader knows what NPI means — appropriate for a provider-facing form.',
+    },
+  },
+
+  pairings: {
+    reinforces: ['Direct', 'Authoritative'],
+    tensions: ['Poetic', 'Witty'],
+  },
+};

--- a/content-system/voices/index.ts
+++ b/content-system/voices/index.ts
@@ -1,0 +1,39 @@
+import type { VoicePattern } from '../schema';
+import type { Voice } from '../vocabularies';
+import { approachable } from './approachable';
+import { authoritative } from './authoritative';
+import { conversational } from './conversational';
+import { direct } from './direct';
+import { empathetic } from './empathetic';
+import { expert } from './expert';
+import { poetic } from './poetic';
+import { witty } from './witty';
+
+/**
+ * Voice pattern registry — maps every Voice value to its VoicePattern.
+ *
+ * Type-level guarantee: the Record<Voice, VoicePattern> shape means adding
+ * a new Voice to `VOICE_VALUES` without a matching pattern will fail
+ * typecheck — same drift-prevention pattern as `industryPacks`.
+ */
+export const voicePatterns: Record<Voice, VoicePattern> = {
+  Direct: direct,
+  Empathetic: empathetic,
+  Witty: witty,
+  Expert: expert,
+  Conversational: conversational,
+  Authoritative: authoritative,
+  Poetic: poetic,
+  Approachable: approachable,
+};
+
+export {
+  approachable,
+  authoritative,
+  conversational,
+  direct,
+  empathetic,
+  expert,
+  poetic,
+  witty,
+};

--- a/content-system/voices/poetic.ts
+++ b/content-system/voices/poetic.ts
@@ -1,0 +1,58 @@
+import type { VoicePattern } from '../schema';
+
+export const poetic: VoicePattern = {
+  slug: 'Poetic',
+  displayName: 'Poetic',
+  version: '1.0.0',
+  lastReviewed: '2026-04-18',
+
+  summary: 'Rhythm and imagery. Longer cadences, sensory detail, language that earns its space. Used sparingly for emotional resonance.',
+
+  rules: {
+    sentenceLength: { avg: 18, range: [8, 32] },
+    contractions: 'neutral',
+    perspective: 'flexible',
+    hedging: 'neutral',
+    imperatives: 'soften',
+    rhetoricalQuestions: 'encouraged',
+    figurativeLanguage: 'encouraged',
+  },
+
+  signaturePatterns: [
+    'Sensory detail — light, sound, texture, time of day — grounds abstraction.',
+    'Parallel clauses and triadic rhythm ("A practice. A home. A beginning.").',
+    'Metaphor carried through a passage rather than dropped.',
+    'White space and pacing — short sentences after long ones for weight.',
+  ],
+
+  avoid: [
+    'Purple prose — ornament without substance.',
+    'Mixed metaphors or metaphors that fall apart under scrutiny.',
+    'Vagueness dressed up as depth.',
+    'Poetic framing on transactional surfaces (pricing, forms, error states).',
+  ],
+
+  examples: {
+    hero: {
+      copy: 'Before the before. Before the first visit, the first question, the first decision. This is where it starts — with listening.',
+      notes: 'Three repetitions of "before" + triadic "first" structure + em-dash pivot to the reveal.',
+    },
+    cta: {
+      copy: 'Begin',
+      notes: 'Single word carrying the weight of the whole passage above.',
+    },
+    paragraph: {
+      copy: 'The practice sits between the old courthouse and the maple that turns first every October. Inside, the light is low and the air is warm. We have been here twenty-two years, and in that time we have learned something simple — that dentistry is not the thing people remember. Being known is the thing people remember.',
+      notes: 'Three sentences, 56 words. Sensory specificity (maple, light, air) grounds the abstract close.',
+    },
+    microcopy: {
+      copy: 'Take your time.',
+      notes: 'Minimal imperative, emotional permission. Works on a long-form intake screen.',
+    },
+  },
+
+  pairings: {
+    reinforces: ['Empathetic'],
+    tensions: ['Direct', 'Expert', 'Witty'],
+  },
+};

--- a/content-system/voices/witty.ts
+++ b/content-system/voices/witty.ts
@@ -1,0 +1,58 @@
+import type { VoicePattern } from '../schema';
+
+export const witty: VoicePattern = {
+  slug: 'Witty',
+  displayName: 'Witty',
+  version: '1.0.0',
+  lastReviewed: '2026-04-18',
+
+  summary: 'Playful, observant, a little sideways. Uses unexpected turns and cultural resonance to make a point memorable.',
+
+  rules: {
+    sentenceLength: { avg: 12, range: [6, 20] },
+    contractions: 'encouraged',
+    perspective: 'flexible',
+    hedging: 'avoid',
+    imperatives: 'neutral',
+    rhetoricalQuestions: 'encouraged',
+    figurativeLanguage: 'encouraged',
+  },
+
+  signaturePatterns: [
+    'Sentence reversals ("We don\'t sell dreams. We fix teeth.").',
+    'Parenthetical asides that wink at the reader.',
+    'Unexpected noun choices ("This isn\'t a dental practice. It\'s a witness-protection program for your molars.").',
+    'Rhetorical questions that answer themselves.',
+  ],
+
+  avoid: [
+    'Humor at the client\'s or reader\'s expense.',
+    'Jokes that require context the reader won\'t have.',
+    'Trying too hard — three-joke paragraphs exhaust goodwill fast.',
+    'Humor in inappropriate contexts (medical emergencies, grief, compliance copy).',
+  ],
+
+  examples: {
+    hero: {
+      copy: 'Your teeth called. They\'d like a word.',
+      notes: 'Personification + familiar phrasing + implicit urgency. Works for a practice that can afford to be playful.',
+    },
+    cta: {
+      copy: 'Say hello',
+      notes: 'Lowercase informality. Specifically avoids "Book Now."',
+    },
+    paragraph: {
+      copy: 'Most dentists want to fix the thing you came in for. Fair enough. We\'re more interested in why it keeps happening. (Spoiler: it\'s almost never the flossing.)',
+      notes: 'Sets up expectation, subverts it, closes with a parenthetical payoff.',
+    },
+    microcopy: {
+      copy: 'Oops — that didn\'t work. Let\'s try again.',
+      notes: 'Keeps composure under failure. Never blames the user.',
+    },
+  },
+
+  pairings: {
+    reinforces: ['Conversational', 'Approachable'],
+    tensions: ['Authoritative'],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "import": "./dist/index.esm.js",
       "require": "./dist/index.cjs.js"
     },
+    "./content-system": {
+      "types": "./dist/content-system/index.d.ts",
+      "import": "./dist/content-system/index.js"
+    },
     "./styles.css": "./dist/styles.css",
     "./tokens.css": "./dist/tokens.css",
     "./bridge.css": "./dist/bridge.css"
@@ -75,7 +79,8 @@
     "build:sd-figma": "node scripts/flatten-tokens-studio.js && npx style-dictionary build --config sd.config.tokens-studio.mjs",
     "build:sd-dark": "node scripts/flatten-tokens-studio.js --mode color=dark --output design-tokens/tokens-figma-dark.json && npx style-dictionary build --config sd.config.dark.mjs",
     "build:all-tokens": "npm run build:sd-figma && npm run build:sd-dark",
-    "build:lib": "vite build --config vite.config.lib.ts && npm run build:types && npm run build:dist-tokens && npm run build:inspector-manifest",
+    "build:lib": "vite build --config vite.config.lib.ts && npm run build:types && npm run build:content-system && npm run build:dist-tokens && npm run build:inspector-manifest",
+    "build:content-system": "tsc --project tsconfig.content-system.json",
     "build:inspector-manifest": "node scripts/build-inspector-manifest.mjs",
     "build:types": "tsc --project tsconfig.build.json",
     "build:dist-tokens": "node scripts/build-dist-tokens.js",

--- a/tsconfig.content-system.json
+++ b/tsconfig.content-system.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "target": "ES2020",
+    "outDir": "./dist/content-system",
+    "rootDir": "./content-system",
+    "paths": {},
+    "allowImportingTsExtensions": false,
+    "skipLibCheck": true
+  },
+  "include": ["content-system/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.mdx", "**/*.stories.ts", "**/*.stories.tsx", "**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
       "@bds/components/*": ["./components/*"]
     }
   },
-  "include": ["components/**/*", "tokens/**/*", "stories/**/*", ".storybook/**/*", "types/**/*"],
+  "include": ["components/**/*", "tokens/**/*", "stories/**/*", ".storybook/**/*", "types/**/*", "content-system/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Establishes the **Brik Content System (BCS)** as the content-vocabulary peer to BDS's visual vocabulary. Same repo, same publishing pipeline, same Storybook MCP endpoint — one source of truth for both design and copy resolution.

Architecture mirrors BDS: locked vocabularies → typed schemas → packs → Storybook-browsable docs → npm-importable public surface.

## What's in this PR

- **Locked enums** (`content-system/vocabularies/`) — 11 Personality, 8 Voice, 11 Visual Style traits + Industry slug registry. Portal will import these directly; any drift fails typecheck.
- **Schemas** (`content-system/schema/`) — `IndustryPack` + `VoicePattern` TypeScript types. `Record<Voice, VoicePattern>` and `Record<IndustrySlug, IndustryPack>` registries mean missing entries fail typecheck instead of silently.
- **Industry packs** (`content-system/industries/`):
  - `dental` v1.1 — includes Brik's retention/DSO/FFS strategic POV
  - `real-estate-rv-mhc` v1.0 — two-segment pack (RV + MHC)
  - `small-business` v1.0 — catch-all baseline with documented promotion criteria
- **Voice patterns** (`content-system/voices/`) — all 8 traits with structured writing rules (sentence length, contractions, hedging, perspective, imperatives, rhetorical questions, figurative language), signature patterns, concrete examples across hero/CTA/paragraph/microcopy, and pairing guidance (reinforces + tensions).
- **Storybook** — new "Content System" section with Overview, Industries/*, Voices/Overview pages. Wired via `.storybook/main.ts` glob.
- **Package surface** — `@brikdesigns/bds/content-system` export emits both `.js` and `.d.ts` via new `tsconfig.content-system.json` build step. Additive to existing exports; no breaking changes.

## Architecture notes worth reviewing

- **Co-located `.ts` + `.mdx` pairs per industry.** `.ts` is the typed data (automations consume it); `.mdx` is the narrative (humans read it, Storybook renders it). Narrative imports from data file so structured values render inline — single source of truth.
- **Voice patterns use a single Overview.mdx**, not 8 separate pages — voices are more useful compared side-by-side than browsed individually.
- **No `./content-system` CJS output.** ESM-only is fine for modern consumers (portal = Next.js 16). Easy to add if a consumer breaks.
- **No portal changes in this PR** — resolver + hydration is the next phase and belongs in the portal repo against its own release cadence.

## Test plan

- [x] TypeScript passes (`npm run typecheck`)
- [x] Storybook builds cleanly (`npm run build-storybook`) — all new MDX pages parse
- [x] `build:content-system` emits `.js` + `.d.ts` to `dist/content-system/`
- [x] Pre-push validate:full — all 5 checks pass (Token Lint, Grid Audit, Theme Compliance, TypeScript, Storybook Build)
- [ ] Visual review of Content System section in Storybook (reviewer)
- [ ] Spot-check dental pack structured data against `industry-reference-dental.md` v1.1 (reviewer)

## Not in this PR (next phases)

- Portal resolver (`resolveBrandLanguage`, `resolveTheme`, `composeBlueprints`) — separate repo, separate branch
- Blueprint library materialization with Personality/Voice/VisualStyle tags
- Voice blender implementation (spec documented in voices/Overview.mdx)
- `content-system.json` build emit for non-TS consumers
- Version bump to 0.8.0 for the new public surface (flagging as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)