### PR TITLE
feat(forms): AddableEntryList card polish + combobox width fix

### DIFF
--- a/components/ui/AddableEntryList/AddableEntryList.css
+++ b/components/ui/AddableEntryList/AddableEntryList.css
@@ -23,15 +23,15 @@
   display: flex;
   align-items: flex-start;
   gap: var(--gap-sm);
-  padding: var(--padding-md);
-  border: var(--border-width-md) solid var(--border-muted);
+  padding: var(--padding-sm);
+  border: var(--border-width-md) solid var(--border-primary);
   border-radius: var(--border-radius-md);
 }
 
 .bds-addable-entry-list__item-content {
   display: flex;
   flex-direction: column;
-  gap: var(--gap-tiny);
+  gap: var(--gap-xs);
   flex: 1 1 auto;
   min-width: 0;
 }
@@ -45,9 +45,15 @@
 
 .bds-addable-entry-list__item-secondary {
   font-family: var(--font-family-body);
+  font-size: var(--body-sm);
   color: var(--text-secondary);
   word-break: break-word;
   white-space: pre-wrap;
+}
+
+.bds-addable-entry-list__item-secondary--empty {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .bds-addable-entry-list__remove {
@@ -90,8 +96,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--gap-sm);
-  padding: var(--padding-md);
-  border: var(--border-width-md) solid var(--border-muted);
+  padding: var(--padding-sm);
+  border: var(--border-width-md) solid var(--border-primary);
   border-radius: var(--border-radius-md);
 }
 
@@ -114,6 +120,12 @@
   display: flex;
   flex-direction: column;
   gap: var(--gap-xs);
+  width: 100%;
+}
+
+.bds-addable-entry-list__primary-combo-field {
+  position: relative;
+  width: 100%;
 }
 
 /* Label above the combobox input — mirrors BDS TextInput label style */

--- a/components/ui/AddableEntryList/AddableEntryList.stories.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.stories.tsx
@@ -228,6 +228,37 @@ export const PrimaryOnly: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
+export const WithEmptyDescriptionLabel: Story = {
+  name: 'Empty description fallback',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `emptyDescriptionLabel` is provided, committed entries with no secondary show a muted italic placeholder instead of collapsing to a bare title. ' +
+          'Matches the "title + body with fallback" pattern used by service catalog views.',
+      },
+    },
+  },
+  args: {
+    label: 'Services',
+    primaryLabel: 'Name',
+    secondaryLabel: 'Description',
+    primaryPlaceholder: 'e.g. Dental cleaning',
+    secondaryPlaceholder: 'What this service covers',
+    addLabel: 'Add Service',
+    emptyDescriptionLabel: 'No description set',
+    entries: [
+      { primary: 'Cleanings including periodontal care (gum care) and oral cancer screenings', secondary: '' },
+      {
+        primary: 'Cosmetic dentistry',
+        secondary: 'Veneers, whitening, bonding — focused on aesthetic outcomes, not function.',
+      },
+    ],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
 export const Variants: Story = {
   render: () => (
     <div style={{ width: 520 }}>

--- a/components/ui/AddableEntryList/AddableEntryList.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.tsx
@@ -42,6 +42,13 @@ export interface AddableEntryListProps {
   removeLabel?: string;
   /** Text shown when list is empty (and form is not revealed) */
   emptyLabel?: string;
+  /**
+   * Text rendered in place of the secondary value for committed items where
+   * `secondary` is empty. When omitted, the secondary slot is collapsed and
+   * nothing is shown — preserves backward behavior for consumers that never
+   * need the fallback.
+   */
+  emptyDescriptionLabel?: string;
   /** Size for input, textarea, and buttons */
   size?: AddableEntryListSize;
   /** Hide all controls */
@@ -125,6 +132,7 @@ export function AddableEntryList({
   addLabel = 'Add New',
   removeLabel = 'Remove entry',
   emptyLabel,
+  emptyDescriptionLabel,
   size = 'md',
   disabled = false,
   maxItems,
@@ -271,9 +279,18 @@ export function AddableEntryList({
             >
               <div className="bds-addable-entry-list__item-content">
                 <span className="bds-addable-entry-list__item-primary">{entry.primary}</span>
-                {entry.secondary && (
+                {entry.secondary ? (
                   <span className="bds-addable-entry-list__item-secondary">{entry.secondary}</span>
-                )}
+                ) : emptyDescriptionLabel ? (
+                  <span
+                    className={bdsClass(
+                      'bds-addable-entry-list__item-secondary',
+                      'bds-addable-entry-list__item-secondary--empty',
+                    )}
+                  >
+                    {emptyDescriptionLabel}
+                  </span>
+                ) : null}
               </div>
               {!disabled && (
                 <button
@@ -311,7 +328,7 @@ export function AddableEntryList({
                   {primaryLabel}
                 </label>
               )}
-              <div style={{ position: 'relative' }}>
+              <div className="bds-addable-entry-list__primary-combo-field">
                 <input
                   ref={primaryInputRef}
                   id={combo.comboId}


### PR DESCRIPTION
## Summary
- feat(forms): AddableEntryList card polish + combobox width fix

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)