### PR TITLE
chore(release)!: v0.12.0 — VISUAL_STYLE_EXAMPLES registry + URLs

### DIFF
--- a/dist/content-system/vocabularies/index.d.ts
+++ b/dist/content-system/vocabularies/index.d.ts
@@ -1,0 +1,5 @@
+export { PERSONALITY_VALUES, isPersonality, type Personality, } from './personality';
+export { VOICE_VALUES, isVoice, type Voice, } from './voice';
+export { VISUAL_STYLE_VALUES, VISUAL_STYLE_EXAMPLES, isVisualStyle, getVisualStyleExamples, getPrimaryVisualStyleExample, type VisualStyle, type VisualStyleExample, } from './visual-style';
+export { INDUSTRY_SLUGS, DEFAULT_INDUSTRY_SLUG, isIndustrySlug, type IndustrySlug, } from './industry';
+//# sourceMappingURL=index.d.ts.map

--- a/dist/content-system/vocabularies/index.js
+++ b/dist/content-system/vocabularies/index.js
@@ -1,0 +1,5 @@
+export { PERSONALITY_VALUES, isPersonality, } from './personality';
+export { VOICE_VALUES, isVoice, } from './voice';
+export { VISUAL_STYLE_VALUES, VISUAL_STYLE_EXAMPLES, isVisualStyle, getVisualStyleExamples, getPrimaryVisualStyleExample, } from './visual-style';
+export { INDUSTRY_SLUGS, DEFAULT_INDUSTRY_SLUG, isIndustrySlug, } from './industry';
+//# sourceMappingURL=index.js.map

--- a/dist/content-system/vocabularies/visual-style.d.ts
+++ b/dist/content-system/vocabularies/visual-style.d.ts
@@ -1,0 +1,69 @@
+/**
+ * Visual Style — the 13 canonical style directions captured in the client portal.
+ *
+ * Drives theme token selection (palette density, typography, spacing),
+ * imagery treatment, and blueprint shortlist trimming. Distinct from
+ * Personality — a "Playful" personality can be expressed in a "Minimal"
+ * visual style, and those tradeoffs are where craftwork lives.
+ *
+ * Clients pick up to 3. "Minimal" and "Playful" also appear in Personality;
+ * "Luxurious" overlaps with Personality's "Luxury" (intentional — singular
+ * adjective form in Personality, adverbial form here).
+ *
+ * Ordering mirrors the portal's onboarding picker so the eventual
+ * `taxonomy.ts` → BCS import swap is a zero-reorder change.
+ */
+export declare const VISUAL_STYLE_VALUES: readonly ["Minimal", "Bold", "Editorial", "Playful", "Luxurious", "Modern", "Classic", "Dark", "Light", "Colorful", "Monochrome", "Textural", "Brutalist"];
+export type VisualStyle = (typeof VISUAL_STYLE_VALUES)[number];
+export declare const isVisualStyle: (value: string) => value is VisualStyle;
+/**
+ * Reference imagery registry.
+ *
+ * A Visual Style can be represented by multiple example images — a pure
+ * primary expression, the same style with a modifier layered on, different
+ * client executions over time. Keeping this a list (not a Record<VisualStyle>)
+ * means you can add rows without re-classifying existing values, and one
+ * style can carry many examples as the design library grows.
+ *
+ * `modifierStyles` is empty for a pure expression, or carries 1–2 other
+ * VisualStyle values to describe a composition ("Minimal × Colorful").
+ * Paper's `bds-theming` file (01KPH6ANXVEPBJ4PAVB7V380JH) is the current
+ * source for the imagery; a follow-up PR exports each artboard as PNG and
+ * populates `referenceImageUrl`.
+ *
+ * Consumers:
+ *   - Storybook MDX (Content System / Visual Styles / {slug})
+ *   - Portal onboarding picker (thumbnail + caption next to each option)
+ *   - Client-facing proposals and mood boards
+ */
+export interface VisualStyleExample {
+    /** The dominant style this example expresses. */
+    primaryStyle: VisualStyle;
+    /**
+     * Zero or more styles layered over `primaryStyle`. Empty for a pure
+     * expression. Modifier order is significant (first pick dominates).
+     */
+    modifierStyles: readonly VisualStyle[];
+    /** Canonical hosted URL of the reference image (PNG/WEBP). */
+    referenceImageUrl: string;
+    /**
+     * Optional source URL that inspired the composition (Webflow template,
+     * published site, etc). Preserved for attribution + follow-up research.
+     */
+    referenceSiteUrl?: string;
+    /** Optional human-readable caption — "Minimal × Colorful — soft take". */
+    caption?: string;
+}
+export declare const VISUAL_STYLE_EXAMPLES: readonly VisualStyleExample[];
+/**
+ * All examples that feature `style` as the primary or as a modifier.
+ * Used by Storybook per-style pages and the portal onboarding picker.
+ */
+export declare const getVisualStyleExamples: (style: VisualStyle) => readonly VisualStyleExample[];
+/**
+ * The canonical "pure" example for a style — first entry where the style
+ * is the primary and there are no modifiers. Returns undefined if the
+ * style has no standalone example authored yet.
+ */
+export declare const getPrimaryVisualStyleExample: (style: VisualStyle) => VisualStyleExample | undefined;
+//# sourceMappingURL=visual-style.d.ts.map

--- a/dist/content-system/vocabularies/visual-style.js
+++ b/dist/content-system/vocabularies/visual-style.js
@@ -1,0 +1,71 @@
+/**
+ * Visual Style — the 13 canonical style directions captured in the client portal.
+ *
+ * Drives theme token selection (palette density, typography, spacing),
+ * imagery treatment, and blueprint shortlist trimming. Distinct from
+ * Personality — a "Playful" personality can be expressed in a "Minimal"
+ * visual style, and those tradeoffs are where craftwork lives.
+ *
+ * Clients pick up to 3. "Minimal" and "Playful" also appear in Personality;
+ * "Luxurious" overlaps with Personality's "Luxury" (intentional — singular
+ * adjective form in Personality, adverbial form here).
+ *
+ * Ordering mirrors the portal's onboarding picker so the eventual
+ * `taxonomy.ts` → BCS import swap is a zero-reorder change.
+ */
+export const VISUAL_STYLE_VALUES = [
+    'Minimal',
+    'Bold',
+    'Editorial',
+    'Playful',
+    'Luxurious',
+    'Modern',
+    'Classic',
+    'Dark',
+    'Light',
+    'Colorful',
+    'Monochrome',
+    'Textural',
+    'Brutalist',
+];
+export const isVisualStyle = (value) => VISUAL_STYLE_VALUES.includes(value);
+/**
+ * Image URLs resolve to `.storybook/public/visual-styles/*.png` hosted at
+ * `https://storybook.brikdesigns.com/visual-styles/{file}`. Source artboards
+ * live in Paper `bds-theming` (file 01KPH6ANXVEPBJ4PAVB7V380JH).
+ *
+ * Bold + Editorial have no Paper artboard yet — their slots ship empty
+ * and get populated when those styles get dedicated hero references.
+ *
+ * See `.storybook/public/visual-styles/README.md` for the export drop-in
+ * convention (filenames + source artboard IDs).
+ */
+const IMG_BASE = 'https://storybook.brikdesigns.com/visual-styles';
+export const VISUAL_STYLE_EXAMPLES = [
+    { primaryStyle: 'Minimal', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/minimal.png`, referenceSiteUrl: 'https://leadify-template.webflow.io' },
+    { primaryStyle: 'Bold', modifierStyles: [], referenceImageUrl: '' },
+    { primaryStyle: 'Editorial', modifierStyles: [], referenceImageUrl: '' },
+    { primaryStyle: 'Playful', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/playful.png`, referenceSiteUrl: 'https://pizza-guy.webflow.io' },
+    { primaryStyle: 'Luxurious', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/luxurious.png`, referenceSiteUrl: 'https://villabliss-wbs.webflow.io' },
+    { primaryStyle: 'Modern', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/modern.png`, referenceSiteUrl: 'https://gradienttemplates.webflow.io' },
+    { primaryStyle: 'Classic', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/classic.png`, caption: 'Editorial masthead tradition' },
+    { primaryStyle: 'Brutalist', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/brutalist.png`, referenceSiteUrl: 'https://blacksmith-sbj.webflow.io' },
+    // Modifier-demo compositions from Paper bds-theming
+    { primaryStyle: 'Modern', modifierStyles: ['Dark'], referenceImageUrl: `${IMG_BASE}/modern-dark.png`, caption: 'Modern × Dark' },
+    { primaryStyle: 'Brutalist', modifierStyles: ['Light'], referenceImageUrl: `${IMG_BASE}/brutalist-light.png`, caption: 'Brutalist × Light' },
+    { primaryStyle: 'Minimal', modifierStyles: ['Colorful'], referenceImageUrl: `${IMG_BASE}/minimal-colorful.png`, caption: 'Minimal × Colorful' },
+    { primaryStyle: 'Luxurious', modifierStyles: ['Monochrome'], referenceImageUrl: `${IMG_BASE}/luxurious-monochrome.png`, caption: 'Luxurious × Monochrome' },
+    { primaryStyle: 'Classic', modifierStyles: ['Textural'], referenceImageUrl: `${IMG_BASE}/classic-textural.png`, caption: 'Classic × Textural' },
+];
+/**
+ * All examples that feature `style` as the primary or as a modifier.
+ * Used by Storybook per-style pages and the portal onboarding picker.
+ */
+export const getVisualStyleExamples = (style) => VISUAL_STYLE_EXAMPLES.filter((ex) => ex.primaryStyle === style || ex.modifierStyles.includes(style));
+/**
+ * The canonical "pure" example for a style — first entry where the style
+ * is the primary and there are no modifiers. Returns undefined if the
+ * style has no standalone example authored yet.
+ */
+export const getPrimaryVisualStyleExample = (style) => VISUAL_STYLE_EXAMPLES.find((ex) => ex.primaryStyle === style && ex.modifierStyles.length === 0);
+//# sourceMappingURL=visual-style.js.map

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Release summary

Bumps `@brikdesigns/bds` from **0.11.0 → 0.12.0**. Batches [#124](https://github.com/brikdesigns/brik-bds/pull/124) + [#126](https://github.com/brikdesigns/brik-bds/pull/126).

| # | Type | Summary |
|---|---|---|
| [#124](https://github.com/brikdesigns/brik-bds/pull/124) | feat! | Replace `VISUAL_STYLE_METADATA` with `VISUAL_STYLE_EXAMPLES` list-shaped registry (Option D) |
| [#126](https://github.com/brikdesigns/brik-bds/pull/126) | feat | Populate 11 of 13 `VISUAL_STYLE_EXAMPLES` with canonical URLs + drop-in README |

## Breaking changes

- `VISUAL_STYLE_METADATA`, `VisualStyleMetadata`, `getVisualStyleMetadata` removed. Migrate to `VISUAL_STYLE_EXAMPLES` + `getPrimaryVisualStyleExample(style)`. Verified no live consumers in portal, renew-pms, or brikdesigns at v0.11.0.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run validate:blueprints` passes
- [x] `npm run lint-tokens` clean
- [x] Pre-push gate: all 6 checks pass
- [x] Dist rebuilt: content-system vocabularies split out (new `dist/content-system/vocabularies/*`)
- [ ] After merge: `npm publish` to GitHub Packages
- [ ] After publish: portal `npm update @brikdesigns/bds` (no breaking changes for portal since it doesn't consume the removed exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)