### PR TITLE
bcs: dental site audit

### DIFF
--- a/content-system/industries/dental.mdx
+++ b/content-system/industries/dental.mdx
@@ -125,6 +125,58 @@ Three transition patterns: **selective drop** (lowest-paying PPOs first), **full
 
 ---
 
+## 11. Site Audit Extractors
+
+When the portal audits a dental client's existing website, four pack-specific extractors run in addition to the universal ones (services, key messages, proof points, social links). Each turns live-site content into structured facts the content + preflight workers can reason about programmatically, rather than re-paraphrasing free text every run.
+
+### Page patterns
+
+The pack declares URL / path / title patterns that route scraped pages to the right extractor:
+
+| Pattern | Matches | Feeds extractor |
+|---|---|---|
+| `membership_plan` | `/membership`, `/membership-plan*`, `/dental-savings-plan`, `/care-plan` · titles containing "membership plan", "dental savings", "care plan" | `membership_plans` |
+| `insurance` | `/insurance`, `/insurance-accepted`, `/financing`, `/payment-options` · titles containing "insurance", "financing", "accepted insurance" | `insurance_accepted` |
+| `new_patients` | `/new-patients`, `/first-visit`, `/welcome`, `/specials`, `/offers` · titles containing "new patient", "first visit", "special offer" | `new_patient_offers` |
+| `contact_or_homepage` | `/`, `/contact*`, `/book`, `/schedule`, `/appointments` · titles containing "book", "schedule", "appointment" | `appointment_systems` |
+
+Matches are case-insensitive. Multiple patterns can match a single page; each matched page routes to every applicable extractor.
+
+### Structured extractors
+
+| Extractor | Writes to `company_profiles` | Shape |
+|---|---|---|
+| **`membership_plans`** | `membership_plans[]`, `has_membership_plan` | `{ tier, monthly_price_cents, annual_price_cents, included_services[], enrollment_cta, source_url }` |
+| **`insurance_accepted`** | `insurance_providers[]`, `insurance_plans[]` | Verbatim carrier names (Delta Dental, Aetna, Cigna) + plan/program names distinct from carriers (Medicaid, PPO, Out-of-Network) |
+| **`new_patient_offers`** | `new_patient_offers[]` | `{ offer, first_visit_duration_minutes, source_url }` |
+| **`appointment_systems`** | `appointment_systems[]` | Integration names (Zocdoc, LocalMed, Weave, NexHealth, "custom web form") |
+
+### Why these four
+
+- **Membership plans** — the most-missed dental fact. Content generators writing `/membership` copy must name tiers + prices verbatim; the paraphrase "plans starting at $X" reads as made-up. Birdwell's `/membership-plan-1` was the validation case that drove this work.
+- **Insurance accepted** — dental clients publish carrier lists specifically because patients filter on them. "We accept most major insurance" is marketing hedging; the actual carrier list is conversion-critical.
+- **New patient offers** — live promos on the existing site are load-bearing on the hero. A redesign that drops them silently breaks conversion copy clients are actively tracking.
+- **Appointment systems** — if the client has LocalMed or Weave wired up, the CTA must route there, not to a generic contact form. Misrouted CTAs are a common regression on template-based rebuilds.
+
+### Portal integration
+
+The portal's `website-audits` worker resolves this pack via `company_profiles.industry_slug === 'dental'`, invokes each matched extractor, validates output against the `fieldSchemas` shapes above, and enriches the profile with `source: 'website_audit'`. Generate-content for dental clients then renders the structured facts verbatim (no LLM paraphrasing on these fields).
+
+Structured fields are also stamped to the `design_decisions` log with `source: 'website_audit'` so re-runs can see what was extracted last time and diff against the current run.
+
+### Adding extractors to a new industry
+
+1. Implement `siteAudit: IndustryPackSiteAudit` on the pack's `.ts` file (schema in [industry-pack.ts](?path=/docs/content-system-schema--docs)).
+2. Declare `pagePatterns` — URL / path / title rules that route scraped pages to extractors.
+3. List the extractors + the `company_profiles` columns they write to. Populate `fieldSchemas` with shape descriptions for each column.
+4. Add portal-side migration for any new columns; extend `enrichProfile` allowlist for `website_audit` to cover them.
+5. Implement the actual extraction logic in `src/lib/website-audits/industry-packs/<slug>.ts` on the portal side.
+6. Document the extractors here in the pack's `.mdx` under "Site Audit Extractors".
+
+Consumers without `siteAudit` defined (`small-business` fallback) run universal extractors only.
+
+---
+
 ## Related
 
 - [Blueprint library](?path=/docs/theming-blueprints--docs) — page layout patterns tagged with industry affinities

--- a/content-system/industries/dental.ts
+++ b/content-system/industries/dental.ts
@@ -541,4 +541,103 @@ export const dental: IndustryPack = {
     scrollBehavior: 'transparent-top-frosted-past-80',
     mobileDrawer: 'fullscreen-overlay',
   },
+
+  // ── Site Audit extractors ─────────────────────────────────────────────
+  //
+  // Dental is the first industry to ship structured site-audit extraction
+  // beyond the universal scrape. Four dental-specific facts surface from a
+  // live site that the universal extractors collapse into free text:
+  //
+  //   1. Membership plan tiers — name, monthly price, inclusions, enrollment
+  //      CTA. Turns /membership-plan-1 into data the /membership page
+  //      generator can render verbatim instead of paraphrasing.
+  //   2. Insurance accepted — the actual carrier list the practice names
+  //      publicly, not just "we accept most major insurance."
+  //   3. New patient offers — live promos, complimentary consults, free
+  //      X-ray offers — the conversion-critical copy the hero needs to
+  //      honor or explicitly replace.
+  //   4. Appointment systems — booking integrations (Zocdoc, LocalMed,
+  //      custom forms) the content generator should reference correctly
+  //      rather than invent a generic "Book online" CTA.
+  //
+  // Portal implementation: src/lib/website-audits/industry-packs/dental.ts
+  // reads the patterns below to route scraped pages into the corresponding
+  // extractors, then writes structured output to the listed profile columns.
+  siteAudit: {
+    pagePatterns: [
+      {
+        key: 'membership_plan',
+        description: 'In-house membership plan page — tier listing with pricing.',
+        urlContains: ['membership', 'dental-plan', 'savings-plan', 'in-house-plan'],
+        pathMatches: ['/membership', '/membership-plan', '/dental-savings-plan', '/care-plan'],
+        titleMatches: ['membership plan', 'dental savings', 'in-house plan', 'care plan'],
+      },
+      {
+        key: 'insurance',
+        description: 'Insurance information page — accepted carriers and plan details.',
+        urlContains: ['insurance', 'financing', 'payment-options'],
+        pathMatches: ['/insurance', '/insurance-accepted', '/financing', '/payment-options'],
+        titleMatches: ['insurance', 'financing', 'payment options', 'accepted insurance'],
+      },
+      {
+        key: 'new_patients',
+        description: 'New patient welcome / offers page — current promos and first-visit flow.',
+        urlContains: ['new-patient', 'first-visit', 'welcome', 'special', 'offer'],
+        pathMatches: ['/new-patients', '/first-visit', '/welcome', '/specials', '/offers'],
+        titleMatches: ['new patient', 'first visit', 'welcome', 'special offer', 'current promotion'],
+      },
+      {
+        key: 'contact_or_homepage',
+        description: 'Homepage + contact page — where appointment-system references surface.',
+        pathMatches: ['/', '/contact', '/contact-us', '/book', '/schedule', '/appointments'],
+        titleMatches: ['contact', 'book', 'schedule', 'appointment'],
+      },
+    ],
+
+    extractors: [
+      {
+        key: 'membership_plans',
+        label: 'Membership plan tiers',
+        description: 'Structured tier inventory — tier name, monthly price, included services, enrollment CTA.',
+        handles: ['membership_plan'],
+        outputFields: ['membership_plans', 'has_membership_plan'],
+      },
+      {
+        key: 'insurance_accepted',
+        label: 'Accepted insurance carriers',
+        description: 'Explicit carrier list the practice publishes — used to populate insurance_providers verbatim.',
+        handles: ['insurance'],
+        outputFields: ['insurance_providers', 'insurance_plans'],
+      },
+      {
+        key: 'new_patient_offers',
+        label: 'New patient offers + first-visit flow',
+        description: 'Live promos (free consult, complimentary X-ray, new patient specials) plus the first-visit experience description.',
+        handles: ['new_patients'],
+        outputFields: ['new_patient_offers'],
+      },
+      {
+        key: 'appointment_systems',
+        label: 'Appointment booking integrations',
+        description: 'Third-party booking systems referenced on contact / homepage (Zocdoc, LocalMed, Weave, NexHealth, custom forms).',
+        handles: ['contact_or_homepage'],
+        outputFields: ['appointment_systems'],
+      },
+    ],
+
+    fieldSchemas: {
+      membership_plans:
+        'Array<{ tier: string; monthly_price_cents: number | null; annual_price_cents: number | null; included_services: string[]; enrollment_cta: string | null; source_url: string }>',
+      has_membership_plan:
+        '{ status: "active" | "in_development" | "planned" | "none"; notes: string | null }',
+      insurance_providers:
+        'string[] — carrier names (e.g. "Delta Dental", "Aetna", "Cigna"). Verbatim from the site.',
+      insurance_plans:
+        'string[] — plan/program names distinct from carriers (e.g. "Medicaid", "PPO", "Out-of-Network").',
+      new_patient_offers:
+        'Array<{ offer: string; first_visit_duration_minutes: number | null; source_url: string }>',
+      appointment_systems:
+        'string[] — integration names (e.g. "Zocdoc", "LocalMed", "Weave", "custom web form").',
+    },
+  },
 };

--- a/content-system/schema/index.ts
+++ b/content-system/schema/index.ts
@@ -17,6 +17,9 @@ export type {
   ServicesMegaMenuCategory,
   ServicesMegaMenuItem,
   ServicesMegaMenuFeature,
+  IndustryPackSiteAudit,
+  PagePattern,
+  SiteAuditExtractor,
 } from './industry-pack';
 
 export type {

--- a/content-system/schema/industry-pack.ts
+++ b/content-system/schema/industry-pack.ts
@@ -183,6 +183,104 @@ export interface IndustryPack {
    * 4 links, no mega-menu).
    */
   navigationIA?: NavigationIA;
+
+  /**
+   * Industry-specific site audit — URL patterns + structured-fact extractors
+   * that turn a crawl of the client's existing website into fields downstream
+   * consumers can reason about programmatically (rather than LLM-paraphrasing
+   * free-text scrape results every time).
+   *
+   * The portal runs universal extractors (services_offered, key_messages,
+   * proof_points, social_links, tagline, value_proposition, target_audience)
+   * on every audit regardless of industry. When a client's `industry_slug`
+   * resolves to a pack with `siteAudit` defined, the pack's extractors run
+   * in addition and land structured facts on industry-specific columns on
+   * `company_profiles`.
+   *
+   * Example (dental): membership-plan tier extraction — turn
+   * `/membership-plan-1` into structured
+   * `{ tier, monthly_price, inclusions[], enrollment_cta }` records the
+   * `/membership` page generator can render verbatim instead of
+   * paraphrasing.
+   *
+   * Leave unset for industries without pack-specific audit logic —
+   * universal extractors still run.
+   */
+  siteAudit?: IndustryPackSiteAudit;
+}
+
+// ─── Site audit contract ────────────────────────────────────────────────
+//
+// The industry pack declares which URL patterns it cares about and a set of
+// named structured-fact extractors. The portal's website-audits worker
+// resolves the pack by the client's industry_slug, routes matching scraped
+// pages through the named extractors, and lands the result on
+// company_profiles columns that downstream consumers (generate-content,
+// preflight, decision-log) can read as canonical facts.
+//
+// Execution model:
+//   1. Universal extractors run first (tagline, services, messaging, proofs).
+//   2. For each page in the crawl:
+//        - test `pagePatterns` against the URL/path/title
+//        - for matches, invoke the corresponding extractor
+//   3. Extractor output is validated (the pack declares target field shapes)
+//      and merged into the profile via enrichProfile(source: 'website_audit').
+//
+// Extractor implementations live in the same pack file (dental.ts, etc.) —
+// kept close to the industry narrative so reviewers see both the logic and
+// the rationale in one place.
+
+/** Rule for matching a scraped page to an extractor. */
+export interface PagePattern {
+  /** Stable identifier used in `siteAudit.extractors[].handles`. */
+  key: string;
+  /**
+   * Match rules. All array entries are OR'd; an object with multiple keys
+   * AND's the keys. At least one of (urlContains | pathMatches | titleMatches)
+   * must match for the page to route to the handler. Patterns are
+   * case-insensitive.
+   */
+  urlContains?: readonly string[];
+  pathMatches?: readonly string[];
+  titleMatches?: readonly string[];
+  /** Human-readable description of what this pattern targets. */
+  description: string;
+}
+
+/**
+ * A named extractor that pulls structured facts out of one or more scraped
+ * pages. The pack declares the output shape inline; the portal validates
+ * the extractor's return value against `outputFields` before persisting.
+ */
+export interface SiteAuditExtractor {
+  /** Stable identifier used in decision-log entries. */
+  key: string;
+  /** Human-readable label used in admin UI + docs. */
+  label: string;
+  /** Short description of what the extractor lands on the profile. */
+  description: string;
+  /** Page-pattern keys whose matched pages feed this extractor. */
+  handles: readonly string[];
+  /**
+   * The `company_profiles` columns this extractor writes to, keyed by
+   * field name. Values describe the expected shape. The portal's
+   * enrichProfile allowlist must permit `source: 'website_audit'` to
+   * write each field listed here.
+   */
+  outputFields: readonly string[];
+}
+
+export interface IndustryPackSiteAudit {
+  /** URL / path / title patterns used to route pages to extractors. */
+  pagePatterns: readonly PagePattern[];
+  /** Industry-specific extractors that run in addition to universal ones. */
+  extractors: readonly SiteAuditExtractor[];
+  /**
+   * Pack-declared schemas for structured fields. Keys match
+   * `company_profiles` columns; values document the expected shape.
+   * The portal uses these to validate extractor output before persisting.
+   */
+  fieldSchemas: Record<string, string>;
 }
 
 export interface NavigationIA {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(bcs): IndustryPackSiteAudit contract + dental implementation

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)