### PR TITLE
fix(infra): cache-control headers for Storybook deploy to stop stale-chunk errors

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,3 +22,47 @@
   [headers.values]
     X-Frame-Options = "SAMEORIGIN"
     X-Content-Type-Options = "nosniff"
+
+# Cache policy — prevent the "Failed to fetch dynamically imported module"
+# error caused by stale chunk hashes.
+#
+# Storybook's Vite build emits content-hashed chunks under /assets/*.js (and
+# .css, etc). The hash is part of the filename, so the URL is stable for a
+# given content and changes on every deploy. Those are safe to cache forever.
+#
+# But index.html, iframe.html, and index.json reference those hashed URLs by
+# name. If a browser holds a stale HTML/JSON that points at a hash Netlify
+# has already evicted, the next dynamic import 404s. Every page-load must
+# revalidate these entry points so the chunk URLs it references are fresh.
+#
+# Bonus: the `assets/` globs also cover woff2 + images, which are hashed too.
+
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/iframe.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/index.json"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/project.json"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/sb-*/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"


### PR DESCRIPTION
## Summary

Fixes the `Failed to fetch dynamically imported module: …/Hover-RFPcwxih.js` red-card error that appears on [storybook.brikdesigns.com](https://storybook.brikdesigns.com) every deploy and requires hard refresh to clear.

## Why

Storybook's Vite build emits content-hashed chunks under `/assets/*.js`. The hash is the filename, so cache-forever is safe — the URL changes on every content change. But `index.html`, `iframe.html`, and `index.json` embed those hashed URLs by name. When a browser holds a stale HTML/JSON that points at a hash Netlify has already evicted, the next dynamic import 404s.

Netlify's default cache policy doesn't distinguish between the two classes, so the entry points can go stale while chunks rotate underneath them.

## Fix

Standard Vite + CDN pattern:

| Path | Cache-Control | Why |
|---|---|---|
| `/index.html`, `/iframe.html` | `max-age=0, must-revalidate` | Entry points embed chunk URLs — must revalidate every load |
| `/index.json`, `/project.json` | `max-age=0, must-revalidate` | Story index / Storybook config — references lazy-loaded chunks |
| `/assets/*` | `max-age=31536000, immutable` | Content-hashed; URL changes when content does |
| `/sb-*/*` | `max-age=31536000, immutable` | Storybook manager + addon chunks — also content-hashed |

Existing `X-Frame-Options` / `X-Content-Type-Options` headers on `/*` are preserved.

## Scope

- Affects only Netlify-hosted deploys (production `storybook.brikdesigns.com` + staging `staging.storybook.brikdesigns.com`)
- Does NOT affect dev (`npm run storybook`) — hot-reload has its own module graph
- Does NOT affect Chromatic — each build is a frozen snapshot on a unique URL, so this class of error is architecturally impossible there

## Test plan

- [x] `netlify.toml` parses as valid TOML (7 `[[headers]]` blocks total)
- [x] `npm run validate:full` — all 6 checks pass
- [ ] After merge: visit `https://storybook.brikdesigns.com`, open DevTools Network tab, verify:
  - `index.html` response has `cache-control: public, max-age=0, must-revalidate`
  - A JS file under `/assets/` has `cache-control: public, max-age=31536000, immutable`
- [ ] After merge: push a trivial BDS change, verify the first post-deploy page-load does not throw `Failed to fetch dynamically imported module`

Pre-existing vitest flakes (Switch / AddableComboList / TimePicker / DatePicker Playground) unrelated to this PR — same 4 fail on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)