### PR TITLE
feat(bcs): add ANIMATION_TIER + IMAGE_MOOD vocabularies

### DIFF
--- a/content-system/vocabularies/animation-tier.ts
+++ b/content-system/vocabularies/animation-tier.ts
@@ -1,0 +1,26 @@
+/**
+ * Animation Tier — the canonical motion intensity captured in the client portal.
+ *
+ * Single source of truth shared by the portal Visual Direction intel topic,
+ * the mockup generator's `resolveAnimationTierNote()` resolver, and the
+ * BDS animation toolkit (animation-toolkit.md). Drift here breaks the
+ * mockup pipeline silently — the worker reads this tier to decide which
+ * libraries (Lenis / GSAP / ScrollTrigger / Granim) to load and which
+ * interaction patterns Claude is allowed to generate.
+ *
+ * Clients pick exactly one. The tier carries forward from onboarding
+ * through design-preflight into every mockup variant.
+ *
+ * Tier semantics (matches `animation-toolkit.md`):
+ *   - subtle     — `.fade-up` IntersectionObserver only. No GSAP.
+ *   - moderate   — fade-ups + SplitText hero H1 + stat counters + hover
+ *                  lifts + CSS animated gradient.
+ *   - expressive — SplitText + ScrollTrigger parallax + staggered card
+ *                  entrances + Granim.js gradient + Lenis smooth scroll.
+ */
+export const ANIMATION_TIER_VALUES = ['subtle', 'moderate', 'expressive'] as const;
+
+export type AnimationTier = (typeof ANIMATION_TIER_VALUES)[number];
+
+export const isAnimationTier = (value: string): value is AnimationTier =>
+  (ANIMATION_TIER_VALUES as readonly string[]).includes(value);

--- a/content-system/vocabularies/image-mood.ts
+++ b/content-system/vocabularies/image-mood.ts
@@ -1,0 +1,35 @@
+/**
+ * Image Mood — the canonical photography / imagery-direction vocabulary
+ * captured in the client portal.
+ *
+ * Single source of truth shared by the portal Visual Direction intel topic,
+ * the stock-asset picker, the design-preflight image approach, and the
+ * mockup generator's image prompts. Distinct from `VISUAL_STYLE_VALUES`
+ * which describes overall aesthetic — mood describes how imagery is
+ * composed and lit.
+ *
+ * Clients pick 1–3. Multi-select because a brand often blends moods
+ * (e.g. editorial × clinical for a luxury medical practice, or lifestyle
+ * × documentary for real estate).
+ *
+ * Mood semantics:
+ *   - editorial        — magazine-styled, composed, aspirational
+ *   - clinical         — clean, precise, sterile (medical/dental/legal)
+ *   - photojournalistic — candid, moment-in-time, real events
+ *   - lifestyle        — people in context, warm, aspirational daily life
+ *   - abstract         — non-representational, textural, artistic
+ *   - documentary      — unposed, real, environmental portraiture
+ */
+export const IMAGE_MOOD_VALUES = [
+  'editorial',
+  'clinical',
+  'photojournalistic',
+  'lifestyle',
+  'abstract',
+  'documentary',
+] as const;
+
+export type ImageMood = (typeof IMAGE_MOOD_VALUES)[number];
+
+export const isImageMood = (value: string): value is ImageMood =>
+  (IMAGE_MOOD_VALUES as readonly string[]).includes(value);

--- a/content-system/vocabularies/index.ts
+++ b/content-system/vocabularies/index.ts
@@ -26,3 +26,15 @@ export {
   isIndustrySlug,
   type IndustrySlug,
 } from './industry';
+
+export {
+  ANIMATION_TIER_VALUES,
+  isAnimationTier,
+  type AnimationTier,
+} from './animation-tier';
+
+export {
+  IMAGE_MOOD_VALUES,
+  isImageMood,
+  type ImageMood,
+} from './image-mood';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
Adds two new locked enums to the Brik Content System for the portal's Visual Direction intel topic.

- `ANIMATION_TIER_VALUES` — `subtle | moderate | expressive`. Matches the tiers already documented in [animation-toolkit.md](https://github.com/brikdesigns/brik-client-portal/blob/staging/.claude/references/animation-toolkit.md) and consumed by the mockup generator's \`resolveAnimationTierNote()\`. Single-select per client.
- `IMAGE_MOOD_VALUES` — `editorial | clinical | photojournalistic | lifestyle | abstract | documentary`. Multi-select (1-3 per client) so a brand can blend moods. Sits alongside the existing \`image_approach\` enum.

Version bumped 0.16.0 → 0.17.0 (additive minor).

## Why
The portal's Visual Direction intel topic currently stores free-text \`animation_notes\` and unstructured \`image_approach\` — the LLM (mockup generator) has a richer motion vocabulary than the intel knows about. Promoting these to locked BCS enums means every design-phase prompt reads BDS-grounded values instead of nulls.

## Test plan
- [ ] \`npm run build:content-system\` regenerates \`dist/content-system/vocabularies/\` cleanly
- [ ] \`import { ANIMATION_TIER_VALUES, IMAGE_MOOD_VALUES } from '@brikdesigns/bds/content-system'\` resolves after publish
- [ ] Portal follow-up PR (migration + Visual Direction sheet pickers) consumes both without needing name changes

## Follow-ups
- Portal: migration + Visual Direction sheet UI + onboarding intake mapping
- Portal: mockup-worker reads \`profile.animation_tier\` first, falls back to intake-derived tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)