### PR TITLE
content: system billing locked vocabularies

### DIFF
--- a/content-system/index.ts
+++ b/content-system/index.ts
@@ -28,6 +28,8 @@ export {
   getIndustryProcedures,
   getIndustryAmenities,
   getIndustriesForParent,
+  getIndustryInsurancePlans,
+  getIndustryFinancing,
 } from './industries';
 export {
   voicePatterns,

--- a/content-system/industries/dental.ts
+++ b/content-system/industries/dental.ts
@@ -15,7 +15,7 @@ export const dental: IndustryPack = {
   slug: 'dental',
   parentIndustry: 'medical',
   displayName: 'Dental',
-  version: '1.3.0',
+  version: '1.4.0',
   reviewCadence: 'quarterly',
   lastReviewed: '2026-04-20',
 
@@ -433,26 +433,47 @@ export const dental: IndustryPack = {
     'Google Pay',
   ],
 
+  // Locked carrier vocabulary — the 10 dental insurance companies a practice
+  // explicitly accepts. Consumed by the portal's Insurance Providers MultiSelect
+  // with zero free-text. Changed from 20 suggestion seeds (pre-0.20.0) to 10
+  // locked carriers to match the sales-team canonical intake list; legacy
+  // non-matching values in company_profiles.insurance_providers are dropped
+  // on first save in the portal (soft-migration pattern).
   insuranceProviders: [
-    'Delta Dental',
-    'Blue Cross Blue Shield',
-    'Cigna Dental',
-    'Aetna Dental',
-    'MetLife Dental',
-    'United Concordia',
-    'Humana Dental',
-    'Guardian Dental',
-    'Principal Financial',
-    'Ameritas',
-    'Sun Life Financial',
+    'Aetna',
     'Anthem',
-    'UnitedHealthcare Dental',
-    'Assurant Dental',
-    'Renaissance Dental',
-    'Dental Select',
-    'DentaQuest (Medicaid/CHIP)',
-    'Liberty Dental (Medicaid/CHIP)',
-    'TRICARE Dental',
-    'Federal Employees Dental (FEDVIP)',
+    'Blue Cross Blue Shield',
+    'Cigna',
+    'Delta Dental',
+    'Guardian',
+    'Humana',
+    'MetLife',
+    'Principal',
+    'UnitedHealthcare',
+  ],
+
+  // Locked plan/program vocabulary — insurance modalities and government
+  // programs distinct from the individual carriers above. Separated from
+  // `insuranceProviders` so practices can answer "which carriers?" and
+  // "which plan postures?" independently; posture data also informs the
+  // financial_model inference downstream.
+  insurancePlans: [
+    'Out-of-Network PPO',
+    'Fee-for-Service Only',
+    'Medicaid',
+    'Medicare',
+  ],
+
+  // Locked financing-product vocabulary — structured financing programs
+  // a practice offers to patients, distinct from point-of-sale payment
+  // methods. CareCredit appears here AND in the global PAYMENT_METHOD_VALUES
+  // intentionally: as a financing product (this list) and as a payment
+  // method clients swipe at checkout (global list).
+  financing: [
+    'CareCredit',
+    'Cherry Finance',
+    'Sunbit',
+    'LendingClub',
+    'In-House Financing',
   ],
 };

--- a/content-system/industries/getters.test.ts
+++ b/content-system/industries/getters.test.ts
@@ -8,7 +8,10 @@ import {
   getIndustryProcedures,
   getIndustryAmenities,
   getIndustriesForParent,
+  getIndustryInsurancePlans,
+  getIndustryFinancing,
 } from './getters';
+import { PAYMENT_METHOD_VALUES, isPaymentMethod } from '../vocabularies';
 
 // ── getIndustryServices ──────────────────────────────────────────────────────
 
@@ -84,14 +87,21 @@ describe('getIndustryPaymentTypes', () => {
 // ── getIndustryInsuranceProviders ────────────────────────────────────────────
 
 describe('getIndustryInsuranceProviders', () => {
-  it('returns a populated list for dental', () => {
+  it('returns exactly the 10 locked dental carriers', () => {
     const providers = getIndustryInsuranceProviders('dental');
-    expect(providers.length).toBeGreaterThanOrEqual(10);
-    expect(providers).toContain('Delta Dental');
-    expect(providers).toContain('Aetna Dental');
-    expect(providers).toContain('MetLife Dental');
-    expect(providers).toContain('Cigna Dental');
-    expect(providers).toContain('Blue Cross Blue Shield');
+    expect(providers).toHaveLength(10);
+    expect(providers).toEqual([
+      'Aetna',
+      'Anthem',
+      'Blue Cross Blue Shield',
+      'Cigna',
+      'Delta Dental',
+      'Guardian',
+      'Humana',
+      'MetLife',
+      'Principal',
+      'UnitedHealthcare',
+    ]);
   });
 
   it('returns empty array for real-estate-rv-mhc (insurance not applicable)', () => {
@@ -207,5 +217,90 @@ describe('getIndustriesForParent', () => {
 
   it('returns empty array for the other parent (no graduated packs)', () => {
     expect(getIndustriesForParent('other')).toEqual([]);
+  });
+});
+
+// ── getIndustryInsurancePlans ────────────────────────────────────────────────
+
+describe('getIndustryInsurancePlans', () => {
+  it('returns exactly the 4 locked dental plan types', () => {
+    const plans = getIndustryInsurancePlans('dental');
+    expect(plans).toEqual([
+      'Out-of-Network PPO',
+      'Fee-for-Service Only',
+      'Medicaid',
+      'Medicare',
+    ]);
+  });
+
+  it('returns empty array when pack has no insurancePlans', () => {
+    expect(getIndustryInsurancePlans('real-estate-rv-mhc')).toEqual([]);
+    expect(getIndustryInsurancePlans('small-business')).toEqual([]);
+  });
+
+  it('falls back to small-business (empty) for null / undefined', () => {
+    expect(getIndustryInsurancePlans(null)).toEqual([]);
+    expect(getIndustryInsurancePlans(undefined)).toEqual([]);
+  });
+
+  it('returns a mutable copy — mutations do not affect the source pack', () => {
+    const plans = getIndustryInsurancePlans('dental');
+    plans.push('__mutation_test__');
+    expect(getIndustryInsurancePlans('dental')).not.toContain('__mutation_test__');
+  });
+});
+
+// ── getIndustryFinancing ─────────────────────────────────────────────────────
+
+describe('getIndustryFinancing', () => {
+  it('returns exactly the 5 locked dental financing products', () => {
+    const financing = getIndustryFinancing('dental');
+    expect(financing).toEqual([
+      'CareCredit',
+      'Cherry Finance',
+      'Sunbit',
+      'LendingClub',
+      'In-House Financing',
+    ]);
+  });
+
+  it('returns empty array when pack has no financing catalog', () => {
+    expect(getIndustryFinancing('real-estate-rv-mhc')).toEqual([]);
+    expect(getIndustryFinancing('small-business')).toEqual([]);
+  });
+
+  it('falls back to small-business (empty) for null / undefined', () => {
+    expect(getIndustryFinancing(null)).toEqual([]);
+    expect(getIndustryFinancing(undefined)).toEqual([]);
+  });
+});
+
+// ── PAYMENT_METHOD_VALUES (global vocabulary) ────────────────────────────────
+
+describe('PAYMENT_METHOD_VALUES', () => {
+  it('contains exactly the 14 locked global payment methods', () => {
+    expect(PAYMENT_METHOD_VALUES).toEqual([
+      'Cash',
+      'Check',
+      'Debit',
+      'Visa',
+      'Mastercard',
+      'Amex',
+      'Discover',
+      'Apple Pay',
+      'Google Pay',
+      'ACH/Bank Transfer',
+      'Venmo',
+      'Zelle',
+      'CareCredit',
+      'HSA/FSA',
+    ]);
+  });
+
+  it('isPaymentMethod guards membership correctly', () => {
+    expect(isPaymentMethod('Cash')).toBe(true);
+    expect(isPaymentMethod('CareCredit')).toBe(true);
+    expect(isPaymentMethod('Bitcoin')).toBe(false);
+    expect(isPaymentMethod('Delta Dental')).toBe(false);
   });
 });

--- a/content-system/industries/getters.ts
+++ b/content-system/industries/getters.ts
@@ -98,3 +98,34 @@ export function getIndustryAmenities(slug: IndustrySlug | null | undefined): str
 export function getIndustriesForParent(parentSlug: ParentIndustrySlug): IndustryPack[] {
   return Object.values(industryPacks).filter((pack) => pack.parentIndustry === parentSlug);
 }
+
+/**
+ * Returns the locked insurance plan / program vocabulary for the given
+ * industry (e.g. Medicaid, Out-of-Network PPO for dental). Returns an
+ * empty array when the pack does not define plan-level granularity.
+ * Falls back to `small-business` (empty) when slug is unknown.
+ *
+ * Consumed by the portal's Insurance Plans MultiSelect as a locked
+ * vocabulary (zero free-text). Distinct from `getIndustryInsuranceProviders`,
+ * which returns the carrier list (Aetna, Cigna, etc.).
+ */
+export function getIndustryInsurancePlans(slug: IndustrySlug | null | undefined): string[] {
+  const pack = resolvePack(slug);
+  return pack.insurancePlans ? [...pack.insurancePlans] : [];
+}
+
+/**
+ * Returns the locked financing-product vocabulary for the given industry
+ * (e.g. CareCredit, Cherry Finance for dental). Returns an empty array
+ * when the pack does not define a financing catalog.
+ * Falls back to `small-business` (empty) when slug is unknown.
+ *
+ * Consumed by the portal's Financing MultiSelect as a locked vocabulary.
+ * Distinct from the global PAYMENT_METHOD_VALUES (point-of-sale methods):
+ * financing products are structured payment programs the business offers
+ * to patients/residents, not methods they collect payment through.
+ */
+export function getIndustryFinancing(slug: IndustrySlug | null | undefined): string[] {
+  const pack = resolvePack(slug);
+  return pack.financing ? [...pack.financing] : [];
+}

--- a/content-system/industries/index.ts
+++ b/content-system/industries/index.ts
@@ -31,4 +31,6 @@ export {
   getIndustryProcedures,
   getIndustryAmenities,
   getIndustriesForParent,
+  getIndustryInsurancePlans,
+  getIndustryFinancing,
 } from './getters';

--- a/content-system/schema/industry-pack.ts
+++ b/content-system/schema/industry-pack.ts
@@ -126,20 +126,46 @@ export interface IndustryPack {
   strategicConsiderations?: readonly StrategicConsideration[];
 
   /**
-   * Billing / intake vocabularies — feed suggestion-driven comboboxes in
-   * the portal's Intel tab (Billing sheet, PR B1).
+   * Billing / intake vocabularies — feed the portal's Intel tab Billing sheet.
    *
-   * These are flat string arrays intentionally — they are suggestion seeds,
-   * not locked enums. Clients can enter free-text values that don't appear here.
+   * The two shapes split along validation posture:
    *
-   * - `services`           Common service/offering names for this vertical.
-   * - `paymentTypes`       Accepted payment methods and financing mechanisms.
-   * - `insuranceProviders` Relevant insurance carriers. Empty array for industries
-   *                        where insurance is not a factor.
+   * - `services` and `paymentTypes` remain **suggestion seeds** — flat string
+   *   arrays rendered in AddableComboList comboboxes, free-text-extendable.
+   * - `insuranceProviders`, `insurancePlans`, and `financing` are **locked
+   *   vocabularies** — rendered in MultiSelect dropdowns with zero free-text.
+   *   The portal filters any legacy non-matching values on first read
+   *   (soft-migration pattern, same as brand taxonomy rollout).
+   *
+   * Fields:
+   *
+   * - `services`           Suggestion seeds — common service/offering names
+   *                        for this vertical (free-text-extendable).
+   * - `paymentTypes`       Suggestion seeds — industry-specific payment +
+   *                        financing mechanisms (free-text-extendable).
+   *                        NOTE: for the global, locked 14 payment methods
+   *                        shared across all industries, import
+   *                        PAYMENT_METHOD_VALUES from vocabularies/.
+   * - `insuranceProviders` Locked carrier vocabulary — insurance companies
+   *                        (e.g. Aetna, Cigna) this industry meaningfully
+   *                        interacts with. Empty array for verticals where
+   *                        insurance is not a factor.
+   * - `insurancePlans`     Locked plan/program vocabulary — insurance
+   *                        modalities and government programs distinct from
+   *                        carriers (e.g. Medicaid, Out-of-Network PPO,
+   *                        Fee-for-Service Only). Populated when the industry
+   *                        has meaningful plan-type granularity beyond carrier.
+   * - `financing`          Locked financing-product vocabulary — structured
+   *                        financing products the business offers to
+   *                        patients/residents (e.g. CareCredit plan, Sunbit,
+   *                        Owner Financing). Distinct from point-of-sale
+   *                        payment methods; populated per vertical.
    */
   services: readonly string[];
   paymentTypes: readonly string[];
   insuranceProviders: readonly string[];
+  insurancePlans?: readonly string[];
+  financing?: readonly string[];
 }
 
 export type Quarter = 'Q1' | 'Q2' | 'Q3' | 'Q4';

--- a/content-system/vocabularies/index.ts
+++ b/content-system/vocabularies/index.ts
@@ -41,3 +41,9 @@ export {
   isImageMood,
   type ImageMood,
 } from './image-mood';
+
+export {
+  PAYMENT_METHOD_VALUES,
+  isPaymentMethod,
+  type PaymentMethod,
+} from './payment-method';

--- a/content-system/vocabularies/payment-method.ts
+++ b/content-system/vocabularies/payment-method.ts
@@ -1,0 +1,49 @@
+/**
+ * Accepted Payments — the global, cross-industry vocabulary of payment
+ * methods a business accepts at checkout.
+ *
+ * Single source of truth. The portal's `company_profiles.payment_types`
+ * column is validated against this list at the UI layer (no DB CHECK,
+ * same pattern as brand_personality / voice_tone / style_preferences).
+ *
+ * These values are industry-agnostic — dental practices, RV parks,
+ * and small businesses all accept Cash, Visa, Apple Pay, etc. The
+ * list is intentionally closed: clients pick from it, no free-text.
+ *
+ * Versioning: adding a new method is additive and requires a minor
+ * BDS bump. Removing or renaming a method is a breaking change —
+ * bump major and coordinate a soft-migration in consumers.
+ *
+ * Distinction from industry-specific financing:
+ *   - Payment methods = how the client COLLECTS payment at point of sale
+ *     (Cash, Check, Visa, CareCredit card, etc.)
+ *   - Industry financing = structured financing PRODUCTS the business
+ *     offers to patients/residents (CareCredit plan, Sunbit, In-House
+ *     Financing, Owner Financing, etc.) — see IndustryPack.financing.
+ *
+ * CareCredit appears in both: it is a payment method (clients swipe
+ * the card at checkout) AND a financing product (extended payment
+ * plans the practice enrolls patients in). The two uses are distinct
+ * and the duplication is intentional.
+ */
+export const PAYMENT_METHOD_VALUES = [
+  'Cash',
+  'Check',
+  'Debit',
+  'Visa',
+  'Mastercard',
+  'Amex',
+  'Discover',
+  'Apple Pay',
+  'Google Pay',
+  'ACH/Bank Transfer',
+  'Venmo',
+  'Zelle',
+  'CareCredit',
+  'HSA/FSA',
+] as const;
+
+export type PaymentMethod = (typeof PAYMENT_METHOD_VALUES)[number];
+
+export const isPaymentMethod = (value: string): value is PaymentMethod =>
+  (PAYMENT_METHOD_VALUES as readonly string[]).includes(value);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(content-system): locked billing vocabularies (payments, insurance, financing)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)