### PR TITLE
feat(content-system): VISUAL_STYLE_METADATA sidecar for reference imagery

### DIFF
--- a/content-system/vocabularies/index.ts
+++ b/content-system/vocabularies/index.ts
@@ -12,8 +12,11 @@ export {
 
 export {
   VISUAL_STYLE_VALUES,
+  VISUAL_STYLE_METADATA,
   isVisualStyle,
+  getVisualStyleMetadata,
   type VisualStyle,
+  type VisualStyleMetadata,
 } from './visual-style';
 
 export {

--- a/content-system/vocabularies/visual-style.ts
+++ b/content-system/vocabularies/visual-style.ts
@@ -28,3 +28,41 @@ export type VisualStyle = (typeof VISUAL_STYLE_VALUES)[number];
 
 export const isVisualStyle = (value: string): value is VisualStyle =>
   (VISUAL_STYLE_VALUES as readonly string[]).includes(value);
+
+/**
+ * Per-style metadata sidecar. Kept separate from the enum so the
+ * `VisualStyle` type stays a clean string-literal union for downstream
+ * consumers (portal, blueprint resolver, schema bridges).
+ *
+ * `referenceImageUrl` points at a canonical thumbnail used in:
+ *   - Storybook MDX (Content System / Visual Styles / {slug})
+ *   - Portal onboarding picker (thumbnail next to each option)
+ *   - Client-facing proposals and mood boards
+ *
+ * TODO(bcs): populate `referenceImageUrl` for all 11 styles. Scaffold
+ * ships with empty strings so dependent wiring (Storybook stories,
+ * portal picker) can proceed in parallel; fill via a follow-up data-only
+ * PR once the canonical URLs are finalized.
+ */
+export interface VisualStyleMetadata {
+  /** Canonical thumbnail URL representing this style direction. */
+  referenceImageUrl: string;
+}
+
+export const VISUAL_STYLE_METADATA: Record<VisualStyle, VisualStyleMetadata> = {
+  Minimal: { referenceImageUrl: '' },
+  Playful: { referenceImageUrl: '' },
+  Luxurious: { referenceImageUrl: '' },
+  Modern: { referenceImageUrl: '' },
+  Classic: { referenceImageUrl: '' },
+  Dark: { referenceImageUrl: '' },
+  Light: { referenceImageUrl: '' },
+  Colorful: { referenceImageUrl: '' },
+  Monochrome: { referenceImageUrl: '' },
+  Textural: { referenceImageUrl: '' },
+  Brutalist: { referenceImageUrl: '' },
+};
+
+export const getVisualStyleMetadata = (
+  style: VisualStyle,
+): VisualStyleMetadata => VISUAL_STYLE_METADATA[style];


### PR DESCRIPTION
## Summary

- Adds `VISUAL_STYLE_METADATA: Record<VisualStyle, VisualStyleMetadata>` to [content-system/vocabularies/visual-style.ts](content-system/vocabularies/visual-style.ts) with a `referenceImageUrl: string` field per style
- Adds `getVisualStyleMetadata` helper and re-exports new symbols from [content-system/vocabularies/index.ts](content-system/vocabularies/index.ts)
- **Non-breaking.** `VISUAL_STYLE_VALUES` and the `VisualStyle` type are untouched — downstream consumers (portal `company_profiles.style_preferences`, blueprint resolver, schema bridges) see no API change

## Why a sidecar instead of inline metadata?

Inlining `referenceImageUrl` into `VISUAL_STYLE_VALUES` would have forced the array from `readonly string[]` to `readonly {slug, referenceImageUrl}[]`, breaking the `VisualStyle` string-literal union and every consumer that types against it (portal [assess.ts](../../../product/brik-client-portal/src/lib/meetings/assess.ts), blueprint resolver, MOOD_TO_VISUAL_STYLE bridges). The sidecar record keeps the enum clean while TypeScript's `Record<VisualStyle, …>` still enforces completeness — forget a slug, build fails.

## URL population

This PR ships with empty-string placeholders for all 11 `referenceImageUrl` values. Intentional — it unblocks dependent work (Storybook MDX stories, portal onboarding picker, blueprint schema) to proceed in parallel against a stable public surface. Canonical URLs land in a follow-up data-only PR, tracked by the TODO at the top of `visual-style.ts`.

## Release

Minor bump candidate — `0.10.1` → `0.11.0`. Per repo convention, version bump is a separate `chore(release)` PR that batches recent features.

## Follow-up sessions (not in scope here)

1. Data PR: populate the 11 `referenceImageUrl` values
2. Storybook MDX: one story per Visual Style under `Content System / Visual Styles / {slug}`
3. Portal onboarding picker: render thumbnail next to each dropdown option
4. Blueprint schema: add explicit `visualStyles: string[]` field

## Test plan

- [x] `tsc --noEmit` — clean (both `tsconfig.json` and `tsconfig.content-system.json`)
- [x] Pre-push gate: all 6 checks pass (Token Lint, Grid Audit, Theme Compliance, Blueprint Library, TypeScript, Storybook Build)
- [ ] Verify `import { VISUAL_STYLE_METADATA } from '@brikdesigns/bds/content-system'` resolves once published and consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)