### PR TITLE
bds: data section

### DIFF
--- a/components/ui/DataSection/DataSection.css
+++ b/components/ui/DataSection/DataSection.css
@@ -1,0 +1,72 @@
+@layer bds-components {
+/* ─── DataSection ──────────────────────────────────────────────── */
+
+.bds-data-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}
+
+/* Vertical rhythm between consecutive sections on the same page. */
+.bds-data-section + .bds-data-section {
+  margin-top: var(--padding-lg);
+}
+
+.bds-data-section--spacing-lg + .bds-data-section {
+  margin-top: var(--padding-xl);
+}
+
+/* ─── Header ───────────────────────────────────────────────────── */
+
+.bds-data-section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--gap-lg);
+}
+
+.bds-data-section__titles {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  min-width: 0;
+}
+
+/* Title — heading-tier typography. Semantic element is `h2` by default (see
+   `titleAs` prop). The BEM class names the role; the HTML tag is semantic. */
+.bds-data-section__title {
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-md);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.bds-data-section__subtitle {
+  font-family: var(--font-family-body);
+  font-size: var(--body-md);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* Action slot — flush-right, does not shrink under long titles. */
+.bds-data-section__actions {
+  flex-shrink: 0;
+}
+
+/* ─── Content ──────────────────────────────────────────────────── */
+
+.bds-data-section__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-lg);
+}
+
+/* Header → content gap is tighter than between content blocks so the header
+   visually groups with its data. */
+.bds-data-section__header + .bds-data-section__content {
+  margin-top: var(--gap-sm);
+}
+}

--- a/components/ui/DataSection/DataSection.mdx
+++ b/components/ui/DataSection/DataSection.mdx
@@ -1,0 +1,83 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './DataSection.stories';
+
+<Meta of={Stories} />
+
+# DataSection
+
+Page-side wrapper for a titled block of read-mode data. Pairs a heading-tier title with an optional subtitle and an actions slot (typically a `<ButtonGroup>` holding a `[View]`/`[Edit]` toggle), then yields the body to whatever composes inside — usually a `<FieldGrid>` of `<Field>`s.
+
+The page analog to `<SheetSection>`. Where `SheetSection` uses an uppercase label heading appropriate inside a sheet, `DataSection` uses a real section title in the page outline.
+
+---
+
+## Playground
+
+<Canvas of={Stories.Playground} />
+
+## Variants
+
+Title only, title + subtitle, no actions, and a single-button actions slot.
+
+<Canvas of={Stories.Variants} />
+
+## Patterns
+
+The canonical Read-Mode Page composition — several `DataSection`s stacked on a page, each with a `[View]`/`[Edit]` `ButtonGroup` in the actions slot. The third section shows `Field` consuming a paragraph and a `BulletList` as its value — no separate `ParagraphField` or `ListField` component is needed; `Field` accepts any `ReactNode`.
+
+<Canvas of={Stories.ReadModePage} />
+
+## Anatomy — vocabulary
+
+<Canvas of={Stories.AnatomyVocabulary} />
+
+---
+
+## Props
+
+<ArgTypes of={Stories} />
+
+---
+
+## Usage
+
+```tsx
+import {
+  DataSection,
+  FieldGrid,
+  Field,
+  ButtonGroup,
+  Button,
+  BulletList,
+} from '@brikdesigns/bds';
+
+<DataSection
+  title="Identity"
+  actions={
+    <ButtonGroup>
+      <Button size="sm" variant="secondary" onClick={openInViewMode}>View</Button>
+      <Button size="sm" variant="secondary" onClick={openInEditMode}>Edit</Button>
+    </ButtonGroup>
+  }
+>
+  <FieldGrid columns={2}>
+    <Field label="Business Name">{client.name}</Field>
+    <Field label="Industry">{client.industry}</Field>
+    <Field label="Care Philosophy">
+      <p>{client.carePhilosophy}</p>
+    </Field>
+    <Field label="Secondary Categories">
+      <BulletList items={client.secondaryCategories} />
+    </Field>
+  </FieldGrid>
+</DataSection>
+```
+
+## Rules
+
+- **`title` is a real heading.** Default `<h2>` — it IS part of the page outline. Use `titleAs="h3"` only when nested under an existing `<h2>`.
+- **Title ≠ heading.** The BEM class is `__title` (role); the HTML element (`h2`/`h3`) is picked by outline position, not by the class name. See [Foundations → Vocabulary](?path=/docs/foundation-vocabulary--docs) for the layer distinction.
+- **`actions` is a slot, not a label.** Put a `<ButtonGroup>` or `<Button>` in it. The text on each button is a *button-label* conceptually, even though it passes as `children` today.
+- **Do not nest `DataSection` inside `DataSection`.** If you need internal sub-structure, use `Field` or `FieldGrid` inside the section.
+- **Do not use `DataSection` inside a Sheet.** Use `SheetSection` there — the two are siblings, not substitutes.
+- **Empty per-field content is a `Field` concern.** `Field` renders a "Not set" inline string when its children are empty; don't hand-roll a placeholder inside `DataSection`.

--- a/components/ui/DataSection/DataSection.stories.tsx
+++ b/components/ui/DataSection/DataSection.stories.tsx
@@ -1,0 +1,177 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DataSection } from './DataSection';
+import { Field } from '../Field';
+import { FieldGrid } from '../FieldGrid';
+import { BulletList } from '../BulletList';
+import { Button } from '../Button';
+import { ButtonGroup } from '../ButtonGroup';
+
+const meta: Meta<typeof DataSection> = {
+  title: 'Displays/Data/data-section',
+  component: DataSection,
+  parameters: { layout: 'padded' },
+  argTypes: {
+    title: { control: 'text' },
+    subtitle: { control: 'text' },
+    spacing: { control: 'select', options: ['md', 'lg'] },
+    titleAs: { control: 'select', options: ['h2', 'h3'] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DataSection>;
+
+/* ─── Story helpers ──────────────────────────────────────────── */
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ maxWidth: '880px', padding: 'var(--padding-lg)', background: 'var(--surface-primary)' }}>
+    {children}
+  </div>
+);
+
+const ViewEditToggle = () => (
+  <ButtonGroup>
+    <Button size="sm" variant="secondary">View</Button>
+    <Button size="sm" variant="secondary">Edit</Button>
+  </ButtonGroup>
+);
+
+/* ─── 1. Playground ──────────────────────────────────────────── */
+
+export const Playground: Story = {
+  args: {
+    title: 'Identity',
+    subtitle: undefined,
+    spacing: 'lg',
+    titleAs: 'h2',
+  },
+  render: (args) => (
+    <Frame>
+      <DataSection {...args} actions={<ViewEditToggle />}>
+        <FieldGrid columns={2}>
+          <Field label="Business Name">Vale Partners</Field>
+          <Field label="Legal Name">Vale Partners, LLC</Field>
+          <Field label="DBA">Vale</Field>
+          <Field label="Year Founded">2019</Field>
+        </FieldGrid>
+      </DataSection>
+    </Frame>
+  ),
+};
+
+/* ─── 2. Variants ────────────────────────────────────────────── */
+
+export const Variants: Story = {
+  render: () => (
+    <Frame>
+      <DataSection title="Title only" actions={<ViewEditToggle />}>
+        <FieldGrid columns={2}>
+          <Field label="Business Name">Vale Partners</Field>
+          <Field label="Industry">Professional Services</Field>
+        </FieldGrid>
+      </DataSection>
+
+      <DataSection
+        title="Title + subtitle"
+        subtitle="Public-facing name and core identifiers."
+        actions={<ViewEditToggle />}
+      >
+        <FieldGrid columns={2}>
+          <Field label="Business Name">Vale Partners</Field>
+          <Field label="Industry">Professional Services</Field>
+        </FieldGrid>
+      </DataSection>
+
+      <DataSection title="No actions">
+        <FieldGrid columns={2}>
+          <Field label="Business Name">Vale Partners</Field>
+          <Field label="Industry">Professional Services</Field>
+        </FieldGrid>
+      </DataSection>
+
+      <DataSection title="Single button in actions" actions={<Button size="sm" variant="secondary">Edit</Button>}>
+        <FieldGrid columns={2}>
+          <Field label="Business Name">Vale Partners</Field>
+          <Field label="Industry">Professional Services</Field>
+        </FieldGrid>
+      </DataSection>
+    </Frame>
+  ),
+};
+
+/* ─── 3. Patterns ────────────────────────────────────────────── */
+
+export const ReadModePage: Story = {
+  name: 'Pattern — Read-Mode Page',
+  render: () => (
+    <Frame>
+      <DataSection title="Identity" actions={<ViewEditToggle />}>
+        <FieldGrid columns={2}>
+          <Field label="Business Name">Vale Partners</Field>
+          <Field label="Legal Name">Vale Partners, LLC</Field>
+          <Field label="DBA">Vale</Field>
+          <Field label="Year Founded">2019</Field>
+          <Field label="Industry">Professional Services</Field>
+          <Field label="Sub-industry">Consulting</Field>
+        </FieldGrid>
+      </DataSection>
+
+      <DataSection title="Location" actions={<ViewEditToggle />}>
+        <FieldGrid columns={2}>
+          <Field label="Address">123 Main St, Suite 400</Field>
+          <Field label="City">Denver</Field>
+          <Field label="State">CO</Field>
+          <Field label="Postal Code">80202</Field>
+          <Field label="Country">United States</Field>
+          <Field label="Timezone">America/Denver</Field>
+        </FieldGrid>
+      </DataSection>
+
+      <DataSection title="Directory Listing" actions={<ViewEditToggle />}>
+        <Field label="Care Philosophy">
+          <p style={{ margin: 0, fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)', color: 'var(--text-primary)', lineHeight: 'var(--font-line-height-normal)' }}>
+            We believe in transparent, partner-led engagement. Every client works directly with a senior strategist from discovery through delivery — no handoffs, no junior pass-throughs.
+          </p>
+        </Field>
+        <Field label="Secondary Categories">
+          <BulletList items={['Strategy Consulting', 'Operations', 'Brand Advisory']} />
+        </Field>
+        <Field label="Holiday Exceptions">
+          <BulletList
+            items={[
+              'Closed Thanksgiving Day through weekend',
+              'Closed December 24 through January 2',
+              'Limited availability July 3–5',
+            ]}
+          />
+        </Field>
+      </DataSection>
+    </Frame>
+  ),
+};
+
+/* ─── 4. Vocabulary demo — what the parts are called ───────── */
+
+export const AnatomyVocabulary: Story = {
+  name: 'Anatomy — vocabulary',
+  render: () => (
+    <Frame>
+      <DataSection
+        title="Identity"
+        subtitle="Public-facing name and core identifiers."
+        actions={<ViewEditToggle />}
+      >
+        <FieldGrid columns={2}>
+          <Field label="Business Name">Vale Partners</Field>
+          <Field label="Industry">Professional Services</Field>
+        </FieldGrid>
+      </DataSection>
+      <div style={{ marginTop: 'var(--padding-xl)', fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-sm)', color: 'var(--text-secondary)', lineHeight: 1.6 }}>
+        <p style={{ margin: 0 }}><strong>title</strong> — &quot;Identity&quot; renders as <code>&lt;h2&gt;</code>, class <code>.bds-data-section__title</code>.</p>
+        <p style={{ margin: 0 }}><strong>subtitle</strong> — secondary line below title, class <code>.bds-data-section__subtitle</code>. Not an eyebrow.</p>
+        <p style={{ margin: 0 }}><strong>actions</strong> — slot holding buttons. The text on each button is a <em>button-label</em>; the slot is not itself a label.</p>
+        <p style={{ margin: 0 }}><strong>field-label / field-value</strong> — one <code>&lt;Field&gt;</code> pair. Stacked by default.</p>
+      </div>
+    </Frame>
+  ),
+};

--- a/components/ui/DataSection/DataSection.tsx
+++ b/components/ui/DataSection/DataSection.tsx
@@ -1,0 +1,84 @@
+import { type HTMLAttributes, type ReactNode } from 'react';
+import { bdsClass } from '../../utils';
+import './DataSection.css';
+
+export type DataSectionSpacing = 'md' | 'lg';
+export type DataSectionTitleAs = 'h2' | 'h3';
+
+export interface DataSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
+  /** Section title — renders as a heading element (default `<h2>`). */
+  title?: string;
+  /** Optional secondary line below the title. */
+  subtitle?: ReactNode;
+  /**
+   * Action slot rendered flush-right of the title row.
+   * Typically a `<ButtonGroup>` with `[View]` / `[Edit]` toggle, or a single `<Button>`.
+   */
+  actions?: ReactNode;
+  /**
+   * Section body — typically a `<FieldGrid>` of `<Field>`s, but any content works.
+   */
+  children?: ReactNode;
+  /** Vertical rhythm between this section and the next. Default `lg`. */
+  spacing?: DataSectionSpacing;
+  /**
+   * HTML element for the title.
+   * Default `h2` — the common case is one DataSection sibling of the page's `<h1>`.
+   * Use `h3` only when a DataSection is nested under an existing `<h2>`.
+   */
+  titleAs?: DataSectionTitleAs;
+}
+
+/**
+ * DataSection — page-side section wrapper for read-mode data.
+ *
+ * Groups a titled block of data (typically a `<FieldGrid>` of `<Field>`s) with
+ * an optional actions slot. Page analog to `<SheetSection>`, which lives
+ * inside a Sheet body and uses an uppercase `<h3>` label style.
+ *
+ * The title is a real heading node in the page outline — default `<h2>`,
+ * rendered with heading-tier typography. It is NOT an uppercase label.
+ *
+ * @see Patterns/Read-Mode Page — composition with FieldGrid + Field + ButtonGroup.
+ */
+export function DataSection({
+  title,
+  subtitle,
+  actions,
+  children,
+  spacing = 'lg',
+  titleAs = 'h2',
+  className,
+  style,
+  ...props
+}: DataSectionProps) {
+  const TitleTag = titleAs;
+  const hasHeader = Boolean(title || subtitle || actions);
+
+  return (
+    <section
+      className={bdsClass(
+        'bds-data-section',
+        `bds-data-section--spacing-${spacing}`,
+        className,
+      )}
+      style={style}
+      {...props}
+    >
+      {hasHeader && (
+        <header className="bds-data-section__header">
+          {(title || subtitle) && (
+            <div className="bds-data-section__titles">
+              {title && <TitleTag className="bds-data-section__title">{title}</TitleTag>}
+              {subtitle && <p className="bds-data-section__subtitle">{subtitle}</p>}
+            </div>
+          )}
+          {actions && <div className="bds-data-section__actions">{actions}</div>}
+        </header>
+      )}
+      {children && <div className="bds-data-section__content">{children}</div>}
+    </section>
+  );
+}
+
+export default DataSection;

--- a/components/ui/DataSection/index.ts
+++ b/components/ui/DataSection/index.ts
@@ -1,0 +1,7 @@
+export {
+  DataSection,
+  type DataSectionProps,
+  type DataSectionSpacing,
+  type DataSectionTitleAs,
+} from './DataSection';
+export { default } from './DataSection';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -27,6 +27,7 @@ export * from './Checkbox';
 export * from './Chip';
 export * from './CollapsibleCard';
 export * from './Counter';
+export * from './DataSection';
 export * from './DatePicker';
 export * from './DevFeedbackWidget';
 export * from './Dialog';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",
         "@iconify/react": ">=5.0.0",
         "@radix-ui/react-popover": "^1.1.15"
+      },
+      "bin": {
+        "bds-find": "scripts/bds-find.mjs"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Brik Design System \u2014 React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",

--- a/stories/foundation/Vocabulary.mdx
+++ b/stories/foundation/Vocabulary.mdx
@@ -1,0 +1,143 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Foundations/Vocabulary" />
+
+# Vocabulary
+
+The words we use have to be tight or the system drifts. This page names the pieces of a BDS component and the rules that govern each word. Every term here is load-bearing — it picks a token scale, picks a BEM class, or picks an HTML element. Reach for this list before you invent a name.
+
+---
+
+## The principle — intent, not shape
+
+Every word below describes a **role** or a **slot**. It does not dictate the visual shape and, critically, it does not dictate the HTML element. The HTML element is chosen by *semantic intent* at the call site — is this thing part of the document outline? Is it interactive? Is it prose? The BEM class names the role; semantics name the element.
+
+This distinction is especially load-bearing for titles and headings (below) — get it wrong and you render outline-invisible content that looks correct visually.
+
+---
+
+## Title vs heading
+
+`title` and `heading` refer to the same typographic role at different layers. They are **not** substitutes for each other.
+
+| Layer | Word | Example |
+|---|---|---|
+| Typography tokens (scale) | `heading` | `--heading-md`, `--font-family-heading` |
+| BEM (role/position) | `title` | `.bds-page-header__title`, `.bds-data-section__title`, `.bds-card-display__title` |
+| HTML element | `h1`–`h3`, or `div`/`p` | Chosen by outline position, not by class name |
+
+### The rule
+
+> Name the role `__title` in BEM. Scale its typography with `--heading-*` tokens. Pick the HTML element at the call site based on whether it is a document outline node.
+
+**When a title IS an outline node** (most cases on a page — `<DataSection title="Identity">` inside the Overview tab is an outline sibling of the page's `<h1>`) → render as `<h2>` (or `<h3>` when nested). Screen readers walk these.
+
+**When a title is NOT an outline node** (decorative card in a grid of many cards, metric tile, repeating marker) → render as `<div>` or `<p>`. It still uses `__title` BEM and heading-tier tokens.
+
+Never pick the HTML tag by guessing from the BEM name. `<div class="bds-card__title">` and `<h3 class="bds-card__title">` are both valid — choose by outline intent.
+
+---
+
+## Subtitle
+
+The secondary line paired with a title. Always `subtitle`. Never `eyebrow`.
+
+- BEM: `.bds-*__subtitle`
+- Usage: `PageHeader`, `Sheet`, `SheetSection`, `BoardCard`, `DataSection`.
+- Rendered as: `<p>` by default.
+
+"Eyebrow" is a common term in marketing-site design systems. It is not a term in BDS. If a design spec uses it, translate to `subtitle` before writing code.
+
+---
+
+## Description
+
+Explanatory prose under a title or subtitle — longer and more neutral than a subtitle.
+
+- BEM: `.bds-*__description`
+- Usage: `CardDisplay`, `Form`, `AlertBanner`, `SheetSection`.
+- Rendered as: `<p>`.
+
+Use when a component needs a short paragraph of context below its title. Not a legal equivalent to subtitle — subtitle is visual chrome, description is content.
+
+---
+
+## The label family
+
+`label` is the umbrella suffix for **any text that names or identifies a discrete thing**. When you're adding a new named text element, reach for a `-label` name before inventing a term.
+
+| Term | What it names | Current implementation |
+|---|---|---|
+| `field-label` | The name on a data pair (`<Field label="Business Name">`) | `.bds-field__label`, `.bds-sheet-field-label` |
+| `card-summary__label` | Label on a metric or stat | `.bds-card-summary__label` |
+| `chip__label` | Text inside a `Chip` | `.bds-chip__label` |
+| `meter__label`, `progress-stepper__label` | Label for progress/measurement markers | existing BEM |
+| `button-label` | The text on a `<Button>` | passed as `children` today — concept-only |
+| `tab-label` | The text on a `<TabBar>` tab | `label: string` prop on Sheet tabs |
+| `paragraph-label` | Scoped label above a paragraph or bullet list (e.g. "Care Philosophy") | not a separate component — use `<Field>` with a paragraph or `<BulletList>` as its value |
+
+### Rules
+
+- New named text element? Use a `-label` term before inventing one.
+- `button-label` and `tab-label` are concepts, not classes. Don't rush to add `label` props to `<Button>` or `<TabBar>`; `children` is fine. Name them in specs and docs.
+- `paragraph-label` describes a *usage of Field* (label + paragraph or list value). There is no `ParagraphField` or `ListField` — `Field` accepts any `ReactNode` as its value and covers both cases.
+
+---
+
+## Action vs button-label (they are different layers)
+
+One category mistake we avoid: calling a button "an action."
+
+- **`action` / `actions`** — the **slot** inside a component that holds one or more buttons. `.bds-page-header__actions`, `.bds-card-display__action`, `.bds-data-section__actions`. It is a `<div>` that receives a `<Button>` or `<ButtonGroup>`.
+- **`button-label`** — the **text on each button** inside that slot. Passed as `children` today.
+
+The slot is not the text. Don't conflate them. When documenting a section header with a `[View]`/`[Edit]` toggle:
+
+- The **slot** holding the toggle is `actions`.
+- The **component** rendering the two buttons is `ButtonGroup`.
+- The **text** on each button is a button-label.
+
+---
+
+## Value
+
+The datum paired with a label.
+
+- BEM: `.bds-*__value` (e.g. `.bds-field__value`, `.bds-card-summary__value`).
+- Rendered as: `<div>` or `<span>` depending on whether the value is block-level content (paragraph, list) or inline text.
+
+`Field` handles the inline vs block distinction internally — put any `ReactNode` as `children`. `CardSummary` renders values as heading-tier typography (it's a stat tile, not a form field) — don't confuse the two.
+
+---
+
+## Section vs card vs board
+
+These are containers, not text. Different words because they have different responsibilities.
+
+| Container | Purpose | When |
+|---|---|---|
+| `DataSection` | Titled block of read-mode data on a **page** | Overview/profile tabs, client-detail pages |
+| `SheetSection` | Titled block inside a **sheet** body (uppercase label heading) | Any block grouping inside `<Sheet>` |
+| `Card` (and variants — `CardSummary`, `CardDisplay`, `CardControl`, `CardFeature`, `CardTestimonial`) | Bordered, self-contained unit of content | Grids of comparable items, dashboards, marketing |
+| `Board` (`BoardColumn`, `BoardCard`) | Kanban-style container | Task boards |
+| `Dialog` / `Modal` / `Sheet` | Overlay containers | Focused interactions |
+
+Don't reach for a `Card` when a `DataSection` is right. Cards are self-contained units in a grid; `DataSection` is one region of a larger page.
+
+---
+
+## Elements that render `<h*>` vs elements that don't
+
+Quick reference. HTML element shown first — it is the load-bearing fact.
+
+| Element | Typical use | BEM role |
+|---|---|---|
+| `<h1>` | Page title (one per page) | `.bds-page-header__title` |
+| `<h2>` | Section title on a page | `.bds-data-section__title` |
+| `<h3>` | Sheet section heading (uppercase label) | `.bds-sheet-section__heading` — different role, different style |
+| `<p>` | Subtitle, description, field-label (when standalone), body prose | `.bds-*__subtitle`, `.bds-*__description` |
+| `<span>` | Inline label (e.g. metadata pair inside a page header) | `.bds-*__label` when inline |
+| `<label>` | Form-control label when `htmlFor` is set | `.bds-sheet-field-label` for form inputs |
+| `<div>` | Slots, containers, wrappers | `__actions`, `__content`, `__header`, `__titles` |
+
+Screen readers walk `<h*>` elements to build the outline. Every `<h*>` decision is an a11y decision. Don't reach for `<h3>` because it "looks right" — use outline position.

--- a/stories/patterns/ReadModePage.mdx
+++ b/stories/patterns/ReadModePage.mdx
@@ -1,0 +1,157 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as DataSectionStories from '../../components/ui/DataSection/DataSection.stories';
+
+<Meta title="Patterns/Read-Mode Page" />
+
+# Read-Mode Page
+
+A page layout archetype for surfaces that **primarily display read-only data** with per-section edit affordances. Client profile Overview, engagement detail, company settings, onboarding summaries — anywhere the default user task is *looking at data*, and editing is a secondary action.
+
+This page pattern composes four BDS components:
+
+1. **`PageHeader`** — page-level `<h1>`, breadcrumbs, metadata.
+2. **`DataSection`** — one per logical group (Identity, Location, Contact, …). Title + actions slot + body.
+3. **`FieldGrid`** — grid wrapper inside each section. 2/3/4 columns.
+4. **`Field`** — one label + value pair. Value can be text, a `<BulletList>`, a paragraph, or any `ReactNode`.
+
+---
+
+## Canonical composition
+
+<Canvas of={DataSectionStories.ReadModePage} />
+
+---
+
+## Two edit conventions
+
+BDS supports two distinct conventions for moving from read to edit. **Neither is wrong — they solve different problems.** Pick one per feature with intent; don't mix them on the same page.
+
+### Convention A — Sheet overlay
+
+Clicking an action opens a `Sheet` overlay; editing happens in the sheet. The page stays in read-mode.
+
+**Use when:**
+- The page is the user's primary navigation context and interrupting it with form state would lose their place.
+- A single section touches many fields (>6–8), or the edit form is tall enough that modal focus is a feature.
+- Data is contextual to a parent record (client profile, engagement) and users drill into one section at a time.
+
+**How the toggle works:**
+- On the `DataSection`, render a `<ButtonGroup>` with `[View]` and `[Edit]` in the `actions` slot.
+- `[View]` opens the sheet in view mode. `[Edit]` opens the sheet in edit mode.
+- Inside the sheet, a **second** `<ButtonGroup>` in the sheet header toggles between view and edit. The user can flip modes without closing the sheet.
+- The sheet header renders the same `[View]`/`[Edit]` `ButtonGroup`, preserving the vocabulary.
+- Footer buttons follow the mode: `[Close]` in view, `[Cancel]` / `[Save]` in edit.
+
+```tsx
+<DataSection
+  title="Identity"
+  actions={
+    <ButtonGroup>
+      <Button size="sm" variant="secondary" onClick={() => openSheet('identity', { mode: 'view' })}>
+        View
+      </Button>
+      <Button size="sm" variant="secondary" onClick={() => openSheet('identity', { mode: 'edit' })}>
+        Edit
+      </Button>
+    </ButtonGroup>
+  }
+>
+  <FieldGrid columns={2}>
+    <Field label="Business Name">{client.name}</Field>
+    <Field label="Industry">{client.industry}</Field>
+    {/* … */}
+  </FieldGrid>
+</DataSection>
+```
+
+Inside the sheet, `useEditableSheetConfig()` wires the header toggle and footer:
+
+```tsx
+const { mode, footer, headerActions } = useEditableSheetConfig({
+  initialMode: options.mode,
+  onSave: handleSave,
+});
+
+return (
+  <Sheet title="Identity" subtitle="Public-facing name and core identifiers." headerActions={headerActions}>
+    {mode === 'view' ? <IdentityView data={data} /> : <IdentityForm data={data} />}
+    {footer}
+  </Sheet>
+);
+```
+
+### Convention B — Inline edit
+
+Clicking `[Edit]` swaps the `DataSection` body in place. The fields become form inputs in the same grid. The page retains focus.
+
+**Use when:**
+- A section is short (≤4–6 fields) and the user is likely to edit many sections in a single session.
+- The parent page has no side-panel real estate (narrow layout) or opening a sheet would feel heavier than the edit warrants.
+- The content is inherently inline (toggles, selects, single-line strings) and form state is trivial.
+
+**How the toggle works:**
+- On the `DataSection`, render a `<ButtonGroup>` with `[View]` and `[Edit]` in `actions`.
+- `[Edit]` swaps the section body from `<FieldGrid>` + `<Field>` to the same grid of form inputs.
+- In edit mode, the `actions` slot replaces the `[View]`/`[Edit]` toggle with `[Cancel]` / `[Save]`.
+- Section title and subtitle do not change — only the body and the actions slot.
+
+```tsx
+const [mode, setMode] = useState<'view' | 'edit'>('view');
+
+<DataSection
+  title="Identity"
+  actions={
+    mode === 'view' ? (
+      <ButtonGroup>
+        <Button size="sm" variant="secondary">View</Button>
+        <Button size="sm" variant="secondary" onClick={() => setMode('edit')}>Edit</Button>
+      </ButtonGroup>
+    ) : (
+      <ButtonGroup>
+        <Button size="sm" variant="secondary" onClick={() => setMode('view')}>Cancel</Button>
+        <Button size="sm" variant="primary" onClick={handleSave}>Save</Button>
+      </ButtonGroup>
+    )
+  }
+>
+  {mode === 'view' ? (
+    <FieldGrid columns={2}>
+      <Field label="Business Name">{client.name}</Field>
+      <Field label="Industry">{client.industry}</Field>
+    </FieldGrid>
+  ) : (
+    <FieldGrid columns={2}>
+      <TextInput label="Business Name" defaultValue={client.name} />
+      <Select label="Industry" defaultValue={client.industry} options={…} />
+    </FieldGrid>
+  )}
+</DataSection>
+```
+
+---
+
+## Dos
+
+- **Stack `DataSection`s vertically** on the page. Spacing between them is owned by the component (`spacing="md"` or `"lg"`). Don't wrap them in flex columns with ad-hoc gaps.
+- **Use `FieldGrid` inside every section.** Even a single pair should live in a `FieldGrid` — the baseline alignment and column template are the point.
+- **Let `Field` handle empty values.** Passing `null` or an empty string renders the "Not set" fallback; don't hand-roll placeholder text.
+- **Use `Field` for paragraphs and lists.** A "paragraph-label" is a usage of `Field` with a `<p>` or `<BulletList>` as its value. Do not build `ParagraphField` / `ListField` — they're redundant.
+- **Match title tier to outline position.** `<h2>` is the default. A nested `DataSection` (rare) uses `titleAs="h3"`.
+
+## Don'ts
+
+- **Don't mix both conventions on the same page.** Pick A or B per feature; inconsistency is worse than either pure choice.
+- **Don't use `SheetSection` on a page.** `SheetSection` has an uppercase label heading appropriate inside a sheet — on a page, use `DataSection`.
+- **Don't put a raw `<h2>` with inline styles in place of `DataSection`.** That reintroduces the pattern this component replaces.
+- **Don't add a "Save" button to a sheet-overlay page.** In Convention A, the page never edits — the sheet does. The page's `ButtonGroup` only routes to modes.
+- **Don't rename the actions slot.** It's always `actions` — even when its only contents are routing buttons, not literal actions.
+
+---
+
+## Related
+
+- [`DataSection`](?path=/docs/displays-data-data-section--docs) — the component this pattern composes.
+- [`FieldGrid`](?path=/docs/displays-field-field-grid--docs) — grid wrapper.
+- [`Field`](?path=/docs/displays-field-field--docs) — label + value primitive.
+- [`SheetSection`](?path=/docs/displays-sheet-sheet-section--docs) — sheet-side analog.
+- [Foundations → Vocabulary](?path=/docs/foundations-vocabulary--docs) — the words that describe these parts.


### PR DESCRIPTION
## Summary
- docs(claude): LLM stack rule — highest-leverage placement (#212)
- feat(bds): DataSection + Vocabulary/Read-Mode Page docs (0.32.0)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)