### PR TITLE
chore(release): v0.18.1 — ship bds-* keyframes

### DIFF
--- a/dist/bds-manifest.json
+++ b/dist/bds-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://brikdesigns.com/schemas/bds-inspector-manifest-v1.json",
-  "bds_version": "0.18.0",
-  "generated_at": "2026-04-20T12:09:10.654Z",
+  "bds_version": "0.18.1",
+  "generated_at": "2026-04-20T13:53:26.325Z",
   "component_count": 82,
   "token_count": 426,
   "components": {

--- a/dist/content-system/blueprints/resolver.d.ts
+++ b/dist/content-system/blueprints/resolver.d.ts
@@ -73,7 +73,7 @@ export declare function scoreBlueprintForProfile(blueprint: NormalizedBlueprint,
  * blueprints fall out instead of padding the tail.
  *
  * Weighting rationale — see `SHORTLIST_WEIGHTS`. The JSDoc on the
- * [Storybook Overview page](https://brikstorybook.netlify.app/?path=/docs/foundations-content-system-blueprints-overview--docs)
+ * [Storybook Overview page](https://brikstorybook.netlify.app/?path=/docs/overview-theming-blueprints--docs)
  * explains how the portal wires this into the mockup generator seed.
  *
  * Sort is stable for equal scores: the earlier entry in the input

--- a/dist/content-system/blueprints/resolver.js
+++ b/dist/content-system/blueprints/resolver.js
@@ -63,7 +63,7 @@ export function scoreBlueprintForProfile(blueprint, profile) {
  * blueprints fall out instead of padding the tail.
  *
  * Weighting rationale — see `SHORTLIST_WEIGHTS`. The JSDoc on the
- * [Storybook Overview page](https://brikstorybook.netlify.app/?path=/docs/foundations-content-system-blueprints-overview--docs)
+ * [Storybook Overview page](https://brikstorybook.netlify.app/?path=/docs/overview-theming-blueprints--docs)
  * explains how the portal wires this into the mockup generator seed.
  *
  * Sort is stable for equal scores: the earlier entry in the input

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -899,3 +899,98 @@
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);   /* symmetric — looping, continuous */
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1); /* overshoot bounce — pop-in, badge appear */
 }
+
+
+/**
+ * BDS Shared Keyframe Library
+ * ─────────────────────────────────────────────────────────────────────────────
+ * All named keyframes live here. Component CSS files reference these by name
+ * instead of defining their own — one source of truth for motion patterns.
+ *
+ * Import in consumer projects alongside figma-tokens.css and gap-fills.css:
+ *   @import '../../brik-bds/tokens/animations.css';
+ *
+ * Usage in components: animation: bds-pulse 1.4s var(--ease-in-out) infinite;
+ * Usage with utility classes: see motion-classes.css
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+/* ─── Pulse — breathing scale + opacity ─────────────────────────────────────
+   Use: notification dots, unread indicators, persistent attention signals    */
+
+@keyframes bds-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.5; transform: scale(1.4); }
+}
+
+/* ─── Pop — bounce scale entrance ───────────────────────────────────────────
+   Use: badge appear, counter increment, notification badge, toast entrance   */
+
+@keyframes bds-pop {
+  0%   { transform: scale(0); opacity: 0; }
+  60%  { transform: scale(1.15); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+/* ─── Shake — rotation oscillation attention-getter ─────────────────────────
+   Use: bell ring, notification alert, form error, nudge                      */
+
+@keyframes bds-shake {
+  0%, 100% { transform: rotate(0deg); }
+  15%      { transform: rotate(12deg); }
+  30%      { transform: rotate(-10deg); }
+  45%      { transform: rotate(8deg); }
+  60%      { transform: rotate(-6deg); }
+  75%      { transform: rotate(3deg); }
+}
+
+/* ─── Spin — continuous rotation ────────────────────────────────────────────
+   Use: loading spinner, refresh indicator, processing state                  */
+
+@keyframes bds-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ─── Shimmer — loading placeholder sweep ───────────────────────────────────
+   Use: skeleton screens, content placeholders                                */
+
+@keyframes bds-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ─── Fade In — subtle entrance ─────────────────────────────────────────────
+   Use: general-purpose content entrance, panel reveal                        */
+
+@keyframes bds-fade-in {
+  from { opacity: 0; transform: scale(0.98); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* ─── Slide Up — vertical entrance from below ───────────────────────────────
+   Use: toasts, bottom sheets, action bars                                    */
+
+@keyframes bds-slide-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ─── Slide Down — vertical entrance from above ─────────────────────────────
+   Use: dropdowns, top sheets, notification panels                            */
+
+@keyframes bds-slide-down {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ─── Reduced motion ────────────────────────────────────────────────────────
+   Disables all animations for users who prefer reduced motion.
+   Individual components may also have their own reduced-motion overrides.    */
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- Bumps `@brikdesigns/bds` to **0.18.1**.
- Pairs with #147, which wired `tokens/animations.css` into `.storybook/preview.tsx` and `scripts/build-dist-tokens.js`.
- Rebuilt `dist/` now ships the `@keyframes bds-spin / bds-pulse / bds-pop / bds-shake / bds-shimmer / bds-fade-in / bds-slide-up / bds-slide-down` definitions inside `dist/tokens.css`.

## What this unblocks for consumers
After merge + `npm publish` + `npm update @brikdesigns/bds`:
- Button loading spinner animates
- Spinner component animates
- Badge notification pop/shake animates
- Dot pulse indicator animates
- Skeleton shimmer animates
- All `.bds-anim-*` utility classes (when consumer also imports `motion-classes.css`) work

## Test plan
- [ ] `npm run build:lib` completes cleanly (already verified locally)
- [ ] `dist/tokens.css` contains `@keyframes bds-spin` (verified: end of file)
- [ ] After merge, run `npm publish` locally against `npm.pkg.github.com`
- [ ] Portal / renew-pms / brikdesigns run `npm update @brikdesigns/bds` and verify spinner rotates in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)