### PR TITLE
chore(release): v0.8.0 — content system public surface + docs parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ These rules apply in every project that imports BDS tokens (portal, renew-pms, b
 | `stories/` | Foundation Storybook docs (tokens, typography, color) |
 | `tokens/` | Token documentation and build scripts |
 | `design-tokens/` | Figma token definitions (Style Dictionary input) |
+| `content-system/` | **BCS** — content vocabulary (industries, voices, locked enums) |
 | `scripts/` | Build automation and linting |
 | `docs/` | Reference docs (token consumption, Figma architecture) |
 
@@ -274,6 +275,68 @@ See [CONSUMING-TOKENS.md](docs/CONSUMING-TOKENS.md) for the full consumption pat
 4. `.husky/pre-commit` - Token compliance gate (blocks hardcoded px values)
 
 **Reference implementation:** brik-client-portal
+
+## Content System (BCS)
+
+BCS is the **content-vocabulary peer** to the token system. Lives at `content-system/` in this repo. Same cascade pattern as tokens, but for copy instead of visuals.
+
+Shipped as a second npm entry point:
+
+```tsx
+import {
+  industryPacks,
+  voicePatterns,
+  PERSONALITY_VALUES,
+  VOICE_VALUES,
+  VISUAL_STYLE_VALUES,
+  DEFAULT_INDUSTRY_SLUG,
+  type IndustryPack,
+  type VoicePattern,
+} from '@brikdesigns/bds/content-system';
+```
+
+### Architecture
+
+```
+content-system/
+├── vocabularies/   Locked enums — Personality × 11, Voice × 8, Visual Style × 11, Industry slugs
+├── schema/         IndustryPack + VoicePattern TypeScript types
+├── industries/     {slug}.ts (data) + {slug}.mdx (narrative) pairs
+└── voices/         {slug}.ts per voice trait + Overview.mdx
+```
+
+Each industry or voice has its structured data in `.ts` and human narrative in `.mdx`. The MDX imports from the `.ts` so values render inline — single source of truth. Storybook renders the MDX; automations consume the TS.
+
+### BCS Discipline
+
+These rules apply to every BCS authoring or consumption task — same weight as the token rules above.
+
+1. **Locked enums are the single source of truth.** `PERSONALITY_VALUES`, `VOICE_VALUES`, `VISUAL_STYLE_VALUES`, `INDUSTRY_SLUGS` are exported from BCS and imported by the portal. Never hardcode these values in consumer code; never drift them between repos.
+2. **Industry slug registry + packs must stay in sync.** Adding a slug to `INDUSTRY_SLUGS` without a matching `industries/{slug}.ts` + `.mdx` fails typecheck via `Record<IndustrySlug, IndustryPack>`. Do not bypass with `as` assertions.
+3. **Versioning + review cadence are mandatory.** Every pack has `version`, `reviewCadence`, `lastReviewed`. Bump on content change (semver); update `lastReviewed` when you've confirmed accuracy on a review pass even without changes.
+4. **The catch-all graduates.** `small-business` is `DEFAULT_INDUSTRY_SLUG`. Graduate a vertical out when Brik has 3+ clients OR seasonality/regulation/terminology diverges meaningfully OR strategy docs repeat 60%+.
+5. **Voice patterns compose compositionally, not via lookup table.** Each voice defines structured rules. The portal resolver blends up to 3 picks with first-pick-60 / second-30 / third-10 weighting. Don't try to enumerate all 336 combinations.
+6. **Client overrides win over industry defaults.** Same cascade as tokens: `company_profile.cta_language` / `anti_messages` / `naming_conventions` override the industry pack. Fill-through where client data is empty.
+7. **No literal `<` in MDX copy.** MDX v3 parses `<` as a JSX tag opening. Use "under" or `&lt;` or wrap in backticks.
+
+### Authoring a new industry pack
+
+1. Add slug to `content-system/vocabularies/industry.ts` in `INDUSTRY_SLUGS`.
+2. Create `content-system/industries/{slug}.ts` — typed `IndustryPack` data. Use `dental.ts` as reference for maximum structure.
+3. Create `content-system/industries/{slug}.mdx` — narrative companion. Include `<Meta title="Content System/Industries/{DisplayName}" />`.
+4. Register the pack in `content-system/industries/index.ts`.
+5. Run `npm run build:content-system && npm run build-storybook` to validate.
+
+### BCS build pipeline
+
+| Command | Input | Output |
+| --- | --- | --- |
+| `npm run build:content-system` | `content-system/**/*.ts` | `dist/content-system/**/*.js` + `.d.ts` |
+| `npm run build:lib` (includes content-system) | Full repo | Publishable `dist/` |
+
+`tsconfig.content-system.json` is the scoped build config — keeps content-system compilation separate from the Vite lib build of components.
+
+See [content-system/README.md](content-system/README.md) and the Storybook **Content System / Overview** page for the full authoring guide.
 
 ## Token PR Checklist
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,115 @@
-Running npm Commands on Your Mac
-Use VS Code's integrated terminal - it's the simplest approach:
+# Brik Design System (BDS)
 
-Open your project folder in VS Code (/Users/nickstanerson/Documents/GitHub/brik-bds)
-Press Ctrl+` (or View > Terminal)
-Run commands directly:
-npm install      # First time only
-npm test         # Run tests
-npm start        # Local server
+React component library with Figma-synced design tokens and a parallel content system (BCS) for voice + industry vocabulary.
 
-That's it. Everything runs from within VS Code, in your project folder.
+**Published to:** `@brikdesigns/bds` (GitHub Packages).
+**Live docs:** [Storybook on Chromatic](https://69b8918cac3056b39424d5d3-jtcwcnhshz.chromatic.com/).
+**Repo:** [brikdesigns/brik-bds](https://github.com/brikdesigns/brik-bds).
 
-Everything in One Place
-Your project folder now contains:
+---
 
-What	Where
-Source code	footer.js, head.css, css/
-Scripts	scripts/
-Tests	__tests__/
-Test reports	coverage/ (after npm run test:coverage)
-Documentation	README.md
-Config	package.json, .env.example
-README Updated
-The README.md now documents:
+## What's inside
 
-Quick start for VS Code
-All npm scripts
-Workflow for deploying changes
-One-time setup instructions
-Troubleshooting
-Also removed a hardcoded API token that was in the old README (security fix).
+| Surface | What it is | npm import |
+|---|---|---|
+| **Components** | 60+ React UI components (Button, Card, DatePicker, Table, etc.) | `@brikdesigns/bds` |
+| **Tokens** | CSS custom properties + TypeScript token maps, synced from Figma via Style Dictionary | `@brikdesigns/bds` (JS) / `@brikdesigns/bds/tokens.css` |
+| **Styles** | Compiled component CSS | `@brikdesigns/bds/styles.css` |
+| **Content System (BCS)** | Vocabularies (Personality, Voice, Visual Style), industry packs, voice patterns | `@brikdesigns/bds/content-system` |
+
+## Architecture
+
+BDS is a **design vocabulary**. BCS is a **content vocabulary**. Both live in this repo because consumers (portal, renew-pms, brikdesigns.com) depend on the same versioned surface for both.
+
+```
+brik-bds/
+├── components/            React UI components
+├── tokens/                CSS tokens + TS maps (Figma-synced)
+├── design-tokens/         Style Dictionary inputs (Figma + Tokens Studio)
+├── content-system/        BCS — content vocabulary (MDX + TS)
+│   ├── vocabularies/      Locked enums (Personality × 11, Voice × 8, Visual Style × 11)
+│   ├── schema/            IndustryPack + VoicePattern types
+│   ├── industries/        Dental, RE-RV/MHC, Small Business (catch-all)
+│   └── voices/            8 voice patterns with rules + examples
+├── blueprints/            Section layout patterns (forthcoming)
+├── stories/               Storybook foundation docs
+├── .storybook/            Storybook config
+└── scripts/               Build, sync, validation tooling
+```
+
+## Token pipeline
+
+```
+Figma Variables → Tokens Studio JSON → Style Dictionary → per-platform outputs
+```
+
+Two modes auto-generated: `tokens/figma-tokens.css` (light) and `tokens/figma-tokens-dark.css` (dark). Never hand-edit these — update Figma, then run `npm run build:sd-figma`.
+
+Client theming is a 2-tier cascade: BDS base tokens → `theme-{client}.css` override. See [docs/CONSUMING-TOKENS.md](docs/CONSUMING-TOKENS.md).
+
+## Content system cascade
+
+Mirrors the token cascade: industry pack defaults → client-specific overrides in the portal.
+
+```
+industry-pack.ctaDefaults + .vocabulary + .pageArchetypes
+   ↓
+company_profile.cta_language, anti_messages, naming_conventions (override)
+   ↓
+Brik automations (brand-strategy-worker, mockup generator) consume the merged output
+```
+
+See [content-system/README.md](content-system/README.md) for authoring packs and the Storybook **Content System / Overview** page for the live docs.
+
+## Getting started
+
+**Consume in an app:**
+
+```tsx
+import { Button, Card } from '@brikdesigns/bds';
+import { industryPacks, voicePatterns } from '@brikdesigns/bds/content-system';
+import '@brikdesigns/bds/tokens.css';
+import '@brikdesigns/bds/styles.css';
+```
+
+**Develop in BDS:**
+
+```bash
+git clone https://github.com/brikdesigns/brik-bds.git
+cd brik-bds
+npm install
+npm run storybook    # http://localhost:6006
+```
+
+## Development workflows
+
+| Task | Command |
+|---|---|
+| Local Storybook | `npm run storybook` |
+| Pull latest Figma tokens | `npm run build:sd-figma` (after Figma MCP pull — see [CLAUDE.md](CLAUDE.md)) |
+| Typecheck | `npm run typecheck` |
+| Token lint | `npm run lint-tokens` |
+| Full validation | `npm run validate:full` (pre-push gate) |
+| Build library | `npm run build:lib` |
+| Build content-system | `npm run build:content-system` |
+| Visual review | `npm run chromatic` |
+
+## Versioning
+
+BDS follows SemVer. Version bumps ship as `chore(release): vX.Y.Z` commits on `main` (see `chore(release): v0.8.0` for the content-system public surface).
+
+- Minor = new public surface or components
+- Patch = bug fixes, token value updates
+- Major = breaking API or token renames
+
+## Related
+
+- [CLAUDE.md](CLAUDE.md) — authoritative agent rules for BDS development
+- [content-system/README.md](content-system/README.md) — BCS authoring guide
+- [docs/CONSUMING-TOKENS.md](docs/CONSUMING-TOKENS.md) — token consumption in app projects
+- [docs/TOKEN-REFERENCE.md](docs/TOKEN-REFERENCE.md) — full token reference
+- [Chromatic dashboard](https://www.chromatic.com/builds?appId=69b8918cac3056b39424d5d3) — visual regression builds
+
+## License
+
+UNLICENSED — internal Brik use only.

--- a/content-system/README.md
+++ b/content-system/README.md
@@ -11,7 +11,7 @@ content-system/
 ├── vocabularies/    Locked enums — portal imports these directly
 ├── schema/          TypeScript types for pack authoring
 ├── industries/      Industry packs ({slug}.ts + {slug}.mdx pairs)
-└── voices/          Voice patterns (phase 2)
+└── voices/          Voice patterns (8 traits — rules, examples, pairings)
 ```
 
 ## Locked enums

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.7.0",
-  "description": "Brik Design System - React component library with Webflow-synced design tokens",
+  "version": "0.8.0",
+  "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/stories/Welcome.mdx
+++ b/stories/Welcome.mdx
@@ -4,7 +4,9 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Brik Design System
 
-The BDS component library provides themed React components powered by CSS custom properties. All components adapt automatically across 9 bundled themes — switch using the paintbrush icon in the toolbar above.
+BDS provides themed React components powered by CSS custom properties. All components adapt automatically across 9 bundled themes — switch using the paintbrush icon in the toolbar above.
+
+Alongside the visual system, the **Brik Content System (BCS)** lives in this repo as the content-vocabulary peer: industry packs, voice patterns, and locked enums that pair with the visual tokens to power the portal's design + copy resolver.
 
 ## Foundation
 
@@ -21,6 +23,16 @@ Design tokens are the atomic visual decisions that power BDS. Every component re
 | [Shadow](?path=/docs/foundations-design-tokens-shadow--docs) | Blur, spread, and elevation scale |
 | [Size](?path=/docs/foundations-design-tokens-size--docs) | Size scale, breakpoints, container widths |
 | [Animation](?path=/docs/foundations-animations-animation--docs) | Three-tier system: CSS reveals, GSAP scroll, premium effects |
+
+## Content System
+
+The content-vocabulary peer to the visual tokens. Paired with BDS to drive end-to-end mockup generation in Claude Design (Paper).
+
+| Category | Description |
+|----------|-------------|
+| [Overview](?path=/docs/content-system-overview--docs) | BCS architecture, vocabulary lock, phase roadmap, consumer examples |
+| [Industries](?path=/docs/content-system-industries-dental--docs) | Dental, Real Estate (RV/MHC), Small Business — structured packs with affinities, page archetypes, services, seasonality, regulatory |
+| [Voices](?path=/docs/content-system-voices-overview--docs) | All 8 voice patterns side-by-side with rules, examples, and pairing guidance |
 
 ## Token system
 


### PR DESCRIPTION
## Summary

Ships v0.8.0 with the BCS public surface from #110 and brings repo-level docs to parity with the new content-system architecture.

This PR unblocks the portal side of Phase 3 — once merged and published, the portal can `npm update @brikdesigns/bds` and start importing from `@brikdesigns/bds/content-system`.

## What's in

- **Version bump** `0.7.0 → 0.8.0` — minor bump for the new public export surface (`./content-system`). No breaking changes.
- **README.md** — full rewrite. Prior was an orphan from a different repo (referenced `footer.js` and non-existent paths). New README covers both BDS and BCS: architecture, npm imports, dev workflows, versioning, links to Chromatic/Storybook.
- **CLAUDE.md** — new **Content System (BCS)** section with 7 discipline rules paralleling the token rules, authoring guide for new packs, build pipeline reference. `content-system/` added to the Key Paths table.
- **stories/Welcome.mdx** — Storybook landing now surfaces Content System (Overview, Industries, Voices) alongside Foundation (design tokens).
- **content-system/README.md** — removed stale "phase 2" marker from `voices/` since all 8 voice patterns shipped in #110.

## Test plan

- [x] TypeScript passes (`npm run typecheck`)
- [x] Content-system builds cleanly (`npm run build:content-system`)
- [x] Storybook builds cleanly (`npm run build-storybook`)
- [x] Pre-push validate:full — all 5 checks pass
- [ ] Visual review of updated Welcome.mdx in Storybook (reviewer)
- [ ] Review README accuracy (reviewer)

## After merge — manual publish required

BDS has no publish workflow — this is manual.

From main after merging:

```bash
git checkout main && git pull
npm ci
npm run build:lib    # includes build:content-system
npm publish          # publishes to GitHub Packages per publishConfig
```

Alternative: create a release workflow in a follow-up PR if we want CI-driven publishes going forward.

## After publish — portal unblocks

```bash
cd product/brik-client-portal
npm update @brikdesigns/bds
```

Portal resolver work (`resolveBrandLanguage`, `resolveTheme`, `composeBlueprints`, industry_slug migration, brand-strategy-worker seeding) then proceeds in its own repo session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)