### PR TITLE
feat(content-system): add blueprint library schema and taxonomy bridges

### DIFF
--- a/blueprints/ARCHITECTURE.md
+++ b/blueprints/ARCHITECTURE.md
@@ -1,0 +1,194 @@
+# Blueprint Library — Architecture
+
+**Status:** Phase A (schema + bridges landed) · **Owner:** BDS · **Last reviewed:** 2026-04-18
+
+The blueprint library is the single source of truth for named layout and interaction patterns used by the Brik mockup generation pipeline. BDS owns the canonical data; the portal `design_blueprints` Supabase table is a downstream cache seeded from this repo.
+
+This document explains the *shape* of the library. The JSON data itself lands in Phase B.
+
+---
+
+## Why two taxonomies
+
+The portal captures brand identity on three axes the client picks themselves:
+
+- `Personality` (13) — what the brand *is*
+- `Voice` (8) — how the brand *speaks*
+- `VisualStyle` (11) — the aesthetic direction
+
+Blueprints, by contrast, are tagged for *matching* — answering the question "which layouts fit this brand?" Historically that surface used two different tags:
+
+- `moods` (11) — brand-feel tags (bold, trustworthy, energetic, …)
+- `industries` (15) — vertical-fit tags (healthcare, real_estate, legal, …)
+
+These are not synonyms. `Personality` is a *client pick*; `moods` is a *layout property*. Collapsing them into one vocabulary would either lose nuance (merging Personality + VisualStyle into `moods`) or force blueprint authors to hand-maintain redundant fields.
+
+### The model
+
+**Authors hand-write match tags (`moods`, `industries`). The library derives client-axis projections at load time.**
+
+```
+Authored:                       Derived (at load):
+  moods: ['bold', 'luxury']  →  personality:  ['Bold', 'Luxury', 'Refined']
+                             →  visual_style: ['Luxurious']
+
+  industries: ['dental',     →  industry_slugs: ['dental']
+               'universal']  →  is_universal:   true
+```
+
+Consumers query either axis. The projections are always kept consistent with the bridges because they are generated, not stored.
+
+---
+
+## The bridges
+
+Defined in [`content-system/blueprints/bridges.ts`](../content-system/blueprints/bridges.ts).
+
+### Mood → Personality
+
+| Mood | Personality |
+|---|---|
+| `bold` | `Bold` |
+| `minimal` | `Minimal` |
+| `warm` | `Warm` |
+| `corporate` | `Corporate` |
+| `playful` | `Playful` |
+| `luxury` | `Luxury`, `Refined` |
+| `trustworthy` | `Trustworthy` |
+| `energetic` | `Energetic` |
+| `professional` | `Professional` |
+| `modern` | `Modern` |
+| `approachable` | `Approachable` |
+
+`Trustworthy` and `Energetic` were added to `PERSONALITY_VALUES` on 2026-04-18 so every mood has a clean Personality target. They also unblock the client-picks axis for medical/legal/financial brands (Trustworthy) and active-lifestyle / youth-forward brands (Energetic).
+
+### Mood → VisualStyle
+
+| Mood | VisualStyle |
+|---|---|
+| `bold` | *(none)* |
+| `minimal` | `Minimal` |
+| `warm` | *(none)* |
+| `corporate` | `Classic` |
+| `playful` | `Playful` |
+| `luxury` | `Luxurious` |
+| `trustworthy` | *(none)* |
+| `energetic` | `Colorful` |
+| `professional` | *(none)* |
+| `modern` | `Modern` |
+| `approachable` | *(none)* |
+
+Empty arrays are intentional — not every brand-feel has a visual correlate. The resolver should treat "no projected visual style" as "no visual-style constraint from this blueprint," not "visual-style mismatch."
+
+### Industry tag → Industry pack slug
+
+15 match tags collapse to 3 pack slugs per the small-business promotion policy in [`content-system/vocabularies/industry.ts`](../content-system/vocabularies/industry.ts):
+
+- `dental` → `dental`
+- `real_estate` → `real-estate-rv-mhc`
+- all other tags → `small-business` (default)
+- `universal` → sentinel (never triggers a pack lookup; see `is_universal`)
+
+When Brik promotes a new industry pack (3+ active clients, or meaningful seasonality/regulation divergence), the mapping updates and a version bump ships.
+
+---
+
+## Schema at a glance
+
+```typescript
+interface Blueprint {
+  // identity
+  key: string;                      // "hero_split_60_40"
+  name: string;                     // "Split Hero 60/40"
+  section_type: SectionType;        // hero | nav | services | …
+
+  // authored match fields
+  moods: Mood[];
+  industries: IndustryTag[];
+
+  // v1 layout archetype
+  layout_spec: string;
+  css_hints?: string;
+  html_snippet?: string;
+  css_snippet?: string;
+
+  // v2 interaction pattern (optional)
+  pattern_type?: PatternType;       // carousel | scroll-reveal | …
+  pattern_spec?: string;
+  js_snippet?: string;
+
+  // metadata
+  source?: string;
+  tier: 'internal' | 'template';
+  is_active: boolean;
+  version: string;                  // semver
+  last_reviewed: string;            // YYYY-MM-DD
+}
+```
+
+After `normalizeBlueprint()`, consumers see the same shape plus derived fields: `personality`, `visual_style`, `industry_slugs`, `is_universal`.
+
+The full schema + dependency-free validator lives in [`content-system/blueprints/schema.ts`](../content-system/blueprints/schema.ts).
+
+---
+
+## v1 / v2 coexistence
+
+The [Notion Blueprints and Templates doc](https://www.notion.so/Blueprints-and-Templates-33897d34ed2880b6a68bc794cc306e73) declares a pivot: blueprints are evolving from layout archetypes → reusable interaction patterns as the Paper-first workflow makes prose `layout_spec` redundant for new work.
+
+The schema supports both states without a breakage:
+
+- **v1 entries** carry `layout_spec` (required when no `pattern_spec` is present).
+- **v2 entries** carry `pattern_spec` + `pattern_type` + `js_snippet`. The `layout_spec` is optional when the Paper artboard supplies the layout.
+- Blueprints may carry both. A hero blueprint with a custom carousel interaction would populate `layout_spec` *and* `pattern_spec`, `pattern_type: 'carousel'`, `js_snippet: '…'`.
+
+The validator rejects blueprints with neither `layout_spec` nor `pattern_spec` — an entry that describes nothing is a mistake.
+
+---
+
+## Data flow
+
+```
+                 ┌──────────────────────────────────┐
+                 │  brik-bds/blueprints/            │
+                 │    blueprint-library.json        │  ← authored (BDS owns)
+                 │    ARCHITECTURE.md               │
+                 └──────────────┬───────────────────┘
+                                │
+                   @brikdesigns/bds/blueprints
+                                │
+        ┌───────────────────────┴───────────────────────┐
+        ▼                                               ▼
+┌──────────────────────────┐              ┌──────────────────────────┐
+│  portal Supabase         │              │  direct TS consumers     │
+│  design_blueprints table │              │  (brik-bds/brikdesigns,  │
+│  (seeded from JSON via   │              │   mockup workers, etc.)  │
+│   new migration)         │              │                          │
+└──────────────────────────┘              └──────────────────────────┘
+```
+
+- **BDS is upstream.** The JSON is authored here, reviewed here, versioned here.
+- **Portal seeds from JSON.** A migration (Phase B) replaces the existing 00080/00081 seed logic with a data load from `@brikdesigns/bds/blueprints`.
+- **No reverse syncs.** Blueprint edits in the portal admin (if they stay) must be treated as drafts; landed changes flow back through a BDS PR.
+
+---
+
+## Phase plan
+
+| Phase | Scope | Status |
+|---|---|---|
+| A | Schema + bridges + vocabularies + ARCHITECTURE.md | ✓ Landed 2026-04-18 |
+| B | Port 25–26 blueprints from `design_blueprints` migrations → `blueprint-library.json`; add portal migration that seeds from BDS JSON; add `resolveBlueprintShortlist(profile)` helper | Pending |
+| C | Update 3 Notion docs to declare BDS canonical; publish `@brikdesigns/bds@0.9.0`; sync all consumers | Pending |
+| D (future) | Begin populating v2 interaction-pattern fields as Paper-first builds capture reusable effects | Ongoing |
+
+---
+
+## Rules
+
+1. **Never hand-author projection fields.** `personality`, `visual_style`, `industry_slugs`, `is_universal` are derived. The validator fails the library if these appear in source JSON.
+2. **Bridge edits are a minor version bump.** Changing `MOOD_TO_PERSONALITY` silently reshuffles every client's shortlist — treat it like a public API change.
+3. **Authored blueprints use lowercase taxonomies** (`moods`, `industries`). Client-axis values are Title Case (`Personality`, `VisualStyle`). Do not mix.
+4. **`universal` is a sentinel, not a pack.** It should always pass through the shortlist regardless of the client's `industry_slug` — enforced via `is_universal` on normalized entries.
+5. **Quarterly review cadence.** Bump `last_reviewed` on each confirmed-still-accurate pass; bump `version` when blueprints are added, removed, or materially edited.
+6. **One concern per PR.** Bridge edits, schema evolutions, and data additions are separate PRs so rollbacks stay surgical.

--- a/content-system/blueprints/bridges.ts
+++ b/content-system/blueprints/bridges.ts
@@ -1,0 +1,158 @@
+import type { Personality, VisualStyle, IndustrySlug } from '../vocabularies';
+import { DEFAULT_INDUSTRY_SLUG } from '../vocabularies';
+import type { Mood, IndustryTag } from './vocabularies';
+
+/**
+ * Two-taxonomy bridge — translates blueprint match tags into the
+ * client-picks axes so the portal can query blueprints using the same
+ * vocabulary a client uses in the onboarding form.
+ *
+ * The source of truth is still the blueprint author's `moods[]` and
+ * `industries[]` picks. `personality[]`, `visualStyle[]`, and
+ * `industrySlugs[]` are PROJECTIONS — derived at load time, never
+ * hand-authored. See ARCHITECTURE.md for the rationale.
+ *
+ * Keep mappings **stable**. Changing a projection silently reshuffles
+ * shortlists for every client; treat edits here as a minor version bump
+ * on @brikdesigns/bds.
+ */
+
+/**
+ * Mood → Personality projection.
+ *
+ * Every mood maps to at least one Personality. A single mood may map
+ * to multiple personalities when the mood straddles axes (e.g. `luxury`
+ * reinforces both `Luxury` and `Refined`).
+ */
+export const MOOD_TO_PERSONALITY: Record<Mood, readonly Personality[]> = {
+  bold: ['Bold'],
+  minimal: ['Minimal'],
+  warm: ['Warm'],
+  corporate: ['Corporate'],
+  playful: ['Playful'],
+  luxury: ['Luxury', 'Refined'],
+  trustworthy: ['Trustworthy'],
+  energetic: ['Energetic'],
+  professional: ['Professional'],
+  modern: ['Modern'],
+  approachable: ['Approachable'],
+} as const;
+
+/**
+ * Mood → VisualStyle projection.
+ *
+ * Not every mood has a VisualStyle equivalent — `warm`, `trustworthy`,
+ * `professional`, and `approachable` are brand-feel moods with no direct
+ * visual correlate. An empty array is explicit, not a bug.
+ */
+export const MOOD_TO_VISUAL_STYLE: Record<Mood, readonly VisualStyle[]> = {
+  bold: [],
+  minimal: ['Minimal'],
+  warm: [],
+  corporate: ['Classic'],
+  playful: ['Playful'],
+  luxury: ['Luxurious'],
+  trustworthy: [],
+  energetic: ['Colorful'],
+  professional: [],
+  modern: ['Modern'],
+  approachable: [],
+} as const;
+
+/**
+ * Industry tag → Industry pack slug.
+ *
+ * 15 match tags collapse to 3 pack slugs per the small-business
+ * promotion policy. `universal` is sentinel-only — it should never
+ * trigger a pack lookup (a universal blueprint fits every pack).
+ */
+export const INDUSTRY_TAG_TO_SLUG: Record<IndustryTag, IndustrySlug | 'universal'> = {
+  universal: 'universal',
+  healthcare: DEFAULT_INDUSTRY_SLUG,
+  real_estate: 'real-estate-rv-mhc',
+  legal: DEFAULT_INDUSTRY_SLUG,
+  finance: DEFAULT_INDUSTRY_SLUG,
+  saas: DEFAULT_INDUSTRY_SLUG,
+  ecommerce: DEFAULT_INDUSTRY_SLUG,
+  beauty: DEFAULT_INDUSTRY_SLUG,
+  salon: DEFAULT_INDUSTRY_SLUG,
+  hospitality: DEFAULT_INDUSTRY_SLUG,
+  restaurant: DEFAULT_INDUSTRY_SLUG,
+  luxury: DEFAULT_INDUSTRY_SLUG,
+  corporate: DEFAULT_INDUSTRY_SLUG,
+  dental: 'dental',
+  veterinary: DEFAULT_INDUSTRY_SLUG,
+} as const;
+
+/**
+ * Project a mood set onto the Personality axis.
+ * Returns a deduplicated, order-preserving array.
+ */
+export function projectMoodsToPersonality(
+  moods: readonly Mood[],
+): readonly Personality[] {
+  const seen = new Set<Personality>();
+  const out: Personality[] = [];
+  for (const mood of moods) {
+    for (const personality of MOOD_TO_PERSONALITY[mood]) {
+      if (!seen.has(personality)) {
+        seen.add(personality);
+        out.push(personality);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Project a mood set onto the VisualStyle axis.
+ * Returns a deduplicated, order-preserving array.
+ */
+export function projectMoodsToVisualStyle(
+  moods: readonly Mood[],
+): readonly VisualStyle[] {
+  const seen = new Set<VisualStyle>();
+  const out: VisualStyle[] = [];
+  for (const mood of moods) {
+    for (const style of MOOD_TO_VISUAL_STYLE[mood]) {
+      if (!seen.has(style)) {
+        seen.add(style);
+        out.push(style);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Project an industry tag set onto the Industry pack slug axis.
+ *
+ * Filters out `universal` (which is sentinel-only) and dedupes. Returns
+ * an empty array if the blueprint is universal-only — the resolver
+ * should treat that as "fits every pack" rather than "fits none."
+ */
+export function projectIndustryTagsToSlugs(
+  tags: readonly IndustryTag[],
+): readonly IndustrySlug[] {
+  const seen = new Set<IndustrySlug>();
+  const out: IndustrySlug[] = [];
+  for (const tag of tags) {
+    const mapped = INDUSTRY_TAG_TO_SLUG[tag];
+    if (mapped === 'universal') continue;
+    if (!seen.has(mapped)) {
+      seen.add(mapped);
+      out.push(mapped);
+    }
+  }
+  return out;
+}
+
+/**
+ * True when the tag set contains `universal`. The resolver uses this
+ * to ensure these blueprints surface regardless of industry slug match.
+ */
+export function isUniversalIndustryFit(
+  tags: readonly IndustryTag[],
+): boolean {
+  return tags.includes('universal');
+}

--- a/content-system/blueprints/index.ts
+++ b/content-system/blueprints/index.ts
@@ -1,0 +1,52 @@
+/**
+ * BDS Blueprint Library — public surface.
+ *
+ * Blueprints are named layout + interaction patterns that ground AI
+ * mockup generation with concrete structural constraints. Consumers
+ * load `blueprint-library.json`, run it through `validateBlueprintLibrary`,
+ * then `normalizeBlueprintLibrary` to get the query-ready records.
+ *
+ * This module owns the *shape* of the library — vocabularies, schema,
+ * bridges. The JSON data itself will ship in `brik-bds/blueprints/`
+ * (outside the TS build) and be loaded at runtime by consumers.
+ */
+
+export {
+  MOOD_VALUES,
+  INDUSTRY_TAG_VALUES,
+  SECTION_TYPE_VALUES,
+  PATTERN_TYPE_VALUES,
+  BLUEPRINT_TIER_VALUES,
+  isMood,
+  isIndustryTag,
+  isSectionType,
+  isPatternType,
+  isBlueprintTier,
+  type Mood,
+  type IndustryTag,
+  type SectionType,
+  type PatternType,
+  type BlueprintTier,
+} from './vocabularies';
+
+export {
+  MOOD_TO_PERSONALITY,
+  MOOD_TO_VISUAL_STYLE,
+  INDUSTRY_TAG_TO_SLUG,
+  projectMoodsToPersonality,
+  projectMoodsToVisualStyle,
+  projectIndustryTagsToSlugs,
+  isUniversalIndustryFit,
+} from './bridges';
+
+export {
+  validateBlueprint,
+  validateBlueprintLibrary,
+  normalizeBlueprint,
+  normalizeBlueprintLibrary,
+  type Blueprint,
+  type NormalizedBlueprint,
+  type BlueprintLibrary,
+  type ValidationIssue,
+  type ValidationResult,
+} from './schema';

--- a/content-system/blueprints/schema.ts
+++ b/content-system/blueprints/schema.ts
@@ -1,0 +1,269 @@
+import type { Personality, VisualStyle, IndustrySlug } from '../vocabularies';
+import type {
+  Mood,
+  IndustryTag,
+  SectionType,
+  PatternType,
+  BlueprintTier,
+} from './vocabularies';
+import {
+  isMood,
+  isIndustryTag,
+  isSectionType,
+  isPatternType,
+  isBlueprintTier,
+} from './vocabularies';
+import {
+  projectMoodsToPersonality,
+  projectMoodsToVisualStyle,
+  projectIndustryTagsToSlugs,
+} from './bridges';
+
+/**
+ * Blueprint — a single entry in the BDS blueprint library.
+ *
+ * Authors hand-write the match fields (`moods`, `industries`) and layout
+ * content; projections (`personality`, `visualStyle`, `industrySlugs`)
+ * are derived by `normalizeBlueprint()` at load time and not stored in
+ * the JSON source. Never hand-author projection fields — it diverges
+ * from the bridge and silently breaks resolver shortlists.
+ *
+ * Shape mirrors the portal `design_blueprints` Supabase table
+ * (migrations 00080, 00081) plus the v2 interaction-pattern extensions.
+ * The portal re-seeds from this JSON; the JSON does not read from the
+ * portal. BDS is upstream.
+ */
+export interface Blueprint {
+  /** Unique slug, e.g. "hero_split_60_40". Stable — external references rely on it. */
+  key: string;
+  /** Human label, e.g. "Split Hero 60/40". */
+  name: string;
+  section_type: SectionType;
+
+  // ── Match fields (authored) ────────────────────────────────────
+  /** Brand-feel tags. Projected onto Personality + VisualStyle via bridges. */
+  moods: readonly Mood[];
+  /** Industry-fit tags. Projected onto IndustrySlug via bridge. */
+  industries: readonly IndustryTag[];
+
+  // ── Layout archetype (v1, current) ─────────────────────────────
+  /** Prose description of the layout — feeds the mockup generator system prompt. */
+  layout_spec: string;
+  /** Optional CSS pattern notes or snippets. */
+  css_hints?: string;
+  /** Optional HTML snippet using BDS `var()` tokens. */
+  html_snippet?: string;
+  /** Optional CSS snippet using BDS `var()` tokens. */
+  css_snippet?: string;
+
+  // ── Interaction pattern (v2, optional) ─────────────────────────
+  /**
+   * v2 pivot: blueprints may describe behavior instead of (or alongside)
+   * layout. When a Paper artboard supplies the layout, the blueprint's
+   * value is the `pattern_spec` + `js_snippet`. Populated as the library
+   * accumulates reusable interaction patterns.
+   */
+  pattern_type?: PatternType;
+  pattern_spec?: string;
+  js_snippet?: string;
+
+  // ── Metadata ──────────────────────────────────────────────────
+  /** Where the pattern was captured from — "Framer - Buildaxa", "Vale demo", etc. */
+  source?: string;
+  tier: BlueprintTier;
+  is_active: boolean;
+  /** Semver. Bump on content change. */
+  version: string;
+  /** ISO date YYYY-MM-DD. */
+  last_reviewed: string;
+}
+
+/**
+ * NormalizedBlueprint — what the library emits after running authored
+ * entries through the bridges. Consumers should type against this when
+ * querying, not the raw `Blueprint` interface.
+ */
+export interface NormalizedBlueprint extends Blueprint {
+  /** Derived from `moods` via MOOD_TO_PERSONALITY. */
+  personality: readonly Personality[];
+  /** Derived from `moods` via MOOD_TO_VISUAL_STYLE. May be empty. */
+  visual_style: readonly VisualStyle[];
+  /**
+   * Derived from `industries` via INDUSTRY_TAG_TO_SLUG.
+   * Empty when the blueprint is universal-only (see `is_universal`).
+   */
+  industry_slugs: readonly IndustrySlug[];
+  /** True when `industries` includes `universal`. */
+  is_universal: boolean;
+}
+
+/**
+ * Library envelope — metadata surrounding the blueprint array so
+ * consumers can detect version mismatches and review staleness.
+ */
+export interface BlueprintLibrary {
+  /** Semver for the library as a whole. Bumps when the set changes. */
+  version: string;
+  /** ISO date YYYY-MM-DD of last full review. */
+  last_reviewed: string;
+  /** Review cadence reminder. */
+  review_cadence: 'quarterly' | 'biannual' | 'annual';
+  blueprints: readonly Blueprint[];
+}
+
+// ── Validation ────────────────────────────────────────────────────
+
+export interface ValidationIssue {
+  key: string;
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  issues: readonly ValidationIssue[];
+}
+
+/**
+ * Validate a Blueprint authored entry against the locked vocabularies.
+ * Dependency-free — returns a diagnostic bundle instead of throwing,
+ * so callers can surface all drift in one pass.
+ */
+export function validateBlueprint(bp: Blueprint): ValidationResult {
+  const issues: ValidationIssue[] = [];
+  const push = (field: string, message: string) =>
+    issues.push({ key: bp.key, field, message });
+
+  if (!bp.key || !/^[a-z][a-z0-9_]*$/.test(bp.key)) {
+    push('key', `Invalid key "${bp.key}" — must be snake_case lowercase.`);
+  }
+  if (!bp.name?.trim()) push('name', 'Name is required.');
+  if (!isSectionType(bp.section_type)) {
+    push('section_type', `Unknown section_type "${bp.section_type}".`);
+  }
+
+  if (!Array.isArray(bp.moods) || bp.moods.length === 0) {
+    push('moods', 'At least one mood is required.');
+  } else {
+    for (const m of bp.moods) {
+      if (!isMood(m)) push('moods', `Unknown mood "${m}".`);
+    }
+  }
+
+  if (!Array.isArray(bp.industries) || bp.industries.length === 0) {
+    push('industries', 'At least one industry tag is required.');
+  } else {
+    for (const i of bp.industries) {
+      if (!isIndustryTag(i)) push('industries', `Unknown industry tag "${i}".`);
+    }
+  }
+
+  if (!bp.layout_spec?.trim() && !bp.pattern_spec?.trim()) {
+    push(
+      'layout_spec',
+      'Must have either layout_spec or pattern_spec — a blueprint with neither describes nothing.',
+    );
+  }
+
+  if (bp.pattern_type !== undefined && !isPatternType(bp.pattern_type)) {
+    push('pattern_type', `Unknown pattern_type "${bp.pattern_type}".`);
+  }
+
+  if (!isBlueprintTier(bp.tier)) {
+    push('tier', `Unknown tier "${bp.tier}".`);
+  }
+
+  if (!/^\d+\.\d+\.\d+/.test(bp.version ?? '')) {
+    push('version', `Invalid semver "${bp.version}".`);
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(bp.last_reviewed ?? '')) {
+    push('last_reviewed', `Invalid ISO date "${bp.last_reviewed}".`);
+  }
+
+  return { ok: issues.length === 0, issues };
+}
+
+/**
+ * Validate a whole library envelope. Returns the flattened issue list
+ * across every blueprint plus any envelope-level problems.
+ */
+export function validateBlueprintLibrary(
+  library: BlueprintLibrary,
+): ValidationResult {
+  const issues: ValidationIssue[] = [];
+
+  if (!/^\d+\.\d+\.\d+/.test(library.version ?? '')) {
+    issues.push({
+      key: '<library>',
+      field: 'version',
+      message: `Invalid semver "${library.version}".`,
+    });
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(library.last_reviewed ?? '')) {
+    issues.push({
+      key: '<library>',
+      field: 'last_reviewed',
+      message: `Invalid ISO date "${library.last_reviewed}".`,
+    });
+  }
+
+  const seen = new Set<string>();
+  for (const bp of library.blueprints) {
+    if (seen.has(bp.key)) {
+      issues.push({
+        key: bp.key,
+        field: 'key',
+        message: `Duplicate key "${bp.key}".`,
+      });
+    }
+    seen.add(bp.key);
+    const result = validateBlueprint(bp);
+    issues.push(...result.issues);
+  }
+
+  // Sanity-check bridges — if a valid projection field accidentally lands
+  // in the authored data, catch it before it shadows the derived value.
+  for (const bp of library.blueprints as readonly (Blueprint & {
+    personality?: unknown;
+    visual_style?: unknown;
+    industry_slugs?: unknown;
+  })[]) {
+    for (const field of ['personality', 'visual_style', 'industry_slugs'] as const) {
+      if (bp[field] !== undefined) {
+        issues.push({
+          key: bp.key,
+          field,
+          message: `Projection field "${field}" is derived — remove from source JSON.`,
+        });
+      }
+    }
+  }
+
+  return { ok: issues.length === 0, issues };
+}
+
+/**
+ * Normalize an authored Blueprint by attaching derived projection fields.
+ * Assumes the input has already been validated; callers should run
+ * `validateBlueprint` first or gate on `validateBlueprintLibrary`.
+ */
+export function normalizeBlueprint(bp: Blueprint): NormalizedBlueprint {
+  return {
+    ...bp,
+    personality: projectMoodsToPersonality(bp.moods),
+    visual_style: projectMoodsToVisualStyle(bp.moods),
+    industry_slugs: projectIndustryTagsToSlugs(bp.industries),
+    is_universal: bp.industries.includes('universal'),
+  };
+}
+
+/**
+ * Normalize every entry in a library. Safe to call after
+ * `validateBlueprintLibrary` reports `ok: true`.
+ */
+export function normalizeBlueprintLibrary(
+  library: BlueprintLibrary,
+): readonly NormalizedBlueprint[] {
+  return library.blueprints.map(normalizeBlueprint);
+}
+

--- a/content-system/blueprints/vocabularies.ts
+++ b/content-system/blueprints/vocabularies.ts
@@ -1,0 +1,130 @@
+/**
+ * Blueprint-side vocabularies.
+ *
+ * These are *match* tags — they describe which layouts fit which brands —
+ * and are intentionally distinct from the client-picks vocabularies
+ * (Personality / Voice / VisualStyle) that clients select in the portal.
+ * See ARCHITECTURE.md for the two-taxonomy model and bridge rules.
+ */
+
+/**
+ * Moods — the brand-feel match tags carried on every blueprint.
+ *
+ * Bridges to Personality + VisualStyle via MOOD_TO_PERSONALITY and
+ * MOOD_TO_VISUAL_STYLE in bridges.ts. A blueprint authored with
+ * `moods: ['bold', 'modern']` automatically projects to
+ * `personality: ['Bold', 'Modern']` and `visualStyle: ['Modern']`
+ * when the JSON is loaded — consumers may query by either axis.
+ */
+export const MOOD_VALUES = [
+  'bold',
+  'minimal',
+  'warm',
+  'corporate',
+  'playful',
+  'luxury',
+  'trustworthy',
+  'energetic',
+  'professional',
+  'modern',
+  'approachable',
+] as const;
+
+export type Mood = (typeof MOOD_VALUES)[number];
+
+export const isMood = (value: string): value is Mood =>
+  (MOOD_VALUES as readonly string[]).includes(value);
+
+/**
+ * Industry tags — the 15 match-side industry labels carried on blueprints.
+ *
+ * Wider than `INDUSTRY_SLUGS` (which is the 3-pack fallback-driven client
+ * axis). Industry tags describe which verticals a layout fits; slugs
+ * describe which industry pack supplies voice/copy/strategic defaults.
+ *
+ * `universal` is a special tag meaning "works for any vertical" — it does
+ * NOT map to `small-business`; the resolver must handle it specially so
+ * universal blueprints always appear in shortlists.
+ */
+export const INDUSTRY_TAG_VALUES = [
+  'universal',
+  'healthcare',
+  'real_estate',
+  'legal',
+  'finance',
+  'saas',
+  'ecommerce',
+  'beauty',
+  'salon',
+  'hospitality',
+  'restaurant',
+  'luxury',
+  'corporate',
+  'dental',
+  'veterinary',
+] as const;
+
+export type IndustryTag = (typeof INDUSTRY_TAG_VALUES)[number];
+
+export const isIndustryTag = (value: string): value is IndustryTag =>
+  (INDUSTRY_TAG_VALUES as readonly string[]).includes(value);
+
+/**
+ * Section types — which page region a blueprint composes.
+ *
+ * Stable superset; new types require a migration + mockup worker update
+ * so both sides know how to slot the blueprint into a variant brief.
+ */
+export const SECTION_TYPE_VALUES = [
+  'hero',
+  'nav',
+  'services',
+  'features',
+  'stats',
+  'testimonials',
+  'cta',
+  'gallery',
+  'team',
+  'faq',
+  'content_block',
+] as const;
+
+export type SectionType = (typeof SECTION_TYPE_VALUES)[number];
+
+export const isSectionType = (value: string): value is SectionType =>
+  (SECTION_TYPE_VALUES as readonly string[]).includes(value);
+
+/**
+ * Pattern types — the v2 interaction/animation taxonomy.
+ *
+ * Optional on current blueprints; required when a blueprint's primary
+ * value is behavior rather than layout (post-Paper pivot). A blueprint
+ * can carry both layout_spec and pattern_spec — they're not exclusive.
+ */
+export const PATTERN_TYPE_VALUES = [
+  'carousel',
+  'scroll-reveal',
+  'hover-card',
+  'parallax',
+  'counter',
+  'accordion',
+  'lightbox',
+] as const;
+
+export type PatternType = (typeof PATTERN_TYPE_VALUES)[number];
+
+export const isPatternType = (value: string): value is PatternType =>
+  (PATTERN_TYPE_VALUES as readonly string[]).includes(value);
+
+/**
+ * Tier — which surfaces a blueprint is cleared for.
+ *
+ * - `internal`: mockup generation only. Not surfaced in brik-templates.
+ * - `template`: eligible for the brik-templates catalog shipped to clients.
+ */
+export const BLUEPRINT_TIER_VALUES = ['internal', 'template'] as const;
+
+export type BlueprintTier = (typeof BLUEPRINT_TIER_VALUES)[number];
+
+export const isBlueprintTier = (value: string): value is BlueprintTier =>
+  (BLUEPRINT_TIER_VALUES as readonly string[]).includes(value);

--- a/content-system/index.ts
+++ b/content-system/index.ts
@@ -10,10 +10,12 @@
  *   - schema/       — TypeScript types for pack authoring
  *   - industries/   — industry packs (data + narrative)
  *   - voices/       — voice patterns (rules, examples, pairings)
+ *   - blueprints/   — layout + interaction pattern library shape
  */
 
 export * from './vocabularies';
 export * from './schema';
+export * from './blueprints';
 export { industryPacks, dental, realEstateRvMhc, smallBusiness } from './industries';
 export {
   voicePatterns,

--- a/content-system/vocabularies/personality.ts
+++ b/content-system/vocabularies/personality.ts
@@ -13,7 +13,8 @@
  *   - v0.9.0: added Trustworthy + Energetic. Cross-vertical load-bearing —
  *     Trustworthy is the default signal for medical/legal/financial;
  *     Energetic fills a gap between Playful and Bold for active-lifestyle
- *     and youth-forward brands.
+ *     and youth-forward brands. Also gives the mood→personality bridge
+ *     (blueprints/ARCHITECTURE.md) a clean target for every mood value.
  */
 export const PERSONALITY_VALUES = [
   'Warm',


### PR DESCRIPTION
## Summary
Phase A of blueprint library consolidation — schema + bridges + vocabularies + ARCHITECTURE.md. No blueprint data yet (that ships in Phase B).

- Adds `content-system/blueprints/` module: vocabularies (Mood, IndustryTag, SectionType, PatternType, BlueprintTier), bridges (mood→Personality/VisualStyle, industry-tag→IndustrySlug with projection helpers), schema (Blueprint, NormalizedBlueprint, BlueprintLibrary + dependency-free validator and normalizer).
- Documents the two-taxonomy model, bridge tables, v1/v2 coexistence, and phase plan in `blueprints/ARCHITECTURE.md`.
- Doc-comment merge in `content-system/vocabularies/personality.ts` to cross-link the mood→personality bridge (values array was already landed in #112; this keeps history coherent).

Schema supports both v1 layout archetypes (`layout_spec` + css/html snippets) and v2 interaction patterns (`pattern_spec` + `pattern_type` + `js_snippet`) so the Paper-first pivot lands without a schema break.

## Test plan
- [x] `npm run validate` passes locally (token lint, grid audit, theme compliance, typecheck, Storybook build)
- [ ] CI green on branch
- [ ] Manual review of `blueprints/ARCHITECTURE.md` bridge tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)