### PR TITLE
feat(blueprints-astro): ship remaining 7 blueprints for v0.1

### DIFF
--- a/content-system/blueprints/astro/AboutStorySplit.astro
+++ b/content-system/blueprints/astro/AboutStorySplit.astro
@@ -1,0 +1,155 @@
+---
+/**
+ * about_story_split — 2-column narrative section. Label + heading +
+ * body on the left; a single pull-quote or supporting callout on the
+ * right. The story blueprint for "who we are" moments on home pages
+ * and about pages.
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading    — section heading (h2)
+ *   - section.subheading — eyebrow (optional)
+ *   - section.body       — the narrative (REQUIRED by content gen)
+ *   - section.items[0]   — optional pull-quote:
+ *                            item.title = attribution (role/name)
+ *                            item.description = the quote
+ *
+ * required_facts: []. Section-driven.
+ *
+ * CSS custom properties:
+ *   --bp-about-story-split-padding-y
+ *   --bp-about-story-split-bg             (default: var(--page-primary))
+ *   --bp-about-story-split-heading-color  (default: var(--text-primary))
+ *   --bp-about-story-split-body-color     (default: var(--text-secondary))
+ *   --bp-about-story-split-quote-accent   (default: var(--border-brand-primary))
+ *
+ * a11y: h2 + aria-labelledby. Pull-quote uses semantic blockquote +
+ * cite. Reading order: narrative first (left column), supporting
+ * callout second (right) — matches DOM order on every viewport.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+const headingId = `bp-about-story-split-${section.sectionKey}-h`;
+const callout = section.items[0];
+---
+
+<section
+  class="bp-about-story-split"
+  aria-labelledby={headingId}
+  data-blueprint-key="about_story_split"
+>
+  <div class="bp-about-story-split__container">
+    <div class="bp-about-story-split__narrative">
+      {section.subheading && (
+        <p class="bp-about-story-split__eyebrow">{section.subheading}</p>
+      )}
+      <h2 id={headingId} class="bp-about-story-split__heading">{section.heading}</h2>
+      {section.body && (
+        <p class="bp-about-story-split__body">{section.body}</p>
+      )}
+    </div>
+
+    {callout && (
+      <aside class="bp-about-story-split__callout">
+        <blockquote class="bp-about-story-split__quote">
+          <p class="bp-about-story-split__quote-text">{callout.description}</p>
+          <cite class="bp-about-story-split__quote-cite">{callout.title}</cite>
+        </blockquote>
+      </aside>
+    )}
+  </div>
+</section>
+
+<style>
+  .bp-about-story-split {
+    background: var(--bp-about-story-split-bg, var(--page-primary));
+    padding-block: var(
+      --bp-about-story-split-padding-y,
+      clamp(var(--space-3xl), 7vw, var(--space-5xl))
+    );
+  }
+
+  .bp-about-story-split__container {
+    max-width: var(--size-container-xl, 1280px);
+    margin-inline: auto;
+    padding-inline: var(--space-xl);
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-2xl);
+  }
+
+  @media (min-width: 768px) {
+    .bp-about-story-split__container {
+      grid-template-columns: 3fr 2fr;
+      gap: var(--space-3xl);
+      align-items: start;
+    }
+  }
+
+  .bp-about-story-split__narrative {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .bp-about-story-split__eyebrow {
+    margin: 0;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-brand-primary);
+  }
+
+  .bp-about-story-split__heading {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--bp-about-story-split-heading-color, var(--text-primary));
+  }
+
+  .bp-about-story-split__body {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--line-height-relaxed);
+    color: var(--bp-about-story-split-body-color, var(--text-secondary));
+    max-width: 65ch;
+  }
+
+  .bp-about-story-split__callout {
+    padding: var(--space-lg);
+    border-left: 2px solid var(--bp-about-story-split-quote-accent, var(--border-brand-primary));
+    background: var(--surface-secondary);
+  }
+
+  .bp-about-story-split__quote {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .bp-about-story-split__quote-text {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-500);
+    font-style: normal;
+    line-height: var(--line-height-relaxed);
+    color: var(--text-primary);
+  }
+
+  .bp-about-story-split__quote-cite {
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-style: normal;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+  }
+</style>

--- a/content-system/blueprints/astro/CtaDarkCentered.astro
+++ b/content-system/blueprints/astro/CtaDarkCentered.astro
@@ -1,0 +1,112 @@
+---
+/**
+ * cta_dark_centered — closing CTA on a dark surface, centered layout.
+ * Heading + optional body + single primary action, all center-aligned.
+ * The workhorse CTA — used on interior pages where the closing moment
+ * doesn't need a split-contact variant.
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading — CTA headline (h2)
+ *   - section.body    — optional supporting paragraph
+ *   - section.cta     — primary action (label + url) (REQUIRED)
+ *
+ * required_facts: []. Section-driven.
+ *
+ * CSS custom properties:
+ *   --bp-cta-dark-centered-padding-y
+ *   --bp-cta-dark-centered-bg              (default: var(--surface-inverse))
+ *   --bp-cta-dark-centered-heading-color   (default: var(--text-on-inverse))
+ *   --bp-cta-dark-centered-body-color      (default: var(--text-muted-on-inverse))
+ *   --bp-cta-dark-centered-cta-bg          (default: var(--background-brand-primary))
+ *   --bp-cta-dark-centered-cta-color       (default: var(--text-on-brand-primary))
+ *
+ * a11y: h2 + aria-labelledby. Center-aligned but reading order is
+ * natural (heading → body → CTA). CTA uses :focus-visible ring with
+ * high contrast against the dark background.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
+---
+
+<section
+  class="bp-cta-dark-centered"
+  aria-labelledby={headingId}
+  data-blueprint-key="cta_dark_centered"
+>
+  <div class="bp-cta-dark-centered__container">
+    <h2 id={headingId} class="bp-cta-dark-centered__heading">{section.heading}</h2>
+    {section.body && (
+      <p class="bp-cta-dark-centered__body">{section.body}</p>
+    )}
+    {section.cta && (
+      <a href={section.cta.url} class="bp-cta-dark-centered__cta">{section.cta.label}</a>
+    )}
+  </div>
+</section>
+
+<style>
+  .bp-cta-dark-centered {
+    background: var(--bp-cta-dark-centered-bg, var(--surface-inverse, var(--color-black)));
+    padding-block: var(
+      --bp-cta-dark-centered-padding-y,
+      clamp(var(--space-3xl), 8vw, var(--space-5xl))
+    );
+  }
+
+  .bp-cta-dark-centered__container {
+    max-width: var(--size-container-md, 960px);
+    margin-inline: auto;
+    padding-inline: var(--space-xl);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-md);
+    text-align: center;
+  }
+
+  .bp-cta-dark-centered__heading {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-700), 4vw, var(--font-size-1000));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--bp-cta-dark-centered-heading-color, var(--text-on-inverse, var(--color-white)));
+  }
+
+  .bp-cta-dark-centered__body {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--line-height-relaxed);
+    color: var(--bp-cta-dark-centered-body-color, var(--text-muted-on-inverse, var(--color-gray-light)));
+    max-width: 55ch;
+  }
+
+  .bp-cta-dark-centered__cta {
+    display: inline-flex;
+    align-items: center;
+    margin-top: var(--space-md);
+    padding: var(--space-sm) var(--space-xl);
+    background: var(--bp-cta-dark-centered-cta-bg, var(--background-brand-primary));
+    color: var(--bp-cta-dark-centered-cta-color, var(--text-on-brand-primary, var(--text-inverse)));
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-300);
+    font-weight: var(--font-weight-semibold);
+    text-decoration: none;
+    border-radius: var(--border-radius-md);
+    transition: background 120ms ease-out;
+  }
+
+  .bp-cta-dark-centered__cta:hover {
+    background: var(--background-brand-primary-hover, var(--background-brand-primary));
+  }
+
+  .bp-cta-dark-centered__cta:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 2px;
+  }
+</style>

--- a/content-system/blueprints/astro/CtaSplitContact.astro
+++ b/content-system/blueprints/astro/CtaSplitContact.astro
@@ -1,0 +1,210 @@
+---
+/**
+ * cta_split_contact — closing CTA with a split layout: messaging on the
+ * left, contact methods on the right. Phone + email are rendered as
+ * tel:/mailto: links. The right column is the conversion surface when
+ * the visitor prefers direct contact over a web form.
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading    — CTA headline (h2 for page hierarchy)
+ *   - section.body       — supporting paragraph
+ *   - section.cta        — primary action button (label + url)
+ *   - clientFacts.phone  — REQUIRED
+ *   - clientFacts.email  — REQUIRED
+ *
+ * required_facts: ['phone', 'email']. Scaffold preflight gates this
+ * blueprint from rendering on a page before those are populated.
+ * If somehow a fact arrives null at runtime, the blueprint emits a
+ * `data-content-needed` stub in place of the missing method — CI grep
+ * on `dist/` blocks publish.
+ *
+ * CSS custom properties:
+ *   --bp-cta-split-contact-padding-y
+ *   --bp-cta-split-contact-bg              (default: var(--surface-primary))
+ *   --bp-cta-split-contact-heading-color   (default: var(--text-primary))
+ *   --bp-cta-split-contact-body-color      (default: var(--text-secondary))
+ *   --bp-cta-split-contact-method-color    (default: var(--text-primary))
+ *   --bp-cta-split-contact-divider         (default: var(--border-secondary))
+ *
+ * a11y: h2 + aria-labelledby. Contact methods use semantic tel:/mailto:
+ * anchors. Focus-visible ring on every interactive surface.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section, clientFacts } = Astro.props;
+const headingId = `bp-cta-split-contact-${section.sectionKey}-h`;
+const phone = clientFacts.phone;
+const email = clientFacts.email;
+---
+
+<section
+  class="bp-cta-split-contact"
+  aria-labelledby={headingId}
+  data-blueprint-key="cta_split_contact"
+>
+  <div class="bp-cta-split-contact__container">
+    <div class="bp-cta-split-contact__message">
+      <h2 id={headingId} class="bp-cta-split-contact__heading">{section.heading}</h2>
+      {section.body && (
+        <p class="bp-cta-split-contact__body">{section.body}</p>
+      )}
+      {section.cta && (
+        <a href={section.cta.url} class="bp-cta-split-contact__cta">{section.cta.label}</a>
+      )}
+    </div>
+
+    <div class="bp-cta-split-contact__methods">
+      {phone ? (
+        <a href={`tel:${phone.replace(/[^+\d]/g, '')}`} class="bp-cta-split-contact__method">
+          <span class="bp-cta-split-contact__method-label">Call</span>
+          <span class="bp-cta-split-contact__method-value">{phone}</span>
+        </a>
+      ) : (
+        <div class="bp-cta-split-contact__method" data-content-needed="phone" role="presentation">
+          <span class="bp-cta-split-contact__method-label">Call</span>
+          <span class="bp-cta-split-contact__method-value">Phone missing</span>
+        </div>
+      )}
+
+      {email ? (
+        <a href={`mailto:${email}`} class="bp-cta-split-contact__method">
+          <span class="bp-cta-split-contact__method-label">Email</span>
+          <span class="bp-cta-split-contact__method-value">{email}</span>
+        </a>
+      ) : (
+        <div class="bp-cta-split-contact__method" data-content-needed="email" role="presentation">
+          <span class="bp-cta-split-contact__method-label">Email</span>
+          <span class="bp-cta-split-contact__method-value">Email missing</span>
+        </div>
+      )}
+    </div>
+  </div>
+</section>
+
+<style>
+  .bp-cta-split-contact {
+    background: var(--bp-cta-split-contact-bg, var(--surface-primary));
+    padding-block: var(
+      --bp-cta-split-contact-padding-y,
+      clamp(var(--space-3xl), 7vw, var(--space-5xl))
+    );
+  }
+
+  .bp-cta-split-contact__container {
+    max-width: var(--size-container-xl, 1280px);
+    margin-inline: auto;
+    padding-inline: var(--space-xl);
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-2xl);
+    align-items: center;
+  }
+
+  @media (min-width: 768px) {
+    .bp-cta-split-contact__container {
+      grid-template-columns: 3fr 2fr;
+      gap: var(--space-3xl);
+    }
+  }
+
+  .bp-cta-split-contact__message {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .bp-cta-split-contact__heading {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--bp-cta-split-contact-heading-color, var(--text-primary));
+  }
+
+  .bp-cta-split-contact__body {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--line-height-relaxed);
+    color: var(--bp-cta-split-contact-body-color, var(--text-secondary));
+    max-width: 55ch;
+  }
+
+  .bp-cta-split-contact__cta {
+    display: inline-flex;
+    align-items: center;
+    margin-top: var(--space-md);
+    padding: var(--space-sm) var(--space-lg);
+    background: var(--background-brand-primary);
+    color: var(--text-on-brand-primary, var(--text-inverse));
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-300);
+    font-weight: var(--font-weight-semibold);
+    text-decoration: none;
+    border-radius: var(--border-radius-md);
+    align-self: flex-start;
+    transition: background 120ms ease-out;
+  }
+
+  .bp-cta-split-contact__cta:hover {
+    background: var(--background-brand-primary-hover, var(--background-brand-primary));
+  }
+
+  .bp-cta-split-contact__cta:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 2px;
+  }
+
+  .bp-cta-split-contact__methods {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    padding-inline-start: 0;
+    border-left: 1px solid var(--bp-cta-split-contact-divider, var(--border-secondary));
+    padding-inline-start: var(--space-lg);
+  }
+
+  @media (max-width: 767px) {
+    .bp-cta-split-contact__methods {
+      border-left: none;
+      border-top: 1px solid var(--bp-cta-split-contact-divider, var(--border-secondary));
+      padding-top: var(--space-lg);
+      padding-inline-start: 0;
+    }
+  }
+
+  .bp-cta-split-contact__method {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    color: var(--bp-cta-split-contact-method-color, var(--text-primary));
+    text-decoration: none;
+    transition: color 120ms ease-out;
+  }
+
+  a.bp-cta-split-contact__method:hover {
+    color: var(--text-brand-primary);
+  }
+
+  a.bp-cta-split-contact__method:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 2px;
+  }
+
+  .bp-cta-split-contact__method-label {
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+  }
+
+  .bp-cta-split-contact__method-value {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-500);
+    font-weight: var(--font-weight-semibold);
+  }
+</style>

--- a/content-system/blueprints/astro/HeroInteriorMinimal.astro
+++ b/content-system/blueprints/astro/HeroInteriorMinimal.astro
@@ -1,0 +1,124 @@
+---
+/**
+ * hero_interior_minimal — text-only interior page hero. Eyebrow +
+ * headline + optional lead, no image. Owns the h1 for the page.
+ *
+ * See blueprints/blueprint-library.json for canonical metadata.
+ *
+ * Contract: BlueprintProps (section + clientFacts + theme).
+ *   - section.heading    — h1 (REQUIRED by content gen)
+ *   - section.subheading — eyebrow above h1 (optional)
+ *   - section.body       — lead paragraph (optional)
+ *   - section.cta        — primary CTA (optional; rare on interior heroes)
+ *
+ * required_facts: []. Renders entirely from section content.
+ *
+ * CSS custom properties:
+ *   --bp-hero-interior-padding-y     (default: clamp block)
+ *   --bp-hero-interior-bg            (default: var(--page-primary))
+ *   --bp-hero-interior-headline-color  (default: var(--text-primary))
+ *   --bp-hero-interior-eyebrow-color   (default: var(--text-brand-primary))
+ *   --bp-hero-interior-lead-color      (default: var(--text-secondary))
+ *
+ * a11y: h1 + aria-labelledby. Decorative-default posture. Static layout,
+ * no motion; prefers-reduced-motion is irrelevant here.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+
+const headingId = `bp-hero-interior-${section.sectionKey}-h`;
+const eyebrow = section.subheading;
+const headline = section.heading ?? '';
+const lead = section.body;
+const cta = section.cta;
+---
+
+<section
+  class="bp-hero-interior-minimal"
+  aria-labelledby={headingId}
+  data-blueprint-key="hero_interior_minimal"
+>
+  <div class="bp-hero-interior-minimal__container">
+    {eyebrow && <p class="bp-hero-interior-minimal__eyebrow">{eyebrow}</p>}
+    <h1 id={headingId} class="bp-hero-interior-minimal__headline">{headline}</h1>
+    {lead && <p class="bp-hero-interior-minimal__lead">{lead}</p>}
+    {cta && (
+      <a href={cta.url} class="bp-hero-interior-minimal__cta">{cta.label}</a>
+    )}
+  </div>
+</section>
+
+<style>
+  .bp-hero-interior-minimal {
+    background: var(--bp-hero-interior-bg, var(--page-primary));
+    padding-block: var(
+      --bp-hero-interior-padding-y,
+      clamp(var(--space-2xl), 6vw, var(--space-4xl))
+    );
+  }
+
+  .bp-hero-interior-minimal__container {
+    max-width: var(--size-container-xl, 1280px);
+    margin-inline: auto;
+    padding-inline: var(--space-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    max-width: 72ch;
+  }
+
+  .bp-hero-interior-minimal__eyebrow {
+    margin: 0;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--bp-hero-interior-eyebrow-color, var(--text-brand-primary));
+  }
+
+  .bp-hero-interior-minimal__headline {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-700), 4vw, var(--font-size-1000));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--bp-hero-interior-headline-color, var(--text-primary));
+  }
+
+  .bp-hero-interior-minimal__lead {
+    margin: var(--space-sm) 0 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--line-height-relaxed);
+    color: var(--bp-hero-interior-lead-color, var(--text-secondary));
+  }
+
+  .bp-hero-interior-minimal__cta {
+    display: inline-flex;
+    align-items: center;
+    margin-top: var(--space-md);
+    padding: var(--space-sm) var(--space-lg);
+    background: var(--background-brand-primary);
+    color: var(--text-on-brand-primary, var(--text-inverse));
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-300);
+    font-weight: var(--font-weight-semibold);
+    text-decoration: none;
+    border-radius: var(--border-radius-md);
+    align-self: flex-start;
+    transition: background 120ms ease-out;
+  }
+
+  .bp-hero-interior-minimal__cta:hover {
+    background: var(--background-brand-primary-hover, var(--background-brand-primary));
+  }
+
+  .bp-hero-interior-minimal__cta:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 2px;
+  }
+</style>

--- a/content-system/blueprints/astro/ServicesDetailTwoColumn.astro
+++ b/content-system/blueprints/astro/ServicesDetailTwoColumn.astro
@@ -1,0 +1,149 @@
+---
+/**
+ * services_detail_two_column — service listing with a 2-column grid of
+ * { title, description } items. Used on home pages as a services
+ * overview and on services-index pages as the canonical grid.
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading    — section heading (h2)
+ *   - section.subheading — optional eyebrow
+ *   - section.body       — optional intro paragraph
+ *   - section.items[]    — REQUIRED, each { title, description }
+ *
+ * required_facts: []. Section-driven.
+ *
+ * CSS custom properties:
+ *   --bp-services-two-col-padding-y
+ *   --bp-services-two-col-bg           (default: var(--page-primary))
+ *   --bp-services-two-col-heading-color (default: var(--text-primary))
+ *   --bp-services-two-col-item-title-color (default: var(--text-primary))
+ *   --bp-services-two-col-item-desc-color  (default: var(--text-secondary))
+ *
+ * a11y: h2 + aria-labelledby. Services list is a role="list" ul so AT
+ * treats it as a list. Each item's title is an h3 nested under the h2,
+ * preserving heading hierarchy.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+const headingId = `bp-services-two-col-${section.sectionKey}-h`;
+---
+
+<section
+  class="bp-services-two-col"
+  aria-labelledby={headingId}
+  data-blueprint-key="services_detail_two_column"
+>
+  <div class="bp-services-two-col__container">
+    <header class="bp-services-two-col__header">
+      {section.subheading && (
+        <p class="bp-services-two-col__eyebrow">{section.subheading}</p>
+      )}
+      <h2 id={headingId} class="bp-services-two-col__heading">{section.heading}</h2>
+      {section.body && (
+        <p class="bp-services-two-col__lead">{section.body}</p>
+      )}
+    </header>
+
+    <ul class="bp-services-two-col__list" role="list">
+      {section.items.map((item) => (
+        <li class="bp-services-two-col__item">
+          <h3 class="bp-services-two-col__item-title">{item.title}</h3>
+          <p class="bp-services-two-col__item-desc">{item.description}</p>
+        </li>
+      ))}
+    </ul>
+  </div>
+</section>
+
+<style>
+  .bp-services-two-col {
+    background: var(--bp-services-two-col-bg, var(--page-primary));
+    padding-block: var(
+      --bp-services-two-col-padding-y,
+      clamp(var(--space-3xl), 7vw, var(--space-5xl))
+    );
+  }
+
+  .bp-services-two-col__container {
+    max-width: var(--size-container-xl, 1280px);
+    margin-inline: auto;
+    padding-inline: var(--space-xl);
+  }
+
+  .bp-services-two-col__header {
+    max-width: 72ch;
+    margin-bottom: var(--space-2xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .bp-services-two-col__eyebrow {
+    margin: 0;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-brand-primary);
+  }
+
+  .bp-services-two-col__heading {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--bp-services-two-col-heading-color, var(--text-primary));
+  }
+
+  .bp-services-two-col__lead {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--line-height-relaxed);
+    color: var(--text-secondary);
+  }
+
+  .bp-services-two-col__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+  }
+
+  @media (min-width: 768px) {
+    .bp-services-two-col__list {
+      grid-template-columns: repeat(2, 1fr);
+      gap: var(--space-2xl) var(--space-3xl);
+    }
+  }
+
+  .bp-services-two-col__item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .bp-services-two-col__item-title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-500);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--bp-services-two-col-item-title-color, var(--text-primary));
+  }
+
+  .bp-services-two-col__item-desc {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-300);
+    line-height: var(--line-height-relaxed);
+    color: var(--bp-services-two-col-item-desc-color, var(--text-secondary));
+  }
+</style>

--- a/content-system/blueprints/astro/StatsDarkBar.astro
+++ b/content-system/blueprints/astro/StatsDarkBar.astro
@@ -1,0 +1,141 @@
+---
+/**
+ * stats_dark_bar — horizontal row of proof-point stats on a dark
+ * surface. Each item renders as { value, label } — item.title carries
+ * the large number/string, item.description the caption underneath.
+ *
+ * Intentionally dark-surfaced (uses a surface-inverse token by
+ * default) so this blueprint is visually distinct from the
+ * adjacent body of the page and reads as a weighty proof moment.
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading (optional, rendered as visually-hidden label
+ *     for the stats region to give assistive tech a name)
+ *   - section.items[] — REQUIRED shape, each: { title, description }
+ *     title = the number/string, description = the caption
+ *
+ * required_facts: []. Section-driven.
+ *
+ * CSS custom properties:
+ *   --bp-stats-dark-bar-padding-y
+ *   --bp-stats-dark-bar-bg        (default: var(--surface-inverse))
+ *   --bp-stats-dark-bar-value-color   (default: var(--text-on-inverse))
+ *   --bp-stats-dark-bar-label-color   (default: var(--text-muted-on-inverse))
+ *   --bp-stats-dark-bar-divider       (default: var(--border-secondary))
+ *
+ * a11y: semantic list (ul/li). If section.heading present, wired via
+ * aria-labelledby; if absent, aria-label fallback. Numbers are
+ * content, not decoration — readable by screen readers.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+
+const headingId = `bp-stats-dark-bar-${section.sectionKey}-h`;
+const hasHeading = Boolean(section.heading);
+const items = section.items;
+---
+
+<section
+  class="bp-stats-dark-bar"
+  aria-labelledby={hasHeading ? headingId : undefined}
+  aria-label={!hasHeading ? 'Key stats' : undefined}
+  data-blueprint-key="stats_dark_bar"
+>
+  <div class="bp-stats-dark-bar__container">
+    {hasHeading && (
+      <h2 id={headingId} class="bp-stats-dark-bar__sr-heading">{section.heading}</h2>
+    )}
+    <ul class="bp-stats-dark-bar__list" role="list">
+      {items.map((item) => (
+        <li class="bp-stats-dark-bar__item">
+          <span class="bp-stats-dark-bar__value">{item.title}</span>
+          <span class="bp-stats-dark-bar__label">{item.description}</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+</section>
+
+<style>
+  .bp-stats-dark-bar {
+    background: var(--bp-stats-dark-bar-bg, var(--surface-inverse, var(--color-black)));
+    padding-block: var(
+      --bp-stats-dark-bar-padding-y,
+      clamp(var(--space-xl), 5vw, var(--space-3xl))
+    );
+  }
+
+  .bp-stats-dark-bar__container {
+    max-width: var(--size-container-xl, 1280px);
+    margin-inline: auto;
+    padding-inline: var(--space-xl);
+  }
+
+  .bp-stats-dark-bar__sr-heading {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .bp-stats-dark-bar__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+  }
+
+  @media (min-width: 640px) {
+    .bp-stats-dark-bar__list {
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+  }
+
+  .bp-stats-dark-bar__item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    padding-block: var(--space-sm);
+    border-left: 1px solid var(--bp-stats-dark-bar-divider, var(--border-secondary));
+    padding-left: var(--space-md);
+  }
+
+  @media (max-width: 639px) {
+    .bp-stats-dark-bar__item {
+      border-left: none;
+      border-top: 1px solid var(--bp-stats-dark-bar-divider, var(--border-secondary));
+      padding-top: var(--space-md);
+      padding-left: 0;
+    }
+    .bp-stats-dark-bar__item:first-child {
+      border-top: none;
+      padding-top: 0;
+    }
+  }
+
+  .bp-stats-dark-bar__value {
+    font-family: var(--font-family-display, var(--font-family-heading));
+    font-size: clamp(var(--font-size-700), 4vw, var(--font-size-900));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--bp-stats-dark-bar-value-color, var(--text-on-inverse, var(--color-white)));
+  }
+
+  .bp-stats-dark-bar__label {
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--bp-stats-dark-bar-label-color, var(--text-muted-on-inverse, var(--color-gray-light)));
+  }
+</style>

--- a/content-system/blueprints/astro/TestimonialsFeaturedLarge.astro
+++ b/content-system/blueprints/astro/TestimonialsFeaturedLarge.astro
@@ -1,0 +1,117 @@
+---
+/**
+ * testimonials_featured_large — one large, featured testimonial
+ * centered on the page. Quote-first treatment; attribution below.
+ * Used when a single client story carries disproportionate weight
+ * (anchor case study, lead industry testimonial).
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading    — section label (h2, often "What clients say")
+ *   - section.items[0]   — REQUIRED, the featured testimonial:
+ *                            item.title       = attribution line
+ *                                               (name · role · company)
+ *                            item.description = the quote
+ *
+ * required_facts: []. Section-driven.
+ *
+ * CSS custom properties:
+ *   --bp-testimonials-featured-padding-y
+ *   --bp-testimonials-featured-bg         (default: var(--surface-primary))
+ *   --bp-testimonials-featured-quote-color (default: var(--text-primary))
+ *   --bp-testimonials-featured-cite-color  (default: var(--text-secondary))
+ *   --bp-testimonials-featured-mark-color  (default: var(--text-brand-primary))
+ *
+ * a11y: h2 + aria-labelledby, semantic blockquote + cite. Decorative
+ * quote mark uses aria-hidden so AT doesn't announce it.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+const headingId = `bp-testimonials-featured-${section.sectionKey}-h`;
+const featured = section.items[0];
+---
+
+<section
+  class="bp-testimonials-featured"
+  aria-labelledby={headingId}
+  data-blueprint-key="testimonials_featured_large"
+>
+  <div class="bp-testimonials-featured__container">
+    <h2 id={headingId} class="bp-testimonials-featured__sr-heading">
+      {section.heading ?? 'Featured testimonial'}
+    </h2>
+
+    {featured && (
+      <blockquote class="bp-testimonials-featured__quote">
+        <span class="bp-testimonials-featured__mark" aria-hidden="true">&ldquo;</span>
+        <p class="bp-testimonials-featured__quote-text">{featured.description}</p>
+        <cite class="bp-testimonials-featured__cite">{featured.title}</cite>
+      </blockquote>
+    )}
+  </div>
+</section>
+
+<style>
+  .bp-testimonials-featured {
+    background: var(--bp-testimonials-featured-bg, var(--surface-primary));
+    padding-block: var(
+      --bp-testimonials-featured-padding-y,
+      clamp(var(--space-3xl), 7vw, var(--space-5xl))
+    );
+  }
+
+  .bp-testimonials-featured__container {
+    max-width: var(--size-container-md, 960px);
+    margin-inline: auto;
+    padding-inline: var(--space-xl);
+    text-align: center;
+  }
+
+  .bp-testimonials-featured__sr-heading {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .bp-testimonials-featured__quote {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-lg);
+  }
+
+  .bp-testimonials-featured__mark {
+    font-family: var(--font-family-display, var(--font-family-heading));
+    font-size: clamp(var(--font-size-1000), 8vw, var(--font-size-1200));
+    line-height: 1;
+    color: var(--bp-testimonials-featured-mark-color, var(--text-brand-primary));
+  }
+
+  .bp-testimonials-featured__quote-text {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-500), 2.5vw, var(--font-size-700));
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-relaxed);
+    color: var(--bp-testimonials-featured-quote-color, var(--text-primary));
+    max-width: 60ch;
+  }
+
+  .bp-testimonials-featured__cite {
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-300);
+    font-style: normal;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--bp-testimonials-featured-cite-color, var(--text-secondary));
+  }
+</style>

--- a/content-system/blueprints/astro/index.ts
+++ b/content-system/blueprints/astro/index.ts
@@ -9,10 +9,10 @@
  *
  * v0.1 scope (see spec §2.1):
  *   Contract types (shipped PR #2).
- *   HeroSplit6040 (this PR).
- *   StatsDarkBar, ServicesDetailTwoColumn, AboutStorySplit,
- *     TestimonialsFeaturedLarge, CtaSplitContact, CtaDarkCentered,
- *     HeroInteriorMinimal (PR #6).
+ *   HeroSplit6040 (shipped PR #5).
+ *   HeroInteriorMinimal, StatsDarkBar, ServicesDetailTwoColumn,
+ *     AboutStorySplit, TestimonialsFeaturedLarge, CtaSplitContact,
+ *     CtaDarkCentered (this PR).
  *   SiteHeader, BlueprintDispatcher, BlueprintFallback (PR #7).
  *
  * Consumer-side type resolution: Astro projects inherit
@@ -40,4 +40,17 @@ export type {
 // a shipped Astro component is re-exported here. The
 // BlueprintDispatcher (PR #7) imports from this barrel to dispatch
 // by `visualNotes.blueprintKey`.
-export { default as HeroSplit6040 } from './HeroSplit6040.astro';
+//
+// v0.1 ships 8 blueprints — the set needed for Vale's first scaffold
+// run. Small-business's `home` composition uses HeroSplit6040 +
+// StatsDarkBar + ServicesDetailTwoColumn + AboutStorySplit +
+// TestimonialsFeaturedLarge + CtaSplitContact. Interior pages use
+// HeroInteriorMinimal + CtaDarkCentered.
+export { default as HeroSplit6040 }             from './HeroSplit6040.astro';
+export { default as HeroInteriorMinimal }       from './HeroInteriorMinimal.astro';
+export { default as StatsDarkBar }              from './StatsDarkBar.astro';
+export { default as ServicesDetailTwoColumn }   from './ServicesDetailTwoColumn.astro';
+export { default as AboutStorySplit }           from './AboutStorySplit.astro';
+export { default as TestimonialsFeaturedLarge } from './TestimonialsFeaturedLarge.astro';
+export { default as CtaSplitContact }           from './CtaSplitContact.astro';
+export { default as CtaDarkCentered }           from './CtaDarkCentered.astro';

--- a/scripts/verify-blueprints-astro-exports.mjs
+++ b/scripts/verify-blueprints-astro-exports.mjs
@@ -115,10 +115,12 @@ writeFileSync(
 mkdirSync(join(scratch, 'src/pages'), { recursive: true });
 writeFileSync(join(scratch, 'src/env.d.ts'), `/// <reference path="../.astro/types.d.ts" />\n`);
 
-// ── 5. Fixture — types probe + shipped blueprints render ──────────
-// Populated `heroImageUrl` so HeroSplit6040 renders the image, not
-// the `data-content-needed` stub. Assertions below confirm the
-// rendered HTML reflects that.
+// ── 5. Fixture — types probe + all shipped blueprints rendered ────
+// Composes a realistic small-business home page: hero → stats →
+// services → about → testimonials → CTA, plus an interior-style
+// hero + dark CTA below to cover every v0.1 blueprint. clientFacts
+// populated so required_facts (hero_image_url, phone, email) all
+// resolve — no data-content-needed stubs expected.
 writeFileSync(
   join(scratch, 'src/pages/index.astro'),
   `---
@@ -133,13 +135,21 @@ import type {
   ResolvedTheme,
   BlueprintProps,
 } from '@brikdesigns/bds/blueprints-astro';
-import { HeroSplit6040 } from '@brikdesigns/bds/blueprints-astro';
+import {
+  HeroSplit6040,
+  HeroInteriorMinimal,
+  StatsDarkBar,
+  ServicesDetailTwoColumn,
+  AboutStorySplit,
+  TestimonialsFeaturedLarge,
+  CtaSplitContact,
+  CtaDarkCentered,
+} from '@brikdesigns/bds/blueprints-astro';
 
 const mode: ResolvedThemeMode = 'dark';
 const atm: ResolvedAtmosphere = 'editorial-luxury';
 const nav: ResolvedNavArchetype = 'editorial-transparent';
 const foot: ResolvedFooterArchetype = 'four_col_directory';
-const key: KnownBlueprintKey = 'hero_split_60_40';
 
 const theme: ResolvedTheme = {
   themeMode: mode,
@@ -153,8 +163,8 @@ const clientFacts: ClientFacts = {
   tagline: 'Proving the Astro exports resolve',
   valueProposition: null,
   services: [],
-  phone: null,
-  email: null,
+  phone: '+1-615-555-0100',
+  email: 'hello@example.com',
   address: null,
   hours: [],
   heroImageUrl: 'https://example.com/hero.webp',
@@ -162,25 +172,137 @@ const clientFacts: ClientFacts = {
   logoVariants: {},
 };
 
-const section: BlueprintSection = {
-  sectionKey: 'home_hero',
-  sectionType: 'hero',
-  heading: 'Built to excel, driven to exceed',
-  subheading: 'Proving ground',
-  body: 'A single-paragraph lead that fits inside 55ch and validates the lead rendering path without actually meaning anything.',
-  items: [],
-  cta: { label: 'Start the conversation', url: '/contact' },
-  visualNotes: {
-    blueprintKey: key,
-    moodKeywords: ['professional', 'luxury'],
-    layoutBlueprint: 'test',
-    imageOpportunity: null,
-    animationSuggestion: null,
-    illustrationOpportunity: null,
-  },
+function makeSection(overrides: Partial<BlueprintSection> & { sectionKey: string; sectionType: string; blueprintKey: KnownBlueprintKey }): BlueprintSection {
+  const { blueprintKey, sectionKey, sectionType, ...rest } = overrides;
+  return {
+    sectionKey,
+    sectionType,
+    heading: null,
+    subheading: null,
+    body: null,
+    items: [],
+    cta: null,
+    visualNotes: {
+      blueprintKey,
+      moodKeywords: ['professional'],
+      layoutBlueprint: 'test',
+      imageOpportunity: null,
+      animationSuggestion: null,
+      illustrationOpportunity: null,
+    },
+    ...rest,
+  };
+}
+
+const heroSplitProps: BlueprintProps = {
+  theme, clientFacts,
+  section: makeSection({
+    sectionKey: 'home_hero',
+    sectionType: 'hero',
+    blueprintKey: 'hero_split_60_40',
+    heading: 'Built to excel, driven to exceed',
+    subheading: 'Proving ground',
+    body: 'A single-paragraph lead that fits inside 55ch and validates the lead rendering path.',
+    cta: { label: 'Start the conversation', url: '/contact' },
+  }),
 };
 
-const props: BlueprintProps = { section, clientFacts, theme };
+const statsProps: BlueprintProps = {
+  theme, clientFacts,
+  section: makeSection({
+    sectionKey: 'home_stats',
+    sectionType: 'stats',
+    blueprintKey: 'stats_dark_bar',
+    heading: 'By the numbers',
+    items: [
+      { title: '22+ years', description: 'Experience' },
+      { title: '3 verticals', description: 'Healthcare · Land · Commercial' },
+      { title: 'Nationwide', description: 'Reach' },
+    ],
+  }),
+};
+
+const servicesProps: BlueprintProps = {
+  theme, clientFacts,
+  section: makeSection({
+    sectionKey: 'home_services',
+    sectionType: 'services',
+    blueprintKey: 'services_detail_two_column',
+    heading: 'How we work with you',
+    subheading: 'Three specialties',
+    body: 'Purpose-built teams for each line of business.',
+    items: [
+      { title: 'Healthcare real estate', description: 'Dental, veterinary, optometry — specialty brokerage with deep vertical expertise.' },
+      { title: 'Commercial real estate', description: 'Office, medical office buildings, mixed-use.' },
+      { title: 'Land', description: 'Residential, agricultural, hunting properties.' },
+      { title: 'Buyer representation', description: 'Partner-direct engagement from tour through closing.' },
+    ],
+  }),
+};
+
+const aboutProps: BlueprintProps = {
+  theme, clientFacts,
+  section: makeSection({
+    sectionKey: 'home_about',
+    sectionType: 'features',
+    blueprintKey: 'about_story_split',
+    heading: 'Boutique by design',
+    subheading: 'Our approach',
+    body: 'Partner-direct from day one — we built the firm so clients never get handed off to a junior agent mid-transaction.',
+    items: [
+      { title: 'Managing partner', description: 'Every client works directly with a partner, not a team.' },
+    ],
+  }),
+};
+
+const testimonialsProps: BlueprintProps = {
+  theme, clientFacts,
+  section: makeSection({
+    sectionKey: 'home_testimonials',
+    sectionType: 'testimonials',
+    blueprintKey: 'testimonials_featured_large',
+    heading: 'Client voices',
+    items: [
+      { title: 'Dr. Reference · Dental Practice', description: 'They understood our practice before we finished describing it. That alone saved us six months.' },
+    ],
+  }),
+};
+
+const ctaSplitProps: BlueprintProps = {
+  theme, clientFacts,
+  section: makeSection({
+    sectionKey: 'home_cta',
+    sectionType: 'cta',
+    blueprintKey: 'cta_split_contact',
+    heading: 'Ready to talk?',
+    body: 'Reach out directly — you\\'ll be speaking with a partner within one business day.',
+    cta: { label: 'Schedule an intro call', url: '/contact' },
+  }),
+};
+
+const heroInteriorProps: BlueprintProps = {
+  theme, clientFacts,
+  section: makeSection({
+    sectionKey: 'services_hero',
+    sectionType: 'hero',
+    blueprintKey: 'hero_interior_minimal',
+    heading: 'Services',
+    subheading: 'What we do',
+    body: 'Purpose-built representation across healthcare, commercial, and land.',
+  }),
+};
+
+const ctaDarkProps: BlueprintProps = {
+  theme, clientFacts,
+  section: makeSection({
+    sectionKey: 'services_cta',
+    sectionType: 'cta',
+    blueprintKey: 'cta_dark_centered',
+    heading: 'Find your fit',
+    body: 'Schedule a consultation with a partner.',
+    cta: { label: 'Book a call', url: '/contact' },
+  }),
+};
 ---
 <html lang="en">
   <head>
@@ -190,11 +312,81 @@ const props: BlueprintProps = { section, clientFacts, theme };
   </head>
   <body>
     <main>
-      <HeroSplit6040 {...props} />
-      <!-- Probe for the type-level types as well by reading props at runtime: -->
-      <p data-probe="section-key">{props.section.sectionKey}</p>
-      <p data-probe="brand">{props.clientFacts.brandName}</p>
-      <p data-probe="atmosphere">{props.theme.atmosphere}</p>
+      <HeroSplit6040 {...heroSplitProps} />
+      <StatsDarkBar {...statsProps} />
+      <ServicesDetailTwoColumn {...servicesProps} />
+      <AboutStorySplit {...aboutProps} />
+      <TestimonialsFeaturedLarge {...testimonialsProps} />
+      <CtaSplitContact {...ctaSplitProps} />
+    </main>
+  </body>
+</html>
+`,
+);
+
+// Interior page fixture — covers the two v0.1 blueprints reserved
+// for interior pages. Keeping hero blueprints on separate pages
+// preserves the "exactly one h1 per page" contract.
+writeFileSync(
+  join(scratch, 'src/pages/interior.astro'),
+  `---
+import type { BlueprintSection, BlueprintProps, ClientFacts, ResolvedTheme, KnownBlueprintKey } from '@brikdesigns/bds/blueprints-astro';
+import { HeroInteriorMinimal, CtaDarkCentered } from '@brikdesigns/bds/blueprints-astro';
+
+const theme: ResolvedTheme = {
+  themeMode: 'dark',
+  atmosphere: 'editorial-luxury',
+  navigationArchetype: 'editorial-transparent',
+  footerArchetype: 'four_col_directory',
+};
+const clientFacts: ClientFacts = {
+  brandName: 'Verify Scratch',
+  tagline: null, valueProposition: null, services: [], phone: null,
+  email: null, address: null, hours: [], heroImageUrl: null,
+  logoUrl: null, logoVariants: {},
+};
+
+function mk(kind: 'hero' | 'cta', blueprintKey: KnownBlueprintKey, over: Partial<BlueprintSection>): BlueprintSection {
+  return {
+    sectionKey: over.sectionKey ?? kind,
+    sectionType: kind,
+    heading: null, subheading: null, body: null, items: [], cta: null,
+    visualNotes: { blueprintKey, moodKeywords: [], layoutBlueprint: 'test',
+      imageOpportunity: null, animationSuggestion: null, illustrationOpportunity: null },
+    ...over,
+  };
+}
+
+const heroInteriorProps: BlueprintProps = {
+  theme, clientFacts,
+  section: mk('hero', 'hero_interior_minimal', {
+    sectionKey: 'services_hero',
+    heading: 'Services',
+    subheading: 'What we do',
+    body: 'Purpose-built representation across healthcare, commercial, and land.',
+  }),
+};
+
+const ctaDarkProps: BlueprintProps = {
+  theme, clientFacts,
+  section: mk('cta', 'cta_dark_centered', {
+    sectionKey: 'services_cta',
+    heading: 'Find your fit',
+    body: 'Schedule a consultation with a partner.',
+    cta: { label: 'Book a call', url: '/contact' },
+  }),
+};
+---
+<html lang="en">
+  <head>
+    <title>BDS interior verify</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <main>
+      <HeroInteriorMinimal {...heroInteriorProps} />
+      <CtaDarkCentered {...ctaDarkProps} />
     </main>
   </body>
 </html>
@@ -230,39 +422,40 @@ try {
 }
 
 // ── 9. Rendered-HTML assertions ──────────────────────────────────
-log.step('Asserting rendered HTML markers');
-const builtHtmlPath = resolve(scratch, 'dist/index.html');
-const html = readFileSync(builtHtmlPath, 'utf8');
+log.step('Asserting rendered HTML markers (home + interior pages)');
+const homeHtmlPath = resolve(scratch, 'dist/index.html');
+const interiorHtmlPath = resolve(scratch, 'dist/interior/index.html');
+const homeHtml = readFileSync(homeHtmlPath, 'utf8');
+const interiorHtml = readFileSync(interiorHtmlPath, 'utf8');
+const bothHtml = homeHtml + '\n' + interiorHtml;
 
 const assertions = [
-  {
-    name: 'blueprint key marker present',
-    pass: html.includes('data-blueprint-key="hero_split_60_40"'),
-  },
-  {
-    name: 'headline text rendered',
-    pass: html.includes('Built to excel, driven to exceed'),
-  },
-  {
-    name: 'eyebrow rendered',
-    pass: html.includes('Proving ground'),
-  },
-  {
-    name: 'hero image src rendered',
-    pass: html.includes('src="https://example.com/hero.webp"'),
-  },
-  {
-    name: 'NO data-content-needed stub (facts provided)',
-    pass: !html.includes('data-content-needed='),
-  },
-  {
-    name: 'h1 aria-labelledby wiring present',
-    pass: html.includes('aria-labelledby=') && html.includes('id="bp-hero-split-home_hero-h"'),
-  },
-  {
-    name: 'CTA link rendered',
-    pass: html.includes('href="/contact"') && html.includes('Start the conversation'),
-  },
+  // Every shipped blueprint's marker present (across both pages)
+  { name: 'hero_split_60_40 marker (home)',         pass: homeHtml.includes('data-blueprint-key="hero_split_60_40"') },
+  { name: 'stats_dark_bar marker (home)',           pass: homeHtml.includes('data-blueprint-key="stats_dark_bar"') },
+  { name: 'services_detail_two_column marker (home)',pass: homeHtml.includes('data-blueprint-key="services_detail_two_column"') },
+  { name: 'about_story_split marker (home)',        pass: homeHtml.includes('data-blueprint-key="about_story_split"') },
+  { name: 'testimonials_featured_large marker (home)',pass: homeHtml.includes('data-blueprint-key="testimonials_featured_large"') },
+  { name: 'cta_split_contact marker (home)',        pass: homeHtml.includes('data-blueprint-key="cta_split_contact"') },
+  { name: 'hero_interior_minimal marker (interior)',pass: interiorHtml.includes('data-blueprint-key="hero_interior_minimal"') },
+  { name: 'cta_dark_centered marker (interior)',    pass: interiorHtml.includes('data-blueprint-key="cta_dark_centered"') },
+
+  // Content probes per blueprint
+  { name: 'hero headline rendered',                 pass: homeHtml.includes('Built to excel, driven to exceed') },
+  { name: 'hero image src rendered',                pass: homeHtml.includes('src="https://example.com/hero.webp"') },
+  { name: 'stats items rendered',                   pass: homeHtml.includes('22+ years') && homeHtml.includes('3 verticals') },
+  { name: 'services items rendered',                pass: homeHtml.includes('Healthcare real estate') && homeHtml.includes('Buyer representation') },
+  { name: 'about story rendered',                   pass: homeHtml.includes('Boutique by design') && homeHtml.includes('Partner-direct from day one') },
+  { name: 'testimonial quote rendered',             pass: homeHtml.includes('They understood our practice') },
+  { name: 'cta_split_contact phone tel:',           pass: homeHtml.includes('href="tel:+16155550100"') },
+  { name: 'cta_split_contact mailto:',              pass: homeHtml.includes('href="mailto:hello@example.com"') },
+  { name: 'interior hero heading rendered',         pass: interiorHtml.includes('What we do') },
+  { name: 'cta_dark_centered CTA rendered',         pass: interiorHtml.includes('Book a call') },
+
+  // Cross-blueprint contract checks
+  { name: 'home: no data-content-needed stubs (all facts provided)', pass: !homeHtml.includes('data-content-needed=') },
+  { name: 'home: exactly one h1 (hero owns it)',    pass: (homeHtml.match(/<h1[\s>]/g) || []).length === 1 },
+  { name: 'interior: exactly one h1 (hero owns it)',pass: (interiorHtml.match(/<h1[\s>]/g) || []).length === 1 },
 ];
 
 let failed = 0;
@@ -289,26 +482,44 @@ try {
   const browser = await chromium.launch();
   const context = await browser.newContext();
   const page = await context.newPage();
-  await page.goto(`file://${builtHtmlPath}`);
-  const results = await new AxeBuilder({ page })
-    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-    .analyze();
+
+  const pagesToScan = [
+    { label: 'home',     path: homeHtmlPath },
+    { label: 'interior', path: interiorHtmlPath },
+  ];
+  let totalPasses = 0;
+  const allViolations = [];
+
+  for (const p of pagesToScan) {
+    await page.goto(`file://${p.path}`);
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+    totalPasses += results.passes.length;
+    if (results.violations.length > 0) {
+      allViolations.push({ page: p.label, violations: results.violations });
+    }
+  }
+
   await context.close();
   await browser.close();
 
-  if (results.violations.length > 0) {
-    log.fail(`${results.violations.length} a11y violation(s):`);
-    for (const v of results.violations) {
-      log.info(`  [${v.impact}] ${v.id} — ${v.help}`);
-      for (const node of v.nodes) {
-        log.info(`     ${node.target.join(' ')}`);
+  if (allViolations.length > 0) {
+    log.fail(`a11y violations found:`);
+    for (const { page: pg, violations } of allViolations) {
+      log.info(`  page: ${pg}`);
+      for (const v of violations) {
+        log.info(`    [${v.impact}] ${v.id} — ${v.help}`);
+        for (const node of v.nodes) {
+          log.info(`       ${node.target.join(' ')}`);
+        }
       }
     }
     log.info(`Scratch project preserved for inspection: ${scratch}`);
     process.exit(1);
   }
 
-  log.ok(`axe-core clean: ${results.passes.length} rules passed, 0 violations`);
+  log.ok(`axe-core clean: ${totalPasses} rule-checks passed across ${pagesToScan.length} pages, 0 violations`);
 } catch (err) {
   log.fail(`axe-core scan failed to run: ${err.message ?? err}`);
   log.info(`Scratch project preserved for inspection: ${scratch}`);
@@ -324,8 +535,15 @@ const expectedFiles = [
   'dist/content-system/blueprints/astro/types.d.ts',
   // Barrel (source — excluded from tsc compile)
   'content-system/blueprints/astro/index.ts',
-  // Component (source, .astro)
+  // Components (source, .astro) — all 8 v0.1 shipped blueprints
   'content-system/blueprints/astro/HeroSplit6040.astro',
+  'content-system/blueprints/astro/HeroInteriorMinimal.astro',
+  'content-system/blueprints/astro/StatsDarkBar.astro',
+  'content-system/blueprints/astro/ServicesDetailTwoColumn.astro',
+  'content-system/blueprints/astro/AboutStorySplit.astro',
+  'content-system/blueprints/astro/TestimonialsFeaturedLarge.astro',
+  'content-system/blueprints/astro/CtaSplitContact.astro',
+  'content-system/blueprints/astro/CtaDarkCentered.astro',
 ];
 
 let allPresent = true;


### PR DESCRIPTION
## Summary
- feat(blueprints-astro): ship remaining 7 blueprints for v0.1

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)