### PR TITLE
feat(sheet): add description prop, subtitle eyebrow, consolidate Storybook folder

### DIFF
--- a/components/providers/SheetStackProvider.tsx
+++ b/components/providers/SheetStackProvider.tsx
@@ -51,8 +51,10 @@ const SheetStackContext = createContext<SheetStackContextValue | undefined>(unde
 /** Configuration set by headless sheet components via useConfigureSheet */
 export interface SheetConfig {
   title?: ReactNode;
-  /** Subtitle rendered under the title */
+  /** Eyebrow label rendered above the title (text-muted, uppercase). */
   subtitle?: ReactNode;
+  /** Long-form secondary text rendered under the title. */
+  description?: ReactNode;
   tabs?: SheetTab[];
   activeTab?: string;
   onTabChange?: (id: string) => void;

--- a/components/providers/SheetStackRenderer.tsx
+++ b/components/providers/SheetStackRenderer.tsx
@@ -98,6 +98,7 @@ export function SheetStackRenderer({ renderFrame, width = '600px', globalFramePr
         onClose={closeAll}
         title={resolvedTitle}
         subtitle={config.subtitle}
+        description={config.description}
         onBack={isDeep ? back : undefined}
         width={width}
         variant={topFrame.variant}

--- a/components/ui/BulletList/BulletList.stories.tsx
+++ b/components/ui/BulletList/BulletList.stories.tsx
@@ -3,7 +3,7 @@ import { BulletList } from './BulletList';
 import { Field } from '../Field';
 
 const meta: Meta<typeof BulletList> = {
-  title: 'Displays/Sheet Body/bullet-list',
+  title: 'Displays/Sheet/bullet-list',
   component: BulletList,
   parameters: { layout: 'padded' },
   argTypes: {

--- a/components/ui/Field/Field.css
+++ b/components/ui/Field/Field.css
@@ -20,10 +20,17 @@
 
 /* ─── Label ───────────────────────────────────────────────── */
 
+/*
+ * Read-mode form labels mirror TextInput input labels (font-family-label,
+ * semi-bold, label-md, tight line-height, capitalize) so the read view reads
+ * as the same typographic surface as the edit view. Only the color differs:
+ * text-muted here (read), text-primary on TextInput (editable).
+ */
 .bds-field__label {
-  font-family: var(--font-family-body);
-  font-size: var(--body-md);
-  line-height: var(--font-line-height-normal);
+  font-family: var(--font-family-label);
+  font-size: var(--label-md);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
   color: var(--text-muted);
   text-transform: capitalize;
   margin: 0;

--- a/components/ui/Field/Field.stories.tsx
+++ b/components/ui/Field/Field.stories.tsx
@@ -4,7 +4,7 @@ import { Tag } from '../Tag';
 import { EmptyState } from '../EmptyState';
 
 const meta: Meta<typeof Field> = {
-  title: 'Displays/Sheet Body/field',
+  title: 'Displays/Sheet/field',
   component: Field,
   parameters: { layout: 'padded' },
   argTypes: {

--- a/components/ui/FieldGrid/FieldGrid.stories.tsx
+++ b/components/ui/FieldGrid/FieldGrid.stories.tsx
@@ -4,7 +4,7 @@ import { Field } from '../Field';
 import { Card } from '../Card';
 
 const meta: Meta<typeof FieldGrid> = {
-  title: 'Displays/Sheet Body/field-grid',
+  title: 'Displays/Sheet/field-grid',
   component: FieldGrid,
   parameters: { layout: 'padded' },
   argTypes: {

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -101,7 +101,20 @@
   margin: 0;
 }
 
+/* Subtitle eyebrow — short categorical context rendered above the title. */
 .bds-sheet__subtitle {
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+/* Description — long-form secondary text rendered under the title. */
+.bds-sheet__description {
   font-family: var(--font-family-body);
   font-size: var(--body-sm);
   line-height: var(--font-line-height-normal);

--- a/components/ui/Sheet/Sheet.mdx
+++ b/components/ui/Sheet/Sheet.mdx
@@ -32,11 +32,12 @@ Right, left, bottom, wide, and no-title configurations.
 
 ## Header
 
-The header composes `title`, `subtitle`, and an optional `onBack` button for nested flows.
+The header composes an optional `subtitle` eyebrow, the `title`, an optional `description`, and an optional `onBack` button for nested flows.
 
 <Canvas of={Stories.Header} />
 
-- Use **`subtitle`** for record state, timestamps, or short context.
+- Use **`subtitle`** for short categorical context (entity type, parent record). Renders above the title in uppercase `text-muted`.
+- Use **`description`** for record state, timestamps, or a one-line summary. Renders below the title in `text-secondary`.
 - Use **`onBack`** when a sheet is pushed on top of another sheet (e.g. a related-entity drilldown). Pair with your sheet stack controller.
 - The close icon uses the Phosphor **bold** weight so it reads at a glance.
 
@@ -67,6 +68,12 @@ This mirrors the renew-pms convention. `brik-client-portal` should adopt the sam
 Pure read content that doesn't require an action can skip the backdrop and render as a floating popover with `variant="floating"`. Skip the footer entirely.
 
 <Canvas of={Stories.ReadOnlyFloating} />
+
+## Read mode floating
+
+Read mode with `variant="floating"` — the sheet sits on the page without a backdrop, but the footer still renders `[Close] [Edit]`. Use when the surrounding page should remain legible while the detail view is open (e.g. inline drill-in from a table row).
+
+<Canvas of={Stories.ReadModeFloating} />
 
 ## Tabs
 
@@ -108,15 +115,15 @@ A custom `footer` always wins over mode-driven auto-footer. Use it for non-stand
 
 ## Body composition
 
-The Sheet body is a composition surface — but the blocks you compose from are locked. Inside a Sheet body, reach for the **sheet-body primitive set** first. Don't invent ad-hoc markup.
+The Sheet body is a composition surface — but the blocks you compose from are locked. Inside a Sheet body, reach for the **sheet primitive set** first. Don't invent ad-hoc markup.
 
 | Primitive | Use for |
 |---|---|
-| [`SheetSection`](/?path=/docs/displays-sheet-body-sheet-section--docs) | Named section wrapper (uppercase heading + content). One per logical grouping of fields. |
-| [`Field`](/?path=/docs/displays-sheet-body-field--docs) | Label + value pair. Value can be text, tags, URLs, lists — any ReactNode. |
-| [`FieldGrid`](/?path=/docs/displays-sheet-body-field-grid--docs) | 2 / 3 / 4-column grid of Fields or Cards. Stat-tile rows. |
-| [`TagList`](/?path=/docs/displays-sheet-body-tag-list--docs) | Horizontal cluster of `<Tag>` elements inside a Field. |
-| [`BulletList`](/?path=/docs/displays-sheet-body-bullet-list--docs) | Short-item lists (anti-messages, proof points, approved CTAs). |
+| [`SheetSection`](/?path=/docs/displays-sheet-sheet-section--docs) | Named section wrapper (uppercase heading + content). One per logical grouping of fields. |
+| [`Field`](/?path=/docs/displays-sheet-field--docs) | Label + value pair. Value can be text, tags, URLs, lists — any ReactNode. |
+| [`FieldGrid`](/?path=/docs/displays-sheet-field-grid--docs) | 2 / 3 / 4-column grid of Fields or Cards. Stat-tile rows. |
+| [`TagList`](/?path=/docs/displays-sheet-tag-list--docs) | Horizontal cluster of `<Tag>` elements inside a Field. |
+| [`BulletList`](/?path=/docs/displays-sheet-bullet-list--docs) | Short-item lists (anti-messages, proof points, approved CTAs). |
 | [`Card`](/?path=/docs/displays-card-card--docs) / [`CardList`](/?path=/docs/displays-card-card-list--docs) / [`CardDisplay`](/?path=/docs/displays-card-card-display--docs) | Entity rows (contacts, services, scraped pages, linked records). |
 | [`Table`](/?path=/docs/displays-table-table--docs) | Tabular data (strategy tables, typography rows, schedules). |
 | [`Accordion`](/?path=/docs/displays-accordion-accordion--docs) | Collapsible groups when a section has many rows. |
@@ -195,8 +202,9 @@ function CompanySheet() {
     <Sheet
       isOpen={open}
       onClose={() => setOpen(false)}
+      subtitle="Company"
       title="Brik Designs"
-      subtitle="Active · Updated 2 days ago"
+      description="Active · Updated 2 days ago"
       mode={mode}
       onEdit={() => setMode('edit')}
       onSave={async () => { await save(); setMode('read'); }}

--- a/components/ui/Sheet/Sheet.stories.tsx
+++ b/components/ui/Sheet/Sheet.stories.tsx
@@ -3,9 +3,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Sheet } from './Sheet';
 import { Button } from '../Button';
 import { TextInput } from '../TextInput';
+import { Field } from '../Field';
 
 const meta: Meta<typeof Sheet> = {
-  title: 'Displays/Overlay/sheet',
+  title: 'Displays/Sheet/sheet',
   component: Sheet,
   parameters: { layout: 'centered' },
   argTypes: {
@@ -14,6 +15,7 @@ const meta: Meta<typeof Sheet> = {
     mode: { control: 'select', options: [undefined, 'read', 'edit'] },
     title: { control: 'text' },
     subtitle: { control: 'text' },
+    description: { control: 'text' },
     width: { control: 'text' },
     closeOnBackdrop: { control: 'boolean' },
     closeOnEscape: { control: 'boolean' },
@@ -55,21 +57,10 @@ const SampleContent = () => (
 
 const ReadOnlyFields = () => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
-    {[
-      { label: 'Company', value: 'Brik Designs' },
-      { label: 'Owner', value: 'Nick Stanerson' },
-      { label: 'Industry', value: 'Design & Engineering' },
-      { label: 'Status', value: 'Active' },
-    ].map((field) => (
-      <div key={field.label} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xs)' }}>
-        <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-          {field.label}
-        </span>
-        <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)', color: 'var(--text-primary)' }}>
-          {field.value}
-        </span>
-      </div>
-    ))}
+    <Field label="Company">Brik Designs</Field>
+    <Field label="Owner">Nick Stanerson</Field>
+    <Field label="Industry">Design & Engineering</Field>
+    <Field label="Status">Active</Field>
   </div>
 );
 
@@ -101,7 +92,7 @@ export const Playground: Story = {
     onClose: () => {},
     children: null,
     title: 'Details',
-    subtitle: 'Metadata for this company record',
+    description: 'Metadata for this company record',
     side: 'right',
     width: '400px',
   },
@@ -191,15 +182,46 @@ export const Header: Story = {
           </div>
         </Row>
 
-        <SectionLabel>Title + subtitle</SectionLabel>
+        <SectionLabel>Title + description</SectionLabel>
+        <Row>
+          <div>
+            <Button onClick={() => open('description')}>Open</Button>
+            <Sheet
+              isOpen={openId === 'description'}
+              onClose={close}
+              title="Company details"
+              description="Metadata for this company record"
+            >
+              <SampleContent />
+            </Sheet>
+          </div>
+        </Row>
+
+        <SectionLabel>Title + subtitle (eyebrow)</SectionLabel>
         <Row>
           <div>
             <Button onClick={() => open('subtitle')}>Open</Button>
             <Sheet
               isOpen={openId === 'subtitle'}
               onClose={close}
-              title="Company details"
-              subtitle="Metadata for this company record"
+              subtitle="Company"
+              title="Brik Designs"
+            >
+              <SampleContent />
+            </Sheet>
+          </div>
+        </Row>
+
+        <SectionLabel>Subtitle + Title + description</SectionLabel>
+        <Row>
+          <div>
+            <Button onClick={() => open('full')}>Open</Button>
+            <Sheet
+              isOpen={openId === 'full'}
+              onClose={close}
+              subtitle="Company"
+              title="Brik Designs"
+              description="Active · Updated 2 days ago"
             >
               <SampleContent />
             </Sheet>
@@ -214,7 +236,7 @@ export const Header: Story = {
               isOpen={openId === 'back'}
               onClose={close}
               title="Contact"
-              subtitle="Opened from Company details"
+              description="Opened from Company details"
               onBack={close}
             >
               <SampleContent />
@@ -237,8 +259,34 @@ export const ReadMode: Story = {
         <Sheet
           isOpen={open}
           onClose={() => setOpen(false)}
+          subtitle="Company"
           title="Brik Designs"
-          subtitle="Active · Updated 2 days ago"
+          description="Active · Updated 2 days ago"
+          mode="read"
+          onEdit={() => alert('Switch to edit mode')}
+        >
+          <ReadOnlyFields />
+        </Sheet>
+      </>
+    );
+  },
+};
+
+/* ─── Read mode floating — no backdrop, rounded, elevated ────── */
+
+export const ReadModeFloating: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>View company</Button>
+        <Sheet
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          variant="floating"
+          subtitle="Company"
+          title="Brik Designs"
+          description="Active · Updated 2 days ago"
           mode="read"
           onEdit={() => alert('Switch to edit mode')}
         >
@@ -269,7 +317,7 @@ export const EditMode: Story = {
           isOpen={open}
           onClose={() => setOpen(false)}
           title="Edit company"
-          subtitle="Update record details"
+          description="Update record details"
           mode="edit"
           onSave={handleSave}
           saveLoading={saving}
@@ -307,8 +355,9 @@ export const ReadEditToggle: Story = {
         <Sheet
           isOpen={open}
           onClose={() => setOpen(false)}
+          subtitle="Company"
           title="Brik Designs"
-          subtitle={mode === 'read' ? 'Active · Updated 2 days ago' : 'Editing record'}
+          description={mode === 'read' ? 'Active · Updated 2 days ago' : 'Editing record'}
           mode={mode}
           onEdit={() => setMode('edit')}
           onSave={handleSave}
@@ -334,7 +383,7 @@ export const ReadOnlyFloating: Story = {
           isOpen={open}
           onClose={() => setOpen(false)}
           title="Quick info"
-          subtitle="Read-only — no CTA needed"
+          description="Read-only — no CTA needed"
           variant="floating"
         >
           <SampleContent />
@@ -402,7 +451,7 @@ export const SecondaryAction: Story = {
           isOpen={open}
           onClose={() => setOpen(false)}
           title="Strategic Brief"
-          subtitle="Last refreshed 2 days ago"
+          description="Last refreshed 2 days ago"
           mode="read"
           onEdit={() => alert('Switch to edit mode')}
           secondaryAction={{
@@ -445,7 +494,7 @@ export const TabsWithSecondaryAction: Story = {
           isOpen={open}
           onClose={() => setOpen(false)}
           title="Strategic Brief"
-          subtitle={mode === 'read' ? 'Active · Updated 2 days ago' : 'Editing brief'}
+          description={mode === 'read' ? 'Active · Updated 2 days ago' : 'Editing brief'}
           mode={mode}
           onEdit={() => setMode('edit')}
           onSave={handleSave}

--- a/components/ui/Sheet/Sheet.tsx
+++ b/components/ui/Sheet/Sheet.tsx
@@ -38,8 +38,17 @@ export interface SheetProps {
   children?: ReactNode;
   side?: SheetSide;
   title?: ReactNode;
-  /** Optional subtitle rendered under the title */
+  /**
+   * Eyebrow label rendered above the title in `text-muted`. Use for short
+   * categorical context like entity type or parent record (e.g. "Company",
+   * "Strategic Brief").
+   */
   subtitle?: ReactNode;
+  /**
+   * Long-form secondary text rendered under the title. Use for record state,
+   * timestamps, or descriptive context (e.g. "Active · Updated 2 days ago").
+   */
+  description?: ReactNode;
   /** Width for left/right sheets (default: 400px) */
   width?: string;
   /**
@@ -110,6 +119,7 @@ export function Sheet({
   side = 'right',
   title,
   subtitle,
+  description,
   width = '400px',
   variant = 'default',
   closeOnBackdrop = true,
@@ -236,7 +246,7 @@ export function Sheet({
     );
   })();
 
-  const hasHeaderContent = title || subtitle || onBack || showCloseButton;
+  const hasHeaderContent = title || subtitle || description || onBack || showCloseButton;
 
   const sheet = (
     <>
@@ -262,8 +272,9 @@ export function Sheet({
                   </button>
                 )}
                 <div className="bds-sheet__titles">
+                  {subtitle && <span className="bds-sheet__subtitle">{subtitle}</span>}
                   {title && <h2 className="bds-sheet__title">{title}</h2>}
-                  {subtitle && <p className="bds-sheet__subtitle">{subtitle}</p>}
+                  {description && <p className="bds-sheet__description">{description}</p>}
                 </div>
               </div>
               {showCloseButton && (

--- a/components/ui/SheetSection/SheetSection.stories.tsx
+++ b/components/ui/SheetSection/SheetSection.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SheetSection } from './SheetSection';
 
 const meta: Meta<typeof SheetSection> = {
-  title: 'Displays/Sheet Body/sheet-section',
+  title: 'Displays/Sheet/sheet-section',
   component: SheetSection,
   parameters: { layout: 'padded' },
   argTypes: {

--- a/components/ui/TagList/TagList.stories.tsx
+++ b/components/ui/TagList/TagList.stories.tsx
@@ -4,7 +4,7 @@ import { Tag } from '../Tag';
 import { Field } from '../Field';
 
 const meta: Meta<typeof TagList> = {
-  title: 'Displays/Sheet Body/tag-list',
+  title: 'Displays/Sheet/tag-list',
   component: TagList,
   parameters: { layout: 'padded' },
   argTypes: {


### PR DESCRIPTION
## Summary

- **Sheet header split into three parts**: `subtitle` is now an eyebrow above the title (`text-muted`, uppercase, `label-sm` semi-bold), `title` stays centered, and a new `description` prop renders below in `text-secondary`. What used to be \`subtitle\` semantics in usage code now belongs on \`description\` — the eyebrow is the new thing.
- **New story: \`ReadModeFloating\`** — floating sheet variant + \`mode=\"read\"\` + \`onEdit\`, so a read-only detail view can render without a backdrop but still expose \`[Close] [Edit]\`.
- **Storybook folder consolidation**: \`Displays/Overlay/sheet\` and \`Displays/Sheet Body/*\` collapsed into a single \`Displays/Sheet/*\` namespace (sheet, sheet-section, field, field-grid, tag-list, bullet-list). No overlap.
- **Field read-mode labels** now mirror TextInput input labels (\`font-family-label\`, \`label-md\`, semi-bold, \`line-height-tight\`, capitalize). Only the color differs — \`text-muted\` (read) vs \`text-primary\` (editable). Replaces the hand-rolled uppercase labels that were in \`ReadOnlyFields\`.

## Consumer-facing API

- \`subtitle\` prop is retained but its placement + styling changed (was below-title body-sm secondary; now above-title uppercase eyebrow). No portal / renew-pms Sheet call sites currently pass \`subtitle\`, so this is additive in practice — verified with \`grep\`.
- \`description\` is the new prop for long-form secondary text under the title.
- \`SheetConfig\` on \`SheetStackProvider\` gained \`description\` alongside \`subtitle\`.

## Test plan

- [ ] Open \`Displays/Sheet/sheet\` — verify single folder, no overlap with old \`Displays/Overlay/sheet\` or \`Displays/Sheet Body\`.
- [ ] Open **Header** story — confirm three variants: Title + description (below), Title + subtitle eyebrow (above), Subtitle + Title + description (both).
- [ ] Open **Read Mode Floating** — confirm no backdrop, \`[Close] [Edit]\` footer still renders.
- [ ] Open **Field / Variants** — confirm label typography matches TextInput label typography (same family, size, weight, line-height, casing) but with \`text-muted\`.
- [ ] \`npm run lint-tokens\` + \`npx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)