### PR TITLE
chore(release)!: v0.14.0 — Sheet secondaryAction + vitest suite repair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Release PR batching two merged PRs into publishable v0.14.0.

- **feat(sheet): add secondaryAction slot + tab-aware auto-footer layout** ([#130](https://github.com/brikdesigns/brik-bds/pull/130))
  - New `SheetProps.secondaryAction` = `{ label, onClick, icon?, loading?, disabled? }`
  - Renders left of the auto-footer's primary actions in **read mode** only (suppressed in edit to keep Save's commit surface unambiguous)
  - Threaded through `SheetConfig` so headless sheets can set it alongside `tabs` / `mode` / `onEdit`
  - Footer layout: `.bds-sheet__footer-secondary` + `.bds-sheet__footer-primary` with `justify-content: space-between`; `:empty` hides the left group so existing sheets are visually unchanged
  - Enables the portal's Refresh Brief / Run Extraction pattern without forcing consumers to override `footer`
  - Storybook + MDX coverage added for `Tabs`, `SecondaryAction`, and `TabsWithSecondaryAction` (tabs were in code but had no story / doc section before)

- **fix(test): repair vitest browser-provider + storybook project annotations** ([#131](https://github.com/brikdesigns/brik-bds/pull/131))
  - Vitest 4 changed `browser.provider` from string → factory import (`playwright()` from `@vitest/browser-playwright`)
  - `@storybook/addon-vitest` no longer auto-wires `setProjectAnnotations([preview])` in the vitest setup — added explicitly
  - Before: suite couldn't initialize (0 runnable). After: 263 / 266 pass
  - 3 remaining failures are pre-existing interaction-test flakes (DatePicker / Switch / TimePicker Playground) — same class as [#48](https://github.com/brikdesigns/brik-bds/pull/48); worth a follow-up

Non-breaking additive API. The `!` on the release commit follows the established BDS release convention (see v0.11.0 – v0.13.0), not a semver signal.

## Version bump

`0.13.0` → `0.14.0` — minor bump (additive Sheet API).

## Test plan

- [ ] CI passes (token lint, grid audit, theme compliance, blueprint library, TypeScript, Storybook build, vitest)
- [ ] After merge: manually publish to GitHub Packages with `npm publish`
- [ ] Consumer sync — portal `npm update @brikdesigns/bds` to pick up `secondaryAction` for the strategic-brief refresh migration (next portal PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)