### PR TITLE
feat(bcs): getIndustryKeywords — CatalogPicker-shaped getter

### DIFF
--- a/content-system/index.ts
+++ b/content-system/index.ts
@@ -21,7 +21,7 @@ export {
   getAtmosphereImportPath,
   type AtmosphereManifestEntry,
 } from './atmospheres';
-export type { IndustryPainPointEntry } from './industries';
+export type { IndustryPainPointEntry, IndustryKeywordEntry } from './industries';
 export {
   industryPacks,
   dental,
@@ -30,6 +30,7 @@ export {
   getIndustryServices,
   getIndustryServicesCatalog,
   getIndustryPainPoints,
+  getIndustryKeywords,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,

--- a/content-system/industries/getters.test.ts
+++ b/content-system/industries/getters.test.ts
@@ -4,6 +4,7 @@ import {
   getIndustryServices,
   getIndustryServicesCatalog,
   getIndustryPainPoints,
+  getIndustryKeywords,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,
@@ -125,6 +126,45 @@ describe('getIndustryPainPoints', () => {
 
   it('every entry has a unique slug within a pack', () => {
     const slugs = getIndustryPainPoints('dental').map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+// ── getIndustryKeywords ──────────────────────────────────────────────────────
+
+describe('getIndustryKeywords', () => {
+  it('returns merged primary + service-level keywords for dental', () => {
+    const keywords = getIndustryKeywords('dental');
+    expect(keywords.length).toBeGreaterThan(5);
+    const primary = keywords.filter((k) => k.tier === 'primary');
+    const serviceLevel = keywords.filter((k) => k.tier === 'service-level');
+    expect(primary.length).toBeGreaterThan(0);
+    expect(serviceLevel.length).toBeGreaterThan(0);
+  });
+
+  it('every entry is CatalogPicker-shaped (slug + displayName + tier)', () => {
+    const keywords = getIndustryKeywords('dental');
+    keywords.forEach((kw) => {
+      expect(kw.slug).toBeTruthy();
+      expect(kw.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(kw.displayName).toBeTruthy();
+      expect(['primary', 'service-level']).toContain(kw.tier);
+    });
+  });
+
+  it('returns keywords for real-estate-rv-mhc', () => {
+    const keywords = getIndustryKeywords('real-estate-rv-mhc');
+    expect(keywords.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to small-business for null / undefined / unknown', () => {
+    const baseline = getIndustryKeywords('small-business');
+    expect(getIndustryKeywords(null)).toEqual(baseline);
+    expect(getIndustryKeywords(undefined)).toEqual(baseline);
+  });
+
+  it('deduplicates slugs across primary and service-level tiers', () => {
+    const slugs = getIndustryKeywords('dental').map((e) => e.slug);
     expect(new Set(slugs).size).toBe(slugs.length);
   });
 });

--- a/content-system/industries/getters.ts
+++ b/content-system/industries/getters.ts
@@ -103,6 +103,57 @@ export function getIndustryPainPoints(
 }
 
 /**
+ * One keyword entry shaped for the portal's `<CatalogPicker>`. Same
+ * structural shape as IndustryPainPointEntry / ServiceEntry — every
+ * Stream C getter normalizes to `{ slug, displayName, aliases? }` so
+ * consumers wire through CatalogPicker uniformly.
+ *
+ * `tier` flags whether the entry came from `keywordBank.primary`
+ * (brand/category-level) or `keywordBank.serviceLevel` (service- or
+ * procedure-level). Consumers can regroup by tier when surfacing picks
+ * in read-only views.
+ */
+export interface IndustryKeywordEntry {
+  slug: string;
+  displayName: string;
+  aliases?: readonly string[];
+  tier: 'primary' | 'service-level';
+}
+
+/**
+ * Returns the SEO keyword catalog for the given industry, merged from
+ * `keywordBank.primary` (brand/category) and `keywordBank.serviceLevel`
+ * (service/procedure). Each entry carries a `tier` flag. Falls back to
+ * the `small-business` pack when slug is unknown. Duplicate slugs
+ * across the two tiers are dropped — `primary` wins first.
+ *
+ * Stream C canary #3: SEO keywords as BCS-seeded client intel. Clients
+ * pick the industry keywords they want to target + add long-tails as
+ * custom entries. Downstream site-structure work consumes the picked
+ * slugs to seed page H1s and meta descriptions.
+ */
+export function getIndustryKeywords(
+  slug: IndustrySlug | null | undefined,
+): readonly IndustryKeywordEntry[] {
+  const pack = resolvePack(slug);
+  const out: IndustryKeywordEntry[] = [];
+  const seen = new Set<string>();
+  for (const kw of pack.keywordBank.primary) {
+    const s = toSlug(kw);
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push({ slug: s, displayName: kw, tier: 'primary' });
+  }
+  for (const kw of pack.keywordBank.serviceLevel) {
+    const s = toSlug(kw);
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push({ slug: s, displayName: kw, tier: 'service-level' });
+  }
+  return out;
+}
+
+/**
  * Returns accepted payment methods and financing mechanisms for the given
  * industry. Falls back to `small-business` payment types when slug is unknown.
  */

--- a/content-system/industries/index.ts
+++ b/content-system/industries/index.ts
@@ -23,11 +23,12 @@ export const industryPacks: Record<IndustrySlug, IndustryPack> = {
 };
 
 export { dental, realEstateRvMhc, smallBusiness };
-export type { IndustryPainPointEntry } from './getters';
+export type { IndustryPainPointEntry, IndustryKeywordEntry } from './getters';
 export {
   getIndustryServices,
   getIndustryServicesCatalog,
   getIndustryPainPoints,
+  getIndustryKeywords,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,


### PR DESCRIPTION
Stream C canary #3. Merges pack.keywordBank.primary + .serviceLevel into a CatalogPicker-consumable array with a tier flag. 52/52 tests pass. Portal consumer follow-up: client_keywords jsonb column + Audience sheet CatalogPicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)