### PR TITLE
feat(indicators): unify sm pill padding + Indicators vs Actions guardrails

### DIFF
--- a/components/ui/Badge/Badge.mdx
+++ b/components/ui/Badge/Badge.mdx
@@ -9,6 +9,21 @@ Status indicators and labels for displaying contextual information. Badges use s
 
 ---
 
+## Indicators vs Actions
+
+Badge is an **indicator** — non-interactive. It reflects state (published, in review, archived). Never wire `onClick`, never wrap in a link, never use Badge to trigger behavior.
+
+| Family | Components | When to use |
+|---|---|---|
+| **Indicator** (display state) | `Badge`, `Tag`, `Dot`, `AlertBanner` | Labeling a record's status, category, or metadata. Read-only. |
+| **Action** (user-initiated) | `Button`, `LinkButton`, `IconButton`, `FilterButton`, `Chip` | Triggering navigation, mutation, filtering, or selection. |
+
+**Badge vs Tag:** Badge carries a semantic status color (positive/warning/error/info/progress/brand). Tag is categorical — no status meaning, neutral styling. Use Badge when the state has a value judgment (good/bad/waiting); use Tag when it doesn't (industry, size, owner).
+
+**Badge vs Chip:** If it's clickable, it's a Chip, not a Badge. "Status: Active" with a dismiss X on an active-filter row is a Chip (user can remove it). "Status: Active" in a read-only table cell is a Badge (just reflecting state).
+
+---
+
 ## Playground
 
 Use the Controls panel to explore all props interactively.

--- a/components/ui/Badge/Badge.tsx
+++ b/components/ui/Badge/Badge.tsx
@@ -26,11 +26,17 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 /**
- * Badge — status indicator with semantic colors
+ * Badge — status indicator with semantic colors.
  *
  * Pill-shaped label for communicating status, category, or count.
  * Uses BDS system color tokens for consistent status semantics.
  * Sizing scale is shared with Tag for side-by-side alignment.
+ *
+ * **Indicator, not action.** Badge is non-interactive. Render it as a
+ * `<span>` reflecting state; never attach `onClick` or wrap it to
+ * navigate. For clickable pills use `Chip` (filters, selections) or
+ * `Button` / `LinkButton` (primary actions). See the "Indicators vs
+ * Actions" section of Badge.mdx for the full decision tree.
  *
  * @example
  * ```tsx

--- a/components/ui/Chip/Chip.css
+++ b/components/ui/Chip/Chip.css
@@ -44,7 +44,7 @@
 /* ─── Sizes ───────────────────────────────────────────────────── */
 
 .bds-chip--sm {
-  padding: var(--space-150) var(--padding-sm);
+  padding: var(--padding-tiny) var(--padding-sm);
   font-size: var(--label-tiny);
   gap: var(--gap-xs);
   height: 28px;

--- a/components/ui/Chip/Chip.mdx
+++ b/components/ui/Chip/Chip.mdx
@@ -5,7 +5,26 @@ import * as Stories from './Chip.stories';
 
 # Chip
 
-Compact label for categorization, filtering, or selection. Use for filter pills, dropdown triggers, and multi-select tokens.
+Compact interactive pill for filtering, selection, and removable tokens. Use for filter dropdown triggers, active-filter chips, and multi-select state.
+
+---
+
+## Indicators vs Actions
+
+Chip is an **action** — always interactive. Render a Chip only when `onChipClick`, `onRemove`, or `showDropdown` is wired up. A Chip with no handler is a bug — use `Badge` (status) or `Tag` (category) instead.
+
+| Family | Components | When to use |
+|---|---|---|
+| **Indicator** (display state) | `Badge`, `Tag`, `Dot`, `AlertBanner` | Labeling a record's status, category, or metadata. Read-only. |
+| **Action** (user-initiated) | `Button`, `LinkButton`, `IconButton`, `FilterButton`, `Chip` | Triggering navigation, mutation, filtering, or selection. |
+
+**Chip vs FilterButton vs Button:**
+
+- `Button` — primary CTAs, form submits, primary workflows. Rectangular.
+- `FilterButton` — dropdown trigger inside a `FilterBar`. Encapsulates the dropdown state machine.
+- `Chip` — compact pill for filter selections *after* a choice is made ("Status: Active" with X), multi-select tokens, or secondary toggle pills. Pair with FilterButton, don't duplicate it.
+
+**Chip vs Badge / Tag:** If the pill is read-only — rendered from data, not clickable — use `Badge` (status) or `Tag` (category). "Published" in a read-only table cell is a Badge. "Published" as a toggleable filter in a facet sidebar is a Chip.
 
 ---
 

--- a/components/ui/Chip/Chip.tsx
+++ b/components/ui/Chip/Chip.tsx
@@ -32,15 +32,24 @@ export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childre
 }
 
 /**
- * Chip — compact interactive element for filtering, selection, or input
+ * Chip — compact interactive pill for filtering, selection, or input.
  *
- * Pill-shaped with two variants (primary/secondary) and two appearances (dark/light).
+ * Pill-shaped with two variants (primary/secondary) and two appearances
+ * (dark/light).
+ *
+ * **Action, not indicator.** Chip always represents user-initiated
+ * state: filter toggles, selection chips, removable tokens, dropdown
+ * triggers. Render a Chip only when `onChipClick`, `onRemove`, or
+ * `showDropdown` is wired up. For static status / metadata labels use
+ * `Badge` (semantic status) or `Tag` (categorization). See the
+ * "Indicators vs Actions" section of Chip.mdx for the full decision
+ * tree.
  *
  * @example
  * ```tsx
- * <Chip label="Category" />
- * <Chip label="Selected" variant="primary" appearance="dark" />
- * <Chip label="Removable" onRemove={() => {}} />
+ * <Chip label="All statuses" showDropdown onChipClick={openMenu} />
+ * <Chip label="Status: Active" onRemove={() => removeFilter('status')} />
+ * <Chip label="Selected" variant="primary" appearance="dark" onChipClick={toggle} />
  * ```
  */
 export function Chip({

--- a/components/ui/Tag/Tag.mdx
+++ b/components/ui/Tag/Tag.mdx
@@ -5,7 +5,22 @@ import * as Stories from './Tag.stories';
 
 # Tag
 
-Categorization and filtering labels with optional left/right icons and remove functionality. Available in three sizes (`sm`, `md`, `lg`).
+Categorization labels for classifying records — industry, segment, owner, size. Available in three sizes (`sm`, `md`, `lg`) plus `xs` icon-only.
+
+---
+
+## Indicators vs Actions
+
+Tag is an **indicator** — non-interactive. It labels *what a record is*, not *what a user can do*. Never wire `onClick`, never wrap in a link.
+
+| Family | Components | When to use |
+|---|---|---|
+| **Indicator** (display state) | `Badge`, `Tag`, `Dot`, `AlertBanner` | Labeling a record's status, category, or metadata. Read-only. |
+| **Action** (user-initiated) | `Button`, `LinkButton`, `IconButton`, `FilterButton`, `Chip` | Triggering navigation, mutation, filtering, or selection. |
+
+**Tag vs Badge:** Tag is neutral categorization (no status meaning). Badge carries a semantic status color (positive/warning/error/info/progress/brand). Industry=`Dental` → Tag. Status=`Active` → Badge.
+
+**Tag vs Chip:** If the pill is clickable — toggling a filter, dismissing an active filter, opening a dropdown — it's a Chip, not a Tag. Tag's `onRemove` prop is **deprecated** (see Props below) because it contradicts the indicator contract; migrate removable pills to Chip.
 
 ---
 
@@ -55,7 +70,8 @@ import { Icon } from '@iconify/react';
 // Right icon
 <Tag trailingIcon={<Icon icon="ph:x-circle" />}>Dismiss</Tag>
 
-// Removable tag
+// Removable tag — DEPRECATED (see "Indicators vs Actions" above).
+// Use Chip with onRemove for removable/interactive pills.
 <Tag onRemove={() => console.log('Removed')}>Filter</Tag>
 
 // Disabled tag

--- a/components/ui/Tag/Tag.tsx
+++ b/components/ui/Tag/Tag.tsx
@@ -17,23 +17,34 @@ export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
   icon?: ReactNode;
   /** Optional trailing icon (right) */
   trailingIcon?: ReactNode;
-  /** Show dismiss button and callback */
+  /**
+   * Show dismiss button and callback.
+   * @deprecated Tag is an indicator — non-interactive by design. For
+   *   removable pills (active filters, dismissible selections) use
+   *   `Chip` with `onRemove` instead. This prop will be removed once
+   *   portal/renew-pms/brikdesigns migrate their last callsites.
+   */
   onRemove?: () => void;
   /** Disabled state */
   disabled?: boolean;
 }
 
 /**
- * Tag — categorization label with optional icons and dismiss
+ * Tag — categorization label.
  *
  * Sizing scale is shared with Badge for side-by-side alignment.
+ *
+ * **Indicator, not action.** Tag is non-interactive by design — use it
+ * to label categories, classifications, or metadata. For interactive
+ * pills (filter selections, removable chips) use `Chip`. See the
+ * "Indicators vs Actions" section of Tag.mdx for the full decision
+ * tree.
  *
  * @example
  * ```tsx
  * <Tag>Category</Tag>
  * <Tag size="xs" icon={<Icon />} />
  * <Tag size="lg" icon={<Icon />}>With Icon</Tag>
- * <Tag onRemove={() => handleRemove()}>Removable</Tag>
  * ```
  */
 export function Tag({


### PR DESCRIPTION
## Summary

- Aligns **Chip sm** vertical padding from `--space-150` (6px raw) to `--padding-tiny` (8px semantic) so Badge + Tag + Chip now share the same padding vocabulary at every size.
- Adds an **Indicators vs Actions** guardrail block to the top of Badge.mdx / Tag.mdx / Chip.mdx with a decision tree — indicator (Badge, Tag, Dot, AlertBanner) vs action (Button, LinkButton, IconButton, FilterButton, Chip).
- JSDoc callouts restate the contract on Badge / Tag / Chip source files so editor tooltips carry the rule.
- Marks `Tag.onRemove` as `@deprecated` — interactive affordance contradicts the indicator contract; consumer migration to Chip is tracked as a follow-up.

## Why

The inspector drift we saw on staging (Badge sm using `--padding-tiny/--padding-sm`, Chip sm using `--space-150/--padding-sm`) broke the "one set of tokens tells one story" principle. With this change, `--space-*` primitives disappear from the indicator/action component surface entirely — everything routes through `--padding-*`.

The Indicators vs Actions guardrail addresses a repeated pattern where consumers reach for Chip when they want a read-only status (should be Badge) or stick status on a Tag (should be Badge). Per design intent: **Badge/Tag/Dot = display only. Chip/Button/FilterButton = interactive.**

## Test plan

- [ ] Storybook: visual check on Badge + Tag alignment story — no regression
- [ ] Storybook: Chip Variants + Patterns — sm pill height still 28px, text still centered
- [ ] Storybook: the new "Indicators vs Actions" MDX block renders on all three component docs
- [ ] Typecheck / tests — 3 pre-existing flakes (DatePicker / Switch / TimePicker play) are unchanged

## Follow-ups (separate PRs)

- Audit and migrate `Tag.onRemove` callsites across portal / renew-pms / brikdesigns to `Chip`
- Then remove `onRemove` from `TagProps` in a breaking BDS release
- Consider promoting the "Indicators vs Actions" block to a top-level `Patterns/IndicatorsVsActions.mdx` if the per-component placement isn't discoverable enough

🤖 Generated with [Claude Code](https://claude.com/claude-code)