### PR TITLE
feat(content-system)!: grow VISUAL_STYLE_VALUES to 13 — add Bold + Editorial

### DIFF
--- a/blueprints/ARCHITECTURE.md
+++ b/blueprints/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The portal captures brand identity on three axes the client picks themselves:
 
 - `Personality` (13) — what the brand *is*
 - `Voice` (8) — how the brand *speaks*
-- `VisualStyle` (11) — the aesthetic direction
+- `VisualStyle` (13) — the aesthetic direction
 
 Blueprints, by contrast, are tagged for *matching* — answering the question "which layouts fit this brand?" Historically that surface used two different tags:
 
@@ -66,7 +66,7 @@ Defined in [`content-system/blueprints/bridges.ts`](../content-system/blueprints
 
 | Mood | VisualStyle |
 |---|---|
-| `bold` | *(none)* |
+| `bold` | `Bold` |
 | `minimal` | `Minimal` |
 | `warm` | *(none)* |
 | `corporate` | `Classic` |

--- a/content-system/blueprints/bridges.ts
+++ b/content-system/blueprints/bridges.ts
@@ -46,7 +46,7 @@ export const MOOD_TO_PERSONALITY: Record<Mood, readonly Personality[]> = {
  * visual correlate. An empty array is explicit, not a bug.
  */
 export const MOOD_TO_VISUAL_STYLE: Record<Mood, readonly VisualStyle[]> = {
-  bold: [],
+  bold: ['Bold'],
   minimal: ['Minimal'],
   warm: [],
   corporate: ['Classic'],

--- a/content-system/vocabularies/visual-style.ts
+++ b/content-system/vocabularies/visual-style.ts
@@ -1,5 +1,5 @@
 /**
- * Visual Style — the 11 canonical style directions captured in the client portal.
+ * Visual Style — the 13 canonical style directions captured in the client portal.
  *
  * Drives theme token selection (palette density, typography, spacing),
  * imagery treatment, and blueprint shortlist trimming. Distinct from
@@ -9,9 +9,14 @@
  * Clients pick up to 3. "Minimal" and "Playful" also appear in Personality;
  * "Luxurious" overlaps with Personality's "Luxury" (intentional — singular
  * adjective form in Personality, adverbial form here).
+ *
+ * Ordering mirrors the portal's onboarding picker so the eventual
+ * `taxonomy.ts` → BCS import swap is a zero-reorder change.
  */
 export const VISUAL_STYLE_VALUES = [
   'Minimal',
+  'Bold',
+  'Editorial',
   'Playful',
   'Luxurious',
   'Modern',
@@ -39,7 +44,7 @@ export const isVisualStyle = (value: string): value is VisualStyle =>
  *   - Portal onboarding picker (thumbnail next to each option)
  *   - Client-facing proposals and mood boards
  *
- * TODO(bcs): populate `referenceImageUrl` for all 11 styles. Scaffold
+ * TODO(bcs): populate `referenceImageUrl` for all 13 styles. Scaffold
  * ships with empty strings so dependent wiring (Storybook stories,
  * portal picker) can proceed in parallel; fill via a follow-up data-only
  * PR once the canonical URLs are finalized.
@@ -51,6 +56,8 @@ export interface VisualStyleMetadata {
 
 export const VISUAL_STYLE_METADATA: Record<VisualStyle, VisualStyleMetadata> = {
   Minimal: { referenceImageUrl: '' },
+  Bold: { referenceImageUrl: '' },
+  Editorial: { referenceImageUrl: '' },
   Playful: { referenceImageUrl: '' },
   Luxurious: { referenceImageUrl: '' },
   Modern: { referenceImageUrl: '' },


### PR DESCRIPTION
## Summary

- Adds `Bold` and `Editorial` to `VISUAL_STYLE_VALUES` (grows 11 → 13); ordering mirrors the portal onboarding picker so the eventual `taxonomy.ts` → BCS import swap is a zero-reorder change
- Extends `VISUAL_STYLE_METADATA` with matching entries — `Record<VisualStyle, …>` enforces completeness
- Wires `MOOD_TO_VISUAL_STYLE.bold` from `[]` → `['Bold']`
- Updates [blueprints/ARCHITECTURE.md](blueprints/ARCHITECTURE.md) style count and mood → visual-style table

## Follow-up to [#120](https://github.com/brikdesigns/brik-bds/pull/120)

That PR added the `VISUAL_STYLE_METADATA` sidecar against the then-current 11 styles. This PR grows the canonical enum and keeps the metadata record consistent.

## Portal coordination: **none needed for this merge**

Audited `product/brik-client-portal` after opening this PR. Original assumption (breaking-change warning) was wrong. Portal does **not** import `VisualStyle` from BCS yet:

- [src/lib/brand/taxonomy.ts:81](../../product/brik-client-portal/blob/staging/src/lib/brand/taxonomy.ts#L81) keeps its own local `VISUAL_STYLE_VALUES` array — already contains all 13 values in lowercase (`minimal`, `bold`, `editorial`, …). File comment (lines 13–21) explicitly flags that BCS swap is pending BCS additions.
- API validation ([`route.ts:27`](../../product/brik-client-portal/blob/staging/src/app/api/admin/company-profiles/%5BcompanyId%5D/route.ts#L27)) uses `z.enum(VISUAL_STYLE_VALUES)` from the local taxonomy, not BCS
- `company_profiles.style_preferences` is `text[]` with no DB-level CHECK constraint (migration 00088) — all vocabulary validation happens in the app layer against the local enum
- No `Record<VisualStyle, …>` exhaustive maps in portal code

**Safe to merge #121 standalone.** Portal continues working unchanged.

## What this unblocks

The portal doc says the Visual Style → BCS swap was "not yet scheduled" because BCS didn't have `Bold` and `Editorial`. With this PR, BCS has them. The planned convergence session can now:

1. Swap `taxonomy.ts` local Visual Style → BCS import (same pattern used for Personality in QW1 2026-04)
2. Add migration `00116_visual_style_title_case.sql` modeled on [`00115_personality_title_case.sql`](../../product/brik-client-portal/blob/staging/supabase/migrations/00115_personality_title_case.sql) — lowercase rows → Title-case
3. Update `VISUAL_STYLE_OPTIONS` to derive from BCS values
4. Retire the "portal-local for now" comment block

That's its own deliberate session — not bundled here.

## Release

Minor bump candidate — `0.10.1` → `0.11.0`. The `!` / `BREAKING CHANGE:` in the commit is still accurate for the **BCS public surface** semantics (the `VisualStyle` type expanded; any external consumer doing exhaustive switches breaks) — just not for the current portal consumer. Release is a separate `chore(release)` PR per repo convention.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] Pre-push gate: all 6 checks pass (Token Lint, Grid Audit, Theme Compliance, Blueprint Library, TypeScript, Storybook Build)
- [x] Portal audit: no BCS `VisualStyle` import, no DB constraint, no exhaustive maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)