### PR TITLE
fix(sheet): bump subtitle eyebrow size down one step

### DIFF
--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -104,7 +104,7 @@
 /* Subtitle eyebrow — short categorical context rendered above the title. */
 .bds-sheet__subtitle {
   font-family: var(--font-family-label);
-  font-size: var(--label-sm);
+  font-size: var(--label-xs);
   font-weight: var(--font-weight-semi-bold);
   line-height: var(--font-line-height-tight);
   color: var(--text-muted);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- Drop `.bds-sheet__subtitle` from `--label-sm` to `--label-xs` so the eyebrow overline reads as secondary context instead of competing with the title
- Bumps package to `0.18.3` — already published to GitHub Packages so portal can pick it up

## Test plan
- [ ] Storybook Sheet stories render subtitle smaller than before; title still dominates
- [ ] Portal Intel sheets (`/admin/companies/<slug>?tab=intel`) show overline in subdued scale