### PR TITLE
bds: guard unification

### DIFF
--- a/scripts/new-task.sh
+++ b/scripts/new-task.sh
@@ -54,18 +54,21 @@ if [ "$PROJECT_ROOT" != "$PRIMARY_PATH" ]; then
 fi
 
 PRIMARY_BRANCH="$(git -C "$PRIMARY_PATH" branch --show-current || echo '(detached)')"
-if [ "$PRIMARY_BRANCH" != "main" ]; then
-  echo -e "${RED}Error: primary worktree is on '${PRIMARY_BRANCH}', not 'main'.${NC}"
-  echo ""
-  echo "  The primary worktree at $PRIMARY_PATH must stay on main."
-  echo "  Task work lives in ../brik-bds-worktrees/{slug} — never in the primary."
-  echo ""
-  echo "  To fix:"
-  echo "    cd $PRIMARY_PATH"
-  echo "    git status             # inspect any uncommitted work"
-  echo "    git switch main        # return to main"
-  exit 1
-fi
+case "$PRIMARY_BRANCH" in
+  main|staging) ;;
+  *)
+    echo -e "${RED}Error: primary worktree is on '${PRIMARY_BRANCH}', not a base branch.${NC}"
+    echo ""
+    echo "  The primary worktree at $PRIMARY_PATH must stay on ${BASE_BRANCH} (or staging)."
+    echo "  Task work lives in ../brik-bds-worktrees/{slug} — never in the primary."
+    echo ""
+    echo "  To fix:"
+    echo "    cd $PRIMARY_PATH"
+    echo "    git status                  # inspect any uncommitted work"
+    echo "    git switch ${BASE_BRANCH}   # return to the base branch"
+    exit 1
+    ;;
+esac
 
 # ── Parse flags ──
 while [[ $# -gt 0 ]]; do

--- a/scripts/worktree-guard.sh
+++ b/scripts/worktree-guard.sh
@@ -62,9 +62,23 @@ if [ "$CURRENT_PATH" = "$PRIMARY_PATH" ]; then
   IN_PRIMARY=1
 fi
 
-VIOLATION=0
-if [ "$PRIMARY_BRANCH" != "main" ]; then
-  VIOLATION=1
+# Canonical rule (same across all four Brik repos): primary sits on a
+# base branch. The accepted set is {main, staging}. Any other value —
+# task/*, chore/*, feat/*, fix/*, a release branch, etc. — is flagged.
+# Repos without a staging branch (brik-bds, brikdesigns) still pass
+# because the primary will never land there; the accepted set is a
+# superset, not a claim that both branches exist.
+VIOLATION=1
+case "$PRIMARY_BRANCH" in
+  main|staging) VIOLATION=0 ;;
+esac
+
+# The recovery branch suggested in the warning — prefer main, fall back
+# to staging if the repo doesn't have main locally (edge case).
+SUGGEST_BRANCH="main"
+if ! git -C "$PRIMARY_PATH" show-ref --verify --quiet refs/heads/main \
+   && git -C "$PRIMARY_PATH" show-ref --verify --quiet refs/heads/staging; then
+  SUGGEST_BRANCH="staging"
 fi
 
 if [ "$JSON" = "1" ]; then
@@ -75,9 +89,9 @@ else
     RED='\033[0;31m'
     YELLOW='\033[1;33m'
     NC='\033[0m'
-    printf '%b\n' "${RED}⚠  Primary worktree is on '${PRIMARY_BRANCH}', not 'main'.${NC}" >&2
+    printf '%b\n' "${RED}⚠  Primary worktree is on '${PRIMARY_BRANCH}', not a base branch.${NC}" >&2
     printf '%b\n' "${YELLOW}   Path: ${PRIMARY_PATH}${NC}" >&2
-    printf '%b\n' "${YELLOW}   Fix:  cd ${PRIMARY_PATH} && git switch main${NC}" >&2
+    printf '%b\n' "${YELLOW}   Fix:  cd ${PRIMARY_PATH} && git switch ${SUGGEST_BRANCH}${NC}" >&2
     printf '%b\n' "${YELLOW}   For the task work, use: ./scripts/new-task.sh {scope}-{name}${NC}" >&2
   fi
 fi


### PR DESCRIPTION
## Summary

Canonicalizes the `worktree-guard.sh` + `new-task.sh` violation rule across all four Brik repos. Follow-up to the original guard PRs that surfaced a drift between them during review.

## Rule (now identical across bds, portal, renew-pms, brikdesigns)

> **Violation = primary branch NOT in `{main, staging}`**

The accepted set is a superset — repos without a `staging` branch (bds, brikdesigns) pass because the primary never lands there, not because `staging` is required. Repos with `staging` (portal, renew-pms) can legitimately sit there. Anything else — `task/*`, `chore/*`, `feat/*`, `fix/*`, `release/*`, ad-hoc names — is flagged.

## What drifted before this PR

| Repo | Previous rule | What it missed |
|------|---------------|----------------|
| brik-bds | `!= "main"` | (correct; just narrower comment) |
| brik-client-portal | `task/*` only | `chore/*`, `feat/*`, `fix/*` on primary |
| renew-pms | `task/*` only | same gap as portal |
| brikdesigns | `!= "main"` | (correct; unified for consistency) |

The two product repos had the bigger gap — they'd miss a primary sitting on `chore/bump-deps` or `feat/some-branch`, both of which are the same class of drift the guard was added to prevent.

## What this PR changes

- `scripts/worktree-guard.sh` — violation check becomes a `case` against `{main, staging}`, with a comment explaining the superset logic.
- `scripts/new-task.sh` — same rule in the preflight block so `new-task.sh` refuses to run from a violating primary.
- Guard warning message now says "not a base branch" instead of "not 'main'" / "a task branch" to reflect the general rule.

## Verify
- [ ] `./scripts/worktree-guard.sh --json` on the primary (clean) returns `violation: 0`
- [ ] Simulating `git switch chore/xyz` on the primary now returns `violation: 1` (previously ignored in portal/renew)
- [ ] `./scripts/new-task.sh foo-bar` from the primary on a non-base branch errors with the updated message

🤖 Generated with [Claude Code](https://claude.com/claude-code)