### PR TITLE
feat(forms): AddableTextList guardrail + When-to-use matrix

### DIFF
--- a/components/ui/AddableComboList/AddableComboList.mdx
+++ b/components/ui/AddableComboList/AddableComboList.mdx
@@ -66,6 +66,18 @@ When `maxEntries` is reached, the add button is hidden.
 - Tags: `role="list"` / `role="listitem"` with accessible labels
 - Screen reader announce on add/remove via `aria-live` on the tag container
 
+## When to use which Addable\* list
+
+Three siblings cover the full add/remove spectrum. Pick by row shape and vocabulary:
+
+| Pick | When | Render |
+| ---- | ---- | ------ |
+| [`AddableTextList`](?path=/docs/components-form-addable-text-list--overview) | Each row is **one short, unstructured value**, no fixed vocabulary. | Removable tag per value. |
+| `AddableComboList` | Each row is **one value from a known vocabulary** (BCS getter, locked enum) with optional free-form fallback. | Removable tag per value + combobox input. |
+| [`AddableEntryList`](?path=/docs/components-form-addable-entry-list--overview) | Each row needs a **primary value and a secondary note** (competitor URL + notes, service + description, reference site + why). | Card per entry with primary heading + secondary body. |
+
+If the row needs **three or more structured fields**, none of these fit — build a local "frame card" pattern; promote to BDS only after a second consumer appears.
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/AddableEntryList/AddableEntryList.mdx
+++ b/components/ui/AddableEntryList/AddableEntryList.mdx
@@ -42,12 +42,17 @@ Sizes, empty/helper/disabled states, and item limit.
 - When `maxItems` is reached, the Add button is hidden.
 - Entries are read-only once added — remove to replace.
 
-## When to use this vs. `AddableTextList`
+## When to use which Addable\* list
 
-| Pick | When |
-| ---- | ---- |
-| `AddableTextList` | Each row is a single short value (service name, payment type, tag). |
-| `AddableEntryList` | Each row needs a primary value **and** a secondary note or description. |
+Three siblings cover the full add/remove spectrum. Pick by row shape and vocabulary:
+
+| Pick | When | Render |
+| ---- | ---- | ------ |
+| [`AddableTextList`](?path=/docs/components-form-addable-text-list--overview) | Each row is **one short, unstructured value**, no fixed vocabulary. | Removable tag per value. |
+| [`AddableComboList`](?path=/docs/components-form-addable-combo-list--overview) | Each row is **one value from a known vocabulary** (BCS getter, locked enum) with optional free-form fallback. | Removable tag per value + combobox input. |
+| `AddableEntryList` | Each row needs a **primary value and a secondary note** (competitor URL + notes, service + description, reference site + why). | Card per entry with primary heading + secondary body. |
+
+If the row needs **three or more structured fields** (e.g. competitor / gap / copy implication), none of these fit — build a local "frame card" pattern; promote to BDS only after a second consumer appears.
 
 ## Props
 

--- a/components/ui/AddableTextList/AddableTextList.mdx
+++ b/components/ui/AddableTextList/AddableTextList.mdx
@@ -5,9 +5,11 @@ import * as Stories from './AddableTextList.stories';
 
 # Addable text list
 
-A list of text values with a reveal-on-click add pattern. The input is hidden until the user clicks the "Add New" button; pressing **Enter** commits the value and re-focuses the input for rapid entry, **Escape** cancels. Existing values render as removable tags.
+A list of **single-line, unstructured** text values with a reveal-on-click add pattern. The input is hidden until the user clicks the "Add New" button; pressing **Enter** commits the value and re-focuses the input for rapid entry, **Escape** cancels. Existing values render as removable tags.
 
-Use for lightweight list capture where a full multi-select is overkill (e.g. services offered, payment types, back-office tools). Designed to be swapped for a MultiSelect later without changing data shape.
+Use for lightweight list capture where each row is one short label (services offered, tags, back-office tools). Designed to be swapped for a MultiSelect later without changing data shape.
+
+> **Not for title + description pairs.** If each row needs a headline and a supporting note, reach for [`AddableEntryList`](?path=/docs/components-form-addable-entry-list--overview). In development, this component console-warns when any value contains structural separators (`—`, `–`, `:`, newline, tab) so the wrong choice gets caught at the source.
 
 ---
 
@@ -33,6 +35,18 @@ Sizes, empty/helper/disabled states, and item limit.
 - **Escape** or **blur on empty** cancels and hides the input.
 - Duplicates are blocked case-insensitively unless `allowDuplicates` is set.
 - When `maxItems` is reached, the Add button is hidden.
+
+## When to use which Addable\* list
+
+Three siblings cover the full add/remove spectrum. Pick by row shape and vocabulary:
+
+| Pick | When | Render |
+| ---- | ---- | ------ |
+| [`AddableTextList`](?path=/docs/components-form-addable-text-list--overview) | Each row is **one short, unstructured value**, no fixed vocabulary (services, tags, back-office tools). | Removable tag per value. |
+| [`AddableComboList`](?path=/docs/components-form-addable-combo-list--overview) | Each row is **one value from a known vocabulary** (BCS getter, locked enum) with optional free-form fallback. | Removable tag per value + combobox input. |
+| [`AddableEntryList`](?path=/docs/components-form-addable-entry-list--overview) | Each row needs a **primary value and a secondary note** (competitor URL + notes, service + description, reference site + why). | Card per entry with primary heading + secondary body. |
+
+If the row needs **three or more structured fields** (e.g. competitor / gap / copy implication), none of these fit — build a local "frame card" pattern; promote to BDS only after a second consumer appears.
 
 ## Props
 

--- a/components/ui/AddableTextList/AddableTextList.stories.tsx
+++ b/components/ui/AddableTextList/AddableTextList.stories.tsx
@@ -140,6 +140,29 @@ export const DuplicateBlocked: Story = {
   },
 };
 
+export const AntiPatternStructuredContent: Story = {
+  name: 'Anti-pattern — structured content in tags',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Do not do this. When values contain title + description pairs (separators `—`, `:`, newlines), each row collapses into a single unreadable tag. ' +
+          'Open the browser console — the component warns on any value matching the structured-content pattern and points at AddableEntryList. ' +
+          'This story exists to make the wrong choice visible, not to endorse it.',
+      },
+    },
+  },
+  args: {
+    label: 'Services (WRONG — use AddableEntryList)',
+    values: [
+      'Molar endodontics — explicitly phased out, do not feature',
+      'Cancellation policy: 24-hour window',
+    ],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
 export const Variants: Story = {
   render: () => (
     <div style={{ width: 480 }}>

--- a/components/ui/AddableTextList/AddableTextList.tsx
+++ b/components/ui/AddableTextList/AddableTextList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type KeyboardEvent } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { Icon } from '@iconify/react';
 import { bdsClass } from '../../utils';
 import { Button, type ButtonSize } from '../Button';
@@ -39,6 +39,23 @@ const TAG_SIZE: Record<AddableTextListSize, TagSize> = { sm: 'sm', md: 'md', lg:
 const BUTTON_SIZE: Record<AddableTextListSize, ButtonSize> = { sm: 'sm', md: 'md', lg: 'lg' };
 const INPUT_SIZE: Record<AddableTextListSize, TextInputSize> = { sm: 'sm', md: 'md', lg: 'lg' };
 
+// Structural separators that suggest a caller is trying to cram a title +
+// description into a single flat tag — AddableEntryList is the right tool.
+// See the "When to use which" matrix in the MDX docs.
+const STRUCTURED_CONTENT_PATTERN = /[\n\t]|\s[—–]\s|:\s/;
+
+const warnedValues = new Set<string>();
+function warnStructuredContent(value: string, label?: string) {
+  if (warnedValues.has(value)) return;
+  if (!STRUCTURED_CONTENT_PATTERN.test(value)) return;
+  warnedValues.add(value);
+  console.warn(
+    `[BDS AddableTextList${label ? ` (${label})` : ''}] Value contains structured separators ` +
+      `("${value}") — AddableTextList renders a single flat tag. ` +
+      `Use AddableEntryList for title + description pairs.`,
+  );
+}
+
 /**
  * AddableTextList — list of text values with a reveal-on-click add pattern.
  *
@@ -74,6 +91,10 @@ export function AddableTextList({
   const [draft, setDraft] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    values.forEach((v) => warnStructuredContent(v, label));
+  }, [values, label]);
+
   const atLimit = typeof maxItems === 'number' && values.length >= maxItems;
 
   const reveal = () => {
@@ -97,6 +118,7 @@ export function AddableTextList({
       cancel();
       return;
     }
+    warnStructuredContent(trimmed, label);
     onChange([...values, trimmed]);
     setDraft('');
     requestAnimationFrame(() => inputRef.current?.focus());


### PR DESCRIPTION
## Summary
- feat(forms): AddableTextList guardrail + When-to-use matrix

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)