### PR TITLE
feat(blueprints-astro): dispatch surface + SiteHeader + catalog docs

### DIFF
--- a/content-system/blueprints/astro/BlueprintDispatcher.astro
+++ b/content-system/blueprints/astro/BlueprintDispatcher.astro
@@ -1,0 +1,97 @@
+---
+/**
+ * BlueprintDispatcher — reads `section.visualNotes.blueprintKey` for
+ * each section in the array and renders the corresponding Astro
+ * component. Unknown keys render `<BlueprintFallback>`.
+ *
+ * This is the ONE component a client Astro page imports to render a
+ * page body. No per-page if/else, no per-blueprint imports in client
+ * repos. The scaffold task emits pages as:
+ *
+ *   <BlueprintDispatcher sections={page.sections}
+ *                        clientFacts={...}
+ *                        theme={...} />
+ *
+ * BLUEPRINT_REGISTRY is a static object — adding a new blueprint =
+ * one import + one registry entry here + one export in index.ts.
+ * The dispatcher's shape never changes.
+ *
+ * ## Contract
+ *
+ *   Props:
+ *     - sections      — ordered array of BlueprintSection
+ *     - clientFacts   — passed through to every blueprint
+ *     - theme         — passed through to every blueprint
+ *
+ *   Behavior:
+ *     - section.visualNotes.blueprintKey ∈ BLUEPRINT_REGISTRY →
+ *         renders the matching component with full BlueprintProps
+ *     - section.visualNotes.blueprintKey ∉ BLUEPRINT_REGISTRY →
+ *         renders BlueprintFallback (which emits a
+ *         data-blueprint-unknown-key attribute for CI grep)
+ *     - section.visualNotes is null →
+ *         same as unknown — falls back
+ *
+ * ## v0.1 registry (8 blueprints)
+ *
+ * Every key listed here has a corresponding component file in this
+ * folder and a re-export in index.ts. When PR #6 or later adds a new
+ * component, update this registry in the same PR.
+ *
+ *   hero_split_60_40              → HeroSplit6040.astro
+ *   hero_interior_minimal         → HeroInteriorMinimal.astro
+ *   stats_dark_bar                → StatsDarkBar.astro
+ *   services_detail_two_column    → ServicesDetailTwoColumn.astro
+ *   about_story_split             → AboutStorySplit.astro
+ *   testimonials_featured_large   → TestimonialsFeaturedLarge.astro
+ *   cta_split_contact             → CtaSplitContact.astro
+ *   cta_dark_centered             → CtaDarkCentered.astro
+ *
+ * The 17 keys in blueprint-library.json without a component here
+ * (hero_centered_gradient, hero_fullbleed_photo, etc.) fall through
+ * to BlueprintFallback — expected during the incremental v0.1 → v1.0
+ * ramp. Each new component PR removes one fallback case.
+ */
+import type { BlueprintSection, ClientFacts, ResolvedTheme } from './types';
+
+import HeroSplit6040 from './HeroSplit6040.astro';
+import HeroInteriorMinimal from './HeroInteriorMinimal.astro';
+import StatsDarkBar from './StatsDarkBar.astro';
+import ServicesDetailTwoColumn from './ServicesDetailTwoColumn.astro';
+import AboutStorySplit from './AboutStorySplit.astro';
+import TestimonialsFeaturedLarge from './TestimonialsFeaturedLarge.astro';
+import CtaSplitContact from './CtaSplitContact.astro';
+import CtaDarkCentered from './CtaDarkCentered.astro';
+import BlueprintFallback from './BlueprintFallback.astro';
+
+// The registry. Key order doesn't matter; lookup is by key. Every
+// entry's component accepts `BlueprintProps` — enforced by the
+// barrel's re-export types.
+const BLUEPRINT_REGISTRY = {
+  hero_split_60_40: HeroSplit6040,
+  hero_interior_minimal: HeroInteriorMinimal,
+  stats_dark_bar: StatsDarkBar,
+  services_detail_two_column: ServicesDetailTwoColumn,
+  about_story_split: AboutStorySplit,
+  testimonials_featured_large: TestimonialsFeaturedLarge,
+  cta_split_contact: CtaSplitContact,
+  cta_dark_centered: CtaDarkCentered,
+} as const;
+
+interface Props {
+  sections: readonly BlueprintSection[];
+  clientFacts: ClientFacts;
+  theme: ResolvedTheme;
+}
+
+const { sections, clientFacts, theme } = Astro.props;
+---
+
+{sections.map((section) => {
+  const key = section.visualNotes?.blueprintKey;
+  const Component =
+    key && key in BLUEPRINT_REGISTRY
+      ? BLUEPRINT_REGISTRY[key as keyof typeof BLUEPRINT_REGISTRY]
+      : BlueprintFallback;
+  return <Component section={section} clientFacts={clientFacts} theme={theme} />;
+})}

--- a/content-system/blueprints/astro/BlueprintFallback.astro
+++ b/content-system/blueprints/astro/BlueprintFallback.astro
@@ -1,0 +1,104 @@
+---
+/**
+ * BlueprintFallback — renders when BlueprintDispatcher encounters a
+ * `visualNotes.blueprintKey` that is not in BLUEPRINT_REGISTRY.
+ *
+ * This is a loud, visible stub by design — zero-sized or silent
+ * fallbacks defeat the whole point of the scaffold-task preflight
+ * (spec §2.4). Two signals for different audiences:
+ *
+ *   1. `data-blueprint-unknown-key={key}` attribute on the wrapper.
+ *      CI greps for `data-blueprint-unknown-key=` in every client
+ *      repo's built `dist/` and blocks publish.
+ *
+ *   2. A visible dashed-border card showing the missing key and
+ *      section metadata. Reviewers opening the page in dev see the
+ *      gap; they don't have to inspect the HTML to find it.
+ *
+ * Contract: BlueprintProps (same shape as every blueprint). Reads
+ * `section.visualNotes.blueprintKey` to report what was unmatched.
+ * Falls back to `null` in the attribute when blueprintKey itself is
+ * missing — still renders the visible stub.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+const unknownKey = section.visualNotes?.blueprintKey ?? null;
+const attrValue = unknownKey ?? '__null__';
+---
+
+<section
+  class="bp-fallback"
+  data-blueprint-key="__fallback__"
+  data-blueprint-unknown-key={attrValue}
+  aria-label="Blueprint not yet shipped"
+>
+  <div class="bp-fallback__container">
+    <p class="bp-fallback__label">Blueprint not yet shipped</p>
+    <p class="bp-fallback__key">
+      Key: <code>{unknownKey ?? '(none — section has no blueprintKey)'}</code>
+    </p>
+    <p class="bp-fallback__meta">
+      Section: <code>{section.sectionKey}</code> · Type: <code>{section.sectionType}</code>
+    </p>
+    <p class="bp-fallback__hint">
+      CI will block publish on any client repo whose built
+      <code>dist/</code> contains <code>data-blueprint-unknown-key=</code>.
+      Add a component for this key in
+      <code>@brikdesigns/bds/blueprints-astro</code> and bump the
+      package version, or remove the key from the content.
+    </p>
+  </div>
+</section>
+
+<style>
+  .bp-fallback {
+    padding: var(--space-xl) var(--space-lg);
+    background: var(--surface-secondary, #f5f5f5);
+    border: 2px dashed var(--border-secondary, #c0c0c0);
+    margin-block: var(--space-md);
+  }
+
+  .bp-fallback__container {
+    max-width: var(--size-container-md, 960px);
+    margin-inline: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+  }
+
+  .bp-fallback__label {
+    margin: 0;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-primary);
+  }
+
+  .bp-fallback__key,
+  .bp-fallback__meta,
+  .bp-fallback__hint {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-300);
+    line-height: var(--line-height-relaxed);
+    color: var(--text-secondary);
+  }
+
+  .bp-fallback__hint {
+    font-size: var(--font-size-200);
+    max-width: 72ch;
+  }
+
+  .bp-fallback code {
+    font-family: var(--font-family-mono, monospace);
+    font-size: 0.9em;
+    padding: 0 var(--space-2xs);
+    background: var(--surface-primary, #ffffff);
+    border-radius: var(--border-radius-xs, 2px);
+  }
+</style>

--- a/content-system/blueprints/astro/SiteHeader.astro
+++ b/content-system/blueprints/astro/SiteHeader.astro
@@ -1,0 +1,405 @@
+---
+/**
+ * SiteHeader — the BDS site-header component. Dispatches on the
+ * `archetype` prop to render one of the locked navigation archetypes
+ * from the vocabulary (`NAV_ARCHETYPE_VALUES`).
+ *
+ * v0.1 implements ONE archetype in full: `editorial-transparent`.
+ * This is the default for both the `small-business` pack (which Vale
+ * resolves to) and the `dental` pack. Every other archetype value
+ * currently renders the editorial-transparent markup with a
+ * `data-unimplemented-archetype="<value>"` attribute on the header,
+ * which CI can grep for in client repos whose pack picks a not-yet-
+ * implemented archetype. Future PRs fill in the render paths for
+ * `utility-first`, `service-centric`, `portfolio-minimal`, `calm-flat`.
+ *
+ * This is NOT a blueprint — SiteHeader takes direct site-shell props,
+ * not BlueprintProps. It lives in `@brikdesigns/bds/blueprints-astro`
+ * alongside the blueprints because that package is the package every
+ * client Astro site imports for shell + sections.
+ *
+ * ## Props
+ *
+ *   archetype       — ResolvedNavArchetype (v0.1: only
+ *                     'editorial-transparent' fully implemented)
+ *   brandName       — site brand label (rendered as the logo text fallback)
+ *   logoUrl         — optional logo image URL (when null, brandName is rendered as text)
+ *   phone           — optional phone number (rendered in utility cluster)
+ *   navItems        — array of { label, href } for primary nav links
+ *   primaryCta      — optional { label, href } for the header CTA button
+ *   currentPath     — optional — when set, the matching navItem gets
+ *                     `aria-current="page"` for AT
+ *
+ * ## editorial-transparent archetype
+ *
+ *   Layout at ≥768px: [logo] [primary nav links, centered] [phone + CTA]
+ *   Layout at  <768px: [logo] [hamburger button + mobile drawer markup]
+ *   Scroll:  transparent over hero at top, frosted glass past 80px
+ *            (behavior added by scaffold layout JS; this component
+ *            emits the markup + CSS custom properties the JS hooks
+ *            into).
+ *   Drawer:  fullscreen-overlay (mobile) — expressed via data-
+ *            attributes + CSS; the actual open/close toggle ships
+ *            with the scaffold layout JS.
+ *
+ * ## a11y
+ *
+ *   - `<nav aria-label="Primary">` landmark.
+ *   - Logo/brand is the first focusable element (logical tab order).
+ *   - `aria-current="page"` on the active link.
+ *   - Phone link uses `tel:` scheme with sanitized digits.
+ *   - Mobile hamburger button has `aria-label`, `aria-expanded`,
+ *     and `aria-controls` pointing at the drawer markup.
+ *   - Focus-visible ring on every interactive surface.
+ */
+import type { ResolvedNavArchetype } from './types';
+
+interface NavItem {
+  label: string;
+  href: string;
+}
+
+interface Props {
+  archetype: ResolvedNavArchetype;
+  brandName: string;
+  logoUrl?: string | null;
+  phone?: string | null;
+  navItems: readonly NavItem[];
+  primaryCta?: { label: string; href: string } | null;
+  currentPath?: string | null;
+}
+
+const {
+  archetype,
+  brandName,
+  logoUrl = null,
+  phone = null,
+  navItems,
+  primaryCta = null,
+  currentPath = null,
+} = Astro.props;
+
+const IMPLEMENTED_ARCHETYPES = ['editorial-transparent'] as const;
+const isImplemented = (IMPLEMENTED_ARCHETYPES as readonly string[]).includes(archetype);
+
+const phoneHref = phone ? `tel:${phone.replace(/[^+\d]/g, '')}` : null;
+
+function isCurrent(href: string): boolean {
+  if (!currentPath) return false;
+  // Exact match OR (section match: current starts with href + '/')
+  if (currentPath === href) return true;
+  if (href !== '/' && currentPath.startsWith(href + '/')) return true;
+  return false;
+}
+---
+
+<header
+  class:list={[
+    'bp-site-header',
+    `bp-site-header--${archetype}`,
+  ]}
+  data-nav-archetype={archetype}
+  data-unimplemented-archetype={isImplemented ? undefined : archetype}
+>
+  <div class="bp-site-header__container">
+    <a class="bp-site-header__brand" href="/" aria-label={`${brandName} home`}>
+      {logoUrl ? (
+        <img src={logoUrl} alt={brandName} class="bp-site-header__logo-image" />
+      ) : (
+        <span class="bp-site-header__brand-text">{brandName}</span>
+      )}
+    </a>
+
+    <nav class="bp-site-header__nav" aria-label="Primary">
+      <ul class="bp-site-header__nav-list" role="list">
+        {navItems.map((item) => {
+          const current = isCurrent(item.href);
+          return (
+            <li class="bp-site-header__nav-item">
+              <a
+                href={item.href}
+                class="bp-site-header__nav-link"
+                aria-current={current ? 'page' : undefined}
+              >
+                {item.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+
+    <div class="bp-site-header__actions">
+      {phoneHref && (
+        <a href={phoneHref} class="bp-site-header__phone">
+          <span class="bp-site-header__phone-label" aria-hidden="true">Call</span>
+          <span class="bp-site-header__phone-value">{phone}</span>
+        </a>
+      )}
+      {primaryCta && (
+        <a href={primaryCta.href} class="bp-site-header__cta">{primaryCta.label}</a>
+      )}
+    </div>
+
+    <button
+      type="button"
+      class="bp-site-header__hamburger"
+      aria-label="Open menu"
+      aria-expanded="false"
+      aria-controls="bp-site-header-drawer"
+      data-bp-site-header-toggle="open"
+    >
+      <span class="bp-site-header__hamburger-bar" aria-hidden="true"></span>
+      <span class="bp-site-header__hamburger-bar" aria-hidden="true"></span>
+      <span class="bp-site-header__hamburger-bar" aria-hidden="true"></span>
+    </button>
+  </div>
+
+  <!-- Drawer is `inert` when closed — the hamburger's click handler
+       (shipped with the scaffold layout JS) removes `inert` and sets
+       aria-expanded="true" on the hamburger. `inert` is preferred over
+       aria-hidden here because it subsumes both the accessibility tree
+       hiding AND focus removal in one attribute — axe flags drawers
+       that are aria-hidden with focusable children. -->
+  <div
+    id="bp-site-header-drawer"
+    class="bp-site-header__drawer"
+    inert
+    data-bp-site-header-drawer
+  >
+    <nav class="bp-site-header__drawer-nav" aria-label="Primary mobile">
+      <ul class="bp-site-header__drawer-list" role="list">
+        {navItems.map((item) => (
+          <li class="bp-site-header__drawer-item">
+            <a href={item.href} class="bp-site-header__drawer-link">{item.label}</a>
+          </li>
+        ))}
+      </ul>
+      <div class="bp-site-header__drawer-actions">
+        {phoneHref && (
+          <a href={phoneHref} class="bp-site-header__drawer-phone">{phone}</a>
+        )}
+        {primaryCta && (
+          <a href={primaryCta.href} class="bp-site-header__drawer-cta">{primaryCta.label}</a>
+        )}
+      </div>
+    </nav>
+  </div>
+</header>
+
+<style>
+  /* editorial-transparent — v0.1's single implemented archetype. When
+   * new archetypes ship, they add sibling `.bp-site-header--<archetype>`
+   * blocks below. The base `.bp-site-header` shape stays archetype-
+   * neutral; each archetype block tweaks layout + scroll behavior. */
+
+  .bp-site-header {
+    /* Per-client tuning */
+    --bp-site-header-bg: var(--surface-navigation, transparent);
+    --bp-site-header-text-color: var(--text-primary);
+    --bp-site-header-cta-bg: var(--background-brand-primary);
+    --bp-site-header-cta-color: var(--text-on-brand-primary, var(--text-inverse));
+
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--bp-site-header-bg);
+    padding-block: var(--space-md);
+  }
+
+  .bp-site-header__container {
+    max-width: var(--size-container-xl, 1280px);
+    margin-inline: auto;
+    padding-inline: var(--space-xl);
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: var(--space-lg);
+  }
+
+  .bp-site-header__brand {
+    color: var(--bp-site-header-text-color);
+    text-decoration: none;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-500);
+    font-weight: var(--font-weight-semibold);
+    line-height: 1;
+  }
+
+  .bp-site-header__brand:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 4px;
+  }
+
+  .bp-site-header__logo-image {
+    display: block;
+    height: 32px;
+    width: auto;
+  }
+
+  .bp-site-header__nav {
+    display: none;
+  }
+
+  @media (min-width: 768px) {
+    .bp-site-header__nav {
+      display: block;
+      justify-self: center;
+    }
+  }
+
+  .bp-site-header__nav-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: var(--space-lg);
+  }
+
+  .bp-site-header__nav-link {
+    color: var(--bp-site-header-text-color);
+    text-decoration: none;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-300);
+    font-weight: var(--font-weight-medium);
+    padding: var(--space-xs) 0;
+    border-bottom: 2px solid transparent;
+    transition: border-color 120ms ease-out;
+  }
+
+  .bp-site-header__nav-link:hover,
+  .bp-site-header__nav-link[aria-current='page'] {
+    border-bottom-color: var(--border-brand-primary);
+  }
+
+  .bp-site-header__nav-link:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 4px;
+  }
+
+  .bp-site-header__actions {
+    display: none;
+  }
+
+  @media (min-width: 768px) {
+    .bp-site-header__actions {
+      display: flex;
+      align-items: center;
+      gap: var(--space-md);
+    }
+  }
+
+  .bp-site-header__phone {
+    color: var(--bp-site-header-text-color);
+    text-decoration: none;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-300);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .bp-site-header__phone-label {
+    display: none;
+  }
+
+  .bp-site-header__phone:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 2px;
+  }
+
+  .bp-site-header__cta {
+    padding: var(--space-sm) var(--space-md);
+    background: var(--bp-site-header-cta-bg);
+    color: var(--bp-site-header-cta-color);
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-300);
+    font-weight: var(--font-weight-semibold);
+    text-decoration: none;
+    border-radius: var(--border-radius-md);
+    transition: background 120ms ease-out;
+  }
+
+  .bp-site-header__cta:hover {
+    background: var(--background-brand-primary-hover, var(--background-brand-primary));
+  }
+
+  .bp-site-header__cta:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 2px;
+  }
+
+  .bp-site-header__hamburger {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    justify-self: end;
+  }
+
+  @media (min-width: 768px) {
+    .bp-site-header__hamburger {
+      display: none;
+    }
+  }
+
+  .bp-site-header__hamburger:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline-offset: 2px;
+  }
+
+  .bp-site-header__hamburger-bar {
+    display: block;
+    width: 24px;
+    height: 2px;
+    background: var(--bp-site-header-text-color);
+    margin-inline: auto;
+  }
+
+  /* Drawer: hidden by default on all viewports. The scaffold layout's
+   * header JS removes the `inert` attribute + flips aria-expanded on
+   * the hamburger when the drawer opens. Using `inert` (not
+   * aria-hidden) keeps the drawer out of the accessibility tree AND
+   * removes its links from the tab order while closed. */
+  .bp-site-header__drawer {
+    position: fixed;
+    inset: 0;
+    background: var(--bp-site-header-bg);
+    padding: var(--space-2xl);
+    display: none;
+  }
+
+  .bp-site-header__drawer:not([inert]) {
+    display: block;
+  }
+
+  .bp-site-header__drawer-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .bp-site-header__drawer-link,
+  .bp-site-header__drawer-phone,
+  .bp-site-header__drawer-cta {
+    color: var(--bp-site-header-text-color);
+    text-decoration: none;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-600);
+    display: block;
+  }
+
+  .bp-site-header__drawer-actions {
+    margin-top: var(--space-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+</style>

--- a/content-system/blueprints/astro/index.ts
+++ b/content-system/blueprints/astro/index.ts
@@ -12,8 +12,8 @@
  *   HeroSplit6040 (shipped PR #5).
  *   HeroInteriorMinimal, StatsDarkBar, ServicesDetailTwoColumn,
  *     AboutStorySplit, TestimonialsFeaturedLarge, CtaSplitContact,
- *     CtaDarkCentered (this PR).
- *   SiteHeader, BlueprintDispatcher, BlueprintFallback (PR #7).
+ *     CtaDarkCentered (shipped PR #6).
+ *   SiteHeader, BlueprintDispatcher, BlueprintFallback (this PR).
  *
  * Consumer-side type resolution: Astro projects inherit
  * `declare module '*.astro'` from Astro's tsconfig presets — no
@@ -54,3 +54,16 @@ export { default as AboutStorySplit }           from './AboutStorySplit.astro';
 export { default as TestimonialsFeaturedLarge } from './TestimonialsFeaturedLarge.astro';
 export { default as CtaSplitContact }           from './CtaSplitContact.astro';
 export { default as CtaDarkCentered }           from './CtaDarkCentered.astro';
+
+// ── Dispatch surface ────────────────────────────────────────────
+// <BlueprintDispatcher> is the primary consumer entrypoint — client
+// pages render a whole page body with a single component call, reading
+// `visualNotes.blueprintKey` on each section to select the matching
+// component from BLUEPRINT_REGISTRY. <BlueprintFallback> handles
+// unknown keys with a loud visible stub + a CI-greppable data
+// attribute. <SiteHeader> is the site-shell nav component — not a
+// blueprint, but lives in this package because every client Astro
+// site imports it alongside the blueprints.
+export { default as BlueprintDispatcher } from './BlueprintDispatcher.astro';
+export { default as BlueprintFallback }   from './BlueprintFallback.astro';
+export { default as SiteHeader }          from './SiteHeader.astro';

--- a/scripts/verify-blueprints-astro-exports.mjs
+++ b/scripts/verify-blueprints-astro-exports.mjs
@@ -144,6 +144,7 @@ import {
   TestimonialsFeaturedLarge,
   CtaSplitContact,
   CtaDarkCentered,
+  SiteHeader,
 } from '@brikdesigns/bds/blueprints-astro';
 
 const mode: ResolvedThemeMode = 'dark';
@@ -311,6 +312,18 @@ const ctaDarkProps: BlueprintProps = {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>
+    <SiteHeader
+      archetype={theme.navigationArchetype}
+      brandName={clientFacts.brandName}
+      phone={clientFacts.phone}
+      navItems={[
+        { label: 'Services', href: '/services' },
+        { label: 'About', href: '/about' },
+        { label: 'Contact', href: '/contact' },
+      ]}
+      primaryCta={{ label: 'Book a call', href: '/contact' }}
+      currentPath="/services"
+    />
     <main>
       <HeroSplit6040 {...heroSplitProps} />
       <StatsDarkBar {...statsProps} />
@@ -393,6 +406,101 @@ const ctaDarkProps: BlueprintProps = {
 `,
 );
 
+// Dispatcher page fixture — exercises <BlueprintDispatcher> end-to-end.
+// Includes 8 known sections (covering every v0.1 component) + 1
+// UNKNOWN section with blueprintKey='hero_centered_gradient' (valid
+// library key but no Astro component yet). The unknown falls through
+// to BlueprintFallback which emits the data-blueprint-unknown-key
+// attribute that CI greps for.
+//
+// Important: the 8 known sections include two hero blueprints. On a
+// dispatcher page we accept the resulting 2× h1 situation — this is
+// a test fixture proving the DISPATCHER resolves keys, not a proof
+// of real-site composition. The "exactly one h1" contract applies to
+// real scaffolded pages, which the scaffold task enforces via pack
+// compositions (each pack's home/interior picks exactly one hero).
+writeFileSync(
+  join(scratch, 'src/pages/dispatched.astro'),
+  `---
+import type { BlueprintSection, ClientFacts, ResolvedTheme, KnownBlueprintKey } from '@brikdesigns/bds/blueprints-astro';
+import { BlueprintDispatcher } from '@brikdesigns/bds/blueprints-astro';
+
+const theme: ResolvedTheme = {
+  themeMode: 'dark',
+  atmosphere: 'editorial-luxury',
+  navigationArchetype: 'editorial-transparent',
+  footerArchetype: 'four_col_directory',
+};
+
+const clientFacts: ClientFacts = {
+  brandName: 'Dispatcher Proving',
+  tagline: null,
+  valueProposition: null,
+  services: [],
+  phone: '+1-615-555-0100',
+  email: 'hello@example.com',
+  address: null,
+  hours: [],
+  heroImageUrl: 'https://example.com/hero.webp',
+  logoUrl: null,
+  logoVariants: {},
+};
+
+function sec(blueprintKey: string, overrides: Partial<BlueprintSection> & { sectionKey: string }): BlueprintSection {
+  return {
+    sectionKey: overrides.sectionKey,
+    sectionType: overrides.sectionType ?? 'content_block',
+    heading: overrides.heading ?? null,
+    subheading: overrides.subheading ?? null,
+    body: overrides.body ?? null,
+    items: overrides.items ?? [],
+    cta: overrides.cta ?? null,
+    visualNotes: {
+      blueprintKey: blueprintKey as KnownBlueprintKey,
+      moodKeywords: [],
+      layoutBlueprint: 'test',
+      imageOpportunity: null,
+      animationSuggestion: null,
+      illustrationOpportunity: null,
+    },
+  };
+}
+
+const sections: BlueprintSection[] = [
+  sec('hero_interior_minimal', { sectionKey: 'd_hero', sectionType: 'hero', heading: 'Dispatcher proving', body: 'Reads visualNotes.blueprintKey per section.' }),
+  sec('stats_dark_bar', { sectionKey: 'd_stats', sectionType: 'stats', items: [
+    { title: '8', description: 'Blueprints shipped' },
+    { title: '25', description: 'Library total' },
+  ] }),
+  sec('services_detail_two_column', { sectionKey: 'd_services', sectionType: 'services', heading: 'What\\'s in v0.1', items: [
+    { title: 'Hero split 60/40', description: 'Text left, image right.' },
+    { title: 'Stats dark bar', description: 'Proof points on dark.' },
+  ] }),
+  sec('about_story_split', { sectionKey: 'd_about', sectionType: 'features', heading: 'How it works', body: 'Single prop shape; registry-driven dispatch.', items: [] }),
+  sec('testimonials_featured_large', { sectionKey: 'd_test', sectionType: 'testimonials', items: [
+    { title: 'Scaffold task · soon', description: 'When the portal scaffold runs, it emits <BlueprintDispatcher sections={...} /> on every page.' },
+  ] }),
+  sec('cta_split_contact', { sectionKey: 'd_cta_split', sectionType: 'cta', heading: 'Reach out', body: 'Split CTA exercising phone + email.', cta: { label: 'Contact', url: '/contact' } }),
+  // Unknown key — falls through to BlueprintFallback.
+  sec('hero_centered_gradient' as KnownBlueprintKey, { sectionKey: 'd_unknown', sectionType: 'hero', heading: 'Not shipped yet' }),
+  sec('cta_dark_centered', { sectionKey: 'd_cta_dark', sectionType: 'cta', heading: 'End of proof', cta: { label: 'Home', url: '/' } }),
+];
+---
+<html lang="en">
+  <head>
+    <title>BDS dispatcher verify</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <main>
+      <BlueprintDispatcher sections={sections} clientFacts={clientFacts} theme={theme} />
+    </main>
+  </body>
+</html>
+`,
+);
+
 // ── 6. Install ────────────────────────────────────────────────────
 log.step('Installing scratch deps (astro@5 + packed BDS tarball)');
 run('npm install --no-audit --no-fund --prefer-offline', { cwd: scratch });
@@ -422,15 +530,16 @@ try {
 }
 
 // ── 9. Rendered-HTML assertions ──────────────────────────────────
-log.step('Asserting rendered HTML markers (home + interior pages)');
+log.step('Asserting rendered HTML markers (home + interior + dispatched)');
 const homeHtmlPath = resolve(scratch, 'dist/index.html');
 const interiorHtmlPath = resolve(scratch, 'dist/interior/index.html');
+const dispatchedHtmlPath = resolve(scratch, 'dist/dispatched/index.html');
 const homeHtml = readFileSync(homeHtmlPath, 'utf8');
 const interiorHtml = readFileSync(interiorHtmlPath, 'utf8');
-const bothHtml = homeHtml + '\n' + interiorHtml;
+const dispatchedHtml = readFileSync(dispatchedHtmlPath, 'utf8');
 
 const assertions = [
-  // Every shipped blueprint's marker present (across both pages)
+  // Every shipped blueprint's marker present across direct-import pages
   { name: 'hero_split_60_40 marker (home)',         pass: homeHtml.includes('data-blueprint-key="hero_split_60_40"') },
   { name: 'stats_dark_bar marker (home)',           pass: homeHtml.includes('data-blueprint-key="stats_dark_bar"') },
   { name: 'services_detail_two_column marker (home)',pass: homeHtml.includes('data-blueprint-key="services_detail_two_column"') },
@@ -451,6 +560,32 @@ const assertions = [
   { name: 'cta_split_contact mailto:',              pass: homeHtml.includes('href="mailto:hello@example.com"') },
   { name: 'interior hero heading rendered',         pass: interiorHtml.includes('What we do') },
   { name: 'cta_dark_centered CTA rendered',         pass: interiorHtml.includes('Book a call') },
+
+  // SiteHeader assertions (home)
+  { name: 'SiteHeader archetype marker',            pass: homeHtml.includes('data-nav-archetype="editorial-transparent"') },
+  { name: 'SiteHeader brand text rendered',         pass: homeHtml.includes('>Verify Scratch<') },
+  { name: 'SiteHeader nav landmark present',        pass: /<nav[^>]*\bbp-site-header__nav\b[^>]*aria-label="Primary"/.test(homeHtml) || /<nav[^>]*aria-label="Primary"[^>]*\bbp-site-header__nav\b/.test(homeHtml) },
+  { name: 'SiteHeader aria-current on active link', pass: homeHtml.includes('aria-current="page"') && homeHtml.includes('href="/services"') },
+  { name: 'SiteHeader phone tel: link',             pass: homeHtml.includes('class="bp-site-header__phone"') && homeHtml.includes('tel:+16155550100') },
+  { name: 'SiteHeader hamburger button',            pass: homeHtml.includes('aria-expanded="false"') && homeHtml.includes('aria-controls="bp-site-header-drawer"') },
+
+  // Dispatcher assertions (dispatched page)
+  { name: 'dispatcher: all 7 known sections rendered', pass:
+      dispatchedHtml.includes('data-blueprint-key="hero_interior_minimal"') &&
+      dispatchedHtml.includes('data-blueprint-key="stats_dark_bar"') &&
+      dispatchedHtml.includes('data-blueprint-key="services_detail_two_column"') &&
+      dispatchedHtml.includes('data-blueprint-key="about_story_split"') &&
+      dispatchedHtml.includes('data-blueprint-key="testimonials_featured_large"') &&
+      dispatchedHtml.includes('data-blueprint-key="cta_split_contact"') &&
+      dispatchedHtml.includes('data-blueprint-key="cta_dark_centered"')
+  },
+  { name: 'dispatcher: unknown key falls through to fallback', pass:
+      dispatchedHtml.includes('data-blueprint-key="__fallback__"') &&
+      dispatchedHtml.includes('data-blueprint-unknown-key="hero_centered_gradient"')
+  },
+  { name: 'dispatcher: fallback stub text visible', pass:
+      dispatchedHtml.includes('Blueprint not yet shipped')
+  },
 
   // Cross-blueprint contract checks
   { name: 'home: no data-content-needed stubs (all facts provided)', pass: !homeHtml.includes('data-content-needed=') },
@@ -484,8 +619,9 @@ try {
   const page = await context.newPage();
 
   const pagesToScan = [
-    { label: 'home',     path: homeHtmlPath },
-    { label: 'interior', path: interiorHtmlPath },
+    { label: 'home',       path: homeHtmlPath },
+    { label: 'interior',   path: interiorHtmlPath },
+    { label: 'dispatched', path: dispatchedHtmlPath },
   ];
   let totalPasses = 0;
   const allViolations = [];
@@ -544,6 +680,10 @@ const expectedFiles = [
   'content-system/blueprints/astro/TestimonialsFeaturedLarge.astro',
   'content-system/blueprints/astro/CtaSplitContact.astro',
   'content-system/blueprints/astro/CtaDarkCentered.astro',
+  // Dispatch surface (PR #7)
+  'content-system/blueprints/astro/BlueprintDispatcher.astro',
+  'content-system/blueprints/astro/BlueprintFallback.astro',
+  'content-system/blueprints/astro/SiteHeader.astro',
 ];
 
 let allPresent = true;

--- a/stories/theming/BlueprintsAstroPackage.mdx
+++ b/stories/theming/BlueprintsAstroPackage.mdx
@@ -1,0 +1,226 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import library from '../../blueprints/blueprint-library.json';
+import { docTable, docTh, docTd, docTdMono } from '../foundation/_components/docTableStyles';
+
+<Meta title="Theming/Blueprints Astro Package" />
+
+# `@brikdesigns/bds/blueprints-astro`
+
+The Astro render surface the Theming tenet has always pointed at.
+Each blueprint key in [`blueprint-library.json`](?path=/docs/theming-blueprints--docs)
+that has a shipped Astro component is exported from this package;
+consumer Astro sites import the components directly or dispatch by
+key via `<BlueprintDispatcher>`.
+
+See [BLUEPRINTS-ASTRO-PACKAGE.md](https://github.com/brikdesigns/brik-bds/blob/main/docs/BLUEPRINTS-ASTRO-PACKAGE.md)
+for the architecture contract, versioning policy, and scale-at-100-clients
+deployment topology.
+
+---
+
+## Package exports
+
+```astro
+---
+// Consumer Astro page — the intended import shape.
+import {
+  SiteHeader,
+  BlueprintDispatcher,
+  // Individual blueprints if you want direct imports:
+  HeroSplit6040,
+  // Types:
+  type BlueprintProps,
+  type ClientFacts,
+  type ResolvedTheme,
+} from '@brikdesigns/bds/blueprints-astro';
+---
+<SiteHeader archetype={...} brandName={...} navItems={[...]} />
+<main>
+  <BlueprintDispatcher sections={page.sections}
+                       clientFacts={clientFacts}
+                       theme={theme} />
+</main>
+```
+
+Types-only entry for contexts without the Astro runtime (e.g. the
+portal's scaffold task that plans compositions):
+
+```ts
+import type { BlueprintSection, KnownBlueprintKey }
+  from '@brikdesigns/bds/blueprints-astro/types';
+```
+
+---
+
+## Dispatch surface (v0.1)
+
+<table style={docTable}>
+  <thead>
+    <tr>
+      <th style={docTh}>Component</th>
+      <th style={docTh}>Purpose</th>
+      <th style={docTh}>Props shape</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={docTdMono}>&lt;BlueprintDispatcher&gt;</td>
+      <td style={docTd}>Reads <code>visualNotes.blueprintKey</code> per section and renders the matching component. Unknown keys fall through to BlueprintFallback.</td>
+      <td style={docTdMono}>{`{ sections, clientFacts, theme }`}</td>
+    </tr>
+    <tr>
+      <td style={docTdMono}>&lt;BlueprintFallback&gt;</td>
+      <td style={docTd}>Loud visible stub for unknown blueprint keys. Emits <code>data-blueprint-unknown-key</code> — CI greps client-repo builds for this attribute.</td>
+      <td style={docTdMono}>BlueprintProps</td>
+    </tr>
+    <tr>
+      <td style={docTdMono}>&lt;SiteHeader&gt;</td>
+      <td style={docTd}>Site-shell nav. Dispatches on the navigation archetype prop. v0.1 fully implements <code>editorial-transparent</code>; other archetypes render with a <code>data-unimplemented-archetype</code> attribute.</td>
+      <td style={docTdMono}>{`{ archetype, brandName, navItems, phone?, primaryCta?, currentPath? }`}</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Shipped blueprints (v0.1)
+
+Eight components — the set needed for Vale's first scaffold run via
+the small-business pack. Each follows the same `BlueprintProps` contract
+(`section` + `clientFacts` + `theme`). See [Blueprints](?path=/docs/theming-blueprints--docs)
+for the canonical library metadata (moods, industries, layout spec).
+
+<table style={docTable}>
+  <thead>
+    <tr>
+      <th style={docTh}>Component</th>
+      <th style={docTh}>Library key</th>
+      <th style={docTh}>Section type</th>
+      <th style={docTh}>required_facts</th>
+    </tr>
+  </thead>
+  <tbody>
+    {[
+      'hero_split_60_40',
+      'hero_interior_minimal',
+      'stats_dark_bar',
+      'services_detail_two_column',
+      'about_story_split',
+      'testimonials_featured_large',
+      'cta_split_contact',
+      'cta_dark_centered',
+    ].map((key) => {
+      const bp = library.blueprints.find(b => b.key === key);
+      const component = key
+        .split('_')
+        .map((w) => w === '60' ? '60' : w === '40' ? '40' : w.charAt(0).toUpperCase() + w.slice(1))
+        .join('');
+      return (
+        <tr key={key}>
+          <td style={docTdMono}>&lt;{component}&gt;</td>
+          <td style={docTdMono}>{key}</td>
+          <td style={docTdMono}>{bp?.section_type}</td>
+          <td style={docTdMono}>
+            {bp?.required_facts?.length ? bp.required_facts.join(' · ') : '(none)'}
+          </td>
+        </tr>
+      );
+    })}
+  </tbody>
+</table>
+
+### Not yet shipped
+
+17 of the 25 library keys don't have a component here yet. They render
+`<BlueprintFallback>` when the dispatcher encounters them — expected
+during the v0.1 → v1.0 incremental ramp. Each follow-up PR adds one
+or more components and removes its key from the fallback case.
+
+<details>
+<summary>Unshipped keys ({library.blueprints.length - 8})</summary>
+<ul>
+{library.blueprints
+  .filter((b) => ![
+    'hero_split_60_40', 'hero_interior_minimal', 'stats_dark_bar',
+    'services_detail_two_column', 'about_story_split',
+    'testimonials_featured_large', 'cta_split_contact', 'cta_dark_centered',
+  ].includes(b.key))
+  .map((b) => <li key={b.key}><code>{b.key}</code> — {b.section_type}</li>)}
+</ul>
+</details>
+
+---
+
+## Contract per blueprint
+
+Every blueprint component accepts **the same props shape**:
+
+```ts
+interface BlueprintProps {
+  section: BlueprintSection;      // content: heading, body, items, cta, visualNotes
+  clientFacts: ClientFacts;       // per-client: brandName, phone, heroImageUrl, etc.
+  theme: ResolvedTheme;           // archetypes + atmosphere + theme mode
+}
+```
+
+This uniformity is deliberate — the dispatcher is trivial (one lookup,
+one pass-through), every blueprint's surface is identical for
+authoring/review, and per-client customization happens through
+`ClientFacts` + CSS custom properties (not per-component props).
+
+### Per-client CSS overrides
+
+Each blueprint exposes documented CSS custom properties for per-client
+tuning — for example:
+
+```
+.bp-hero-split-60-40 {
+  --bp-hero-split-eyebrow-color: ...;
+  --bp-hero-split-accent-line: ...;
+  --bp-hero-split-image-radius: ...;
+  /* ... more, see each component's header comment */
+}
+```
+
+Per-client overrides MUST live in the client repo's
+`src/styles/client-overrides.css` with a `/* BDS-ISSUE: <url> */`
+comment on the preceding line. CI in each client repo enforces the
+comment requirement. See [spec §6.3](https://github.com/brikdesigns/brik-bds/blob/main/docs/BLUEPRINTS-ASTRO-PACKAGE.md#63-client-overridescss-escape-hatch--ci-gated-not-review-gated)
+for rationale.
+
+### Non-hallucinatable content
+
+Blueprints with `required_facts` render a visible
+`data-content-needed="<field>"` stub when the fact is null at render
+time — CI grep blocks publish. This is defense-in-depth; the portal's
+`dev_scaffold_site` task preflights `required_facts` before generating
+the client repo, so a missing fact should never reach the build stage.
+
+---
+
+## Verification
+
+The package has a dedicated verification script at
+[`scripts/verify-blueprints-astro-exports.mjs`](https://github.com/brikdesigns/brik-bds/blob/main/scripts/verify-blueprints-astro-exports.mjs)
+that runs on every BDS pre-push:
+
+1. Packs a tarball matching a real publish.
+2. Creates a scratch Astro 5 project, installs the tarball.
+3. `astro check` — type + import resolver.
+4. `astro build` — SSR render to static HTML.
+5. Asserts rendered HTML markers per blueprint.
+6. `@axe-core/playwright` scan against every built page (WCAG 2.1 AA).
+7. Confirms all expected files shipped in the tarball.
+
+Any failure blocks the PR. This is the enforcement behind the "no slop,
+no unfinished work" mandate for this package.
+
+---
+
+## Related
+
+- [Blueprints library](?path=/docs/theming-blueprints--docs) — canonical metadata (moods, industries, layout specs)
+- [Navigation archetypes](?path=/docs/theming-navigation-archetypes--docs) — vocabulary the SiteHeader dispatches on
+- [Footer archetypes](?path=/docs/theming-footer-archetypes--docs) — sibling vocabulary (SiteFooter lands in v0.2)
+- [Atmospheres](?path=/docs/theming-atmospheres--docs) — ambient CSS layer composed by the scaffold task
+- [Package spec (GitHub)](https://github.com/brikdesigns/brik-bds/blob/main/docs/BLUEPRINTS-ASTRO-PACKAGE.md)


### PR DESCRIPTION
## Summary
- feat(blueprints-astro): dispatch surface + SiteHeader + catalog docs
- Merge remote-tracking branch 'origin/main' into task/blueprints-astro-dispatcher

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)