### PR TITLE
feat(infra): block commits with CRITICAL anti-slop findings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -59,3 +59,26 @@ fi
 
 # Typecheck always runs (fast, catches real errors)
 npm run typecheck
+
+# ── Anti-slop CRITICAL check ──
+# Blocks commits that introduce silent bugs on staged files:
+#   - empty catch blocks
+#   - swallowed promise rejections
+#   - relative/@-aliased imports that don't resolve on disk
+#
+# HIGH findings (raw hex, arbitrary Tailwind values, raw rgba) are surfaced by
+# the token lint block above, so this gate only raises threshold to CRITICAL.
+#
+# Scanner lives at ~/.claude/skills/anti-slop/ (global install). If it's
+# missing (fresh machine, CI), the helper gracefully skips — pre-commit
+# never breaks for infra reasons.
+ANTI_SLOP_CHECK="$HOME/.claude/skills/anti-slop/brik-rules/check-staged.sh"
+if [ -x "$ANTI_SLOP_CHECK" ]; then
+  echo "🔍 Running anti-slop CRITICAL scan on staged files..."
+  if ! "$ANTI_SLOP_CHECK" critical; then
+    echo "   Silent-failure + hallucinated-import findings block commits."
+    echo "   Fix the listed lines, or justify inline with a logger/throw."
+    echo "   To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary

- Adds the same anti-slop CRITICAL pre-commit gate shipped to [brik-client-portal#356](https://github.com/brikdesigns/brik-client-portal/pull/356) and [renew-pms#22](https://github.com/brikdesigns/renew-pms/pull/22).
- On every commit, staged TS/TSX/JS/CSS files are scanned by `~/.claude/skills/anti-slop/brik-rules/scan-brik-ts.py` at CRITICAL severity. Any silent-failure (empty catch, swallowed promise) or hallucinated-import finding blocks the commit.
- **Non-destructive to existing debt:** the gate only looks at files in the staged diff. Pre-existing code is unaffected until someone next touches it.

## Baseline

| Severity | Count | Notes |
|---|---|---|
| **CRITICAL** | **0** | Clean. Handoff predicted "low count since BDS is the cleanest repo" — actually zero. |
| HIGH | 121 | 106 in `tokens/index.ts` + `tokens/storybook-themes.ts` (token-palette data files); 9 in `DevFeedbackWidget`; 6 in `Board/Sheet/Slider/Snackbar/Toast` CSS. |

The HIGH findings are surfaced by `scripts/lint-tokens.js` (existing token-compliance block at lines 45-58 of the hook) and stay non-blocking for now.

## Scanner allowlist bug (follow-up)

The 106 findings in `tokens/index.ts` and `tokens/storybook-themes.ts` are false positives. The scanner's `is_token_allowlisted` check uses `/tokens/` (with leading slash), which requires absolute paths and misses repo-relative `tokens/` directories. Fixing this belongs in the later `~/.claude/skills/anti-slop` extensions session along with the `@token-exempt` JSDoc support flagged in portal #357.

## Graceful-skip

If the scanner isn't installed (fresh machine, CI without `~/.claude/skills/`), the hook continues silently — pre-commit never breaks for infra reasons.

## Test plan

- [x] Hook runs on this commit: BDS component completeness + token lint (skipped, no staged .tsx) + typecheck + anti-slop CRITICAL scan (ran, found 0) → all pass
- [x] Syntax check: `sh -n .husky/pre-commit` → ok
- [x] Executable: `-rwxr-xr-x` preserved
- [ ] After merge: confirm no in-flight task branch breaks on first commit (expected — baseline is 0 CRITICAL)

## Merge order

Per handoff:
1. ✅ portal #356 + renew-pms #22 (gate infrastructure)
2. ✅ portal #357 (portal CRITICAL cleanup — awaiting merge)
3. **This PR** — BDS gate
4. (Later) `~/.claude/skills/anti-slop` extensions — `@token-exempt` JSDoc + `__fixtures__/` path allowlist + fix `/tokens/` leading-slash bug; then flip HIGH threshold to blocking

## Dirty-`main` note

When I started, `main` had 6 modified files in `dist/` — all rebuild artifacts from the tab-bar fix (#161), not in-progress Figma work as the handoff feared. Stashed as `dist/ rebuild artifacts from d68a200 tab-bar fix (per handoff)` before branching. `dist/` is in `.gitignore` (line 11) but 6 files are tracked from before the gitignore entry — a separate cleanup candidate (likely `git rm --cached dist/` when the publish workflow is reviewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)