### PR TITLE
feat(content-system): stats content-driven only (0.36.0)

### DIFF
--- a/content-system/industries/dental.ts
+++ b/content-system/industries/dental.ts
@@ -30,7 +30,10 @@ export const dental: IndustryPack = {
       slug: 'home',
       displayName: 'Home',
       required: true,
-      blueprintDefaults: ['hero_split_60_40', 'services_detail_two_column', 'stats_centered_light', 'testimonials_3col_cards', 'cta_split_contact'],
+      // Stats intentionally absent — render only when content generation
+      // emits a sectionType: 'stats' section (i.e. the practice has real
+      // numbers worth leading with). See issue #217.
+      blueprintDefaults: ['hero_split_60_40', 'services_detail_two_column', 'testimonials_3col_cards', 'cta_split_contact'],
     },
     {
       slug: 'meet-the-doctor',

--- a/content-system/industries/real-estate-commercial.ts
+++ b/content-system/industries/real-estate-commercial.ts
@@ -39,7 +39,9 @@ export const realEstateCommercial: IndustryPack = {
       slug: 'home',
       displayName: 'Home',
       required: true,
-      blueprintDefaults: ['hero_split_60_40', 'services_numbered_accordion', 'stats_dark_bar', 'testimonials_featured_large', 'cta_dark_centered'],
+      // Stats intentionally absent — render only when content generation
+      // emits a sectionType: 'stats' section. See issue #217.
+      blueprintDefaults: ['hero_split_60_40', 'services_numbered_accordion', 'testimonials_featured_large', 'cta_dark_centered'],
       description: 'Lead with authority and segmentation. The homepage must orient three different audiences (Healthcare / Land / Investors) without making any feel secondary. The hero introduces the broker; the navigation is the segmentation mechanism.',
     },
     {
@@ -60,8 +62,10 @@ export const realEstateCommercial: IndustryPack = {
       slug: 'investors',
       displayName: 'Investor Services',
       required: true,
-      blueprintDefaults: ['hero_interior_minimal', 'stats_dark_bar', 'services_detail_two_column', 'process_grid_4step_numbered', 'cta_dark_centered'],
-      description: 'Medical office buildings and Nashville-market investment. Capital-markets-literate tone — returns-focused, deal-flow-aware. Stats section earns credibility before asking for a meeting.',
+      // Investor pages benefit from stats, but only when the broker has
+      // real deal volume / portfolio numbers. Content generation decides.
+      blueprintDefaults: ['hero_interior_minimal', 'services_detail_two_column', 'process_grid_4step_numbered', 'cta_dark_centered'],
+      description: 'Medical office buildings and Nashville-market investment. Capital-markets-literate tone — returns-focused, deal-flow-aware. If the broker has portfolio stats worth leading with, content generation will emit a stats section; otherwise the page leans on process + CTA for credibility.',
     },
     {
       slug: 'about',
@@ -514,7 +518,6 @@ export const realEstateCommercial: IndustryPack = {
       sections: [
         'hero_split_60_40',
         'services_numbered_accordion',
-        'stats_dark_bar',
         'testimonials_featured_large',
         'cta_dark_centered',
       ],
@@ -542,7 +545,6 @@ export const realEstateCommercial: IndustryPack = {
       pageArchetype: 'investors',
       sections: [
         'hero_interior_minimal',
-        'stats_dark_bar',
         'services_detail_two_column',
         'process_grid_4step_numbered',
         'cta_dark_centered',

--- a/content-system/industries/real-estate-rv-mhc.ts
+++ b/content-system/industries/real-estate-rv-mhc.ts
@@ -34,8 +34,10 @@ export const realEstateRvMhc: IndustryPack = {
       slug: 'home',
       displayName: 'Home',
       required: true,
-      blueprintDefaults: ['hero_fullbleed_photo', 'services_detail_two_column', 'stats_dark_bar', 'cta_split_contact'],
-      description: 'Lead with a hero photo of the property — drone/aerial or amenity-forward. Trust signals (years in operation, number of sites, rating) pair well here.',
+      // Stats intentionally absent — render only when content generation
+      // emits a sectionType: 'stats' section. See issue #217.
+      blueprintDefaults: ['hero_fullbleed_photo', 'services_detail_two_column', 'cta_split_contact'],
+      description: 'Lead with a hero photo of the property — drone/aerial or amenity-forward. Trust signals (years in operation, number of sites, rating) pair well here when the client has real numbers to show.',
     },
     {
       slug: 'sites-availability',
@@ -497,7 +499,6 @@ export const realEstateRvMhc: IndustryPack = {
       pageArchetype: 'home',
       sections: [
         'hero_fullbleed_photo',
-        'stats_dark_bar',
         'services_detail_two_column',
         'testimonials_3col_cards',
         'cta_split_contact',

--- a/content-system/industries/small-business.ts
+++ b/content-system/industries/small-business.ts
@@ -324,10 +324,12 @@ export const smallBusiness: IndustryPack = {
   // with a sequence of section blueprints. Small-business is the
   // fallback pack, so compositions stick to the blueprint set that
   // ships in `@brikdesigns/bds/blueprints-astro@0.1.x` (hero_split_60_40,
-  // stats_dark_bar, services_detail_two_column, about_story_split,
-  // testimonials_featured_large, cta_split_contact, cta_dark_centered,
-  // hero_interior_minimal). This guarantees a zero-fallback render for
-  // any v0.1 client using this pack — notably Vale Partners at launch.
+  // services_detail_two_column, about_story_split, testimonials_featured_large,
+  // cta_split_contact, cta_dark_centered, hero_interior_minimal). This
+  // guarantees a zero-fallback render for any v0.1 client using this pack.
+  //
+  // Stats are intentionally NOT in any composition — render only when
+  // content generation emits a sectionType: 'stats' section. See #217.
   //
   // Dedicated verticals graduating to their own pack can reference any
   // blueprint key, since their render comes later (once more components
@@ -338,7 +340,6 @@ export const smallBusiness: IndustryPack = {
       pageArchetype: 'home',
       sections: [
         'hero_split_60_40',
-        'stats_dark_bar',
         'services_detail_two_column',
         'about_story_split',
         'testimonials_featured_large',
@@ -350,7 +351,6 @@ export const smallBusiness: IndustryPack = {
       sections: [
         'hero_interior_minimal',
         'about_story_split',
-        'stats_dark_bar',
         'cta_dark_centered',
       ],
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Brik Design System \u2014 React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(content-system): add real-estate-commercial industry pack + navigationIA audience accents (0.35.0) (#216)
- chore(storybook): update favicon to filled orange Brik mark (#219)
- feat(content-system): stats content-driven only (0.36.0)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)