### PR TITLE
feat(blueprints): scaffold blueprints-astro package exports + types

### DIFF
--- a/content-system/blueprints/astro/index.ts
+++ b/content-system/blueprints/astro/index.ts
@@ -1,0 +1,24 @@
+/**
+ * `@brikdesigns/bds/blueprints-astro` — public surface.
+ *
+ * v0.1 scope (see docs/BLUEPRINTS-ASTRO-PACKAGE.md §2.1):
+ *   Contract types (this PR).
+ *   <SiteHeader>, <BlueprintDispatcher>, <BlueprintFallback> (later PR).
+ *   8 blueprint components (later PRs).
+ *
+ * Contract types ship first so consumers + downstream tooling
+ * (portal, scaffold task, verification scripts) can resolve the shape
+ * before any component exists.
+ */
+
+export type {
+  KnownBlueprintKey,
+  BlueprintSection,
+  ClientFacts,
+  ResolvedThemeMode,
+  ResolvedAtmosphere,
+  ResolvedNavArchetype,
+  ResolvedFooterArchetype,
+  ResolvedTheme,
+  BlueprintProps,
+} from './types';

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -1,0 +1,201 @@
+/**
+ * Blueprint Astro package — contract types.
+ *
+ * Every blueprint component in `@brikdesigns/bds/blueprints-astro` accepts
+ * the SAME props shape (`BlueprintProps`). No blueprint-specific props.
+ * This keeps the dispatcher trivial and the maintenance cost linear in
+ * the blueprint count, not quadratic in keys × call-sites.
+ *
+ * These types are the public surface consumers import from
+ * `@brikdesigns/bds/blueprints-astro`. Changes here are MAJOR bumps.
+ * See `docs/BLUEPRINTS-ASTRO-PACKAGE.md` §2.8 for the versioning policy.
+ */
+
+/**
+ * Known blueprint keys. Mirrors `blueprints/blueprint-library.json` as a
+ * literal union for consumer type-safety. When adding a new blueprint to
+ * the library, append its key here in the same PR — the v0.1 policy is
+ * hand-maintained; a build-time generator replaces this in a future pass.
+ */
+export type KnownBlueprintKey =
+  | 'hero_split_60_40'
+  | 'hero_centered_gradient'
+  | 'hero_fullbleed_photo'
+  | 'hero_dark_minimal'
+  | 'hero_interior_minimal'
+  | 'services_numbered_rows'
+  | 'services_detail_two_column'
+  | 'features_3col_icon_grid'
+  | 'features_alternating_split'
+  | 'features_bento_asymmetric'
+  | 'about_story_split'
+  | 'stats_dark_bar'
+  | 'stats_centered_light'
+  | 'testimonials_3col_cards'
+  | 'testimonials_featured_large'
+  | 'cta_dark_centered'
+  | 'cta_split_contact'
+  | 'contact_form_split'
+  | 'faq_accordion_grouped'
+  | 'team_cards_centered'
+  | 'team_bio_grid'
+  | 'gallery_masonry_3col'
+  | 'nav_sticky_blur'
+  | 'nav_light_clean'
+  | 'content_legal_centered';
+
+/**
+ * Resolved section content — what the portal's content generator emits
+ * and the dispatcher consumes. Shape matches the typed section output
+ * produced by `generate-content-page-worker` in the portal.
+ *
+ * `body` is nullable by design — stat + testimonial sections omit prose
+ * bodies; the scaffold template must render conditionally on null rather
+ * than emitting `<p>null</p>` (the bug the Birdwell `NotionPageBody`
+ * template shipped). See intel entry #18.
+ */
+export interface BlueprintSection {
+  readonly sectionKey: string;
+  readonly sectionType: string;
+  readonly heading: string | null;
+  readonly subheading: string | null;
+  readonly body: string | null;
+  readonly items: readonly {
+    readonly title: string;
+    readonly description: string;
+  }[];
+  readonly cta: {
+    readonly label: string;
+    readonly url: string;
+  } | null;
+  readonly visualNotes: {
+    readonly blueprintKey: KnownBlueprintKey | null;
+    readonly moodKeywords: readonly string[];
+    readonly layoutBlueprint: string;
+    readonly imageOpportunity: string | null;
+    readonly animationSuggestion: string | null;
+    readonly illustrationOpportunity: string | null;
+  } | null;
+}
+
+/**
+ * Per-client facts the dispatcher passes to every blueprint. Projected
+ * from `company_profile` columns by the scaffold task. Required fields
+ * are narrow; blueprints may read optional fields via the index signature
+ * (for extensibility without modifying this interface every time a new
+ * fact appears).
+ *
+ * The scaffold task MUST validate that every blueprint's `required_facts`
+ * (see `blueprint-library.json`) is populated here before emitting the
+ * client repo. See docs/BLUEPRINTS-ASTRO-PACKAGE.md §2.4.
+ */
+export interface ClientFacts {
+  readonly brandName: string;
+  readonly tagline: string | null;
+  readonly valueProposition: string | null;
+
+  readonly services: readonly {
+    readonly slug: string;
+    readonly displayName: string;
+    readonly description?: string | null;
+  }[];
+
+  readonly phone: string | null;
+  readonly email: string | null;
+
+  readonly address: {
+    readonly street: string | null;
+    readonly city: string | null;
+    readonly state: string | null;
+    readonly zip: string | null;
+  } | null;
+
+  readonly hours: readonly {
+    readonly day: string;
+    readonly open: string | null;
+    readonly close: string | null;
+    readonly closed: boolean;
+  }[];
+
+  readonly heroImageUrl: string | null;
+  readonly logoUrl: string | null;
+  readonly logoVariants: Readonly<Record<string, string>>;
+
+  /**
+   * Extension escape hatch for blueprint-specific facts that don't
+   * warrant promotion to the canonical interface yet. Keys are snake_case
+   * matching `required_facts` entries in `blueprint-library.json`.
+   */
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Theme mode — light or dark. Mirrors portal `company_profiles.theme_mode`.
+ */
+export type ResolvedThemeMode = 'light' | 'dark';
+
+/**
+ * Atmosphere slug — one of the 7 locked values in
+ * `content-system/vocabularies/atmosphere.ts`. Re-stated here as a union
+ * so `@brikdesigns/bds/blueprints-astro` is importable without also
+ * importing the vocabularies module (keeps the Astro-package import
+ * surface narrow).
+ *
+ * Source of truth: `content-system/vocabularies/atmosphere.ts :: ATMOSPHERE_VALUES`.
+ * Keep in sync; a vocabulary test validates this union matches.
+ */
+export type ResolvedAtmosphere =
+  | 'editorial-luxury'
+  | 'cinematic-dramatic'
+  | 'minimal-clinical'
+  | 'warm-soft'
+  | 'clean-bright'
+  | 'organic-textured'
+  | 'none';
+
+/**
+ * Navigation archetype slug. Source of truth:
+ * `content-system/vocabularies/nav-archetype.ts :: NAV_ARCHETYPE_VALUES`.
+ */
+export type ResolvedNavArchetype =
+  | 'editorial-transparent'
+  | 'utility-first'
+  | 'service-centric'
+  | 'portfolio-minimal'
+  | 'calm-flat';
+
+/**
+ * Footer archetype slug. v0.1 vocabulary ships 3 values.
+ * Source of truth (after PR #3): `content-system/vocabularies/footer-archetype.ts`.
+ * Locked vocabulary — extend-only after first production use.
+ */
+export type ResolvedFooterArchetype =
+  | 'four_col_directory'
+  | 'cta_focused'
+  | 'legal_heavy';
+
+/**
+ * Resolved theming decisions — the output of the scaffold task's
+ * theming resolver (pack default + client override). Every blueprint
+ * receives this and may adapt rendering based on atmosphere or theme
+ * mode, but does not re-resolve on its own.
+ */
+export interface ResolvedTheme {
+  readonly themeMode: ResolvedThemeMode;
+  readonly atmosphere: ResolvedAtmosphere;
+  readonly navigationArchetype: ResolvedNavArchetype;
+  readonly footerArchetype: ResolvedFooterArchetype;
+}
+
+/**
+ * The single prop shape every blueprint Astro component accepts.
+ * No blueprint-specific props, ever. If a blueprint needs data the
+ * `ClientFacts` surface doesn't expose, add the field to `ClientFacts`
+ * (via the index signature if not canonical), or extend `ClientFacts`
+ * in a MAJOR bump.
+ */
+export interface BlueprintProps {
+  readonly section: BlueprintSection;
+  readonly clientFacts: ClientFacts;
+  readonly theme: ResolvedTheme;
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
       "types": "./dist/content-system/index.d.ts",
       "import": "./dist/content-system/index.js"
     },
+    "./blueprints-astro": {
+      "types": "./dist/content-system/blueprints/astro/index.d.ts",
+      "import": "./dist/content-system/blueprints/astro/index.js",
+      "default": "./dist/content-system/blueprints/astro/index.js"
+    },
+    "./blueprints-astro/*.astro": "./content-system/blueprints/astro/*.astro",
     "./blueprints": "./blueprints/blueprint-library.json",
     "./blueprints/library.json": "./blueprints/blueprint-library.json",
     "./content-system/compliance/healthcare-ada.md": "./content-system/compliance/healthcare-ada.md",
@@ -34,7 +40,8 @@
     "dist",
     "blueprints/blueprint-library.json",
     "content-system/compliance/*.md",
-    "content-system/atmospheres/*.css"
+    "content-system/atmospheres/*.css",
+    "content-system/blueprints/astro/**/*.astro"
   ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
@@ -107,7 +114,8 @@
     "populate-notion": "node scripts/populate-notion-tokens.js",
     "propagate": "bash scripts/propagate.sh",
     "propagate:dry": "bash scripts/propagate.sh --dry-run",
-    "prepare": "husky"
+    "prepare": "husky",
+    "verify:blueprints-astro": "node scripts/verify-blueprints-astro-exports.mjs"
   },
   "keywords": [
     "brik",

--- a/scripts/verify-blueprints-astro-exports.mjs
+++ b/scripts/verify-blueprints-astro-exports.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * verify-blueprints-astro-exports.mjs
+ *
+ * Proves that `@brikdesigns/bds/blueprints-astro` resolves correctly in
+ * a real Astro 5 consumer, AS INSTALLED FROM A PACKED TARBALL of this
+ * repo — i.e. exactly what a client site will see after
+ * `npm install @brikdesigns/bds`.
+ *
+ * Runs on BDS pre-push and on-demand. If this script ever fails, the
+ * package exports shape is broken and NO BLUEPRINT COMPONENT SHOULD
+ * LAND until the exports are fixed. See
+ * docs/BLUEPRINTS-ASTRO-PACKAGE.md §2.7 for the rationale.
+ *
+ * Flow:
+ *   1. npm run build:lib   — emit dist/ so the tarball has compiled files
+ *   2. npm pack            — produce a tarball matching a real publish
+ *   3. mkdtemp             — isolated scratch project
+ *   4. init Astro 5 minimal — package.json + tsconfig + astro.config
+ *   5. npm install         — tarball + astro
+ *   6. write test fixture  — imports every exported type + verifies shape
+ *   7. npx astro check     — Astro's native type + import resolver
+ *   8. cleanup (on success; preserve on failure for inspection)
+ */
+
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = resolve(__filename, '..');
+const BDS_ROOT = resolve(__dirname, '..');
+const SCRATCH_PREFIX = 'bds-verify-blueprints-astro-';
+
+const log = {
+  step: (msg) => console.log(`\n\x1b[1;33m▸ ${msg}\x1b[0m`),
+  ok: (msg) => console.log(`\x1b[0;32m✓ ${msg}\x1b[0m`),
+  fail: (msg) => console.error(`\x1b[0;31m✗ ${msg}\x1b[0m`),
+  info: (msg) => console.log(`  ${msg}`),
+};
+
+function run(cmd, opts = {}) {
+  return execSync(cmd, { stdio: 'inherit', ...opts });
+}
+
+function runCapture(cmd, opts = {}) {
+  return execSync(cmd, { encoding: 'utf8', ...opts });
+}
+
+// ── 1. Build dist ─────────────────────────────────────────────────
+log.step('Building dist/ (ensures tarball has latest compiled output)');
+run('npm run build:lib', { cwd: BDS_ROOT });
+log.ok('build:lib complete');
+
+// ── 2. Pack tarball ───────────────────────────────────────────────
+log.step('Packing tarball');
+const packOutput = runCapture('npm pack --pack-destination /tmp', { cwd: BDS_ROOT });
+const tarballName = packOutput.trim().split('\n').pop().trim();
+const tarballPath = `/tmp/${tarballName}`;
+log.ok(`Tarball: ${tarballPath}`);
+
+// ── 3. Scratch project ────────────────────────────────────────────
+const scratch = mkdtempSync(join(tmpdir(), SCRATCH_PREFIX));
+log.step(`Scratch project: ${scratch}`);
+
+// ── 4. Init Astro 5 minimal ───────────────────────────────────────
+writeFileSync(
+  join(scratch, 'package.json'),
+  JSON.stringify(
+    {
+      name: 'bds-verify-scratch',
+      version: '0.0.0',
+      type: 'module',
+      private: true,
+      dependencies: {
+        astro: '^5.0.0',
+        '@astrojs/check': '^0.9.0',
+        typescript: '^5.5.0',
+        '@brikdesigns/bds': `file:${tarballPath}`,
+      },
+      scripts: { check: 'astro check' },
+    },
+    null,
+    2
+  )
+);
+
+writeFileSync(
+  join(scratch, 'tsconfig.json'),
+  JSON.stringify(
+    {
+      extends: 'astro/tsconfigs/strict',
+      compilerOptions: { jsx: 'preserve' },
+      include: ['src/**/*.ts', 'src/**/*.astro', 'src/**/*.d.ts'],
+    },
+    null,
+    2
+  )
+);
+
+writeFileSync(
+  join(scratch, 'astro.config.mjs'),
+  `import { defineConfig } from 'astro/config';\nexport default defineConfig({});\n`
+);
+
+mkdirSync(join(scratch, 'src/pages'), { recursive: true });
+mkdirSync(join(scratch, 'src/env.d.ts').replace(/\/src\/env\.d\.ts$/, '/src'), { recursive: true });
+writeFileSync(join(scratch, 'src/env.d.ts'), `/// <reference path="../.astro/types.d.ts" />\n`);
+
+// Test fixture — imports every type and constructs a structurally-valid value.
+// If any type fails to resolve, tsc/astro-check surfaces it as an error.
+writeFileSync(
+  join(scratch, 'src/pages/index.astro'),
+  `---
+import type {
+  KnownBlueprintKey,
+  BlueprintSection,
+  ClientFacts,
+  ResolvedThemeMode,
+  ResolvedAtmosphere,
+  ResolvedNavArchetype,
+  ResolvedFooterArchetype,
+  ResolvedTheme,
+  BlueprintProps,
+} from '@brikdesigns/bds/blueprints-astro';
+
+// Type-level checks — if any import above failed to resolve, these error.
+const key: KnownBlueprintKey = 'hero_split_60_40';
+const mode: ResolvedThemeMode = 'dark';
+const atm: ResolvedAtmosphere = 'editorial-luxury';
+const nav: ResolvedNavArchetype = 'editorial-transparent';
+const foot: ResolvedFooterArchetype = 'four_col_directory';
+
+const section: BlueprintSection = {
+  sectionKey: 'home_hero',
+  sectionType: 'hero',
+  heading: 'Test heading',
+  subheading: null,
+  body: null,
+  items: [],
+  cta: null,
+  visualNotes: {
+    blueprintKey: key,
+    moodKeywords: ['professional'],
+    layoutBlueprint: 'test',
+    imageOpportunity: null,
+    animationSuggestion: null,
+    illustrationOpportunity: null,
+  },
+};
+
+const clientFacts: ClientFacts = {
+  brandName: 'Test Brand',
+  tagline: null,
+  valueProposition: null,
+  services: [],
+  phone: null,
+  email: null,
+  address: null,
+  hours: [],
+  heroImageUrl: null,
+  logoUrl: null,
+  logoVariants: {},
+};
+
+const theme: ResolvedTheme = {
+  themeMode: mode,
+  atmosphere: atm,
+  navigationArchetype: nav,
+  footerArchetype: foot,
+};
+
+const props: BlueprintProps = { section, clientFacts, theme };
+---
+<html lang="en">
+  <head><title>BDS exports verify</title></head>
+  <body>
+    <p>sectionKey: {props.section.sectionKey}</p>
+    <p>brand: {props.clientFacts.brandName}</p>
+    <p>atmosphere: {props.theme.atmosphere}</p>
+  </body>
+</html>
+`
+);
+
+// ── 5. Install ────────────────────────────────────────────────────
+log.step('Installing scratch deps (astro@5 + packed BDS tarball)');
+run('npm install --no-audit --no-fund --prefer-offline', { cwd: scratch });
+log.ok('install complete');
+
+// ── 6. Check resolver via astro check ─────────────────────────────
+log.step('Running astro check (type + import resolver)');
+try {
+  run('npx astro check', { cwd: scratch });
+  log.ok('astro check passed');
+} catch (err) {
+  log.fail('astro check FAILED — exports do not resolve correctly');
+  log.info(`Scratch project preserved for inspection: ${scratch}`);
+  log.info(`Tarball preserved for inspection:         ${tarballPath}`);
+  process.exit(1);
+}
+
+// ── 7. Verify files shipped ───────────────────────────────────────
+log.step('Verifying tarball contents include expected paths');
+const installedPkg = resolve(scratch, 'node_modules/@brikdesigns/bds');
+const expectedFiles = [
+  'dist/content-system/blueprints/astro/index.js',
+  'dist/content-system/blueprints/astro/index.d.ts',
+  'dist/content-system/blueprints/astro/types.js',
+  'dist/content-system/blueprints/astro/types.d.ts',
+];
+
+let allPresent = true;
+for (const rel of expectedFiles) {
+  const abs = join(installedPkg, rel);
+  try {
+    readdirSync(resolve(abs, '..'));
+    // readdirSync on parent confirms parent exists; explicit check:
+    execSync(`test -f ${JSON.stringify(abs)}`, { stdio: 'ignore' });
+    log.info(`  ✓ ${rel}`);
+  } catch {
+    log.fail(`  missing: ${rel}`);
+    allPresent = false;
+  }
+}
+
+if (!allPresent) {
+  log.fail('Tarball is missing expected files — check package.json files[] glob');
+  log.info(`Scratch project preserved for inspection: ${scratch}`);
+  process.exit(1);
+}
+
+log.ok('All expected files present in installed package');
+
+// ── 8. Cleanup ────────────────────────────────────────────────────
+log.step('Cleaning up');
+rmSync(scratch, { recursive: true, force: true });
+rmSync(tarballPath, { force: true });
+log.ok('Scratch project + tarball removed');
+
+console.log('\n\x1b[1;32m═══════════════════════════════════════\x1b[0m');
+console.log('\x1b[1;32m  blueprints-astro exports verified\x1b[0m');
+console.log('\x1b[1;32m═══════════════════════════════════════\x1b[0m');


### PR DESCRIPTION
## Summary
- feat(blueprints): scaffold @brikdesigns/bds/blueprints-astro exports + types

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)