### PR TITLE
fix(tokens): ship bds-* keyframes to Storybook + consumers

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,11 +18,13 @@ import { FeedbackWidget } from './FeedbackWidget';
 // 2. Gap-fills (manual tokens not yet in Figma)
 // 3. Brik Brand theme (light + dark)
 // 4. Font Audit tool (client-sim theme for font-family validation)
-// 5. Storybook overrides (Base mode spacing, UI fixes)
+// 5. BDS shared keyframe library (bds-spin, bds-pulse, bds-pop, etc.)
+// 6. Storybook overrides (Base mode spacing, UI fixes)
 import '../tokens/figma-tokens.css';
 import '../tokens/gap-fills.css';
 import '../tokens/theme-brand-brik.css';
 import '../tokens/font-audit.css';
+import '../tokens/animations.css';
 import '../css/animations.css';
 import '../css/premium-effects.css';
 import './storybook-overrides.css';

--- a/scripts/build-dist-tokens.js
+++ b/scripts/build-dist-tokens.js
@@ -4,7 +4,7 @@
  * Called by: npm run build:lib (as the final step)
  *
  * Produces:
- *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + figma-dark-corrections.css + theme-brand-brik.css + gap-fills.css concatenated
+ *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + figma-dark-corrections.css + theme-brand-brik.css + gap-fills.css + animations.css concatenated
  *   dist/bridge.css  — clean name ↔ Webflow internal name aliases
  */
 const fs = require('fs');
@@ -63,7 +63,13 @@ if (fs.existsSync(themeBrandBrikPath)) {
   console.log('  ✓ Including Brik brand theme');
 }
 
-fs.writeFileSync(path.join(DIST_DIR, 'tokens.css'), header + figmaTokens + darkTokens + darkCorrections + themeBrandBrik + '\n\n' + gapFills);
+// Shared keyframe library — required for any component using bds-spin, bds-pulse, bds-pop, etc.
+const animations = fs.readFileSync(path.join(TOKENS_DIR, 'animations.css'), 'utf8');
+
+fs.writeFileSync(
+  path.join(DIST_DIR, 'tokens.css'),
+  header + figmaTokens + darkTokens + darkCorrections + themeBrandBrik + '\n\n' + gapFills + '\n\n' + animations,
+);
 console.log('  ✓ dist/tokens.css');
 
 // Copy bridge.css

--- a/tokens/CASCADE.md
+++ b/tokens/CASCADE.md
@@ -14,10 +14,11 @@ renew-pms, brikdesigns) via `@brikdesigns/bds/tokens.css`. Built by
 3. `figma-dark-corrections.css` — manual overrides for known-wrong Figma dark values
 4. `theme-brand-brik.css` — Brik brand overrides (scoped to `.theme-brand-brik` class)
 5. `gap-fills.css` — manual tokens not yet in Figma
+6. `animations.css` — shared keyframe library (`bds-spin`, `bds-pulse`, `bds-pop`, etc.) — required by any component CSS that references these names
 
 **Not bundled:** `bridge.css` (opt-in via separate export), `font-audit.css`
-(Storybook-only), `animations.css`, `motion-classes.css`, `storybook-themes.ts`,
-`index.ts`.
+(Storybook-only), `motion-classes.css` (opt-in utility classes — consumers import
+directly if they want them), `storybook-themes.ts`, `index.ts`.
 
 ## Dark-mode selector contract
 


### PR DESCRIPTION
## Summary
- `@keyframes bds-spin` / `bds-pulse` / `bds-pop` / `bds-shake` / `bds-shimmer` lived only in `tokens/animations.css`, which was imported by nothing that shipped — not `.storybook/preview.tsx`, not `dist/tokens.css`.
- Every BDS animation using a `bds-*` name was silent in every environment: Storybook (storybook.brikdesigns.com), portal, renew-pms, brikdesigns.
- Affected components: **Button loading spinner, Spinner, Badge notification pop/shake, Dot pulse, Skeleton shimmer,** and every `.bds-anim-*` utility class in `motion-classes.css`.

## Changes
- [.storybook/preview.tsx](.storybook/preview.tsx) — import `tokens/animations.css` so the live Storybook deploy has the keyframes.
- [scripts/build-dist-tokens.js](scripts/build-dist-tokens.js) — concatenate `tokens/animations.css` into `dist/tokens.css` so every `@brikdesigns/bds/tokens.css` consumer gets the keyframes.
- [tokens/CASCADE.md](tokens/CASCADE.md) — document the new bundle order. `motion-classes.css` stays opt-in (utility classes only; consumers that don't want them shouldn't be forced to load them).

`dist/tokens.css` rebuild + version bump land in the follow-up `chore(release)` PR — portal / renew-pms / brikdesigns pick this up on next `npm update @brikdesigns/bds`.

## Test plan
- [ ] Open http://localhost:6006/?path=/story/components-action-button--loading — all three loading buttons spin
- [ ] Open http://localhost:6006/?path=/story/components-indicator-spinner--variants — both `sm` and `lg` spinners rotate
- [ ] Open a Badge story with notification variant — pop/shake animates on mount
- [ ] Open Skeleton story — shimmer sweep animates
- [ ] Verify `dist/tokens.css` contains `@keyframes bds-spin`, `bds-pulse`, `bds-pop` after running `npm run build:dist-tokens` (already verified locally at lines 921/929/950)

🤖 Generated with [Claude Code](https://claude.com/claude-code)