### PR TITLE
docs(bds): mark 5 component CSS files @token-exempt (drops 6 HIGH)

### DIFF
--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -1,5 +1,12 @@
 @layer bds-components {
-/* Board — Kanban-style horizontal board layout */
+/*
+ * Board — Kanban-style horizontal board layout.
+ *
+ * @token-exempt — the raw #fff values (card-check icon border) are var()
+ * fallbacks for --text-on-color-dark. They activate only if the token
+ * pipeline fails (stylesheet race, consumer missing BDS), matching the
+ * defensive pattern in portal's global-error.tsx. Not a migration candidate.
+ */
 
 /* ─── Board container ─────────────────────────────────── */
 

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -1,6 +1,13 @@
 @layer bds-components {
-/* ─── Sheet ──────────────────────────────────────────────────── */
-/* Overlay treatment aligned with Modal (2026-03-20)            */
+/*
+ * Sheet — overlay treatment aligned with Modal (2026-03-20).
+ *
+ * @token-exempt — the floating variant uses a custom multi-layer rgba
+ * shadow (line 36) that has no BDS token equivalent: two stacked
+ * rgba(0,0,0, 0.12 + 0.08) layers produce the floating-panel depth that
+ * no single --shadow-* token reproduces. Promote to Figma as
+ * --shadow-floating and remove this exemption once published.
+ */
 
 .bds-sheet-backdrop {
   position: fixed;

--- a/components/ui/Slider/Slider.css
+++ b/components/ui/Slider/Slider.css
@@ -1,7 +1,16 @@
 @layer bds-components {
-/* Slider CSS — needed for pseudo-elements (::-webkit-slider-thumb, etc.) */
-/* --bds-slider-track-height, --bds-slider-thumb-size, --bds-slider-percent are component-local
-   custom properties set by Slider.tsx. The --bds-* prefix marks them as non-global. */
+/*
+ * Slider CSS — needed for pseudo-elements (::-webkit-slider-thumb, etc.).
+ *
+ * --bds-slider-track-height, --bds-slider-thumb-size, --bds-slider-percent
+ * are component-local custom properties set by Slider.tsx. The --bds-*
+ * prefix marks them as non-global.
+ *
+ * @token-exempt — the thumb shadow (line 8) uses a custom rgba(0,0,0,0.1)
+ * deliberately lighter than --shadow-sm; already annotated
+ * `bds-lint-ignore — promote to Figma`. Remove this exemption once the
+ * value ships as a Figma token.
+ */
 
 /* ─── Component-scoped override surface ── */
 .bds-slider {

--- a/components/ui/Snackbar/Snackbar.css
+++ b/components/ui/Snackbar/Snackbar.css
@@ -1,5 +1,12 @@
 @layer bds-components {
-/* ─── Snackbar ───────────────────────────────────────────────── */
+/*
+ * Snackbar — toast-like floating notification at the page edge.
+ *
+ * @token-exempt — the shadow (line 6) uses rgba(0,0,0,0.2), a stronger
+ * alpha than --shadow-lg; already annotated
+ * `bds-lint-ignore — promote to Figma`. Remove this exemption once the
+ * stronger-alpha shadow ships as a Figma token.
+ */
 
 .bds-snackbar {
   /* ─── Component-scoped override surface ── */

--- a/components/ui/Toast/Toast.css
+++ b/components/ui/Toast/Toast.css
@@ -1,5 +1,12 @@
 @layer bds-components {
-/* ─── Toast ──────────────────────────────────────────────────── */
+/*
+ * Toast — inline notification with custom spread shadow.
+ *
+ * @token-exempt — the shadow (line 6) uses rgba(0,0,0,0.24) with a 4px
+ * spread, a unique combination no BDS shadow token provides; already
+ * annotated `bds-lint-ignore — promote to Figma`. Remove this exemption
+ * once the spread-shadow variant ships as a Figma token.
+ */
 
 .bds-toast {
   /* ─── Component-scoped override surface ── */


### PR DESCRIPTION
## Summary

- BDS `components/` + `tokens/` HIGH anti-slop findings: **6 → 0**. Zero remaining HIGH across the whole scanner surface in BDS.
- **Doc-only change** — no CSS values modified. Each of the 5 files gets a JSDoc header explaining why the raw values it contains are legitimate and what needs to happen for the exemption to be removed.
- **Zero visual regression risk**. The original session plan called for Storybook verification on token swaps; once I investigated each finding the reality was different — all 6 are either safety fallbacks or intentional custom shadows already annotated `bds-lint-ignore — promote to Figma` in prior work. No swap was the right call.

## Per-file classification

| File | What the scanner saw | Why it's exempt | Permanent or interim? |
|---|---|---|---|
| [Board.css:274-275](components/ui/Board/Board.css#L274-L275) | 2× `#fff` | `var(--text-on-color-dark, #fff)` safety fallbacks — `#fff` activates only if the token pipeline fails (same pattern as portal's `global-error.tsx`) | **Permanent** |
| [Sheet.css:36](components/ui/Sheet/Sheet.css#L36) | multi-layer rgba | Custom floating-panel shadow (two stacked rgba layers, 0.12 + 0.08) with no `--shadow-*` equivalent | **Interim** → promote to `--shadow-floating` in Figma |
| [Slider.css:8](components/ui/Slider/Slider.css#L8) | rgba shadow | Already annotated `bds-lint-ignore — lighter than --shadow-sm; promote to Figma` | **Interim** → Figma |
| [Snackbar.css:6](components/ui/Snackbar/Snackbar.css#L6) | rgba shadow | Already annotated `bds-lint-ignore — stronger alpha than --shadow-lg; promote to Figma` | **Interim** → Figma |
| [Toast.css:6](components/ui/Toast/Toast.css#L6) | rgba shadow | Already annotated `bds-lint-ignore — unique spread, no token equivalent; promote to Figma` | **Interim** → Figma |

## Why `@token-exempt` instead of real token migration

3 of the 5 files (Slider, Snackbar, Toast) ALREADY had `bds-lint-ignore` annotations in the source with explicit TODO to promote the shadow values to Figma. That promotion needs:

1. Figma Desktop open with the dev plugin
2. Design approval for the new shadow tokens
3. `npm run build:sd-figma` to regenerate `tokens/figma-tokens.css`
4. Coordinated `@brikdesigns/bds` version bump for consumers

None of that is scope for a "clear the scanner baseline" task. `@token-exempt` is the interim documentation that the anti-slop scanner recognizes; when the Figma promotion happens, someone removes the header AND replaces the raw rgba with `var(--shadow-xxx)` in one PR.

The 2 Board.css findings are `var()` fallbacks — the defensive pattern portal's `global-error.tsx` already uses — and are never going to be migrated.

## Test plan

- [x] `scan-brik-ts.py --severity high components tokens` → 0 findings (was 6)
- [x] `scan-brik-ts.py --severity critical components tokens` → 0 findings
- [x] Pre-commit gate: BDS token linter, typecheck, anti-slop CRITICAL — all pass
- [x] No runtime change to any CSS output → nothing to visually verify

## What this unlocks

With this merged, BDS joins portal at **0 HIGH / 0 CRITICAL**. The final Phase 3 step is a coordinated change: flip HIGH → blocking in `.husky/pre-commit` across portal, renew-pms, and brik-bds. Single session, three small PRs (one per repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)