### PR TITLE
chore(release)!: v0.13.0 — Bold + Editorial references + full PNG set

### DIFF
--- a/dist/content-system/vocabularies/visual-style.js
+++ b/dist/content-system/vocabularies/visual-style.js
@@ -34,17 +34,14 @@ export const isVisualStyle = (value) => VISUAL_STYLE_VALUES.includes(value);
  * `https://storybook.brikdesigns.com/visual-styles/{file}`. Source artboards
  * live in Paper `bds-theming` (file 01KPH6ANXVEPBJ4PAVB7V380JH).
  *
- * Bold + Editorial have no Paper artboard yet — their slots ship empty
- * and get populated when those styles get dedicated hero references.
- *
  * See `.storybook/public/visual-styles/README.md` for the export drop-in
  * convention (filenames + source artboard IDs).
  */
 const IMG_BASE = 'https://storybook.brikdesigns.com/visual-styles';
 export const VISUAL_STYLE_EXAMPLES = [
     { primaryStyle: 'Minimal', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/minimal.png`, referenceSiteUrl: 'https://leadify-template.webflow.io' },
-    { primaryStyle: 'Bold', modifierStyles: [], referenceImageUrl: '' },
-    { primaryStyle: 'Editorial', modifierStyles: [], referenceImageUrl: '' },
+    { primaryStyle: 'Bold', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/bold.png`, caption: 'Contemporary display poster' },
+    { primaryStyle: 'Editorial', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/editorial.png`, caption: 'Magazine feature story' },
     { primaryStyle: 'Playful', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/playful.png`, referenceSiteUrl: 'https://pizza-guy.webflow.io' },
     { primaryStyle: 'Luxurious', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/luxurious.png`, referenceSiteUrl: 'https://villabliss-wbs.webflow.io' },
     { primaryStyle: 'Modern', modifierStyles: [], referenceImageUrl: `${IMG_BASE}/modern.png`, referenceSiteUrl: 'https://gradienttemplates.webflow.io' },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Release PR batching one merged feature PR into a publishable v0.13.0.

- **feat(content-system): wire Bold + Editorial reference images + drop in all 13 Visual Style PNGs** (#128)
  - Fills previously-empty `VISUAL_STYLE_EXAMPLES` slots for `Bold` (`8W-0`) and `Editorial` (`9O-0`)
  - Lands the full 13-artboard PNG set at `.storybook/public/visual-styles/`
  - Every `referenceImageUrl` in the registry now resolves (no more 404s)

Non-breaking — only new artwork + two data-row URL populations. The `!` on the release commit follows the established BDS release convention (see v0.11.0, v0.12.0), not a semver signal.

## Version bump

`0.12.0` → `0.13.0` — minor bump (new data + assets, backwards-compatible)

## Test plan

- [ ] CI passes (token lint, grid audit, theme compliance, blueprint library, TypeScript, Storybook build)
- [ ] After merge: manually publish to GitHub Packages with `npm publish`
- [ ] Verify https://storybook.brikdesigns.com/visual-styles/bold.png + `editorial.png` (and the other 11) resolve on next Storybook deploy
- [ ] Consumer sync (portal, renew-pms via npm; brikdesigns via submodule) on their next routine refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)