### PR TITLE
feat(bcs): getIndustryPainPoints — CatalogPicker-shaped getter

### DIFF
--- a/content-system/index.ts
+++ b/content-system/index.ts
@@ -21,6 +21,7 @@ export {
   getAtmosphereImportPath,
   type AtmosphereManifestEntry,
 } from './atmospheres';
+export type { IndustryPainPointEntry } from './industries';
 export {
   industryPacks,
   dental,
@@ -28,6 +29,7 @@ export {
   smallBusiness,
   getIndustryServices,
   getIndustryServicesCatalog,
+  getIndustryPainPoints,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,

--- a/content-system/industries/getters.test.ts
+++ b/content-system/industries/getters.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getIndustryServices,
   getIndustryServicesCatalog,
+  getIndustryPainPoints,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,
@@ -84,6 +85,46 @@ describe('getIndustryServicesCatalog', () => {
 
   it('every entry has a unique slug within a pack', () => {
     const slugs = getIndustryServicesCatalog('dental').map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+// ── getIndustryPainPoints ────────────────────────────────────────────────────
+
+describe('getIndustryPainPoints', () => {
+  it('returns CatalogPicker-shaped entries for dental', () => {
+    const painPoints = getIndustryPainPoints('dental');
+    expect(painPoints.length).toBeGreaterThanOrEqual(5);
+    painPoints.forEach((pp) => {
+      expect(pp.slug).toBeTruthy();
+      expect(pp.displayName).toBeTruthy();
+      // Slug should be lowercase-kebab and capped at 40 chars so long
+      // summaries still produce stable identifiers.
+      expect(pp.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(pp.slug.length).toBeLessThanOrEqual(40);
+    });
+  });
+
+  it('displayName is the raw summary (preserves detail clauses)', () => {
+    const painPoints = getIndustryPainPoints('dental');
+    const costAnxiety = painPoints.find((pp) => pp.slug.startsWith('cost-anxiety'));
+    expect(costAnxiety).toBeDefined();
+    expect(costAnxiety?.displayName).toContain('Cost anxiety');
+  });
+
+  it('returns pain points for real-estate-rv-mhc', () => {
+    const painPoints = getIndustryPainPoints('real-estate-rv-mhc');
+    expect(painPoints.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to small-business pain points for null / undefined / unknown', () => {
+    const baseline = getIndustryPainPoints('small-business');
+    expect(getIndustryPainPoints(null)).toEqual(baseline);
+    expect(getIndustryPainPoints(undefined)).toEqual(baseline);
+  });
+
+  it('every entry has a unique slug within a pack', () => {
+    const slugs = getIndustryPainPoints('dental').map((e) => e.slug);
     expect(new Set(slugs).size).toBe(slugs.length);
   });
 });

--- a/content-system/industries/getters.ts
+++ b/content-system/industries/getters.ts
@@ -46,6 +46,63 @@ export function getIndustryServicesCatalog(
 }
 
 /**
+ * One pain-point entry shaped for the portal's `<CatalogPicker>`.
+ *
+ * The pack's `customerPainPoints[]` has a richer shape (`summary`,
+ * optional `segment`, optional `detail`) — this getter flattens it to
+ * the minimal `{ slug, displayName }` that CatalogPicker expects so
+ * consumers can pass the result directly without writing an adapter.
+ * Call the pack's `customerPainPoints` member directly when you need
+ * segment + detail.
+ */
+export interface IndustryPainPointEntry {
+  slug: string;
+  displayName: string;
+  aliases?: readonly string[];
+}
+
+/**
+ * Slugify a free-text string for use as a stable identifier. Lowercase,
+ * collapse non-alphanumerics to `-`, trim leading/trailing dashes, cap
+ * at 40 chars so CustomerPainPoint's long summaries don't produce
+ * unreadable slugs.
+ */
+function toSlug(raw: string): string {
+  const base = raw
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40)
+    .replace(/-$/, '');
+  return base || 'custom';
+}
+
+/**
+ * Returns the customer-pain-point catalog for the given industry, shaped
+ * for the portal's `<CatalogPicker>`. Each entry carries a stable slug
+ * derived from the pack's `summary` field plus the `summary` itself as
+ * `displayName`. Falls back to the `small-business` pack when slug is
+ * unknown.
+ *
+ * Pain points are client-intel that industry intel seeds — Brik has
+ * learned a durable set of verticalized frictions (dental: cost anxiety,
+ * insurance confusion, trust deficit; real-estate: reservation
+ * confusion, hookup details, rig-size limits) and each client picks
+ * from those, plus their own observed frictions as custom entries.
+ */
+export function getIndustryPainPoints(
+  slug: IndustrySlug | null | undefined,
+): readonly IndustryPainPointEntry[] {
+  const pack = resolvePack(slug);
+  return pack.customerPainPoints.map((pp) => ({
+    slug: toSlug(pp.summary),
+    displayName: pp.summary,
+  }));
+}
+
+/**
  * Returns accepted payment methods and financing mechanisms for the given
  * industry. Falls back to `small-business` payment types when slug is unknown.
  */

--- a/content-system/industries/index.ts
+++ b/content-system/industries/index.ts
@@ -23,9 +23,11 @@ export const industryPacks: Record<IndustrySlug, IndustryPack> = {
 };
 
 export { dental, realEstateRvMhc, smallBusiness };
+export type { IndustryPainPointEntry } from './getters';
 export {
   getIndustryServices,
   getIndustryServicesCatalog,
+  getIndustryPainPoints,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.24.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary

Second BCS→client canary getter (first was getIndustryServicesCatalog). Lets the portal's `<CatalogPicker>` seed Audience-sheet pain points from the industry pack's `customerPainPoints` without the portal having to write an adapter.

## What ships

- `getIndustryPainPoints(slug)` in `content-system/industries/getters.ts`
- `IndustryPainPointEntry` type — `{ slug, displayName, aliases? }` — structurally compatible with CatalogPicker's `CatalogEntry`
- Exported from `content-system/industries/index.ts` and the package root
- 5 new getter tests (47/47 content-system suite passes)

## Why this shape

`pack.customerPainPoints[]` has `{ summary, segment?, detail? }`. CatalogPicker needs `{ slug, displayName }`. The getter flattens: `summary` becomes `displayName`, slug is derived from summary (kebab-case, 40-char cap). Segment + detail are dropped at the catalog boundary — consumers that want them read from `pack.customerPainPoints` directly.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run content-system/industries/getters.test.ts` — 47/47 pass
- [ ] After merge + version bump: portal PR wires pain_points column to `<CatalogPicker>` (migration + ~25 consumer updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)