### PR TITLE
docs(blueprints): add Storybook Overview page for the blueprint library

### DIFF
--- a/content-system/blueprints/Overview.mdx
+++ b/content-system/blueprints/Overview.mdx
@@ -1,0 +1,179 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import library from '../../blueprints/blueprint-library.json';
+import {
+  MOOD_VALUES,
+  INDUSTRY_TAG_VALUES,
+  SECTION_TYPE_VALUES,
+  MOOD_TO_PERSONALITY,
+  MOOD_TO_VISUAL_STYLE,
+  INDUSTRY_TAG_TO_SLUG,
+  normalizeBlueprintLibrary,
+} from './index';
+
+<Meta title="Content System/Blueprints/Overview" />
+
+# Blueprint Library
+
+Named layout + interaction patterns that ground AI mockup generation with concrete structural constraints. **BDS owns the canonical data**; portal `design_blueprints` is a downstream seed.
+
+See [Architecture](https://github.com/brikdesigns/brik-bds/blob/main/blueprints/ARCHITECTURE.md) for the two-taxonomy model, bridge rules, and v1/v2 coexistence.
+
+<table>
+  <tbody>
+    <tr><td><strong>Library version</strong></td><td><code>{library.version}</code></td></tr>
+    <tr><td><strong>Last reviewed</strong></td><td>{library.last_reviewed}</td></tr>
+    <tr><td><strong>Review cadence</strong></td><td>{library.review_cadence}</td></tr>
+    <tr><td><strong>Blueprint count</strong></td><td>{library.blueprints.length}</td></tr>
+    <tr><td><strong>Section types covered</strong></td><td>{[...new Set(library.blueprints.map(b => b.section_type))].length} of {SECTION_TYPE_VALUES.length}</td></tr>
+  </tbody>
+</table>
+
+---
+
+## Two taxonomies
+
+Authors hand-write match tags (`moods`, `industries`). Client-axis projections (`personality`, `visual_style`, `industry_slugs`) are derived at load time via the bridges — never stored in source JSON, never authored by hand.
+
+### Mood → Personality
+
+<table>
+  <thead><tr><th>Mood</th><th>Personality projection</th></tr></thead>
+  <tbody>
+    {MOOD_VALUES.map(m => (
+      <tr key={m}>
+        <td><code>{m}</code></td>
+        <td>{MOOD_TO_PERSONALITY[m]?.join(' · ') || <em>(none)</em>}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+
+### Mood → Visual Style
+
+<table>
+  <thead><tr><th>Mood</th><th>Visual Style projection</th></tr></thead>
+  <tbody>
+    {MOOD_VALUES.map(m => (
+      <tr key={m}>
+        <td><code>{m}</code></td>
+        <td>{MOOD_TO_VISUAL_STYLE[m]?.length ? MOOD_TO_VISUAL_STYLE[m].join(' · ') : <em>(none — no visual-style constraint)</em>}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+
+### Industry tag → Industry pack slug
+
+<table>
+  <thead><tr><th>Tag</th><th>Pack slug</th></tr></thead>
+  <tbody>
+    {INDUSTRY_TAG_VALUES.map(tag => (
+      <tr key={tag}>
+        <td><code>{tag}</code></td>
+        <td>{tag === 'universal' ? <em>universal sentinel — no pack lookup</em> : <code>{INDUSTRY_TAG_TO_SLUG[tag]}</code>}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+
+---
+
+## Coverage matrix
+
+Which section types have which moods covered. Cell = blueprint count. Gaps are opportunities to author.
+
+<table>
+  <thead>
+    <tr>
+      <th>Section</th>
+      {MOOD_VALUES.map(m => <th key={m} style={{ fontSize: 11, textAlign: 'center' }}>{m}</th>)}
+    </tr>
+  </thead>
+  <tbody>
+    {SECTION_TYPE_VALUES.map(section => {
+      const rowBlueprints = library.blueprints.filter(b => b.section_type === section);
+      if (rowBlueprints.length === 0) return null;
+      return (
+        <tr key={section}>
+          <td><code>{section}</code></td>
+          {MOOD_VALUES.map(m => {
+            const count = rowBlueprints.filter(b => b.moods.includes(m)).length;
+            return (
+              <td key={m} style={{ textAlign: 'center', color: count === 0 ? '#ccc' : 'inherit' }}>
+                {count || '·'}
+              </td>
+            );
+          })}
+        </tr>
+      );
+    })}
+  </tbody>
+</table>
+
+---
+
+## Library — grouped by section type
+
+{SECTION_TYPE_VALUES.map(section => {
+  const entries = library.blueprints.filter(b => b.section_type === section);
+  if (entries.length === 0) return null;
+  return (
+    <div key={section} style={{ marginBottom: 48 }}>
+      <h3 style={{ marginBottom: 8, textTransform: 'capitalize' }}>
+        {section.replace('_', ' ')} <span style={{ color: '#888', fontWeight: 400, fontSize: 14 }}>({entries.length})</span>
+      </h3>
+      {entries.map(bp => (
+        <details key={bp.key} style={{ border: '1px solid #e5e5e5', borderRadius: 8, padding: '12px 16px', marginBottom: 8 }}>
+          <summary style={{ cursor: 'pointer', fontWeight: 600 }}>
+            {bp.name}
+            <code style={{ marginLeft: 8, fontSize: 12, color: '#888', fontWeight: 400 }}>{bp.key}</code>
+            {!bp.is_active && <span style={{ marginLeft: 8, fontSize: 11, color: '#c00' }}>inactive</span>}
+          </summary>
+          <div style={{ marginTop: 12, fontSize: 14, lineHeight: 1.6 }}>
+            <div style={{ marginBottom: 8 }}>
+              <strong>Moods:</strong>{' '}
+              {bp.moods.map(m => <code key={m} style={{ marginRight: 6, padding: '1px 6px', background: '#f4f4f4', borderRadius: 4, fontSize: 12 }}>{m}</code>)}
+            </div>
+            <div style={{ marginBottom: 8 }}>
+              <strong>Industries:</strong>{' '}
+              {bp.industries.map(i => <code key={i} style={{ marginRight: 6, padding: '1px 6px', background: '#f4f4f4', borderRadius: 4, fontSize: 12 }}>{i}</code>)}
+            </div>
+            <div style={{ marginBottom: 8 }}>
+              <strong>Layout spec:</strong>
+              <p style={{ margin: '4px 0 0', color: '#444' }}>{bp.layout_spec}</p>
+            </div>
+            {bp.css_hints && (
+              <details style={{ marginBottom: 8 }}>
+                <summary style={{ cursor: 'pointer', fontSize: 12, color: '#666' }}>CSS hints</summary>
+                <pre style={{ fontSize: 11, background: '#fafafa', padding: 8, borderRadius: 4, overflow: 'auto', marginTop: 4 }}>{bp.css_hints}</pre>
+              </details>
+            )}
+            <div style={{ fontSize: 12, color: '#888', marginTop: 8 }}>
+              <strong>Tier:</strong> {bp.tier}
+              {bp.source && <> · <strong>Source:</strong> {bp.source}</>}
+              {' · '}<strong>v{bp.version}</strong> · reviewed {bp.last_reviewed}
+            </div>
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+})}
+
+---
+
+## Authoring
+
+Blueprint edits flow **through BDS**. Portal admin edits (if kept) are drafts — landed changes flow back through a BDS PR. Full rules in [Architecture](https://github.com/brikdesigns/brik-bds/blob/main/blueprints/ARCHITECTURE.md).
+
+1. Edit `blueprints/blueprint-library.json` on a task branch.
+2. Run `npm run validate:blueprints` (also runs as part of `npm run validate`).
+3. Bump `version` on the affected blueprint(s) and the library envelope if the set changes. Update `last_reviewed` on confirmed-accurate passes.
+4. Open a PR. Bridge edits, schema changes, and data additions stay separate.
+5. After merge: publish the new BDS version and regenerate the portal seed migration via `npx tsx scripts/generate-blueprint-seed.mts` in `brik-client-portal`.
+
+## Related
+
+- [Architecture (GitHub)](https://github.com/brikdesigns/brik-bds/blob/main/blueprints/ARCHITECTURE.md)
+- [Content System Overview](?path=/docs/content-system-overview--docs)
+- [Voices Overview](?path=/docs/content-system-voices-overview--docs)


### PR DESCRIPTION
## Summary
Makes the 25-entry blueprint library reviewable in Storybook. Until now the library only shipped as JSON — authors and reviewers had to read the raw file. This page is the canonical viewer other docs (Notion, Paper, portal admin) should link to.

**Page path:** `Content System / Blueprints / Overview`

### What it renders
- Library metadata — version, last_reviewed, cadence, section-type coverage
- Bridge reference tables — Mood → Personality, Mood → VisualStyle, industry tag → pack slug
- Section × mood coverage matrix — counts per cell so gaps are visible
- Collapsible entry cards grouped by `section_type`, each showing moods, industries, layout_spec, optional CSS hints, source, tier, version

### Mechanics
- Imports `blueprints/blueprint-library.json` directly (Vite handles JSON imports)
- Reuses `MOOD_TO_PERSONALITY` / `MOOD_TO_VISUAL_STYLE` / `INDUSTRY_TAG_TO_SLUG` from `./index` so the bridge tables never drift from the runtime projections
- Indexed by the existing `.storybook/main.ts` `content-system/**/*.mdx` glob — no config change

## Test plan
- [x] `npm run build-storybook` succeeds
- [x] Page indexed at `content-system-blueprints-overview--overview` (verified in `storybook-static/index.json`)
- [ ] CI green
- [ ] Visual check on Storybook deploy preview

## Follow-up (Phase C)
- `resolveBlueprintShortlist(profile)` helper — can cite this page in its JSDoc
- Notion doc updates declaring BDS canonical — link to this page as the viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)