### PR TITLE
refactor(storybook)!: rewire Typography.mdx to live tokens, delete deprecated exports

### DIFF
--- a/stories/foundation/Typography.mdx
+++ b/stories/foundation/Typography.mdx
@@ -5,7 +5,7 @@ import {
   SemanticTypographyTable,
   FontWeightShowcase,
 } from './_components';
-import { fontSizeScale, fontWeights, semanticTypography } from '../../tokens';
+import { fontSizeScale, fontWeights } from '../../tokens';
 
 <Meta title="Foundations/Design Tokens/Typography" />
 
@@ -17,10 +17,10 @@ Typography tokens control font families, sizes, weights, and line heights. Each 
 
 <FontFamilyShowcase
   families={[
-    { name: 'Display', cssVar: '--font-family-display', value: semanticTypography['font-family--display'] },
-    { name: 'Heading', cssVar: '--font-family-heading', value: semanticTypography['font-family--heading'] },
-    { name: 'Body', cssVar: '--font-family-body', value: semanticTypography['font-family--body'] },
-    { name: 'Label', cssVar: '--font-family-label', value: semanticTypography['font-family--label'] },
+    { name: 'Display', cssVar: '--font-family-display' },
+    { name: 'Heading', cssVar: '--font-family-heading' },
+    { name: 'Body', cssVar: '--font-family-body' },
+    { name: 'Label', cssVar: '--font-family-label' },
   ]}
 />
 
@@ -28,23 +28,79 @@ Typography tokens control font families, sizes, weights, and line heights. Each 
 
 ### Heading sizes
 
-<SemanticTypographyTable title="Headings" tokens={semanticTypography} category="heading" />
+<SemanticTypographyTable
+  title="Headings"
+  category="heading"
+  tokens={[
+    'heading-tiny',
+    'heading-sm',
+    'heading-md',
+    'heading-lg',
+    'heading-xl',
+    'heading-xxl',
+    'heading-huge',
+  ]}
+/>
 
 ### Body sizes
 
-<SemanticTypographyTable title="Body" tokens={semanticTypography} category="body" />
+<SemanticTypographyTable
+  title="Body"
+  category="body"
+  tokens={[
+    'body-tiny',
+    'body-xs',
+    'body-sm',
+    'body-md',
+    'body-lg',
+    'body-xl',
+    'body-huge',
+  ]}
+/>
 
 ### Label sizes
 
-<SemanticTypographyTable title="Labels" tokens={semanticTypography} category="label" />
+<SemanticTypographyTable
+  title="Labels"
+  category="label"
+  tokens={[
+    'label-tiny',
+    'label-xs',
+    'label-sm',
+    'label-md',
+    'label-lg',
+    'label-xl',
+  ]}
+/>
 
 ### Display sizes
 
-<SemanticTypographyTable title="Display" tokens={semanticTypography} category="display" />
+<SemanticTypographyTable
+  title="Display"
+  category="display"
+  tokens={[
+    'display-sm',
+    'display-md',
+    'display-lg',
+    'display-xl',
+  ]}
+/>
 
 ### Icon sizes
 
-<SemanticTypographyTable title="Icons" tokens={semanticTypography} category="icon" />
+<SemanticTypographyTable
+  title="Icons"
+  category="icon"
+  tokens={[
+    'icon-tiny',
+    'icon-xs',
+    'icon-sm',
+    'icon-md',
+    'icon-lg',
+    'icon-xl',
+    'icon-huge',
+  ]}
+/>
 
 ## Font size scale
 

--- a/stories/foundation/_components.tsx
+++ b/stories/foundation/_components.tsx
@@ -305,7 +305,7 @@ export function TypographyScale({ scale, prefix }: TypographyScaleProps) {
 interface FontFamilyDef {
   name: string;
   cssVar: string;
-  value: string;
+  value?: string;
 }
 
 interface FontFamilyShowcaseProps {
@@ -319,7 +319,7 @@ export function FontFamilyShowcase({ families }: FontFamilyShowcaseProps) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)', marginBottom: 'var(--padding-lg)' }}>
       {families.map((f) => {
-        const liveValue = resolved[f.cssVar] || f.value;
+        const liveValue = resolved[f.cssVar] || f.value || '';
         return (
           <div
             key={f.cssVar}
@@ -369,16 +369,17 @@ export function FontFamilyShowcase({ families }: FontFamilyShowcaseProps) {
 // ---------------------------------------------------------------------------
 
 interface SemanticTypographyTableProps {
-  title: string;
-  tokens: Record<string, string>;
-  category: string;
+  title?: string;
+  tokens: readonly string[];
+  category: 'heading' | 'body' | 'label' | 'display' | 'icon';
 }
 
 export function SemanticTypographyTable({ tokens, category }: SemanticTypographyTableProps) {
-  const entries = Object.entries(tokens).filter(([key]) => key.startsWith(`${category}--`) || key.startsWith(`${category}-`));
-  if (entries.length === 0) return null;
+  const cssVars = tokens.map((t) => `--${t}`);
+  const resolved = useComputedVars(cssVars);
 
-  // Determine font family var for this category
+  if (tokens.length === 0) return null;
+
   const fontFamilyVar = category === 'icon'
     ? '--font-family-icon'
     : `--font-family-${category === 'body' || category === 'label' ? category : 'heading'}`;
@@ -386,11 +387,12 @@ export function SemanticTypographyTable({ tokens, category }: SemanticTypography
   return (
     <div style={{ marginBottom: 'var(--padding-lg)' }}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0' }}>
-        {entries.map(([key, refValue]) => {
-          const cssVar = `--${key}`;
+        {tokens.map((token) => {
+          const cssVar = `--${token}`;
+          const liveValue = resolved[cssVar] || '';
           return (
             <div
-              key={key}
+              key={token}
               style={{
                 display: 'grid',
                 gridTemplateColumns: '160px 160px 1fr',
@@ -401,7 +403,7 @@ export function SemanticTypographyTable({ tokens, category }: SemanticTypography
               }}
             >
               <span style={tokenLabel}>{cssVar}</span>
-              <span style={valueLabel}>{refValue}</span>
+              <span style={valueLabel}>{liveValue}</span>
               <span
                 style={{
                   fontSize: `var(${cssVar})`,

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -451,54 +451,6 @@ export const fontLineHeights = {
 } as const;
 
 /**
- * Semantic color tokens (default theme values)
- *
- * @deprecated These reference Webflow-format variable names (--grayscale--, --_themes---).
- * Do NOT use these in components or new code. Use CSS custom properties from
- * figma-tokens.css directly (--text-primary, --background-brand-primary, etc.)
- * or import from @/lib/tokens in consuming projects.
- *
- * Retained for legacy Storybook compatibility only.
- */
-export const semanticColors = {
-  "border--secondary": "var(--grayscale--light)",
-  "surface--nav": "var(--grayscale--white)",
-  "background--brand-primary": "var(--_themes---blue-green--blue-light)",
-  "text--inverse": "var(--grayscale--white)",
-  "text--on-color-dark": "var(--grayscale--white)",
-  "text--on-color-light": "var(--grayscale--black)",
-  "border--brand": "var(--_themes---blue-green--blue-light)",
-  "background--primary": "var(--grayscale--white)",
-  "border--inverse": "var(--grayscale--white)",
-  "text--primary": "var(--grayscale--darkest)",
-  "text--brand": "var(--_themes---blue-green--blue-light)",
-  "surface--primary": "var(--grayscale--white)",
-  "border--primary": "var(--grayscale--dark)",
-  "surface--secondary": "var(--grayscale--lightest)",
-  "page--primary": "var(--grayscale--white)",
-  "text--muted": "var(--grayscale--dark)",
-  "surface--brand-primary": "var(--_themes---blue-green--blue-light)",
-  "border--input": "var(--grayscale--light)",
-  "border--muted": "var(--grayscale--lighter)",
-  "border--on-color": "white",
-  "surface--brand-secondary": "var(--_themes---blue-green--green)",
-  "text--secondary": "var(--grayscale--darker)",
-  "background--secondary": "var(--grayscale--lightest)",
-  "theme--accent": "var(--_themes---blue-green--green)",
-  "theme--tertiary": "var(--_themes---blue-green--blue-dark)",
-  "theme--secondary": "var(--_themes---blue-green--blue-lighter)",
-  "theme--primary": "var(--_themes---blue-green--blue-light)",
-  "page--brand": "var(--_themes---blue-green--blue-light)",
-  "background--brand-secondary": "white",
-  "background--inverse": "var(--grayscale--white)",
-  "background--input": "var(--grayscale--white)",
-  "background--image": "#17171799",
-  "background--image-brand": "var(--_themes---blue-green--blue-light)",
-  "page--secondary": "var(--grayscale--lighter)",
-  "theme--fourth": "white"
-} as const;
-
-/**
  * Semantic space tokens (default values)
  * Used by Storybook Spacing.mdx to render the semantic spacing scale.
  * Maps to SD single-dash --space-* variables (NOT the legacy --space-- double-dash format).
@@ -524,43 +476,3 @@ export const semanticSpace = {
   "input": "var(--space-200)"
 } as const;
 
-/**
- * Semantic typography tokens (default values)
- *
- * @deprecated Font family values here reflect an old Webflow theme configuration
- * and do not match the current BDS token stack (Poppins/Avenir/Century Schoolbook).
- * Do NOT use these in components. Use --font-family-heading/body/label/display from
- * figma-tokens.css, or import font.family.* from @/lib/tokens in consuming projects.
- *
- * Retained for legacy Storybook compatibility only.
- */
-export const semanticTypography = {
-  "font-family--label": "\"Open Sans\", sans-serif",
-  "body--sm": "var(--font-size--75)",
-  "label--md-base": "var(--font-size--100)",
-  "font-family--body": "\"Open Sans\", sans-serif",
-  "body--md-base": "var(--font-size--100)",
-  "font-family--heading": "\"Droid Sans\", sans-serif",
-  "heading--xxx-large": "var(--font-size--1200)",
-  "heading--large": "var(--font-size--700)",
-  "label--lg": "var(--font-size--200)",
-  "label--xl": "var(--font-size--300)",
-  "label--sm": "var(--font-size--75)",
-  "body--xl": "var(--font-size--300)",
-  "font-family--display": "\"Droid Sans\", sans-serif",
-  "display--large": "var(--font-size--1400)",
-  "display--medium": "var(--font-size--1500)",
-  "display--small": "var(--font-size--1600)",
-  "heading--xx-large": "var(--font-size--1000)",
-  "heading--x-large": "var(--font-size--900)",
-  "heading--medium": "var(--font-size--500)",
-  "heading--small": "var(--font-size--300)",
-  "body--lg": "var(--font-size--200)",
-  "heading--tiny": "var(--font-size--100)",
-  "font-family--icon": "\"Apple Symbols\", \"Segoe UI Symbol\", sans-serif",
-  "body--tiny": "var(--font-size--25)",
-  "body--xs": "var(--font-size--50)",
-  "icon--small": "var(--font-size--75)",
-  "icon--medium-base": "var(--font-size--100)",
-  "icon--large": "var(--font-size--200)"
-} as const;


### PR DESCRIPTION
## Summary

The `semanticTypography` and `semanticColors` exports in [tokens/index.ts](tokens/index.ts) carried Webflow-format variable names (`heading--tiny` double-dash keys referencing `var(--font-size--100)`) that no longer match the live token set. [stories/foundation/Typography.mdx](stories/foundation/Typography.mdx) rendered blank cells for every semantic-size row because `--heading--tiny` etc. don't exist in `figma-tokens.css` — the doc has been silently broken since the 2026-03-08 switch to single-dash token names.

- **Typography.mdx** passes live semantic-token short-names (`heading-tiny`, `body-md`, `icon-lg`, …) directly to `SemanticTypographyTable` and drops the stale `semanticTypography` import.
- **`SemanticTypographyTable`** now accepts `readonly string[]` of short names (not a `Record<string, string>` + category prefix filter) and resolves live values via `useComputedVars` so the value column reflects theme switches.
- **`FontFamilyShowcase`** `value` prop is now optional — live resolution via `useComputedVars` is primary; MDX no longer needs to source a fallback from the deprecated map.
- **`tokens/index.ts`**: deletes `semanticColors` (Webflow-format color refs) and `semanticTypography` (Webflow-format typography refs). No callers remain in this repo or in any BDS consumer (portal, renew-pms, brikdesigns).

## Breaking change

Removes `semanticColors` and `semanticTypography` named exports from `@brikdesigns/bds/tokens`. These were marked `@deprecated` and had no live consumers — verified via grep across `brik-bds`, `product/brik-client-portal`, `product/renew-pms`, and `brik/brikdesigns`. Any external code must migrate to reading `var(--*)` tokens from `figma-tokens.css` directly, or to the per-element presets in `@/lib/tokens`.

## Visual verification

After merge, check Storybook Foundations / Design Tokens / Typography:
- [ ] Every semantic-size row (heading-tiny → heading-huge, body-tiny → body-huge, label-tiny → label-xl, display-sm → display-xl, icon-tiny → icon-huge) renders with a real sample, resolved px value, and live size
- [ ] Icon row renders FA glyphs (not blank)
- [ ] Theme toggle updates resolved values live

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run validate:blueprints` passes (25 blueprints valid)
- [x] `npm run lint-tokens` clean (1 pre-existing warning unrelated)
- [x] Pre-push gate: all 6 checks pass (Token Lint, Grid Audit, Theme Compliance, Blueprint Library, TypeScript, Storybook Build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)