### PR TITLE
feat(content-system)!: replace VISUAL_STYLE_METADATA with examples registry

### DIFF
--- a/content-system/vocabularies/index.ts
+++ b/content-system/vocabularies/index.ts
@@ -12,11 +12,12 @@ export {
 
 export {
   VISUAL_STYLE_VALUES,
-  VISUAL_STYLE_METADATA,
+  VISUAL_STYLE_EXAMPLES,
   isVisualStyle,
-  getVisualStyleMetadata,
+  getVisualStyleExamples,
+  getPrimaryVisualStyleExample,
   type VisualStyle,
-  type VisualStyleMetadata,
+  type VisualStyleExample,
 } from './visual-style';
 
 export {

--- a/content-system/vocabularies/visual-style.ts
+++ b/content-system/vocabularies/visual-style.ts
@@ -35,41 +35,80 @@ export const isVisualStyle = (value: string): value is VisualStyle =>
   (VISUAL_STYLE_VALUES as readonly string[]).includes(value);
 
 /**
- * Per-style metadata sidecar. Kept separate from the enum so the
- * `VisualStyle` type stays a clean string-literal union for downstream
- * consumers (portal, blueprint resolver, schema bridges).
+ * Reference imagery registry.
  *
- * `referenceImageUrl` points at a canonical thumbnail used in:
+ * A Visual Style can be represented by multiple example images — a pure
+ * primary expression, the same style with a modifier layered on, different
+ * client executions over time. Keeping this a list (not a Record<VisualStyle>)
+ * means you can add rows without re-classifying existing values, and one
+ * style can carry many examples as the design library grows.
+ *
+ * `modifierStyles` is empty for a pure expression, or carries 1–2 other
+ * VisualStyle values to describe a composition ("Minimal × Colorful").
+ * Paper's `bds-theming` file (01KPH6ANXVEPBJ4PAVB7V380JH) is the current
+ * source for the imagery; a follow-up PR exports each artboard as PNG and
+ * populates `referenceImageUrl`.
+ *
+ * Consumers:
  *   - Storybook MDX (Content System / Visual Styles / {slug})
- *   - Portal onboarding picker (thumbnail next to each option)
+ *   - Portal onboarding picker (thumbnail + caption next to each option)
  *   - Client-facing proposals and mood boards
- *
- * TODO(bcs): populate `referenceImageUrl` for all 13 styles. Scaffold
- * ships with empty strings so dependent wiring (Storybook stories,
- * portal picker) can proceed in parallel; fill via a follow-up data-only
- * PR once the canonical URLs are finalized.
  */
-export interface VisualStyleMetadata {
-  /** Canonical thumbnail URL representing this style direction. */
+export interface VisualStyleExample {
+  /** The dominant style this example expresses. */
+  primaryStyle: VisualStyle;
+  /**
+   * Zero or more styles layered over `primaryStyle`. Empty for a pure
+   * expression. Modifier order is significant (first pick dominates).
+   */
+  modifierStyles: readonly VisualStyle[];
+  /** Canonical hosted URL of the reference image (PNG/WEBP). */
   referenceImageUrl: string;
+  /**
+   * Optional source URL that inspired the composition (Webflow template,
+   * published site, etc). Preserved for attribution + follow-up research.
+   */
+  referenceSiteUrl?: string;
+  /** Optional human-readable caption — "Minimal × Colorful — soft take". */
+  caption?: string;
 }
 
-export const VISUAL_STYLE_METADATA: Record<VisualStyle, VisualStyleMetadata> = {
-  Minimal: { referenceImageUrl: '' },
-  Bold: { referenceImageUrl: '' },
-  Editorial: { referenceImageUrl: '' },
-  Playful: { referenceImageUrl: '' },
-  Luxurious: { referenceImageUrl: '' },
-  Modern: { referenceImageUrl: '' },
-  Classic: { referenceImageUrl: '' },
-  Dark: { referenceImageUrl: '' },
-  Light: { referenceImageUrl: '' },
-  Colorful: { referenceImageUrl: '' },
-  Monochrome: { referenceImageUrl: '' },
-  Textural: { referenceImageUrl: '' },
-  Brutalist: { referenceImageUrl: '' },
-};
+export const VISUAL_STYLE_EXAMPLES: readonly VisualStyleExample[] = [
+  { primaryStyle: 'Minimal',    modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://leadify-template.webflow.io' },
+  { primaryStyle: 'Bold',       modifierStyles: [], referenceImageUrl: '' },
+  { primaryStyle: 'Editorial',  modifierStyles: [], referenceImageUrl: '' },
+  { primaryStyle: 'Playful',    modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://pizza-guy.webflow.io' },
+  { primaryStyle: 'Luxurious',  modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://villabliss-wbs.webflow.io' },
+  { primaryStyle: 'Modern',     modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://gradienttemplates.webflow.io' },
+  { primaryStyle: 'Classic',    modifierStyles: [], referenceImageUrl: '', caption: 'Editorial masthead tradition' },
+  { primaryStyle: 'Brutalist',  modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://blacksmith-sbj.webflow.io' },
+  // Modifier-demo compositions from Paper bds-theming
+  { primaryStyle: 'Modern',     modifierStyles: ['Dark'],       referenceImageUrl: '' },
+  { primaryStyle: 'Brutalist',  modifierStyles: ['Light'],      referenceImageUrl: '' },
+  { primaryStyle: 'Minimal',    modifierStyles: ['Colorful'],   referenceImageUrl: '' },
+  { primaryStyle: 'Luxurious',  modifierStyles: ['Monochrome'], referenceImageUrl: '' },
+  { primaryStyle: 'Classic',    modifierStyles: ['Textural'],   referenceImageUrl: '' },
+];
 
-export const getVisualStyleMetadata = (
+/**
+ * All examples that feature `style` as the primary or as a modifier.
+ * Used by Storybook per-style pages and the portal onboarding picker.
+ */
+export const getVisualStyleExamples = (
   style: VisualStyle,
-): VisualStyleMetadata => VISUAL_STYLE_METADATA[style];
+): readonly VisualStyleExample[] =>
+  VISUAL_STYLE_EXAMPLES.filter(
+    (ex) => ex.primaryStyle === style || ex.modifierStyles.includes(style),
+  );
+
+/**
+ * The canonical "pure" example for a style — first entry where the style
+ * is the primary and there are no modifiers. Returns undefined if the
+ * style has no standalone example authored yet.
+ */
+export const getPrimaryVisualStyleExample = (
+  style: VisualStyle,
+): VisualStyleExample | undefined =>
+  VISUAL_STYLE_EXAMPLES.find(
+    (ex) => ex.primaryStyle === style && ex.modifierStyles.length === 0,
+  );


### PR DESCRIPTION
## Summary

Option D from the 2026-04-19 design review: keep the `VisualStyle` enum flat (it's the client-facing vocabulary) and put reference imagery in a **separate list** rather than a `Record<VisualStyle, …>` sidecar.

## Why a list instead of a Record

The v0.11.0 `VISUAL_STYLE_METADATA: Record<VisualStyle, {...}>` sidecar committed us to exactly-one image per style. That doesn't match how the Paper reference library actually works — a style can legitimately have a pure expression AND modifier-layered expressions (*Minimal × Colorful*, *Classic × Textural*) that are all useful references. A Record would have forced artificial "primary vs modifier" category splits and couldn't hold multiple images per style.

A list lets:
- One style carry many example images over time (pure + modifier + different client executions)
- New modifier compositions added without schema churn
- Storybook + portal filter by primary OR modifier appearance

## API surface

```ts
interface VisualStyleExample {
  primaryStyle: VisualStyle;
  modifierStyles: readonly VisualStyle[];
  referenceImageUrl: string;
  referenceSiteUrl?: string;
  caption?: string;
}

export const VISUAL_STYLE_EXAMPLES: readonly VisualStyleExample[];
export const getVisualStyleExamples = (style: VisualStyle) => readonly VisualStyleExample[];
export const getPrimaryVisualStyleExample = (style: VisualStyle) => VisualStyleExample | undefined;
```

Seeded with 13 entries from Paper [`bds-theming`](https://app.paper.design/file/01KPH6ANXVEPBJ4PAVB7V380JH) — 8 pure primaries + 5 modifier-demo compositions. `referenceImageUrl` slots are empty pending a follow-up data-only PR that exports each artboard to PNG and hosts them at `storybook.brikdesigns.com/visual-styles/*.png`. `referenceSiteUrl` preserves the Webflow template each composition was inspired by.

## Breaking change

`VISUAL_STYLE_METADATA`, `VisualStyleMetadata`, `getVisualStyleMetadata` are removed from `@brikdesigns/bds/content-system`. These shipped in [v0.10.0 (#120)](https://github.com/brikdesigns/brik-bds/pull/120) / [v0.11.0 (#123)](https://github.com/brikdesigns/brik-bds/pull/123) with empty scaffolds — **no known live consumers** (grep across brik-bds, portal, renew-pms, brikdesigns returns zero hits). Downstream should migrate to `VISUAL_STYLE_EXAMPLES` + `getPrimaryVisualStyleExample(style)`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run validate:blueprints` passes
- [x] `npm run build:content-system` passes
- [x] Pre-push gate: all 6 checks pass
- [ ] Next PR: Paper export + populate `referenceImageUrl` for the 13 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)