### PR TITLE
chore(release): v0.31.0 — CTA getters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.25.1",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.25.1",
+      "version": "0.31.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.30.0",
-  "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
+  "version": "0.31.0",
+  "description": "Brik Design System \u2014 React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Ships PR #198.

Fourth Stream C canary — `getIndustryCtaApproved` / `getIndustryCtaRejected` exposed as `<CatalogPicker>`-shaped reads. Portal side (migration 00149 + Brand-Identity sheet CatalogPickers) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)