### PR TITLE
feat(content-system): populate VISUAL_STYLE_EXAMPLES image URLs

### DIFF
--- a/.storybook/public/visual-styles/README.md
+++ b/.storybook/public/visual-styles/README.md
@@ -1,0 +1,54 @@
+# Visual Style reference images
+
+Hosted at `https://storybook.brikdesigns.com/visual-styles/{filename}`. Consumed by `VISUAL_STYLE_EXAMPLES` in [`content-system/vocabularies/visual-style.ts`](../../../content-system/vocabularies/visual-style.ts).
+
+## Source
+
+All 11 images below are Paper artboards exported from file [`bds-theming`](https://app.paper.design/file/01KPH6ANXVEPBJ4PAVB7V380JH) at 1440×900. Export at 2x scale (2880×1800) for retina-sharp delivery; Storybook and the portal picker will down-scale as needed.
+
+## Required files
+
+### Primary-style heroes (6)
+
+| Filename | Paper artboard | Source of inspiration |
+|---|---|---|
+| `minimal.png` | Minimal — Hero (`14-0`) | leadify-template.webflow.io |
+| `playful.png` | Playful — Hero (`1S-0`) | pizza-guy.webflow.io |
+| `luxurious.png` | Luxurious — Hero (`L-0`) | villabliss-wbs.webflow.io |
+| `modern.png` | Modern — Hero (`2V-0`) | gradienttemplates.webflow.io |
+| `classic.png` | Classic — Hero (`43-0`) | editorial masthead tradition |
+| `brutalist.png` | Brutalist — Hero (`1-0`) | blacksmith-sbj.webflow.io |
+
+### Modifier-demo compositions (5)
+
+| Filename | Paper artboard |
+|---|---|
+| `modern-dark.png` | Modern + Dark (`59-0`) |
+| `brutalist-light.png` | Brutalist + Light (`61-0`) |
+| `minimal-colorful.png` | Minimal + Colorful (`6K-0`) |
+| `luxurious-monochrome.png` | Luxurious + Monochrome (`79-0`) |
+| `classic-textural.png` | Classic + Textural (`7S-0`) |
+
+### Pending (2)
+
+No Paper artboards yet — registry entries ship with empty `referenceImageUrl`. Populate when dedicated heroes are authored.
+
+- `bold.png` — Bold primary hero
+- `editorial.png` — Editorial primary hero
+
+## Export workflow
+
+In Paper (desktop or web app):
+
+1. Select the artboard listed above.
+2. Export → PNG, 2x scale.
+3. Rename to the target filename (e.g. `minimal.png`).
+4. Drop into this directory.
+5. Commit in a data-only PR; Storybook's next deploy picks up the new files automatically (the files are served from `.storybook/public/` → site root).
+
+## Adding a new composition
+
+1. Author the artboard in Paper's `bds-theming` file.
+2. Export + drop the PNG here with a filename matching the slug convention (`{primary}.png` for pure, `{primary}-{modifier}.png` for composition).
+3. Add a row to `VISUAL_STYLE_EXAMPLES` in `visual-style.ts` referencing the new URL.
+4. Ship as one PR.

--- a/content-system/vocabularies/visual-style.ts
+++ b/content-system/vocabularies/visual-style.ts
@@ -73,21 +73,34 @@ export interface VisualStyleExample {
   caption?: string;
 }
 
+/**
+ * Image URLs resolve to `.storybook/public/visual-styles/*.png` hosted at
+ * `https://storybook.brikdesigns.com/visual-styles/{file}`. Source artboards
+ * live in Paper `bds-theming` (file 01KPH6ANXVEPBJ4PAVB7V380JH).
+ *
+ * Bold + Editorial have no Paper artboard yet — their slots ship empty
+ * and get populated when those styles get dedicated hero references.
+ *
+ * See `.storybook/public/visual-styles/README.md` for the export drop-in
+ * convention (filenames + source artboard IDs).
+ */
+const IMG_BASE = 'https://storybook.brikdesigns.com/visual-styles';
+
 export const VISUAL_STYLE_EXAMPLES: readonly VisualStyleExample[] = [
-  { primaryStyle: 'Minimal',    modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://leadify-template.webflow.io' },
+  { primaryStyle: 'Minimal',    modifierStyles: [], referenceImageUrl: `${IMG_BASE}/minimal.png`,    referenceSiteUrl: 'https://leadify-template.webflow.io' },
   { primaryStyle: 'Bold',       modifierStyles: [], referenceImageUrl: '' },
   { primaryStyle: 'Editorial',  modifierStyles: [], referenceImageUrl: '' },
-  { primaryStyle: 'Playful',    modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://pizza-guy.webflow.io' },
-  { primaryStyle: 'Luxurious',  modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://villabliss-wbs.webflow.io' },
-  { primaryStyle: 'Modern',     modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://gradienttemplates.webflow.io' },
-  { primaryStyle: 'Classic',    modifierStyles: [], referenceImageUrl: '', caption: 'Editorial masthead tradition' },
-  { primaryStyle: 'Brutalist',  modifierStyles: [], referenceImageUrl: '', referenceSiteUrl: 'https://blacksmith-sbj.webflow.io' },
+  { primaryStyle: 'Playful',    modifierStyles: [], referenceImageUrl: `${IMG_BASE}/playful.png`,    referenceSiteUrl: 'https://pizza-guy.webflow.io' },
+  { primaryStyle: 'Luxurious',  modifierStyles: [], referenceImageUrl: `${IMG_BASE}/luxurious.png`,  referenceSiteUrl: 'https://villabliss-wbs.webflow.io' },
+  { primaryStyle: 'Modern',     modifierStyles: [], referenceImageUrl: `${IMG_BASE}/modern.png`,     referenceSiteUrl: 'https://gradienttemplates.webflow.io' },
+  { primaryStyle: 'Classic',    modifierStyles: [], referenceImageUrl: `${IMG_BASE}/classic.png`,    caption: 'Editorial masthead tradition' },
+  { primaryStyle: 'Brutalist',  modifierStyles: [], referenceImageUrl: `${IMG_BASE}/brutalist.png`,  referenceSiteUrl: 'https://blacksmith-sbj.webflow.io' },
   // Modifier-demo compositions from Paper bds-theming
-  { primaryStyle: 'Modern',     modifierStyles: ['Dark'],       referenceImageUrl: '' },
-  { primaryStyle: 'Brutalist',  modifierStyles: ['Light'],      referenceImageUrl: '' },
-  { primaryStyle: 'Minimal',    modifierStyles: ['Colorful'],   referenceImageUrl: '' },
-  { primaryStyle: 'Luxurious',  modifierStyles: ['Monochrome'], referenceImageUrl: '' },
-  { primaryStyle: 'Classic',    modifierStyles: ['Textural'],   referenceImageUrl: '' },
+  { primaryStyle: 'Modern',     modifierStyles: ['Dark'],       referenceImageUrl: `${IMG_BASE}/modern-dark.png`,       caption: 'Modern × Dark' },
+  { primaryStyle: 'Brutalist',  modifierStyles: ['Light'],      referenceImageUrl: `${IMG_BASE}/brutalist-light.png`,   caption: 'Brutalist × Light' },
+  { primaryStyle: 'Minimal',    modifierStyles: ['Colorful'],   referenceImageUrl: `${IMG_BASE}/minimal-colorful.png`,  caption: 'Minimal × Colorful' },
+  { primaryStyle: 'Luxurious',  modifierStyles: ['Monochrome'], referenceImageUrl: `${IMG_BASE}/luxurious-monochrome.png`, caption: 'Luxurious × Monochrome' },
+  { primaryStyle: 'Classic',    modifierStyles: ['Textural'],   referenceImageUrl: `${IMG_BASE}/classic-textural.png`,  caption: 'Classic × Textural' },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Re-opens [#125](https://github.com/brikdesigns/brik-bds/pull/125) (closed when its base branch was deleted on #124 merge). Cherry-picked the URL population commit onto main.

Commits canonical image URLs to 11 of the 13 `VISUAL_STYLE_EXAMPLES` registry entries. Each points at `/visual-styles/{slug}.png` under Storybook's public root, served from `https://storybook.brikdesigns.com/visual-styles/{file}`.

## Filename convention

- Pure expressions: `{primary-lowercase}.png`
- Compositions: `{primary}-{modifier}.png`

## What's populated (11 of 13)

From Paper [`bds-theming`](https://app.paper.design/file/01KPH6ANXVEPBJ4PAVB7V380JH): 6 pure primaries + 5 modifier-demo compositions.

`Bold` and `Editorial` rows ship with empty `referenceImageUrl` — no Paper artboards yet. Populate when dedicated heroes are authored.

## ⚠️ PNG files NOT in this commit

Paper MCP exposes screenshots visually but not as saveable bytes. PNG drop-in is a one-time manual export per artboard per the [README](.storybook/public/visual-styles/README.md) committed here.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build:content-system` passes
- [x] Pre-push gate: all 6 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)