### PR TITLE
feat(bcs): getIndustryCtaApproved/Rejected — CatalogPicker-shaped getters

### DIFF
--- a/content-system/index.ts
+++ b/content-system/index.ts
@@ -21,7 +21,11 @@ export {
   getAtmosphereImportPath,
   type AtmosphereManifestEntry,
 } from './atmospheres';
-export type { IndustryPainPointEntry, IndustryKeywordEntry } from './industries';
+export type {
+  IndustryPainPointEntry,
+  IndustryKeywordEntry,
+  IndustryCtaEntry,
+} from './industries';
 export {
   industryPacks,
   dental,
@@ -31,6 +35,8 @@ export {
   getIndustryServicesCatalog,
   getIndustryPainPoints,
   getIndustryKeywords,
+  getIndustryCtaApproved,
+  getIndustryCtaRejected,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,

--- a/content-system/industries/getters.test.ts
+++ b/content-system/industries/getters.test.ts
@@ -5,6 +5,8 @@ import {
   getIndustryServicesCatalog,
   getIndustryPainPoints,
   getIndustryKeywords,
+  getIndustryCtaApproved,
+  getIndustryCtaRejected,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,
@@ -166,6 +168,56 @@ describe('getIndustryKeywords', () => {
   it('deduplicates slugs across primary and service-level tiers', () => {
     const slugs = getIndustryKeywords('dental').map((e) => e.slug);
     expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+// ── getIndustryCtaApproved ───────────────────────────────────────────────────
+
+describe('getIndustryCtaApproved', () => {
+  it('returns CatalogPicker-shaped approved CTA defaults for dental', () => {
+    const entries = getIndustryCtaApproved('dental');
+    expect(entries.length).toBeGreaterThan(0);
+    entries.forEach((e) => {
+      expect(e.slug).toBeTruthy();
+      expect(e.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(e.displayName).toBeTruthy();
+    });
+  });
+
+  it('preserves original CTA text as displayName (e.g. "Request Your Consultation")', () => {
+    const entries = getIndustryCtaApproved('dental');
+    const names = entries.map((e) => e.displayName);
+    expect(names.some((n) => n.toLowerCase().includes('consultation'))).toBe(true);
+  });
+
+  it('falls back to small-business CTAs for null / undefined / unknown', () => {
+    const baseline = getIndustryCtaApproved('small-business');
+    expect(getIndustryCtaApproved(null)).toEqual(baseline);
+    expect(getIndustryCtaApproved(undefined)).toEqual(baseline);
+  });
+
+  it('every entry has a unique slug within a pack', () => {
+    const slugs = getIndustryCtaApproved('dental').map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+// ── getIndustryCtaRejected ───────────────────────────────────────────────────
+
+describe('getIndustryCtaRejected', () => {
+  it('returns CatalogPicker-shaped rejected CTA defaults', () => {
+    const entries = getIndustryCtaRejected('dental');
+    expect(entries.length).toBeGreaterThan(0);
+    entries.forEach((e) => {
+      expect(e.slug).toBeTruthy();
+      expect(e.displayName).toBeTruthy();
+    });
+  });
+
+  it('falls back to small-business rejections for null / undefined', () => {
+    const baseline = getIndustryCtaRejected('small-business');
+    expect(getIndustryCtaRejected(null)).toEqual(baseline);
+    expect(getIndustryCtaRejected(undefined)).toEqual(baseline);
   });
 });
 

--- a/content-system/industries/getters.ts
+++ b/content-system/industries/getters.ts
@@ -154,6 +154,50 @@ export function getIndustryKeywords(
 }
 
 /**
+ * One CTA-defaults entry shaped for `<CatalogPicker>`. Same structural
+ * shape as every other Stream C getter's output — `{ slug, displayName,
+ * aliases? }` — so consumers wire uniformly.
+ */
+export interface IndustryCtaEntry {
+  slug: string;
+  displayName: string;
+  aliases?: readonly string[];
+}
+
+/**
+ * Returns the "approved" CTA defaults for the given industry. These are
+ * the spoken-form CTAs the industry typically converts on — used as seed
+ * options in the Brand Identity sheet's CTA Language section. Clients
+ * pick from these + can add custom variants with source='custom'.
+ *
+ * Pairs with `getIndustryCtaRejected` — together they form the
+ * Approved/Rejected split the existing `cta_language` column already
+ * tracks on `company_profiles`.
+ */
+export function getIndustryCtaApproved(
+  slug: IndustrySlug | null | undefined,
+): readonly IndustryCtaEntry[] {
+  return resolvePack(slug).ctaDefaults.approved.map((cta) => ({
+    slug: toSlug(cta),
+    displayName: cta,
+  }));
+}
+
+/**
+ * Returns the "rejected" CTA defaults for the given industry — phrasing
+ * that demonstrably underperforms or signals the wrong tone. Drives the
+ * client-side rejection list in the Brand Identity sheet.
+ */
+export function getIndustryCtaRejected(
+  slug: IndustrySlug | null | undefined,
+): readonly IndustryCtaEntry[] {
+  return resolvePack(slug).ctaDefaults.rejected.map((cta) => ({
+    slug: toSlug(cta),
+    displayName: cta,
+  }));
+}
+
+/**
  * Returns accepted payment methods and financing mechanisms for the given
  * industry. Falls back to `small-business` payment types when slug is unknown.
  */

--- a/content-system/industries/index.ts
+++ b/content-system/industries/index.ts
@@ -23,12 +23,18 @@ export const industryPacks: Record<IndustrySlug, IndustryPack> = {
 };
 
 export { dental, realEstateRvMhc, smallBusiness };
-export type { IndustryPainPointEntry, IndustryKeywordEntry } from './getters';
+export type {
+  IndustryPainPointEntry,
+  IndustryKeywordEntry,
+  IndustryCtaEntry,
+} from './getters';
 export {
   getIndustryServices,
   getIndustryServicesCatalog,
   getIndustryPainPoints,
   getIndustryKeywords,
+  getIndustryCtaApproved,
+  getIndustryCtaRejected,
   getIndustryPaymentTypes,
   getIndustryInsuranceProviders,
   getIndustryConditions,


### PR DESCRIPTION
## Summary

Fourth Stream C canary — exposes `ctaDefaults.{approved, rejected}` from each industry pack as `<CatalogPicker>`-shaped reads. Mirrors the pattern established by `getIndustryPainPoints` (PR #194) and `getIndustryKeywords` (PR #196).

- New `IndustryCtaEntry` type: `{ slug, displayName, aliases? }` — identical shape to every prior Stream C getter's output
- `getIndustryCtaApproved(slug)` / `getIndustryCtaRejected(slug)` — both fall back to `small-business` for null/undefined/unknown slug
- 6 new tests (shape, content, fallback, unique slugs)
- No content changes — all three packs already carry `ctaDefaults`; this is purely the read surface

## What lands next (portal)

Migration `00149_cta_language_jsonb.sql` collapses `cta_language.{approved, rejected}: string[]` into `PickedCatalogEntry[]` (matches services / pain_points / keywords migrations). Brand Identity sheet swaps its two CTA TextAreas for `<CatalogPicker>`s.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run content-system/industries/getters.test.ts` — 58/58 passing
- [x] CI (token lint, grid, theme, blueprint, typecheck, storybook build) green locally on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)