### PR TITLE
docs(bds): mark DevFeedbackWidget @token-exempt (drops 9 HIGH)

### DIFF
--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
@@ -23,6 +23,12 @@ import { createPortal } from 'react-dom';
  *
  * Integrates with the Brik DevBar (`window.BrikDevBar`) when present,
  * falling back to a standalone FAB otherwise.
+ *
+ * @token-exempt — the inlined BDS object below holds raw hex values on
+ * purpose: this widget is a dev overlay that must render consistently even
+ * when the host's stylesheet has failed to load or is mid-swap. Referencing
+ * BDS tokens here would defeat the stability guarantee. If you're adding a
+ * new host-surface component, use tokens instead.
  */
 
 // ── Brand tokens (inlined — widget is a dev overlay, not consumer surface) ──


### PR DESCRIPTION
## Summary

- BDS HIGH anti-slop findings: **15 → 6** (all 9 DevFeedbackWidget hex values drop).
- Zero code change: single `@token-exempt` tag added to the existing JSDoc.
- The widget is a dev overlay whose inlined brand colors are a stability guarantee; the existing inline comment at line 28 (`// ── Brand tokens (inlined — widget is a dev overlay, not consumer surface) ──`) already documented the intent.

## What changed

[`components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx`](components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx#L13-L32) — added `@token-exempt` to the file-level JSDoc. The scanner (as of [brik-llm#14](https://github.com/brikdesigns/brik-llm/pull/14)) honors this tag within the first 30 lines of a file and short-circuits the `raw_hex_color` rule.

## Why not token-ize

The widget needs to render identically across any host regardless of theme state or stylesheet load failures — that's the whole point of consolidating the three prior drifting copies into this single component. Using `var(--token)` references would break this when:

- The host's `@import` chain has a fetch failure
- The dev overlay renders before hydration on a page with broken CSS
- A Storybook theme swap is mid-flight

Cold review in portal [#357](https://github.com/brikdesigns/brik-client-portal/pull/357) confirmed the same pattern for portal's `global-error.tsx` — error-boundary UIs that must survive stylesheet failures are the canonical `@token-exempt` case.

## What's left

| Severity | Before all cleanup | After portal#361 | After this PR | Remaining work |
|---|---|---|---|---|
| Portal `src/app` HIGH | 25 | **0** | 0 | none |
| BDS `components/` + `tokens/` HIGH | 121 | 15 | **6** | token-ize Board/Sheet/Slider/Snackbar/Toast CSS (next session, visual regression risk) |

After the remaining 6 are addressed, we can flip HIGH → blocking in all three pre-commit gates.

## Test plan

- [x] `scan-brik-ts.py --severity high components/ui/DevFeedbackWidget` → 0 findings
- [x] `scan-brik-ts.py --severity high components tokens` → 6 findings (down from 15)
- [x] Pre-commit gate: BDS component completeness, token lint, typecheck, anti-slop CRITICAL — all pass
- [ ] After merge: consumer `npm update @brikdesigns/bds` pulls the doc-only change on next version bump (no code change, no behavior change, no version needed specifically for this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)