### PR TITLE
feat(bcs): navigation IA per industry + Storybook documentation

### DIFF
--- a/content-system/industries/dental.mdx
+++ b/content-system/industries/dental.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { dental } from './dental';
-import { NavigationIASpec } from '../../stories/foundation/_components';
+import { NavigationIASpec } from '../../stories/foundation/_components/index';
 
 <Meta title="Content/Industries/Dental" />
 

--- a/content-system/industries/dental.mdx
+++ b/content-system/industries/dental.mdx
@@ -1,5 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { dental } from './dental';
+import { NavigationIASpec } from '../../stories/foundation/_components';
 
 <Meta title="Content/Industries/Dental" />
 
@@ -86,7 +87,22 @@ Independent practices skew warmer and more conversational; cosmetic boutiques sk
   </tbody>
 </table>
 
-## 9. Brik Strategic POV
+## 9. Navigation IA
+
+Default site-header shape for dental. Drives the BDS `<SiteHeader>` component in
+`@brikdesigns/bds/blueprints-astro` when consumer sites (e.g. Birdwell & Mutlak)
+build. Clients can override any field per-engagement in the portal Intel tab, but
+the pack default represents Brik's curated recommendation for the vertical.
+
+Design intent: keep the top bar quiet (4 primary links, not 6) and route service
+discovery through a grouped mega-menu so cosmetic + restorative + comfort live in
+separate columns rather than a flat list. The frosted-glass-past-80 scroll
+behavior lets hero photography breathe at first load without sacrificing
+return-navigation reach.
+
+<NavigationIASpec industry="Dental" ia={dental.navigationIA} />
+
+## 10. Brik Strategic POV
 
 Three considerations that differentiate Brik's dental strategy. These are not generic industry facts — they reflect Brik's POV and should surface in briefs where applicable.
 

--- a/content-system/industries/dental.ts
+++ b/content-system/industries/dental.ts
@@ -476,4 +476,69 @@ export const dental: IndustryPack = {
     'LendingClub',
     'In-House Financing',
   ],
+
+  // Navigation IA — the dental archetype is `editorial-transparent`:
+  // hero photography breathes at first load, header becomes frosted-glass
+  // past 80px scroll. Services mega-menu groups the catalog by treatment
+  // category (Cosmetic / Restorative & Preventive / Comfort & Support)
+  // + a featured "new patient" card that directs to the first-visit
+  // landing page — dental's primary conversion surface.
+  //
+  // Primary link count kept tight at 4 to resist the "stale + bloated"
+  // failure mode observed on generic dental template sites. Utility
+  // cluster leads with phone (still the #1 booking channel for dental)
+  // and a solid Book CTA.
+  navigationIA: {
+    archetype: 'editorial-transparent',
+    primaryLinkCount: 4,
+    primaryLinks: [
+      { label: 'Services', href: '/services' },
+      { label: 'About', href: '/about' },
+      { label: 'Smile Gallery', href: '/smile-gallery' },
+      { label: 'Financing', href: '/financing' },
+    ],
+    servicesMegaMenu: {
+      triggerLabel: 'Services',
+      columns: 4,
+      categories: [
+        {
+          heading: 'Cosmetic',
+          items: [
+            { label: 'Porcelain veneers', href: '/services/veneers', note: 'Custom-crafted restorations' },
+            { label: 'Cosmetic dentistry', href: '/services/cosmetic-dentistry', note: 'Whitening, bonding, smile design' },
+            { label: 'Teeth whitening', href: '/services/whitening', note: 'In-office + take-home systems' },
+          ],
+        },
+        {
+          heading: 'Restorative & Preventive',
+          items: [
+            { label: 'Restorative dentistry', href: '/services/restorative-dentistry', note: 'Crowns, bridges, full-mouth rehab' },
+            { label: 'Preventive care', href: '/services/preventive-care', note: 'Cleanings, exams, family care' },
+            { label: 'Dentures', href: '/services/dentures', note: 'Custom-fit, natural look' },
+          ],
+        },
+        {
+          heading: 'Comfort & Support',
+          items: [
+            { label: 'Sedation dentistry', href: '/services/sedation-dentistry', note: 'Nitrous oxide available' },
+            { label: 'Your first visit', href: '/first-visit', note: '90 minutes, no surprises' },
+            { label: 'Membership', href: '/membership', note: 'In-house care plan' },
+          ],
+        },
+      ],
+      featured: {
+        eyebrow: 'New patient?',
+        heading: '90 minutes with the doctor you choose',
+        body: 'Choose your doctor when you book. Both doctors are accepting new patients.',
+        ctaLabel: 'Request your first visit',
+        ctaHref: '/contact',
+      },
+    },
+    utility: {
+      showPhone: true,
+      primaryCTA: { label: 'Book', href: '/contact', variant: 'solid' },
+    },
+    scrollBehavior: 'transparent-top-frosted-past-80',
+    mobileDrawer: 'fullscreen-overlay',
+  },
 };

--- a/content-system/industries/real-estate-rv-mhc.mdx
+++ b/content-system/industries/real-estate-rv-mhc.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { realEstateRvMhc } from './real-estate-rv-mhc';
-import { NavigationIASpec } from '../../stories/foundation/_components';
+import { NavigationIASpec } from '../../stories/foundation/_components/index';
 
 <Meta title="Content/Industries/Real Estate" />
 

--- a/content-system/industries/real-estate-rv-mhc.mdx
+++ b/content-system/industries/real-estate-rv-mhc.mdx
@@ -1,5 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { realEstateRvMhc } from './real-estate-rv-mhc';
+import { NavigationIASpec } from '../../stories/foundation/_components';
 
 <Meta title="Content/Industries/Real Estate" />
 
@@ -125,7 +126,20 @@ NAP consistency across all platforms is critical given these directories cross-r
   </tbody>
 </table>
 
-## 9. Future — Brik Strategic POV
+## 9. Navigation IA
+
+Default site-header shape for RV parks + manufactured housing communities. Uses
+the `utility-first` archetype — the top bar is a task surface, not a branding
+surface. Primary CTA ("Find a Site") leads; mega-menu groups the community
+catalog by community type so prospects can filter before they land.
+
+Mobile drawer is `slide-left-panel` (not fullscreen overlay) because users
+arrive in search mode and don't want a full-screen modal interrupt between
+filter + listing + amenity steps.
+
+<NavigationIASpec industry="Real Estate" ia={realEstateRvMhc.navigationIA} />
+
+## 10. Future — Brik Strategic POV
 
 Not yet populated. This pack has no `strategicConsiderations` entries because Brik does not yet have a defensible POV backed by client outcomes in this vertical. As the client portfolio grows, add sections for topics like:
 

--- a/content-system/industries/real-estate-rv-mhc.ts
+++ b/content-system/industries/real-estate-rv-mhc.ts
@@ -471,4 +471,67 @@ export const realEstateRvMhc: IndustryPack = {
   // of their billing relationship with guests/residents. Individual guest
   // travel insurance or resident homeowner insurance is handled privately.
   insuranceProviders: [],
+
+  // Navigation IA — `utility-first` archetype: always-solid header, primary
+  // task ("Find a Site") leads the utility cluster. Mega-menu groups the
+  // community catalog by type (RV / MHC / Vacation Rental) so prospects
+  // can filter before they land.
+  //
+  // Mobile uses `slide-left-panel` — users are in task mode (filtering
+  // listings, checking amenities); they don't want a full-screen modal
+  // interrupt between steps.
+  navigationIA: {
+    archetype: 'utility-first',
+    primaryLinkCount: 5,
+    primaryLinks: [
+      { label: 'Communities', href: '/communities' },
+      { label: 'Amenities', href: '/amenities' },
+      { label: 'Rates', href: '/rates' },
+      { label: 'About', href: '/about' },
+      { label: 'Contact', href: '/contact' },
+    ],
+    servicesMegaMenu: {
+      triggerLabel: 'Communities',
+      columns: 3,
+      categories: [
+        {
+          heading: 'RV Parks',
+          items: [
+            { label: 'All RV parks', href: '/rv-parks' },
+            { label: 'Seasonal sites', href: '/rv-parks/seasonal', note: 'Weekly + monthly stays' },
+            { label: 'Premium sites', href: '/rv-parks/premium', note: 'Pull-through, full hookup' },
+          ],
+        },
+        {
+          heading: 'Mobile Home Communities',
+          items: [
+            { label: 'All communities', href: '/mhc' },
+            { label: 'Homes for sale', href: '/mhc/homes-for-sale' },
+            { label: 'Lot rental', href: '/mhc/lot-rental' },
+          ],
+        },
+        {
+          heading: 'Vacation Rentals',
+          items: [
+            { label: 'Cabins', href: '/vacation-rentals/cabins' },
+            { label: 'Glamping', href: '/vacation-rentals/glamping' },
+            { label: 'Group bookings', href: '/vacation-rentals/groups' },
+          ],
+        },
+      ],
+      featured: {
+        eyebrow: 'New here?',
+        heading: 'Find your site in under a minute',
+        body: "Tell us the dates + site type; we'll surface availability across all communities.",
+        ctaLabel: 'Check availability',
+        ctaHref: '/find-a-site',
+      },
+    },
+    utility: {
+      showPhone: true,
+      primaryCTA: { label: 'Find a Site', href: '/find-a-site', variant: 'solid' },
+    },
+    scrollBehavior: 'sticky-solid',
+    mobileDrawer: 'slide-left-panel',
+  },
 };

--- a/content-system/industries/small-business.mdx
+++ b/content-system/industries/small-business.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { smallBusiness } from './small-business';
-import { NavigationIASpec } from '../../stories/foundation/_components';
+import { NavigationIASpec } from '../../stories/foundation/_components/index';
 
 <Meta title="Content/Industries/Small Business (General)" />
 

--- a/content-system/industries/small-business.mdx
+++ b/content-system/industries/small-business.mdx
@@ -1,5 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { smallBusiness } from './small-business';
+import { NavigationIASpec } from '../../stories/foundation/_components';
 
 <Meta title="Content/Industries/Small Business (General)" />
 
@@ -118,6 +119,17 @@ When graduating:
 2. Create `{new-slug}.ts` (IndustryPack) + `{new-slug}.mdx` (narrative) in `content-system/industries/`.
 3. Backfill existing clients in the portal by updating `company_profiles.industry_slug`.
 4. Bump this pack's `version` and log the graduation in the changelog section of this file.
+
+---
+
+## Navigation IA
+
+Baseline site-header for the catch-all pack. `editorial-transparent` archetype,
+4 primary links, no mega-menu (generic small businesses rarely need grouped
+catalogs). Verticals that demand a mega-menu should graduate to their own pack —
+see dental for the template.
+
+<NavigationIASpec industry="Small Business" ia={smallBusiness.navigationIA} />
 
 ---
 

--- a/content-system/industries/small-business.ts
+++ b/content-system/industries/small-business.ts
@@ -312,4 +312,26 @@ export const smallBusiness: IndustryPack = {
   // verticals that require insurance (health, legal, financial) should be
   // promoted to dedicated packs where insurance arrays are meaningful.
   insuranceProviders: [],
+
+  // Navigation IA — `editorial-transparent` is the generic baseline.
+  // 4 primary links, no mega-menu (small businesses rarely need grouped
+  // catalogs), reveal-on-scroll keeps chrome out of the way during
+  // content consumption. Dedicated verticals that need a mega-menu
+  // should graduate to their own pack (see dental for the template).
+  navigationIA: {
+    archetype: 'editorial-transparent',
+    primaryLinkCount: 4,
+    primaryLinks: [
+      { label: 'About', href: '/about' },
+      { label: 'Services', href: '/services' },
+      { label: 'Work', href: '/work' },
+      { label: 'Contact', href: '/contact' },
+    ],
+    utility: {
+      showPhone: true,
+      primaryCTA: { label: 'Get in Touch', href: '/contact', variant: 'solid' },
+    },
+    scrollBehavior: 'reveal-on-scroll',
+    mobileDrawer: 'fullscreen-overlay',
+  },
 };

--- a/content-system/schema/index.ts
+++ b/content-system/schema/index.ts
@@ -9,6 +9,14 @@ export type {
   CompetitorArchetype,
   StrategicConsideration,
   Quarter,
+  NavigationIA,
+  NavigationLink,
+  NavigationUtility,
+  NavigationCTA,
+  ServicesMegaMenu,
+  ServicesMegaMenuCategory,
+  ServicesMegaMenuItem,
+  ServicesMegaMenuFeature,
 } from './industry-pack';
 
 export type {

--- a/content-system/schema/industry-pack.ts
+++ b/content-system/schema/industry-pack.ts
@@ -4,6 +4,9 @@ import type {
   Personality,
   Voice,
   VisualStyle,
+  NavArchetype,
+  ScrollBehavior,
+  DrawerPattern,
 } from '../vocabularies';
 
 /**
@@ -166,6 +169,93 @@ export interface IndustryPack {
   insuranceProviders: readonly string[];
   insurancePlans?: readonly string[];
   financing?: readonly string[];
+
+  /**
+   * Navigation IA defaults — the site-header archetype this industry ships.
+   *
+   * The BDS `<SiteHeader>` component (in `@brikdesigns/bds/blueprints-astro`)
+   * reads this to render the correct shape at build time. Clients can
+   * override any field per-engagement via the portal Intel tab, but the
+   * pack's defaults represent Brik's curated recommendation for the
+   * vertical's audience.
+   *
+   * Leave unset to get the `small-business` fallback (editorial-transparent,
+   * 4 links, no mega-menu).
+   */
+  navigationIA?: NavigationIA;
+}
+
+export interface NavigationIA {
+  /** Overall archetype — see NAV_ARCHETYPE_VALUES for semantics. */
+  archetype: NavArchetype;
+  /**
+   * Number of primary links the header surfaces (excluding the logo and
+   * the utility cluster). Research target: 3-5. Higher counts produce
+   * "bloated" feeling at the top of the page.
+   */
+  primaryLinkCount: number;
+  /** Default primary link slots — clients override per-engagement. */
+  primaryLinks: readonly NavigationLink[];
+  /** Optional Services / Practice Areas / Specialties mega-menu spec. */
+  servicesMegaMenu?: ServicesMegaMenu;
+  /** Utility cluster spec — phone + primary CTA + optional secondary login. */
+  utility: NavigationUtility;
+  /** How the header responds to scroll. */
+  scrollBehavior: ScrollBehavior;
+  /** Mobile drawer shape. */
+  mobileDrawer: DrawerPattern;
+}
+
+export interface NavigationLink {
+  label: string;
+  href: string;
+}
+
+export interface ServicesMegaMenu {
+  /** The trigger label shown in the primary nav row. */
+  triggerLabel: string;
+  /** Number of columns in the mega-menu grid. Typically 3-4. */
+  columns: number;
+  /** Grouped categories — each category renders one column. */
+  categories: readonly ServicesMegaMenuCategory[];
+  /** Optional featured card anchored to the rightmost column. */
+  featured?: ServicesMegaMenuFeature;
+}
+
+export interface ServicesMegaMenuCategory {
+  heading: string;
+  items: readonly ServicesMegaMenuItem[];
+}
+
+export interface ServicesMegaMenuItem {
+  label: string;
+  href: string;
+  /** One-line descriptor shown under the label on hover / focus. */
+  note?: string;
+}
+
+export interface ServicesMegaMenuFeature {
+  eyebrow: string;
+  heading: string;
+  body: string;
+  ctaLabel: string;
+  ctaHref: string;
+}
+
+export interface NavigationUtility {
+  /** Render a click-to-call phone link in the utility cluster. */
+  showPhone: boolean;
+  /** Primary CTA — the conversion action the vertical is optimizing for. */
+  primaryCTA: NavigationCTA;
+  /** Optional secondary CTA (e.g. patient login, member portal). */
+  secondaryCTA?: NavigationCTA;
+}
+
+export interface NavigationCTA {
+  label: string;
+  href: string;
+  /** Visual treatment — drives the button variant in `<SiteHeader>`. */
+  variant: 'solid' | 'ghost' | 'link';
 }
 
 export type Quarter = 'Q1' | 'Q2' | 'Q3' | 'Q4';

--- a/content-system/vocabularies/drawer-pattern.ts
+++ b/content-system/vocabularies/drawer-pattern.ts
@@ -1,0 +1,37 @@
+/**
+ * Drawer Pattern — the mobile navigation drawer shape.
+ *
+ * Paired with NAV_ARCHETYPE_VALUES on the BCS industry pack and
+ * consumed by the BDS `<SiteHeader>` component's mobile drawer render.
+ *
+ * Pattern semantics:
+ *
+ *   fullscreen-overlay
+ *     Full-viewport dark panel over the content with backdrop-filter
+ *     blur on the body beneath. Services mega-menu expands inline.
+ *     Utility cluster (phone, book CTA) pinned to bottom. The premium
+ *     default — reads as a room change, not a sidebar.
+ *
+ *   slide-left-panel
+ *     Panel slides in from the left covering ~80% of viewport width.
+ *     Content remains partially visible on the right with a dark
+ *     backdrop. Categories + nested links list vertically; no inline
+ *     mega-menu expansion (tap through to category pages).
+ *     Fit: utility-first sites where users are already in task mode.
+ *
+ *   bottom-sheet
+ *     Sheet rises from the bottom edge, covering ~70% of viewport.
+ *     Primary navigation + filter/search controls share the space.
+ *     Fit: directory or listing sites where the nav does double duty
+ *     as a search surface.
+ */
+export const DRAWER_PATTERN_VALUES = [
+  'fullscreen-overlay',
+  'slide-left-panel',
+  'bottom-sheet',
+] as const;
+
+export type DrawerPattern = (typeof DRAWER_PATTERN_VALUES)[number];
+
+export const isDrawerPattern = (value: string): value is DrawerPattern =>
+  (DRAWER_PATTERN_VALUES as readonly string[]).includes(value);

--- a/content-system/vocabularies/index.ts
+++ b/content-system/vocabularies/index.ts
@@ -47,3 +47,21 @@ export {
   isPaymentMethod,
   type PaymentMethod,
 } from './payment-method';
+
+export {
+  NAV_ARCHETYPE_VALUES,
+  isNavArchetype,
+  type NavArchetype,
+} from './nav-archetype';
+
+export {
+  SCROLL_BEHAVIOR_VALUES,
+  isScrollBehavior,
+  type ScrollBehavior,
+} from './scroll-behavior';
+
+export {
+  DRAWER_PATTERN_VALUES,
+  isDrawerPattern,
+  type DrawerPattern,
+} from './drawer-pattern';

--- a/content-system/vocabularies/nav-archetype.ts
+++ b/content-system/vocabularies/nav-archetype.ts
@@ -1,0 +1,59 @@
+/**
+ * Navigation Archetype — the canonical site-header pattern per industry.
+ *
+ * Single source of truth shared by BCS industry packs (which declare a
+ * default archetype per vertical), the portal Intel tab (admin can
+ * override per client), and the BDS `<SiteHeader>` component in
+ * `@brikdesigns/bds/blueprints-astro` that renders the actual navigation.
+ *
+ * Archetypes are LAYOUT-level decisions, not styling — they describe how
+ * many primary links appear, whether a mega-menu is exposed, where the
+ * utility cluster (phone, CTA) sits, and the scroll + mobile behaviors.
+ * Styling is inherited from the client theme + atmosphere selection
+ * (see theme_mode + atmosphere on company_profile).
+ *
+ * Archetype semantics:
+ *
+ *   editorial-transparent
+ *     4 primary links + Services mega-menu + utility cluster (phone + CTA).
+ *     Nav is transparent over hero, frosted glass past 80px scroll.
+ *     Fit: luxury dental, med-aesthetic, editorial brands where the
+ *     hero photography must breathe at first load.
+ *
+ *   utility-first
+ *     5 primary links + Services mega-menu (optionally with inline
+ *     search or map). Always-solid background, no hide-on-scroll.
+ *     Utility cluster leads with a task-oriented CTA ("Find a Home",
+ *     "Schedule a Tour", "Free Consultation").
+ *     Fit: real-estate / RV / MHC, directories, legal multi-practice.
+ *
+ *   service-centric
+ *     5 primary links + prominent mega-menu on Services / Practice Areas
+ *     / Specialties. Mega-menu is the product — 2-column layout with
+ *     categories + featured attorney/practitioner card.
+ *     Fit: multi-practice legal, specialty medical groups, agencies.
+ *
+ *   portfolio-minimal
+ *     3-4 primary links, no dropdowns, text-only serif treatment with
+ *     wide tracking. Hide-on-scroll-down + reveal-on-scroll-up. Utility
+ *     cluster is minimal — often just an IG icon and a ghost "Inquire".
+ *     Fit: MUA, creative portfolios, photographers, wedding.
+ *
+ *   calm-flat
+ *     3-4 primary links, NO dropdowns (anxiety-sensitive audiences don't
+ *     hover-explore). Always solid at low contrast. Single warm CTA like
+ *     "Book Session" — no secondary actions.
+ *     Fit: wellness, mental health, therapy, recovery.
+ */
+export const NAV_ARCHETYPE_VALUES = [
+  'editorial-transparent',
+  'utility-first',
+  'service-centric',
+  'portfolio-minimal',
+  'calm-flat',
+] as const;
+
+export type NavArchetype = (typeof NAV_ARCHETYPE_VALUES)[number];
+
+export const isNavArchetype = (value: string): value is NavArchetype =>
+  (NAV_ARCHETYPE_VALUES as readonly string[]).includes(value);

--- a/content-system/vocabularies/scroll-behavior.ts
+++ b/content-system/vocabularies/scroll-behavior.ts
@@ -1,0 +1,42 @@
+/**
+ * Scroll Behavior — how the site header responds to user scroll.
+ *
+ * Paired with NAV_ARCHETYPE_VALUES on the BCS industry pack and
+ * consumed by the BDS `<SiteHeader>` component's runtime script.
+ *
+ * Behavior semantics:
+ *
+ *   transparent-top-frosted-past-80
+ *     Over-hero transparent at load; backdrop-filter(blur 18px) +
+ *     rgba(0,0,0,0.78) past 80px scrollY. Hides on scroll-down past
+ *     120px, reveals on scroll-up. The editorial default — lets hero
+ *     photography dominate first impression while keeping the header
+ *     within a reach for return navigation.
+ *
+ *   sticky-solid
+ *     Always visible, always solid background, never hides. Predictable
+ *     for utility-dense sites where users rely on the nav to navigate
+ *     between catalog states (listings, filters, specialty pages).
+ *
+ *   reveal-on-scroll
+ *     Solid background. Visible at top, hides immediately on scroll-down
+ *     past 120px, reveals on scroll-up. Single-CTA sites where chrome
+ *     should get out of the way during content consumption.
+ *
+ *   hide-on-scroll
+ *     Transparent or solid (archetype decides), hides on scroll-down
+ *     past 80px, no reveal until the user hits the top of the page.
+ *     Aggressive — only use for portfolio / artist sites where the
+ *     work demands the full viewport.
+ */
+export const SCROLL_BEHAVIOR_VALUES = [
+  'transparent-top-frosted-past-80',
+  'sticky-solid',
+  'reveal-on-scroll',
+  'hide-on-scroll',
+] as const;
+
+export type ScrollBehavior = (typeof SCROLL_BEHAVIOR_VALUES)[number];
+
+export const isScrollBehavior = (value: string): value is ScrollBehavior =>
+  (SCROLL_BEHAVIOR_VALUES as readonly string[]).includes(value);

--- a/stories/content/NavigationArchetypes.mdx
+++ b/stories/content/NavigationArchetypes.mdx
@@ -7,7 +7,7 @@ import {
 import { dental } from '../../content-system/industries/dental';
 import { realEstateRvMhc } from '../../content-system/industries/real-estate-rv-mhc';
 import { smallBusiness } from '../../content-system/industries/small-business';
-import { NavigationIASpec } from '../foundation/_components';
+import { NavigationIASpec } from '../foundation/_components/index';
 import { docTable, docTh, docTd, docTdMono } from '../foundation/_components/docTableStyles';
 
 <Meta title="Content/Navigation Archetypes" />
@@ -148,7 +148,7 @@ the right.
 **Fit:** legal multi-practice, specialty medical groups, agencies with a
 productized service catalog.
 
-**Avoid when:** service catalog is small (<6 items). A flat nav does the job.
+**Avoid when:** service catalog is small (under 6 items). A flat nav does the job.
 
 ### `portfolio-minimal`
 

--- a/stories/content/NavigationArchetypes.mdx
+++ b/stories/content/NavigationArchetypes.mdx
@@ -1,0 +1,219 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import {
+  NAV_ARCHETYPE_VALUES,
+  SCROLL_BEHAVIOR_VALUES,
+  DRAWER_PATTERN_VALUES,
+} from '../../content-system/vocabularies';
+import { dental } from '../../content-system/industries/dental';
+import { realEstateRvMhc } from '../../content-system/industries/real-estate-rv-mhc';
+import { smallBusiness } from '../../content-system/industries/small-business';
+import { NavigationIASpec } from '../foundation/_components';
+import { docTable, docTh, docTd, docTdMono } from '../foundation/_components/docTableStyles';
+
+<Meta title="Content/Navigation Archetypes" />
+
+# Navigation Archetypes
+
+The locked vocabulary of site-header patterns Brik builds from. Each industry
+pack declares a default archetype in its `navigationIA` field; consumer sites
+(e.g. Birdwell & Mutlak) render the shape at build time via the BDS
+`<SiteHeader>` component in `@brikdesigns/bds/blueprints-astro`.
+
+Archetypes are **layout-level decisions**, not styling — they describe how many
+primary links appear, whether a mega-menu is exposed, where the utility cluster
+sits, and how the header responds to scroll. Styling is inherited from the
+client theme + atmosphere.
+
+Treat archetype selection as a **pack default** — clients can override per
+engagement in the portal Intel tab, but the default represents Brik's curated
+recommendation. If a client wants something outside the vocabulary, either (a)
+graduate their vertical to its own pack, or (b) extend this vocabulary with a
+new canonical archetype and document it here.
+
+---
+
+## Vocabularies
+
+Three locked enums drive archetype selection. Full source in `content-system/vocabularies/`.
+
+<table style={docTable}>
+  <thead>
+    <tr>
+      <th style={docTh}>Vocabulary</th>
+      <th style={docTh}>Values</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={docTd}>NAV_ARCHETYPE_VALUES</td>
+      <td style={docTdMono}>{NAV_ARCHETYPE_VALUES.join(' · ')}</td>
+    </tr>
+    <tr>
+      <td style={docTd}>SCROLL_BEHAVIOR_VALUES</td>
+      <td style={docTdMono}>{SCROLL_BEHAVIOR_VALUES.join(' · ')}</td>
+    </tr>
+    <tr>
+      <td style={docTd}>DRAWER_PATTERN_VALUES</td>
+      <td style={docTdMono}>{DRAWER_PATTERN_VALUES.join(' · ')}</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Decision matrix — archetype by industry
+
+The canonical starting point. Agents picking an archetype for a new client
+should match the vertical first; if no pack exists yet, fall back to the
+`small-business` baseline until the vertical graduates.
+
+<table style={docTable}>
+  <thead>
+    <tr>
+      <th style={docTh}>Industry</th>
+      <th style={docTh}>Archetype</th>
+      <th style={docTh}>Links</th>
+      <th style={docTh}>Mega-menu</th>
+      <th style={docTh}>Scroll</th>
+      <th style={docTh}>Mobile</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={docTd}><strong>Dental</strong></td>
+      <td style={docTdMono}>editorial-transparent</td>
+      <td style={docTd}>4</td>
+      <td style={docTd}>Services · 4-col</td>
+      <td style={docTdMono}>transparent-top-frosted-past-80</td>
+      <td style={docTdMono}>fullscreen-overlay</td>
+    </tr>
+    <tr>
+      <td style={docTd}><strong>Real Estate (RV / MHC)</strong></td>
+      <td style={docTdMono}>utility-first</td>
+      <td style={docTd}>5</td>
+      <td style={docTd}>Communities · 3-col</td>
+      <td style={docTdMono}>sticky-solid</td>
+      <td style={docTdMono}>slide-left-panel</td>
+    </tr>
+    <tr>
+      <td style={docTd}><strong>Small Business (general)</strong></td>
+      <td style={docTdMono}>editorial-transparent</td>
+      <td style={docTd}>4</td>
+      <td style={docTd}>None</td>
+      <td style={docTdMono}>reveal-on-scroll</td>
+      <td style={docTdMono}>fullscreen-overlay</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Archetype semantics
+
+What each archetype is **for** — audience assumptions, conversion intent, and
+when to pick it vs. its neighbors.
+
+### `editorial-transparent`
+
+4 primary links + Services mega-menu + utility cluster (phone + primary CTA).
+Nav is transparent over the hero at page-load, frosted glass past 80px scroll,
+hides on scroll-down past 120px.
+
+**Fit:** luxury dental, med-aesthetic, editorial hospitality — verticals where
+hero photography must breathe at first load and the header is a secondary
+surface during browsing.
+
+**Avoid when:** users land in task mode (search, filter, compare). An
+always-solid nav serves them better.
+
+### `utility-first`
+
+5 primary links + task-oriented mega-menu + utility cluster with the primary
+conversion action leading (e.g. "Find a Site", "Schedule a Tour", "Free
+Consultation"). Always-solid background — never hides, never goes
+transparent. The top bar is a task surface, not a branding surface.
+
+**Fit:** real-estate/RV/MHC directories, multi-practice legal, SaaS with
+deep product catalogs.
+
+**Avoid when:** the brand moment matters more than the task (luxury, editorial).
+
+### `service-centric`
+
+5 primary links + a prominent mega-menu on Services / Practice Areas /
+Specialties — the mega-menu IS the product discovery surface. 2-column
+internal layout: categories on the left, featured practitioner/case card on
+the right.
+
+**Fit:** legal multi-practice, specialty medical groups, agencies with a
+productized service catalog.
+
+**Avoid when:** service catalog is small (<6 items). A flat nav does the job.
+
+### `portfolio-minimal`
+
+3-4 primary links, no dropdowns, text-only serif treatment with wide tracking.
+Hide-on-scroll-down, reveal-on-scroll-up. Utility cluster is minimal — often
+just an IG icon and a ghost "Inquire" link.
+
+**Fit:** MUA, photographers, wedding vendors, creative portfolios.
+
+**Avoid when:** the site has more than one conversion path (book vs. contact
+vs. shop).
+
+### `calm-flat`
+
+3-4 primary links, NO dropdowns — anxiety-sensitive audiences (wellness,
+mental health, therapy) don't hover-explore. Always solid at low contrast.
+Single warm CTA — "Book Session" — no secondary actions competing.
+
+**Fit:** wellness, mental health, therapy, recovery, palliative care.
+
+**Avoid when:** the audience is in research / comparison mode — they'll need
+a mega-menu to survey options.
+
+---
+
+## Live pack previews
+
+Each current industry pack with its seeded `navigationIA` rendered via
+`<NavigationIASpec>`. Click through to the dedicated industry MDX for the
+full context (pain points, seasonality, strategic POV, etc.).
+
+### Dental
+
+<NavigationIASpec industry="Dental" ia={dental.navigationIA} />
+
+### Real Estate — RV Parks & MHC
+
+<NavigationIASpec industry="Real Estate" ia={realEstateRvMhc.navigationIA} />
+
+### Small Business (General)
+
+<NavigationIASpec industry="Small Business" ia={smallBusiness.navigationIA} />
+
+---
+
+## For future agents — how to pick
+
+When you're building a new client's site:
+
+1. **Read their `industry_slug`** from `company_profiles`.
+2. **Look up the pack** via `getPackByIndustrySlug(industry_slug)` from `@brikdesigns/bds/content-system`.
+3. **Read `pack.navigationIA`** — that's the default. If absent, fall back to `smallBusiness.navigationIA`.
+4. **Check the portal Intel tab** — admin may have overridden fields per-client. Overrides win.
+5. **Pass the resolved `NavigationIA` to `<SiteHeader>`** when that component ships in `@brikdesigns/bds/blueprints-astro`.
+
+Until the Astro blueprint component lands, client Astro sites can hand-roll
+their header and treat this pack data as the spec. The Birdwell & Mutlak site
+is the reference implementation of `editorial-transparent` — see
+`web/birdwell-mutlak/src/components/Nav.astro`.
+
+---
+
+## Related
+
+- [Blueprints](?path=/docs/theming-blueprints--docs) — page-layout patterns
+- [Content — Industries — Dental](?path=/docs/content-industries-dental--docs)
+- [Content — Industries — Real Estate](?path=/docs/content-industries-real-estate--docs)
+- [Content — Industries — Small Business](?path=/docs/content-industries-small-business-general---docs)

--- a/stories/foundation/_components/NavigationIASpec.tsx
+++ b/stories/foundation/_components/NavigationIASpec.tsx
@@ -1,0 +1,279 @@
+import type { NavigationIA } from '../../../content-system/schema';
+import { docTable, docTh, docTd, docTdMono } from './docTableStyles';
+
+interface Props {
+  /** Label for the industry this IA belongs to (shown in the preview header). */
+  industry: string;
+  ia: NavigationIA;
+}
+
+/**
+ * NavigationIASpec — Storybook renderer for a pack's `navigationIA` field.
+ *
+ * Three blocks:
+ *   1. Visual preview — simplified mock of the rendered header bar.
+ *   2. Primary data table — archetype, link count, scroll + mobile behavior.
+ *   3. Mega-menu preview (if defined) — category grid with featured card.
+ *
+ * Designed as a shared doc component so all industry `.mdx` files render
+ * IA consistently. When the BDS `<SiteHeader>` Astro blueprint component
+ * ships, this preview should be replaced with a live render at realistic
+ * dimensions; for now the static mock is adequate for scanning the IA
+ * decisions at a glance.
+ */
+export function NavigationIASpec({ industry, ia }: Props) {
+  return (
+    <div style={{ marginBottom: 'var(--padding-xl, 40px)' }}>
+      {/* ── Visual preview ──────────────────────────────────── */}
+      <div
+        style={{
+          borderRadius: 'var(--border-radius-lg, 12px)',
+          border: '1px solid var(--border-primary, #333)',
+          overflow: 'hidden',
+          marginBottom: 'var(--gap-lg, 16px)',
+          background: 'linear-gradient(to bottom, rgba(0,0,0,0.0), rgba(0,0,0,0.04))',
+        }}
+      >
+        {/* Mock header bar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 24,
+            padding: '14px 20px',
+            borderBottom: '1px solid var(--border-primary, #333)',
+            background:
+              ia.scrollBehavior === 'transparent-top-frosted-past-80'
+                ? 'rgba(0,0,0,0.78)'
+                : 'var(--background-primary, #fff)',
+            color:
+              ia.scrollBehavior === 'transparent-top-frosted-past-80'
+                ? '#fff'
+                : 'var(--text-primary, #000)',
+          }}
+        >
+          <span style={{ fontFamily: 'var(--font-family-heading)', fontWeight: 600 }}>
+            {industry} Brand
+          </span>
+          <nav style={{ display: 'flex', gap: 20, flex: 1, fontSize: 13 }}>
+            {ia.servicesMegaMenu && (
+              <span style={{ opacity: 0.9 }}>{ia.servicesMegaMenu.triggerLabel} ▾</span>
+            )}
+            {ia.primaryLinks
+              .filter((l) => l.label !== (ia.servicesMegaMenu?.triggerLabel ?? ''))
+              .slice(0, ia.primaryLinkCount - (ia.servicesMegaMenu ? 1 : 0))
+              .map((l) => (
+                <span key={l.href} style={{ opacity: 0.8 }}>
+                  {l.label}
+                </span>
+              ))}
+          </nav>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'center', fontSize: 13 }}>
+            {ia.utility.showPhone && <span style={{ opacity: 0.7 }}>(555) 000-0000</span>}
+            <span
+              style={{
+                padding: '6px 14px',
+                background:
+                  ia.utility.primaryCTA.variant === 'solid' ? 'var(--background-brand-primary, #c49a2f)' : 'transparent',
+                border:
+                  ia.utility.primaryCTA.variant === 'ghost'
+                    ? '1px solid var(--color-gold, #c49a2f)'
+                    : 'none',
+                color:
+                  ia.utility.primaryCTA.variant === 'solid'
+                    ? 'var(--color-black, #000)'
+                    : 'var(--color-gold, #c49a2f)',
+                borderRadius: 'var(--border-radius-pill, 9999px)',
+                fontFamily: 'var(--font-family-label)',
+                fontSize: 11,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                fontWeight: 600,
+              }}
+            >
+              {ia.utility.primaryCTA.label}
+            </span>
+          </div>
+        </div>
+
+        {/* Caption */}
+        <div
+          style={{
+            padding: '8px 20px',
+            fontSize: 11,
+            opacity: 0.55,
+            fontFamily: 'var(--font-family-label)',
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+          }}
+        >
+          Archetype: {ia.archetype}  ·  {ia.primaryLinkCount} primary  ·  {ia.scrollBehavior}
+        </div>
+      </div>
+
+      {/* ── Data table ──────────────────────────────────── */}
+      <table style={docTable}>
+        <thead>
+          <tr>
+            <th style={docTh}>Field</th>
+            <th style={docTh}>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style={docTd}>Archetype</td>
+            <td style={docTdMono}>{ia.archetype}</td>
+          </tr>
+          <tr>
+            <td style={docTd}>Primary link count</td>
+            <td style={docTdMono}>{ia.primaryLinkCount}</td>
+          </tr>
+          <tr>
+            <td style={docTd}>Primary links</td>
+            <td style={docTd}>
+              {ia.primaryLinks.map((l) => l.label).join('  ·  ')}
+            </td>
+          </tr>
+          <tr>
+            <td style={docTd}>Services mega-menu</td>
+            <td style={docTd}>
+              {ia.servicesMegaMenu
+                ? `Yes — ${ia.servicesMegaMenu.columns} columns, ${ia.servicesMegaMenu.categories.length} categories`
+                : 'No'}
+            </td>
+          </tr>
+          <tr>
+            <td style={docTd}>Utility cluster</td>
+            <td style={docTd}>
+              {[
+                ia.utility.showPhone ? 'phone' : null,
+                `${ia.utility.primaryCTA.variant} CTA "${ia.utility.primaryCTA.label}"`,
+                ia.utility.secondaryCTA ? `+ ${ia.utility.secondaryCTA.label}` : null,
+              ]
+                .filter(Boolean)
+                .join('  ·  ')}
+            </td>
+          </tr>
+          <tr>
+            <td style={docTd}>Scroll behavior</td>
+            <td style={docTdMono}>{ia.scrollBehavior}</td>
+          </tr>
+          <tr>
+            <td style={docTd}>Mobile drawer</td>
+            <td style={docTdMono}>{ia.mobileDrawer}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      {/* ── Mega-menu preview ──────────────────────────────────── */}
+      {ia.servicesMegaMenu && (
+        <div style={{ marginTop: 'var(--padding-lg, 24px)' }}>
+          <h4
+            style={{
+              fontFamily: 'var(--font-family-heading)',
+              fontSize: 'var(--heading-sm, 18px)',
+              marginBottom: 'var(--gap-md, 12px)',
+            }}
+          >
+            {ia.servicesMegaMenu.triggerLabel} mega-menu
+          </h4>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: `repeat(${ia.servicesMegaMenu.columns}, 1fr)`,
+              gap: 'var(--gap-lg, 16px)',
+              padding: 'var(--padding-md, 20px)',
+              border: '1px solid var(--border-primary, #333)',
+              borderRadius: 'var(--border-radius-md, 8px)',
+              background: 'rgba(0,0,0,0.02)',
+            }}
+          >
+            {ia.servicesMegaMenu.categories.map((cat) => (
+              <div key={cat.heading}>
+                <p
+                  style={{
+                    fontFamily: 'var(--font-family-label)',
+                    fontSize: 11,
+                    letterSpacing: '0.2em',
+                    textTransform: 'uppercase',
+                    color: 'var(--color-gold, #c49a2f)',
+                    marginBottom: 12,
+                  }}
+                >
+                  {cat.heading}
+                </p>
+                <ul
+                  style={{
+                    listStyle: 'none',
+                    padding: 0,
+                    margin: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 10,
+                  }}
+                >
+                  {cat.items.map((item) => (
+                    <li key={item.href}>
+                      <div style={{ fontSize: 14, fontWeight: 500 }}>{item.label}</div>
+                      {item.note && (
+                        <div style={{ fontSize: 12, opacity: 0.6, marginTop: 2 }}>{item.note}</div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+            {ia.servicesMegaMenu.featured && (
+              <div
+                style={{
+                  background:
+                    'linear-gradient(135deg, rgba(196,154,47,0.08), transparent)',
+                  border: '1px solid rgba(196,154,47,0.2)',
+                  borderRadius: 'var(--border-radius-md, 8px)',
+                  padding: 'var(--padding-md, 16px)',
+                }}
+              >
+                <p
+                  style={{
+                    fontFamily: 'var(--font-family-label)',
+                    fontSize: 10,
+                    letterSpacing: '0.2em',
+                    textTransform: 'uppercase',
+                    color: 'var(--color-gold, #c49a2f)',
+                    marginBottom: 8,
+                  }}
+                >
+                  {ia.servicesMegaMenu.featured.eyebrow}
+                </p>
+                <h5
+                  style={{
+                    fontFamily: 'var(--font-family-heading)',
+                    fontSize: 16,
+                    marginBottom: 8,
+                    lineHeight: 1.3,
+                  }}
+                >
+                  {ia.servicesMegaMenu.featured.heading}
+                </h5>
+                <p style={{ fontSize: 13, opacity: 0.7, marginBottom: 12, lineHeight: 1.5 }}>
+                  {ia.servicesMegaMenu.featured.body}
+                </p>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-family-label)',
+                    fontSize: 11,
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: 'var(--color-gold, #c49a2f)',
+                  }}
+                >
+                  {ia.servicesMegaMenu.featured.ctaLabel} →
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/stories/foundation/_components/index.ts
+++ b/stories/foundation/_components/index.ts
@@ -19,3 +19,4 @@ export {
   UtilityClassTable,
   StaggerDemo,
 } from './MotionTokenDemos';
+export { NavigationIASpec } from './NavigationIASpec';


### PR DESCRIPTION
## Summary

Track A of the systemic integration plan — encodes navigation IA as structured BCS pack data so industry packs declare their site-header defaults, and consumer Astro sites render them via the forthcoming `<SiteHeader>` blueprint.

**What ships:**

- **3 new locked vocabularies** (`nav-archetype`, `scroll-behavior`, `drawer-pattern`) covering 5 archetypes × 4 scroll behaviors × 3 mobile drawers.
- **`navigationIA` field on `IndustryPack`** + 7 supporting interfaces (`NavigationIA`, `NavigationLink`, `NavigationUtility`, `NavigationCTA`, `ServicesMegaMenu*`).
- **Seed data** for `dental`, `real-estate-rv-mhc`, `small-business` — each with rationale comments explaining why that archetype fits the vertical.
- **`NavigationIASpec` Storybook doc component** — reusable renderer (preview bar + data table + mega-menu mock) surfaced across all industry MDX.
- **`Content/Navigation Archetypes` gallery story** — full vocabulary decision matrix + per-archetype "fit / avoid" semantics + live previews + how-to-pick guide for future agents.

**Why:** Birdwell & Mutlak just shipped a hand-rolled `editorial-transparent` nav. Without this encoded somewhere canonical, every future client nav becomes another hand-roll with no shared vocabulary. This lands the seam that BDS `<SiteHeader>` (blueprints-astro) and the portal Intel tab override UI both plug into.

## Commits

1. `feat(bcs): add navigation IA vocabularies (archetype / scroll / drawer)`
2. `feat(bcs): add navigationIA to IndustryPack schema`
3. `feat(bcs): seed navigationIA on dental / real-estate / small-business packs`
4. `docs(storybook): add NavigationIASpec + NavigationArchetypes gallery`
5. `fix(storybook): resolve NavigationIASpec via explicit directory index`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx storybook build` succeeds (was blocked on `<6 items` MDX parse + legacy `_components.tsx` resolution shadow — both fixed)
- [x] All 6 pre-push checks pass
- [ ] Visual review in deployed Storybook — `/?path=/docs/content-industries-dental--docs` has Section 9 with NavigationIASpec rendered
- [ ] Visual review — `/?path=/docs/content-navigation-archetypes--docs` shows full vocabulary + decision matrix + live previews

## Follow-up (separate PRs)

- **Legacy `_components.tsx` collapse** — file shadows `_components/index.ts` under Vite's resolver; works today by coincidence. Next Storybook housekeeping PR.
- **Track B** (atmospheres library + `theme_mode` + `atmosphere` profile columns).
- **Track C** (portal reference-builds task enforcement).
- **BDS `<SiteHeader>` blueprint-astro component** — the consumer that reads `pack.navigationIA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)