### PR TITLE
feat(content-system): add Trustworthy + Energetic to PERSONALITY_VALUES

### DIFF
--- a/content-system/vocabularies/personality.ts
+++ b/content-system/vocabularies/personality.ts
@@ -1,5 +1,5 @@
 /**
- * Brand Personality — the 11 canonical traits captured in the client portal.
+ * Brand Personality — the 13 canonical traits captured in the client portal.
  *
  * Single source of truth. The portal enum and BDS blueprint/theme tags
  * must reference these values. Drift here causes silent resolver failures.
@@ -7,18 +7,27 @@
  * Clients pick up to 3. Repeated traits across Personality + Voice +
  * Visual Style indicate reinforced intent and should be weighted higher
  * by the resolver.
+ *
+ * Version history:
+ *   - v0.8.0: 11 traits (initial set)
+ *   - v0.9.0: added Trustworthy + Energetic. Cross-vertical load-bearing —
+ *     Trustworthy is the default signal for medical/legal/financial;
+ *     Energetic fills a gap between Playful and Bold for active-lifestyle
+ *     and youth-forward brands.
  */
 export const PERSONALITY_VALUES = [
   'Warm',
   'Approachable',
   'Playful',
   'Bold',
+  'Energetic',
   'Professional',
   'Modern',
   'Minimal',
   'Luxury',
   'Corporate',
   'Authoritative',
+  'Trustworthy',
   'Refined',
 ] as const;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

v0.9.0 — minor bump, additive only. No breaking changes.

Promotes two Personality values from portal-local drift into the canonical BCS enum:

- **Trustworthy** — default signal for medical, legal, financial verticals.
- **Energetic** — fills the gap between Playful and Bold for active-lifestyle / youth-forward brands.

## Context

Surfaced during a Brik Client Portal intel audit (2026-04-17). The portal had a local `BRAND_PERSONALITY_VALUES` array with 13 lowercase values (source: `brik-client-portal/src/lib/brand/taxonomy.ts`). BCS had 11 Title-case values. Birdwell & Mutlak's active `brand_personality: [trustworthy, energetic, bold]` — two of three traits were not in BCS.

Per [BCS Discipline rule #1](CLAUDE.md) ("Locked enums are single source of truth"), the fix is coordinated:

1. **This PR** — BCS adds the missing values (promote drift upward).
2. **Portal PR follow-on** — `brik-client-portal` imports `PERSONALITY_VALUES` from `@brikdesigns/bds/content-system` and drops its local enum. Migrates `brand_personality[]` values lowercase → Title-case on write.

## What's NOT in this PR

Voice drift (portal has 10, BCS has 8 — portal adds `Confident` and `Calm`). New Voice traits require full `VoicePattern` authoring (summary, rules, signaturePatterns, avoid, examples, pairings). Deferred to a coordinated PR with the content-design-system team so they can author the patterns with intent.

Portal will keep its local Voice enum with a documented TODO pointer until that pack lands.

## Verification

- `npm run typecheck` — clean
- `npm run build:content-system` — clean
- `INDUSTRY_SLUGS` / `voicePatterns` `Record<Voice, VoicePattern>` typecheck still satisfied (no new Voice values introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)