### PR TITLE
bds: data section divider

### DIFF
--- a/components/ui/DataSection/DataSection.css
+++ b/components/ui/DataSection/DataSection.css
@@ -7,13 +7,19 @@
   gap: var(--gap-md);
 }
 
-/* Vertical rhythm between consecutive sections on the same page. */
+/* Vertical rhythm + divider between consecutive sections on the same page.
+   On an outline page each DataSection is a peer of its siblings — the divider
+   is the page's structural separator, not decoration. Matches the token
+   treatment used by <Divider />. */
 .bds-data-section + .bds-data-section {
   margin-top: var(--padding-lg);
+  padding-top: var(--padding-lg);
+  border-top: var(--border-width-sm) solid var(--border-muted);
 }
 
 .bds-data-section--spacing-lg + .bds-data-section {
   margin-top: var(--padding-xl);
+  padding-top: var(--padding-xl);
 }
 
 /* ─── Header ───────────────────────────────────────────────────── */

--- a/components/ui/DataSection/DataSection.mdx
+++ b/components/ui/DataSection/DataSection.mdx
@@ -75,6 +75,7 @@ import {
 
 ## Rules
 
+- **Consecutive DataSections show a divider automatically.** The sibling combinator handles it — do not place a `<Divider />` between DataSections manually. Divider uses `--border-muted` at `--border-width-sm`, matching `<Divider />`.
 - **`title` is a real heading.** Default `<h2>` — it IS part of the page outline. Use `titleAs="h3"` only when nested under an existing `<h2>`.
 - **Title ≠ heading.** The BEM class is `__title` (role); the HTML element (`h2`/`h3`) is picked by outline position, not by the class name. See [Foundations → Vocabulary](?path=/docs/foundation-vocabulary--docs) for the layer distinction.
 - **`actions` is a slot, not a label.** Put a `<ButtonGroup>` or `<Button>` in it. The text on each button is a *button-label* conceptually, even though it passes as `children` today.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Brik Design System \u2014 React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(bds): DataSection auto-divider between sibling sections (0.33.0)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)