### PR TITLE
fix(counter): finish dark-mode pass — all variants semantic

### DIFF
--- a/components/ui/Counter/Counter.css
+++ b/components/ui/Counter/Counter.css
@@ -24,10 +24,10 @@
 
 /* ─── Status colors ──────────────────────────────────────────── */
 
-.bds-counter--success  { background-color: var(--background-positive);      color: var(--text-on-color-light); }
-.bds-counter--error    { background-color: var(--background-negative);      color: var(--text-on-color-light); }
+.bds-counter--success  { background-color: var(--background-positive);      color: var(--text-on-color-dark);  }
+.bds-counter--error    { background-color: var(--background-negative);      color: var(--text-on-color-dark);  }
 .bds-counter--warning  { background-color: var(--background-warning);       color: var(--text-on-color-light); }
 .bds-counter--neutral  { background-color: var(--background-neutral);       color: var(--text-on-color-light); }
-.bds-counter--progress { background-color: var(--background-status-info);   color: var(--text-on-color-light); }
-.bds-counter--brand    { background-color: var(--background-brand-primary); color: var(--text-on-color-light); }
+.bds-counter--progress { background-color: var(--background-status-info);   color: var(--text-on-color-dark);  }
+.bds-counter--brand    { background-color: var(--background-brand-primary); color: var(--text-on-color-dark);  }
 }

--- a/components/ui/Counter/Counter.css
+++ b/components/ui/Counter/Counter.css
@@ -24,10 +24,10 @@
 
 /* ─── Status colors ──────────────────────────────────────────── */
 
-.bds-counter--success  { background-color: var(--background-positive);     color: var(--text-inverse); }
-.bds-counter--error    { background-color: var(--background-negative);     color: var(--text-inverse); }
-.bds-counter--warning  { background-color: var(--background-warning);      color: var(--text-on-color-light); }
-.bds-counter--neutral  { background-color: var(--color-grayscale-lighter); color: var(--text-on-color-light); }
-.bds-counter--progress { background-color: var(--background-status-info);  color: var(--text-inverse); }
-.bds-counter--brand    { background-color: var(--background-brand-primary); color: var(--text-inverse); }
+.bds-counter--success  { background-color: var(--background-positive);      color: var(--text-on-color-light); }
+.bds-counter--error    { background-color: var(--background-negative);      color: var(--text-on-color-light); }
+.bds-counter--warning  { background-color: var(--background-warning);       color: var(--text-on-color-light); }
+.bds-counter--neutral  { background-color: var(--background-neutral);       color: var(--text-on-color-light); }
+.bds-counter--progress { background-color: var(--background-status-info);   color: var(--text-on-color-light); }
+.bds-counter--brand    { background-color: var(--background-brand-primary); color: var(--text-on-color-light); }
 }

--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -121,6 +121,7 @@
   --background-status-info:           var(--color-system-blue);
   --background-status-info-subtle:    var(--color-system-blue-light);
   --background-status-neutral:        var(--color-system-neutral-light);
+  --background-neutral:               var(--color-system-neutral-light); /* sibling to --background-positive/negative/warning — use for neutral/gray semantic surfaces. */
   --background-status-purple:         var(--color-system-purple);
   --background-status-orange:         var(--color-system-orange);
   --text-status-info:                 var(--color-system-blue);


### PR DESCRIPTION
## Summary

Follow-up to #152, which shipped a partial fix (neutral + warning text only). Two problems remained in main:

1. **success / error / progress / brand** still used `--text-inverse` for text color. `--text-inverse` is theme-aware and flips to white in dark mode → white-on-green, white-on-red, white-on-blue, white-on-orange — all unreadable against the mid-tone pill backgrounds.
2. The **neutral** variant's background referenced the primitive `--color-grayscale-lighter`. Component CSS must consume semantic tokens, not primitives — this was a BDS token-layer violation.

## What changes

- `tokens/gap-fills.css` — add `--background-neutral: var(--color-system-neutral-light)` as a sibling to `--background-positive/negative/warning/brand-primary`. Closes the naming drift between the counter variant name (`neutral`) and the available tokens (which until now only had `--background-status-neutral`).
- `components/ui/Counter/Counter.css` — every variant now uses a semantic bg + `--text-on-color-light`:

| Variant  | bg (semantic)                    | text                     |
|----------|----------------------------------|--------------------------|
| success  | `--background-positive`          | `--text-on-color-light`  |
| error    | `--background-negative`          | `--text-on-color-light`  |
| warning  | `--background-warning`           | `--text-on-color-light`  |
| neutral  | `--background-neutral` (new)     | `--text-on-color-light`  |
| progress | `--background-status-info`       | `--text-on-color-light`  |
| brand    | `--background-brand-primary`     | `--text-on-color-light`  |

All six backgrounds are theme-agnostic mid-tones, so the count always needs dark text regardless of theme. `--text-on-color-light` resolves to `--color-grayscale-black` in both themes.

## Why the previous PR was insufficient

`--text-primary` and `--text-inverse` are both theme-aware — they flip with the active theme. On fixed-color pill backgrounds like these, theme-aware text is never right. The correct tokens are the `--text-on-color-*` family, which always contrast with a specified background lightness regardless of theme.

I'm saving a memory guardrail to preview **every** variant in **both** themes before claiming a BDS theme fix is complete.

## Test plan

- [ ] Counter → Variants story in light theme — verify all six counts are readable
- [ ] Counter → Variants story in dark theme — verify all six counts are readable (black text on every pill)
- [ ] DevTools inspector on `.bds-counter--neutral` — confirm `background-color` resolves via `--background-neutral`, not `--color-grayscale-lighter`
- [ ] `node scripts/lint-tokens.js` → 0 errors
- [ ] After merge + release + `npm update @brikdesigns/bds` in portal: verify the "Intel" tab counter in dark mode on `staging.portal.brikdesigns.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)