### PR TITLE
feat(theming): theme registry so client themes auto-enter the contrast audit

### DIFF
--- a/stories/ContrastCompliance.stories.tsx
+++ b/stories/ContrastCompliance.stories.tsx
@@ -2,40 +2,11 @@ import { useLayoutEffect, useState, type CSSProperties } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DashboardFrame, DashboardSection } from './_components/DashboardFrame';
 import { contrastRatio } from './_components/wcag-contrast';
+import { getAllThemes } from '../tokens/theme-registry';
 
-// ─── Themes under test ──────────────────────────────────────────────
-
-interface ThemeSpec {
-  key: string;
-  name: string;
-  description: string;
-  bodyClasses: string[];
-  dataTheme: 'light' | 'dark';
-}
-
-const THEMES: ThemeSpec[] = [
-  {
-    key: 'brik',
-    name: 'Brik',
-    description: 'Default brand — poppy on white, light mode',
-    bodyClasses: ['body', 'theme-brand-brik'],
-    dataTheme: 'light',
-  },
-  {
-    key: 'brik-dark',
-    name: 'Brik Dark',
-    description: 'Default brand — poppy on near-black, dark mode',
-    bodyClasses: ['body', 'theme-brand-brik'],
-    dataTheme: 'dark',
-  },
-  {
-    key: 'client-sim',
-    name: 'Client Sim',
-    description: 'Font-audit theme — Georgia / Verdana / Courier New to expose family misuse',
-    bodyClasses: ['body', 'theme-brand-brik', 'theme-client-sim'],
-    dataTheme: 'light',
-  },
-];
+// Themes under test come from the registry — BDS ships 3 built-ins, and
+// consumer Storybooks can extend the probe via `registerClientTheme()`
+// from `tokens/theme-registry`. No hand-editing this file per new client.
 
 // ─── Contrast pairs to evaluate ─────────────────────────────────────
 
@@ -89,7 +60,7 @@ function probeThemes(): ThemeResult[] {
 
   const results: ThemeResult[] = [];
 
-  for (const theme of THEMES) {
+  for (const theme of getAllThemes()) {
     body.className = '';
     for (const c of theme.bodyClasses) body.classList.add(c);
     html.setAttribute('data-theme', theme.dataTheme);
@@ -345,7 +316,21 @@ function ContrastComplianceDashboard() {
 const meta: Meta<typeof ContrastComplianceDashboard> = {
   title: 'Overview/Health/Contrast Compliance',
   component: ContrastComplianceDashboard,
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'WCAG AA contrast audit across every theme in the BDS theme registry. ' +
+          "By default that's the 3 built-ins (Brik, Brik Dark, Client Sim); " +
+          'consumer Storybooks add their own client themes by calling ' +
+          '`registerClientTheme({...})` from `@brikdesigns/bds` in their ' +
+          '`.storybook/preview.ts` (alongside the theme CSS import). Once ' +
+          'registered, the client theme enters this audit automatically — no ' +
+          'hand-edit of this file per new brand.',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -476,3 +476,12 @@ export const semanticSpace = {
   "input": "var(--space-200)"
 } as const;
 
+// Theme registry — consumer entry point for adding client themes to the
+// Contrast Compliance audit (and future multi-theme probes). See
+// ./theme-registry for usage.
+export {
+  type ThemeSpec,
+  BUILT_IN_THEMES,
+  registerClientTheme,
+  getAllThemes,
+} from './theme-registry';

--- a/tokens/theme-registry.ts
+++ b/tokens/theme-registry.ts
@@ -1,0 +1,123 @@
+/**
+ * Theme registry — the single source of truth for every theme the
+ * Contrast Compliance audit (and any future multi-theme probe) should
+ * evaluate.
+ *
+ * Why this exists
+ * ---------------
+ * BDS ships 3 built-in themes (Brik, Brik Dark, Client Sim). Client
+ * brands ship their own `theme-{client}.css` in consumer repos (portal,
+ * renew-pms, brikdesigns, client sites). The Contrast Compliance story
+ * used to hardcode a `THEMES` array, which meant adding a client theme
+ * to the WCAG probe required hand-editing stories code.
+ *
+ * With this registry, consumers with a client theme loaded in their
+ * Storybook composition can call `registerClientTheme({...})` once (e.g.
+ * in `.storybook/preview.ts`) and the theme enters every registry-aware
+ * probe automatically.
+ *
+ * Usage from a consumer Storybook
+ * -------------------------------
+ *   // .storybook/preview.ts (consumer repo)
+ *   import { registerClientTheme } from '@brikdesigns/bds';
+ *   import './styles/theme-freedom.css'; // must also load the stylesheet
+ *
+ *   registerClientTheme({
+ *     key: 'freedom',
+ *     name: 'Freedom',
+ *     description: 'Freedom Group — slate on warm ivory',
+ *     bodyClasses: ['body', 'theme-brand-freedom'],
+ *     dataTheme: 'light',
+ *   });
+ *
+ * Registration only tells the audit the theme exists; it does not load
+ * the stylesheet. The CSS import is what makes the class + data-theme
+ * selectors actually resolve on the page.
+ */
+
+export interface ThemeSpec {
+  /** Stable identifier for the theme — used as React key + audit row id. */
+  key: string;
+  /** Human-readable name shown in audit output. */
+  name: string;
+  /** One-line description surfaced under the name in audit cards. */
+  description: string;
+  /**
+   * Classes to apply to `<body>` when probing this theme. The built-in
+   * 'brand' class (`theme-brand-brik`) plus any additional theme-specific
+   * class (`theme-client-sim`) goes here — order matters for cascade.
+   */
+  bodyClasses: string[];
+  /**
+   * Value to set on `html[data-theme]` when probing. Used by Figma-generated
+   * dark-mode tokens to scope their overrides.
+   */
+  dataTheme: 'light' | 'dark';
+}
+
+/**
+ * The three themes BDS itself ships. Never mutate — consumers extend via
+ * `registerClientTheme`.
+ */
+export const BUILT_IN_THEMES: readonly ThemeSpec[] = [
+  {
+    key: 'brik',
+    name: 'Brik',
+    description: 'Default brand — poppy on white, light mode',
+    bodyClasses: ['body', 'theme-brand-brik'],
+    dataTheme: 'light',
+  },
+  {
+    key: 'brik-dark',
+    name: 'Brik Dark',
+    description: 'Default brand — poppy on near-black, dark mode',
+    bodyClasses: ['body', 'theme-brand-brik'],
+    dataTheme: 'dark',
+  },
+  {
+    key: 'client-sim',
+    name: 'Client Sim',
+    description: 'Font-audit theme — Georgia / Verdana / Courier New to expose family misuse',
+    bodyClasses: ['body', 'theme-brand-brik', 'theme-client-sim'],
+    dataTheme: 'light',
+  },
+] as const;
+
+// Module-level registry of client themes. Populated by `registerClientTheme`
+// at consumer Storybook init; read by `getAllThemes()` at probe time.
+const registeredClientThemes: ThemeSpec[] = [];
+
+/**
+ * Register a client theme so it enters every registry-aware probe
+ * (Contrast Compliance, future font-audit passes, etc.). Call from a
+ * consumer Storybook's `.storybook/preview.ts` alongside the stylesheet
+ * import for the theme.
+ *
+ * If a theme with the same `key` is already registered, the new spec
+ * replaces it — no duplicates.
+ */
+export function registerClientTheme(spec: ThemeSpec): void {
+  const existingIndex = registeredClientThemes.findIndex((t) => t.key === spec.key);
+  if (existingIndex >= 0) {
+    registeredClientThemes[existingIndex] = spec;
+    return;
+  }
+  registeredClientThemes.push(spec);
+}
+
+/**
+ * Return every theme the audit should evaluate: the three BDS built-ins
+ * followed by any client themes registered by a consumer Storybook.
+ * Callers should not mutate the returned array.
+ */
+export function getAllThemes(): readonly ThemeSpec[] {
+  return [...BUILT_IN_THEMES, ...registeredClientThemes];
+}
+
+/**
+ * Test-only escape hatch — resets the registered client themes list.
+ * Not exported from the package index; use only in unit tests.
+ */
+export function _resetClientThemesForTests(): void {
+  registeredClientThemes.length = 0;
+}


### PR DESCRIPTION
## Summary

Closes the last multi-tenant gap from the IA audit: **the Contrast Compliance probe no longer requires hand-editing the stories file per new client**. Client themes register themselves from consumer Storybooks and enter every registry-aware audit automatically.

## Before

[stories/ContrastCompliance.stories.tsx](stories/ContrastCompliance.stories.tsx) hardcoded a `THEMES: ThemeSpec[]` array with the 3 built-ins. Adding a new client theme required:
1. Editing BDS source
2. Bumping the BDS version
3. Publishing
4. `npm update @brikdesigns/bds` in every consumer

This pattern fights the 2-tier architecture — client themes live in CONSUMER repos, not BDS.

## After

New module [tokens/theme-registry.ts](tokens/theme-registry.ts) exposes:

| Export | Purpose |
|---|---|
| `ThemeSpec` | Canonical shape — `key`, `name`, `description`, `bodyClasses`, `dataTheme` |
| `BUILT_IN_THEMES` | Readonly const with the 3 BDS-shipped themes |
| `registerClientTheme(spec)` | Consumer-callable — appends (or replaces by key) a client theme |
| `getAllThemes()` | Returns `[...built-ins, ...registered]` at probe time |
| `_resetClientThemesForTests()` | Underscore-prefixed test escape hatch |

Re-exported from [tokens/index.ts](tokens/index.ts) so consumers import from the public API via the main `@brikdesigns/bds` entry (no dedicated sub-path needed).

## Consumer usage

```ts
// consumer-repo/.storybook/preview.ts
import { registerClientTheme } from '@brikdesigns/bds';
import './styles/theme-freedom.css'; // CSS must also load

registerClientTheme({
  key: 'freedom',
  name: 'Freedom',
  description: 'Freedom Group — slate on warm ivory',
  bodyClasses: ['body', 'theme-brand-freedom'],
  dataTheme: 'light',
});
```

Once registered, the theme enters Contrast Compliance automatically — and any **future** multi-theme audit (font-family check, spacing probe, etc.) that reads the same registry picks it up with zero additional wiring.

## Why a single module

The gap list had separate "contrast registry" vs "per-theme preview" items, but both audits want the same question answered: *what are all the themes we're testing against?* Centralizing that answer in one module means the next audit to land inherits multi-tenant awareness for free.

## Test plan

- [x] `npm run validate:full` — all 6 checks pass (token lint, grid audit, theme compliance, blueprints, typecheck, Storybook build)
- [x] Contrast Compliance story renders unchanged (same 3 built-ins, same layout) — registry is backward-compatible since `BUILT_IN_THEMES` replicates the old `THEMES` array exactly
- [ ] After merge: bump BDS in [brik-client-portal](/../brik-client-portal), add `registerClientTheme({...})` + theme CSS import to `.storybook/preview.ts` once the portal ships its first non-Brik theme, verify it appears in the portal Storybook's Contrast Compliance audit

Pre-existing vitest flakes (Switch / AddableComboList / TimePicker / DatePicker Playground) unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)