### PR TITLE
feat(task-console)+refactor(tokens): cleanup + adopt --icon-lg for 20px hardcodes

### DIFF
--- a/components/icons.ts
+++ b/components/icons.ts
@@ -14,6 +14,7 @@ export const MagnifyingGlass = 'ph:magnifying-glass';
 export const MapPin = 'ph:map-pin';
 export const CloudArrowUp = 'ph:cloud-arrow-up';
 export const CheckCircle = 'ph:check-circle';
+export const Circle = 'ph:circle';
 export const WarningCircle = 'ph:warning-circle';
 export const Warning = 'ph:warning';
 export const Info = 'ph:info';

--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -83,8 +83,8 @@
 }
 
 .bds-badge--lg .bds-badge__icon {
-  width: 20px;
-  height: 20px;
+  width: var(--icon-lg);
+  height: var(--icon-lg);
   font-size: var(--label-xl);
 }
 

--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -338,8 +338,8 @@
 }
 
 .bds-button--lg .bds-button__spinner-icon {
-  width: 20px;
-  height: 20px;
+  width: var(--icon-lg);
+  height: var(--icon-lg);
 }
 
 .bds-button--xl .bds-button__spinner-icon {
@@ -414,7 +414,7 @@
 }
 
 .bds-icon-button--lg .bds-icon-button__icon {
-  font-size: 20px;
+  font-size: var(--icon-lg);
 }
 
 .bds-icon-button--xl .bds-icon-button__icon {

--- a/components/ui/Chip/Chip.css
+++ b/components/ui/Chip/Chip.css
@@ -124,8 +124,8 @@
 }
 
 .bds-chip--lg .bds-chip__icon {
-  width: 20px;
-  height: 20px;
+  width: var(--icon-lg);
+  height: var(--icon-lg);
   font-size: var(--label-xl);
 }
 

--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -100,8 +100,8 @@
 }
 
 .bds-tag--lg .bds-tag__icon {
-  width: 20px;
-  height: 20px;
+  width: var(--icon-lg);
+  height: var(--icon-lg);
   font-size: var(--label-xl);
 }
 

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -186,9 +186,9 @@
 
 .bds-task-console__icon {
   flex-shrink: 0;
-  width: 20px; /* bds-lint-ignore — status icon sized between --icon-sm (16) and --icon-md (18) to match spinner diameter */
-  height: 20px; /* bds-lint-ignore — status icon sized between --icon-sm (16) and --icon-md (18) to match spinner diameter */
-  font-size: 20px; /* bds-lint-ignore — status icon sized to match spinner diameter */
+  width: var(--icon-lg);
+  height: var(--icon-lg);
+  font-size: var(--icon-lg);
 }
 
 .bds-task-console__icon--completed {
@@ -203,8 +203,8 @@
    3/4 track (default --border-primary reads dark on white surfaces). The
    leading quadrant keeps the brand accent. */
 .bds-task-console .bds-task-console__icon--in-progress {
-  width: 20px; /* bds-lint-ignore — match status icon diameter */
-  height: 20px; /* bds-lint-ignore — match status icon diameter */
+  width: var(--icon-lg);
+  height: var(--icon-lg);
   border-color: var(--surface-muted);
   border-top-color: var(--border-brand-primary);
 }

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -2,9 +2,6 @@
 /* ─── TaskConsole ─────────────────────────────────────────────── */
 
 .bds-task-console {
-  /* ─── Component-scoped override surface ── */
-  --task-console-btn-hover-bg: var(--state-hover-overlay);
-
   position: fixed;
   z-index: 9999;
   width: 360px; /* bds-lint-ignore — design constraint matching Google Drive widget */
@@ -12,7 +9,7 @@
   display: flex;
   flex-direction: column;
   background-color: var(--surface-primary);
-  border: var(--border-width-lg) solid var(--border-primary);
+  border: var(--border-width-sm) solid var(--border-primary);
   border-radius: var(--border-radius-lg);
   box-shadow: var(--shadow-xl);
   overflow: hidden;
@@ -37,7 +34,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--padding-md) var(--padding-lg);
+  gap: var(--gap-md);
+  padding: var(--padding-sm) var(--padding-md) var(--padding-sm) var(--padding-lg);
   background-color: var(--surface-secondary);
   cursor: pointer;
   user-select: none;
@@ -56,7 +54,7 @@
 .bds-task-console__header-text {
   display: flex;
   flex-direction: column;
-  gap: 2px; /* bds-lint-ignore — tight spacing for subtitle */
+  gap: var(--gap-xs);
   min-width: 0;
   flex: 1;
 }
@@ -81,53 +79,24 @@
 }
 
 .bds-task-console__header-actions {
-  display: flex;
-  align-items: center;
   gap: var(--gap-xs);
   flex-shrink: 0;
-}
-
-/* ─── Header buttons ─────────────────────────────────────────── */
-
-.bds-task-console__btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px; /* bds-lint-ignore — icon button sizing */
-  height: 28px; /* bds-lint-ignore — icon button sizing */
-  background: none;
-  border: none;
-  border-radius: var(--border-radius-sm);
-  cursor: pointer;
-  color: var(--text-primary);
-  opacity: 0.6;
-  font-size: var(--icon-sm);
-  padding: 0;
-  transition: opacity var(--duration-fast) var(--ease-out),
-    background-color var(--duration-fast) var(--ease-out);
-}
-
-.bds-task-console__btn:hover {
-  opacity: 1;
-  background-color: var(--task-console-btn-hover-bg); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
+  flex-wrap: nowrap;
 }
 
 /* ─── Progress bar ───────────────────────────────────────────── */
 
-.bds-task-console__progress-track {
-  height: 3px; /* bds-lint-ignore — thin progress bar */
-  background-color: var(--border-primary);
+.bds-task-console .bds-task-console__progress {
+  border-radius: 0;
   flex-shrink: 0;
+  height: var(--space-100);
 }
 
-.bds-task-console__progress-fill {
-  height: 100%;
-  background-color: var(--background-status-info);
-  transition: width var(--duration-400) var(--ease-out);
-  border-radius: 0 2px 2px 0; /* bds-lint-ignore — progress bar cap */
+.bds-task-console .bds-task-console__progress .bds-progress-bar__fill {
+  border-radius: 0;
 }
 
-.bds-task-console__progress-fill--error {
+.bds-task-console__progress--error .bds-progress-bar__fill {
   background-color: var(--background-negative);
 }
 
@@ -155,10 +124,6 @@
   border-bottom: none;
 }
 
-.bds-task-console__item--in_progress {
-  background-color: var(--surface-status-info);
-}
-
 .bds-task-console__item--failed {
   background-color: var(--surface-negative);
 }
@@ -168,7 +133,7 @@
 .bds-task-console__item-content {
   display: flex;
   flex-direction: column;
-  gap: 2px; /* bds-lint-ignore — tight spacing */
+  gap: var(--gap-xs);
   min-width: 0;
   flex: 1;
 }
@@ -184,8 +149,14 @@
   text-overflow: ellipsis;
 }
 
-.bds-task-console__item--completed .bds-task-console__item-label {
+.bds-task-console__item--completed .bds-task-console__item-label,
+.bds-task-console__item--pending .bds-task-console__item-label {
   color: var(--text-muted);
+}
+
+.bds-task-console__item--in_progress .bds-task-console__item-label {
+  font-weight: var(--font-weight-semi-bold);
+  color: var(--text-primary);
 }
 
 .bds-task-console__item-link {
@@ -193,7 +164,7 @@
   font-size: var(--body-sm);
   font-weight: var(--font-weight-semi-bold);
   line-height: var(--font-line-height-normal);
-  color: var(--text-status-info);
+  color: var(--text-brand-primary);
   text-decoration: none;
   cursor: pointer;
 }
@@ -215,7 +186,9 @@
 
 .bds-task-console__icon {
   flex-shrink: 0;
-  font-size: var(--icon-sm);
+  width: 20px; /* bds-lint-ignore — status icon sized between --icon-sm (16) and --icon-md (18) to match spinner diameter */
+  height: 20px; /* bds-lint-ignore — status icon sized between --icon-sm (16) and --icon-md (18) to match spinner diameter */
+  font-size: 20px; /* bds-lint-ignore — status icon sized to match spinner diameter */
 }
 
 .bds-task-console__icon--completed {
@@ -226,16 +199,17 @@
   color: var(--text-negative);
 }
 
-.bds-task-console__icon--in-progress {
-  color: var(--text-status-info);
+/* Spinner overrides — size up to match the other 20px icons and lighten the
+   3/4 track (default --border-primary reads dark on white surfaces). The
+   leading quadrant keeps the brand accent. */
+.bds-task-console .bds-task-console__icon--in-progress {
+  width: 20px; /* bds-lint-ignore — match status icon diameter */
+  height: 20px; /* bds-lint-ignore — match status icon diameter */
+  border-color: var(--surface-muted);
+  border-top-color: var(--border-brand-primary);
 }
 
 .bds-task-console__icon--pending {
-  display: inline-block;
-  width: var(--icon-sm);
-  height: var(--icon-sm);
-  border-radius: var(--border-radius-pill);
-  border: var(--border-width-lg) solid var(--border-primary);
-  box-sizing: border-box;
+  color: var(--text-muted);
 }
 }

--- a/components/ui/TaskConsole/TaskConsole.tsx
+++ b/components/ui/TaskConsole/TaskConsole.tsx
@@ -1,8 +1,12 @@
 import { type ReactNode, type HTMLAttributes, useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { Icon } from '@iconify/react';
-import { CaretDown, CaretUp, X, CheckCircle, WarningCircle, Spinner } from '../../icons';
+import { CaretDown, CaretUp, X, CheckCircle, Circle, WarningCircle } from '../../icons';
 import { bdsClass } from '../../utils';
+import { IconButton } from '../Button/IconButton';
+import { ButtonGroup } from '../ButtonGroup';
+import { ProgressBar } from '../ProgressBar';
+import { Spinner } from '../Spinner';
 import './TaskConsole.css';
 
 /* ─── Types ──────────────────────────────────────────────────── */
@@ -52,10 +56,10 @@ function StatusIcon({ status }: { status: TaskItemStatus }) {
     case 'failed':
       return <Icon icon={WarningCircle} className="bds-task-console__icon bds-task-console__icon--failed" />;
     case 'in_progress':
-      return <Icon icon={Spinner} className="bds-task-console__icon bds-task-console__icon--in-progress" />;
+      return <Spinner size="sm" className="bds-task-console__icon bds-task-console__icon--in-progress" />;
     case 'pending':
     default:
-      return <span className="bds-task-console__icon bds-task-console__icon--pending" />;
+      return <Icon icon={Circle} className="bds-task-console__icon bds-task-console__icon--pending" />;
   }
 }
 
@@ -89,6 +93,9 @@ export function TaskConsole({
   const failedCount = items.filter((i) => i.status === 'failed').length;
   const allDone = items.length > 0 && completedCount + failedCount === items.length;
   const allSucceeded = allDone && failedCount === 0;
+  const progressValue = items.length > 0
+    ? ((completedCount + failedCount) / items.length) * 100
+    : 0;
 
   // Auto-dismiss after all items complete
   useEffect(() => {
@@ -101,7 +108,7 @@ export function TaskConsole({
 
   if (!isOpen) return null;
 
-  const console = (
+  const consoleEl = (
     <div
       className={bdsClass(
         'bds-task-console',
@@ -122,39 +129,39 @@ export function TaskConsole({
           <span className="bds-task-console__title">{title}</span>
           {subtitle && <span className="bds-task-console__subtitle">{subtitle}</span>}
         </div>
-        <div className="bds-task-console__header-actions">
-          <button
-            type="button"
-            className="bds-task-console__btn"
-            onClick={(e) => { e.stopPropagation(); toggleCollapse(); }}
-            aria-label={collapsed ? 'Expand' : 'Collapse'}
-          >
-            <Icon icon={collapsed ? CaretUp : CaretDown} />
-          </button>
+        <ButtonGroup
+          className="bds-task-console__header-actions"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <IconButton
+            variant="ghost"
+            size="sm"
+            icon={<Icon icon={collapsed ? CaretUp : CaretDown} />}
+            label={collapsed ? 'Expand' : 'Collapse'}
+            onClick={toggleCollapse}
+          />
           {onDismiss && (
-            <button
-              type="button"
-              className="bds-task-console__btn"
-              onClick={(e) => { e.stopPropagation(); onDismiss(); }}
-              aria-label="Dismiss"
-            >
-              <Icon icon={X} />
-            </button>
+            <IconButton
+              variant="ghost"
+              size="sm"
+              icon={<Icon icon={X} />}
+              label="Dismiss"
+              onClick={onDismiss}
+            />
           )}
-        </div>
+        </ButtonGroup>
       </div>
 
       {/* ── Progress bar ───────────────────────────────────────── */}
       {!collapsed && items.length > 0 && (
-        <div className="bds-task-console__progress-track">
-          <div
-            className={bdsClass(
-              'bds-task-console__progress-fill',
-              failedCount > 0 && 'bds-task-console__progress-fill--error',
-            )}
-            style={{ width: `${((completedCount + failedCount) / items.length) * 100}%` }}
-          />
-        </div>
+        <ProgressBar
+          className={bdsClass(
+            'bds-task-console__progress',
+            failedCount > 0 && 'bds-task-console__progress--error',
+          )}
+          value={progressValue}
+          label="Task progress"
+        />
       )}
 
       {/* ── Item list ──────────────────────────────────────────── */}
@@ -194,7 +201,7 @@ export function TaskConsole({
   );
 
   if (typeof document === 'undefined') return null;
-  return createPortal(console, document.body);
+  return createPortal(consoleEl, document.body);
 }
 
 export default TaskConsole;


### PR DESCRIPTION
## Summary

Two linked commits. The first reworks TaskConsole styling; the second retires the 20px hardcodes it (and several siblings) had been carrying.

### 1. `feat(task-console)` — styling cleanup
- Header actions → `ButtonGroup` of ghost `IconButton`s (was hand-rolled `<button>` + custom hover opacity).
- Progress → BDS `ProgressBar` using `--background-brand-primary` (was `--background-status-info` blue that read as a selection state).
- In-progress row → BDS `Spinner` component (loading-state standard) instead of a Phosphor spinner icon; pending row → `ph:circle` so all four states share Phosphor's stroke weight.
- Dropped the `--surface-status-info` row highlight (the "selection" blue); active row is signalled by spinner + semibold label.
- Spinner track lightened to `--surface-muted`; brand-primary stays on the leading quadrant.
- "View" link color → `--text-brand-primary` (was status-info blue).

### 2. `refactor(tokens)` — adopt `--icon-lg`
`--icon-lg` = 20px has been a gap-fill token since the 2026-04 icon-size restoration (`tokens/gap-fills.css:86`), but Chip / Tag / Badge / Button / TaskConsole all reached for literal `20px` for their lg-size icon containers. Normalized to the token — zero visual change, every swap resolves to the same 20px, but future resize happens in one place.

Considered adding a parallel `--indicator-*` family for status-glyph semantics (TaskConsole row state, ProgressStepper steps, NotificationList markers) but declined: that distinction isn't backed by Figma yet and "never invent token names" wins. Can promote later if indicator semantics become load-bearing.

## Test plan
- [ ] Storybook: TaskConsole Playground, States, All Completed, With Errors, Live Simulation — progress bar is brand-primary (Brik poppy), in-progress row no longer has blue background, all four status icons align at 20px.
- [ ] Storybook: Chip / Tag / Badge `lg` variants render identically to prior snapshot.
- [ ] Storybook: Button / IconButton `lg` loading + icon states render identically.
- [ ] `npm run lint-tokens` passes.
- [ ] `npm run typecheck` passes.
- [ ] Chromatic diff clean (or expected-only on TaskConsole stories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)