### PR TITLE
fix(counter): on-color-light for neutral + warning text

### DIFF
--- a/components/ui/Counter/Counter.css
+++ b/components/ui/Counter/Counter.css
@@ -26,8 +26,8 @@
 
 .bds-counter--success  { background-color: var(--background-positive);     color: var(--text-inverse); }
 .bds-counter--error    { background-color: var(--background-negative);     color: var(--text-inverse); }
-.bds-counter--warning  { background-color: var(--background-warning);      color: var(--text-primary); }
-.bds-counter--neutral  { background-color: var(--color-grayscale-lighter); color: var(--text-primary); }
+.bds-counter--warning  { background-color: var(--background-warning);      color: var(--text-on-color-light); }
+.bds-counter--neutral  { background-color: var(--color-grayscale-lighter); color: var(--text-on-color-light); }
 .bds-counter--progress { background-color: var(--background-status-info);  color: var(--text-inverse); }
 .bds-counter--brand    { background-color: var(--background-brand-primary); color: var(--text-inverse); }
 }


### PR DESCRIPTION
## Summary

- Counter's `neutral` and `warning` variants used `--text-primary` for text color. `--text-primary` is theme-aware (dark in light mode, white in dark mode), but the counter's background for these two variants is fixed-light (`--color-grayscale-lighter`, `--background-warning`) regardless of theme. Result: the count number disappears against its own chip in dark mode.
- Fix: swap both to `--text-on-color-light` (theme-agnostic, always `grayscale-black`) so the pattern matches the other solid-bg variants (success/error/progress/brand use `--text-inverse` for dark backgrounds; neutral/warning now use the on-color-light equivalent for light backgrounds).
- Two-line CSS change in `components/ui/Counter/Counter.css`. No API change, no Storybook story change — existing `Variants` story visualizes all statuses and already surfaces the bug when toggled to dark mode.

## Test plan

- [ ] Open Counter → Variants in Storybook
- [ ] Toggle theme to dark — verify neutral + warning counts remain readable (black text on light bg)
- [ ] Toggle back to light — verify no regression
- [ ] Spot-check the "Intel" tab counter in the portal after bump + sync (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)