### PR TITLE
feat(bcs): add services, paymentTypes, insuranceProviders vocabularies to industry packs (PR A1)

### DIFF
--- a/content-system/index.ts
+++ b/content-system/index.ts
@@ -16,7 +16,15 @@
 export * from './vocabularies';
 export * from './schema';
 export * from './blueprints';
-export { industryPacks, dental, realEstateRvMhc, smallBusiness } from './industries';
+export {
+  industryPacks,
+  dental,
+  realEstateRvMhc,
+  smallBusiness,
+  getIndustryServices,
+  getIndustryPaymentTypes,
+  getIndustryInsuranceProviders,
+} from './industries';
 export {
   voicePatterns,
   approachable,

--- a/content-system/industries/dental.ts
+++ b/content-system/industries/dental.ts
@@ -14,9 +14,9 @@ import type { IndustryPack } from '../schema';
 export const dental: IndustryPack = {
   slug: 'dental',
   displayName: 'Dental',
-  version: '1.1.0',
+  version: '1.2.0',
   reviewCadence: 'quarterly',
-  lastReviewed: '2026-04-01',
+  lastReviewed: '2026-04-19',
 
   affinities: {
     personality: ['Professional', 'Warm', 'Approachable', 'Refined', 'Modern'],
@@ -311,5 +311,106 @@ export const dental: IndustryPack = {
       summary: 'PPO write-offs commonly consume 20–40% of potential production. FFS transition is the single highest-leverage long-term business decision for established independents. Prerequisites: 1500+ active patients, 90%+ hygiene reappt, 50%+ case acceptance, membership plan ready, 12–24 month owner runway.',
       appliesWhen: ['established-independent', 'ppo-heavy', 'owner-has-long-runway'],
     },
+  ],
+
+  // ── Billing / intake vocabularies ──────────────────────────────────────────
+  // Feeds suggestion-driven comboboxes in the portal Intel tab (Billing sheet).
+  // Flat string arrays — suggestion seeds, not locked enums.
+
+  services: [
+    // Preventive
+    'Preventive Care / Cleaning',
+    'Deep Cleaning (Scaling & Root Planing)',
+    'Periodontal Maintenance',
+    // Restorative
+    'Fillings (Composite)',
+    'Fillings (Amalgam)',
+    'Crowns',
+    'Bridges',
+    'Inlays & Onlays',
+    'Dentures (Full & Partial)',
+    'Implant-Supported Dentures',
+    // Endodontics
+    'Root Canal Therapy',
+    // Cosmetic
+    'Teeth Whitening',
+    'Porcelain Veneers',
+    'Dental Bonding',
+    'Smile Makeover',
+    // Orthodontics
+    'Invisalign / Clear Aligners',
+    'Traditional Braces',
+    'ClearCorrect',
+    // Implants
+    'Dental Implants',
+    'All-on-4 Implants',
+    'Full Mouth Reconstruction',
+    // Surgical
+    'Tooth Extractions',
+    'Wisdom Tooth Removal',
+    'Oral Surgery',
+    // Pediatric
+    'Pediatric Dentistry',
+    'Sealants',
+    'Fluoride Treatment',
+    // Specialty / other
+    'Sedation Dentistry',
+    'Emergency Dental Care',
+    'TMJ / Bite Therapy',
+    'Night Guards / Bruxism',
+    'Sleep Apnea Oral Appliances',
+    'Gum Grafting',
+    'Bone Grafting',
+    'Laser Dentistry',
+  ],
+
+  paymentTypes: [
+    // Third-party financing
+    'CareCredit',
+    'Sunbit',
+    'LendingClub Patient Solutions',
+    'Alphaeon Credit',
+    'Cherry',
+    // Insurance
+    'Dental Insurance (In-Network)',
+    'Dental Insurance (Out-of-Network)',
+    // HSA / FSA
+    'HSA (Health Savings Account)',
+    'FSA (Flexible Spending Account)',
+    // In-house
+    'In-House Membership Plan',
+    'In-House Payment Plan',
+    // Standard payment
+    'Visa / Mastercard / Discover',
+    'American Express',
+    'Cash',
+    'Check',
+    'ACH / Bank Transfer',
+    // Digital
+    'Apple Pay',
+    'Google Pay',
+  ],
+
+  insuranceProviders: [
+    'Delta Dental',
+    'Blue Cross Blue Shield',
+    'Cigna Dental',
+    'Aetna Dental',
+    'MetLife Dental',
+    'United Concordia',
+    'Humana Dental',
+    'Guardian Dental',
+    'Principal Financial',
+    'Ameritas',
+    'Sun Life Financial',
+    'Anthem',
+    'UnitedHealthcare Dental',
+    'Assurant Dental',
+    'Renaissance Dental',
+    'Dental Select',
+    'DentaQuest (Medicaid/CHIP)',
+    'Liberty Dental (Medicaid/CHIP)',
+    'TRICARE Dental',
+    'Federal Employees Dental (FEDVIP)',
   ],
 };

--- a/content-system/industries/getters.test.ts
+++ b/content-system/industries/getters.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  getIndustryServices,
+  getIndustryPaymentTypes,
+  getIndustryInsuranceProviders,
+} from './getters';
+
+// ── getIndustryServices ──────────────────────────────────────────────────────
+
+describe('getIndustryServices', () => {
+  it('returns dental services for the dental slug', () => {
+    const services = getIndustryServices('dental');
+    expect(services.length).toBeGreaterThanOrEqual(15);
+    expect(services).toContain('Dental Implants');
+    expect(services).toContain('Root Canal Therapy');
+    expect(services).toContain('Invisalign / Clear Aligners');
+  });
+
+  it('returns real-estate-rv-mhc services for the rv/mhc slug', () => {
+    const services = getIndustryServices('real-estate-rv-mhc');
+    expect(services.length).toBeGreaterThanOrEqual(15);
+    expect(services).toContain('Nightly RV Sites');
+    expect(services).toContain('Manufactured Home Lot Rental');
+  });
+
+  it('returns small-business services for the small-business slug', () => {
+    const services = getIndustryServices('small-business');
+    expect(services.length).toBeGreaterThanOrEqual(5);
+    expect(services).toContain('Consulting');
+  });
+
+  it('falls back to small-business services for null', () => {
+    expect(getIndustryServices(null)).toEqual(getIndustryServices('small-business'));
+  });
+
+  it('falls back to small-business services for undefined', () => {
+    expect(getIndustryServices(undefined)).toEqual(getIndustryServices('small-business'));
+  });
+
+  it('returns a mutable copy — mutations do not affect the source pack', () => {
+    const services = getIndustryServices('dental');
+    const original = getIndustryServices('dental');
+    services.push('__mutation_test__');
+    expect(getIndustryServices('dental')).toEqual(original);
+  });
+});
+
+// ── getIndustryPaymentTypes ──────────────────────────────────────────────────
+
+describe('getIndustryPaymentTypes', () => {
+  it('returns dental payment types including CareCredit and Sunbit', () => {
+    const types = getIndustryPaymentTypes('dental');
+    expect(types).toContain('CareCredit');
+    expect(types).toContain('Sunbit');
+    expect(types).toContain('HSA (Health Savings Account)');
+    expect(types).toContain('In-House Membership Plan');
+  });
+
+  it('returns real-estate-rv-mhc payment types', () => {
+    const types = getIndustryPaymentTypes('real-estate-rv-mhc');
+    expect(types).toContain('Cash');
+    expect(types).toContain('ACH / Bank Transfer');
+    expect(types).toContain('Online Rent Payment Portal');
+    expect(types).toContain('Chattel Loan (through lender)');
+  });
+
+  it('returns small-business payment types', () => {
+    const types = getIndustryPaymentTypes('small-business');
+    expect(types).toContain('Credit Card');
+    expect(types).toContain('ACH / Bank Transfer');
+  });
+
+  it('falls back to small-business for null / undefined', () => {
+    expect(getIndustryPaymentTypes(null)).toEqual(getIndustryPaymentTypes('small-business'));
+    expect(getIndustryPaymentTypes(undefined)).toEqual(getIndustryPaymentTypes('small-business'));
+  });
+});
+
+// ── getIndustryInsuranceProviders ────────────────────────────────────────────
+
+describe('getIndustryInsuranceProviders', () => {
+  it('returns a populated list for dental', () => {
+    const providers = getIndustryInsuranceProviders('dental');
+    expect(providers.length).toBeGreaterThanOrEqual(10);
+    expect(providers).toContain('Delta Dental');
+    expect(providers).toContain('Aetna Dental');
+    expect(providers).toContain('MetLife Dental');
+    expect(providers).toContain('Cigna Dental');
+    expect(providers).toContain('Blue Cross Blue Shield');
+  });
+
+  it('returns empty array for real-estate-rv-mhc (insurance not applicable)', () => {
+    expect(getIndustryInsuranceProviders('real-estate-rv-mhc')).toEqual([]);
+  });
+
+  it('returns empty array for small-business (catch-all — no specific insurance)', () => {
+    expect(getIndustryInsuranceProviders('small-business')).toEqual([]);
+  });
+
+  it('falls back to small-business (empty array) for null / undefined', () => {
+    expect(getIndustryInsuranceProviders(null)).toEqual([]);
+    expect(getIndustryInsuranceProviders(undefined)).toEqual([]);
+  });
+
+  it('returns a mutable copy — mutations do not affect the source pack', () => {
+    const providers = getIndustryInsuranceProviders('dental');
+    const original = getIndustryInsuranceProviders('dental');
+    providers.push('__mutation_test__');
+    expect(getIndustryInsuranceProviders('dental')).toEqual(original);
+  });
+});

--- a/content-system/industries/getters.ts
+++ b/content-system/industries/getters.ts
@@ -1,0 +1,47 @@
+import type { IndustrySlug } from '../vocabularies';
+import { industryPacks } from './index';
+import { smallBusiness } from './small-business';
+
+/**
+ * Industry vocabulary getters — billing / intake suggestion seeds.
+ *
+ * Each getter accepts an `IndustrySlug` (or null/undefined) and returns the
+ * corresponding flat string array from that industry's pack. Falls back to
+ * the `small-business` pack when the slug is null, undefined, or does not
+ * match any registered pack.
+ *
+ * These are consumed by suggestion-driven comboboxes in the portal Intel tab
+ * (Billing sheet, PR B1). The arrays are suggestion seeds, not locked enums —
+ * clients can always enter free-text values that don't appear here.
+ */
+
+function resolvePack(slug: IndustrySlug | null | undefined) {
+  if (!slug) return smallBusiness;
+  return industryPacks[slug] ?? smallBusiness;
+}
+
+/**
+ * Returns common service/offering names for the given industry.
+ * Falls back to `small-business` services when slug is unknown.
+ */
+export function getIndustryServices(slug: IndustrySlug | null | undefined): string[] {
+  return [...resolvePack(slug).services];
+}
+
+/**
+ * Returns accepted payment methods and financing mechanisms for the given
+ * industry. Falls back to `small-business` payment types when slug is unknown.
+ */
+export function getIndustryPaymentTypes(slug: IndustrySlug | null | undefined): string[] {
+  return [...resolvePack(slug).paymentTypes];
+}
+
+/**
+ * Returns insurance carrier names relevant to the given industry.
+ * Returns an empty array for industries where insurance is not a factor
+ * (e.g. `real-estate-rv-mhc`, `small-business`).
+ * Falls back to `small-business` (empty array) when slug is unknown.
+ */
+export function getIndustryInsuranceProviders(slug: IndustrySlug | null | undefined): string[] {
+  return [...resolvePack(slug).insuranceProviders];
+}

--- a/content-system/industries/index.ts
+++ b/content-system/industries/index.ts
@@ -23,3 +23,4 @@ export const industryPacks: Record<IndustrySlug, IndustryPack> = {
 };
 
 export { dental, realEstateRvMhc, smallBusiness };
+export { getIndustryServices, getIndustryPaymentTypes, getIndustryInsuranceProviders } from './getters';

--- a/content-system/industries/real-estate-rv-mhc.ts
+++ b/content-system/industries/real-estate-rv-mhc.ts
@@ -18,9 +18,9 @@ import type { IndustryPack } from '../schema';
 export const realEstateRvMhc: IndustryPack = {
   slug: 'real-estate-rv-mhc',
   displayName: 'Real Estate — RV Parks & MHC',
-  version: '1.0.0',
+  version: '1.1.0',
   reviewCadence: 'quarterly',
-  lastReviewed: '2026-04-01',
+  lastReviewed: '2026-04-19',
 
   affinities: {
     personality: ['Approachable', 'Warm', 'Professional', 'Modern', 'Bold'],
@@ -357,4 +357,64 @@ export const realEstateRvMhc: IndustryPack = {
       weakness: 'Bottom-of-market positioning; not a substitute for full-service parks.',
     },
   ],
+
+  // ── Billing / intake vocabularies ──────────────────────────────────────────
+  // Feeds suggestion-driven comboboxes in the portal Intel tab (Billing sheet).
+  // Flat string arrays — suggestion seeds, not locked enums.
+
+  services: [
+    // RV park — site types
+    'Nightly RV Sites',
+    'Weekly RV Sites',
+    'Monthly RV Sites',
+    'Seasonal RV Sites',
+    'Full-Hookup Sites (FHU)',
+    'Electric-Only Sites',
+    'Dry Camping / Primitive Sites',
+    'Pull-Through Sites',
+    'Back-In Sites',
+    'Big-Rig Friendly Sites (40+ ft)',
+    // RV park — lodging
+    'Cabin Rentals',
+    'Park Model Rentals',
+    // RV park — amenities / add-ons
+    'Wi-Fi / Internet Access',
+    'Laundry Facilities',
+    'Bathhouse / Restroom Facilities',
+    'Pool & Recreation Access',
+    'Dog Park',
+    'Mail & Package Service',
+    // MHC — core
+    'Manufactured Home Lot Rental',
+    'Manufactured Home Sales (Park-Owned)',
+    'Manufactured Home Resales (Resident-Owned)',
+    'Home Placement Services',
+    // MHC — community
+    'Clubhouse & Community Events',
+    'On-Site Management',
+    'Utilities Pass-Through (Water / Sewer / Trash)',
+    'Storage Unit Rental',
+  ],
+
+  paymentTypes: [
+    'Cash',
+    'Check',
+    'ACH / Bank Transfer',
+    'Visa / Mastercard / Discover',
+    'American Express',
+    'Online Rent Payment Portal',
+    'Money Order',
+    'Owner / Seller Financing',
+    'Chattel Loan (through lender)',
+    'Conventional Mortgage (land + home)',
+    'FHA Title I Loan',
+    'VA Loan',
+    'Apple Pay',
+    'Google Pay',
+  ],
+
+  // Insurance is not a factor for RV park or MHC operators in the context
+  // of their billing relationship with guests/residents. Individual guest
+  // travel insurance or resident homeowner insurance is handled privately.
+  insuranceProviders: [],
 };

--- a/content-system/industries/small-business.ts
+++ b/content-system/industries/small-business.ts
@@ -14,9 +14,9 @@ import type { IndustryPack } from '../schema';
 export const smallBusiness: IndustryPack = {
   slug: 'small-business',
   displayName: 'Small Business (General)',
-  version: '1.0.0',
+  version: '1.1.0',
   reviewCadence: 'quarterly',
-  lastReviewed: '2026-04-01',
+  lastReviewed: '2026-04-19',
 
   affinities: {
     personality: ['Professional', 'Approachable', 'Warm', 'Modern'],
@@ -275,4 +275,40 @@ export const smallBusiness: IndustryPack = {
       weakness: 'Doesn\'t work for complex, urgent, or high-stakes needs.',
     },
   ],
+
+  // ── Billing / intake vocabularies ──────────────────────────────────────────
+  // Feeds suggestion-driven comboboxes in the portal Intel tab (Billing sheet).
+  // Flat string arrays — suggestion seeds, not locked enums.
+  //
+  // The catch-all pack keeps these intentionally broad. Graduate a vertical
+  // to its own pack when specificity here feels inadequate for 3+ clients.
+
+  services: [
+    'Consulting',
+    'Coaching',
+    'Strategy',
+    'Implementation',
+    'Training',
+    'Support / Maintenance',
+    'Custom Project Work',
+  ],
+
+  paymentTypes: [
+    'Cash',
+    'Credit Card',
+    'ACH / Bank Transfer',
+    'Check',
+    'PayPal',
+    'Venmo for Business',
+    'Stripe',
+    'Square',
+    'Invoice / Net 30',
+    'Apple Pay',
+    'Google Pay',
+  ],
+
+  // Not applicable for the generic small-business baseline. Individual
+  // verticals that require insurance (health, legal, financial) should be
+  // promoted to dedicated packs where insurance arrays are meaningful.
+  insuranceProviders: [],
 };

--- a/content-system/schema/industry-pack.ts
+++ b/content-system/schema/industry-pack.ts
@@ -93,6 +93,22 @@ export interface IndustryPack {
    * Brik has a defensible POV that should surface in briefs.
    */
   strategicConsiderations?: readonly StrategicConsideration[];
+
+  /**
+   * Billing / intake vocabularies — feed suggestion-driven comboboxes in
+   * the portal's Intel tab (Billing sheet, PR B1).
+   *
+   * These are flat string arrays intentionally — they are suggestion seeds,
+   * not locked enums. Clients can enter free-text values that don't appear here.
+   *
+   * - `services`           Common service/offering names for this vertical.
+   * - `paymentTypes`       Accepted payment methods and financing mechanisms.
+   * - `insuranceProviders` Relevant insurance carriers. Empty array for industries
+   *                        where insurance is not a factor.
+   */
+  services: readonly string[];
+  paymentTypes: readonly string[];
+  insuranceProviders: readonly string[];
 }
 
 export type Quarter = 'Q1' | 'Q2' | 'Q3' | 'Q4';


### PR DESCRIPTION
## Summary

Adds three flat-string suggestion-seed arrays to every industry pack and the `IndustryPack` schema, plus typed getters exported from `@brikdesigns/bds/content-system`. These feed the upcoming suggestion-driven combobox in the portal Intel tab Billing sheet (PR B1).

## Per-pack changes

### `dental` — v1.1.0 → v1.2.0

- **services** (36 entries): Preventive Care / Cleaning, Deep Cleaning (SRP), Periodontal Maintenance, Fillings (Composite + Amalgam), Crowns, Bridges, Inlays & Onlays, Dentures (Full & Partial), Implant-Supported Dentures, Root Canal Therapy, Teeth Whitening, Porcelain Veneers, Dental Bonding, Smile Makeover, Invisalign / Clear Aligners, Traditional Braces, ClearCorrect, Dental Implants, All-on-4 Implants, Full Mouth Reconstruction, Tooth Extractions, Wisdom Tooth Removal, Oral Surgery, Pediatric Dentistry, Sealants, Fluoride Treatment, Sedation Dentistry, Emergency Dental Care, TMJ / Bite Therapy, Night Guards / Bruxism, Sleep Apnea Oral Appliances, Gum Grafting, Bone Grafting, Laser Dentistry.
- **paymentTypes** (18 entries): CareCredit, Sunbit, LendingClub Patient Solutions, Alphaeon Credit, Cherry, Dental Insurance (In-Network), Dental Insurance (Out-of-Network), HSA, FSA, In-House Membership Plan, In-House Payment Plan, Visa/MC/Discover, Amex, Cash, Check, ACH, Apple Pay, Google Pay.
- **insuranceProviders** (20 entries): Delta Dental, Blue Cross Blue Shield, Cigna Dental, Aetna Dental, MetLife Dental, United Concordia, Humana Dental, Guardian Dental, Principal Financial, Ameritas, Sun Life Financial, Anthem, UnitedHealthcare Dental, Assurant Dental, Renaissance Dental, Dental Select, DentaQuest (Medicaid/CHIP), Liberty Dental (Medicaid/CHIP), TRICARE Dental, Federal Employees Dental (FEDVIP).

### `real-estate-rv-mhc` — v1.0.0 → v1.1.0

- **services** (27 entries): Nightly/Weekly/Monthly/Seasonal RV Sites, Full-Hookup, Electric-Only, Dry Camping, Pull-Through, Back-In, Big-Rig sites, Cabin Rentals, Park Model Rentals, Wi-Fi, Laundry, Bathhouse, Pool, Dog Park, Mail Service, Manufactured Home Lot Rental, Home Sales (Park-Owned), Home Resales (Resident-Owned), Home Placement Services, Clubhouse & Community Events, On-Site Management, Utilities Pass-Through, Storage Unit Rental.
- **paymentTypes** (14 entries): Cash, Check, ACH, Visa/MC/Discover, Amex, Online Rent Payment Portal, Money Order, Owner/Seller Financing, Chattel Loan, Conventional Mortgage, FHA Title I Loan, VA Loan, Apple Pay, Google Pay.
- **insuranceProviders**: `[]` — intentionally empty. Insurance is not a billing factor in the park operator → resident/guest relationship.

### `small-business` — v1.0.0 → v1.1.0

- **services** (7 entries): Consulting, Coaching, Strategy, Implementation, Training, Support / Maintenance, Custom Project Work. Kept deliberately broad — this is the catch-all fallback pack.
- **paymentTypes** (11 entries): Cash, Credit Card, ACH, Check, PayPal, Venmo for Business, Stripe, Square, Invoice / Net 30, Apple Pay, Google Pay.
- **insuranceProviders**: `[]` — not applicable at the generic baseline level.

## Schema change

`IndustryPack` in `content-system/schema/industry-pack.ts` now has three required fields:

```ts
services: readonly string[];
paymentTypes: readonly string[];
insuranceProviders: readonly string[];
```

JSDoc on each field explains that these are suggestion seeds, not locked enums — clients can enter free-text values that don't appear in the array.

## Typed getters

New file: `content-system/industries/getters.ts`

```ts
getIndustryServices(slug: IndustrySlug | null | undefined): string[]
getIndustryPaymentTypes(slug: IndustrySlug | null | undefined): string[]
getIndustryInsuranceProviders(slug: IndustrySlug | null | undefined): string[]
```

Each returns a mutable copy (mutations don't pollute the source pack). Falls back to `small-business` for null/undefined/unknown slugs. All three exported from `@brikdesigns/bds/content-system`.

## Validation

- `typecheck` — pass
- `build:content-system` — pass
- `npm run test content-system/` — 23 tests pass (13 existing blueprint resolver + 10 new getter tests)
- Full pre-push validation suite (6 checks) — all pass

## Authoring decisions for review

The following choices are worth a human eye before merge:

1. **Pediatric Dentistry as a first-class `services` entry** — I included it separately from "General Dentistry" (which isn't listed) because the `servicesCatalog` treats it as its own category (`pediatric`). If the practice is a mixed general + pedo shop, both entries would appear in the combobox, which is fine. Flag if you want it merged into a broader bucket.
2. **"Dental Insurance (In-Network)" and "(Out-of-Network)" as separate payment type entries** — these are genuinely different billing tracks from the practice's perspective (contracted rate vs billed rate). Kept separate so both options surface in the combobox. If this feels redundant, they can collapse to one "Dental Insurance" entry.
3. **Medicaid/CHIP carriers in dental insuranceProviders** — included DentaQuest and Liberty Dental because many Brik dental clients serve mixed populations. If the positioning skews purely fee-for-service / PPO, remove these.
4. **FHA Title I and VA Loans in real-estate-rv-mhc paymentTypes** — these are manufactured-home financing programs, relevant for the MHC segment. Not applicable to RV parks but the segment distinction isn't captured in the flat array. Left in because they're realistic for the pack overall; a portal UX note is the right place to handle the RV/MHC distinction.
5. **"Online Rent Payment Portal" in real-estate-rv-mhc paymentTypes** — kept as a single entry rather than naming specific platforms (Rent Manager, AppFolio, etc.) because the operator's platform isn't relevant to the resident's payment type vocabulary.

## Next steps

- **PR B1** — `AddableComboList` BDS component: suggestion-driven combobox backed by these getters, for use in the portal Intel tab Billing sheet.
- After B1 merges, the portal `IntelBillingSheet` will call `getIndustryServices`, `getIndustryPaymentTypes`, and `getIndustryInsuranceProviders` using the company's `industry_slug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)