### PR TITLE
tag: list to tag group

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -369,7 +369,6 @@ const preview: Preview = {
               'field',
               'field-grid',
               'bullet-list',
-              'tag-list',
               'Read-Mode Sheet',
               '*',
             ],

--- a/components/ui/Field/Field.mdx
+++ b/components/ui/Field/Field.mdx
@@ -44,7 +44,7 @@ When an entire section has no data (vs. one missing field), pass an `<EmptyState
 
 ## Value types
 
-`children` accepts any ReactNode — text, `<TagList>` / `<Tag>` groups, `<a>` links, `<BulletList>`, or compound content.
+`children` accepts any ReactNode — text, `<TagGroup>` / `<Tag>` groups, `<a>` links, `<BulletList>`, or compound content.
 
 <Canvas of={Stories.ValueTypes} />
 
@@ -70,7 +70,7 @@ Typical sheet-body field stack with mixed filled and empty values.
 ## Usage
 
 ```tsx
-import { Field, FieldGrid, TagList, Tag, BulletList } from '@brikdesigns/bds';
+import { Field, FieldGrid, TagGroup, Tag, BulletList } from '@brikdesigns/bds';
 
 // Single stacked field
 <Field label="Status">Active</Field>
@@ -83,10 +83,10 @@ import { Field, FieldGrid, TagList, Tag, BulletList } from '@brikdesigns/bds';
 
 // Value with tags
 <Field label="Services">
-  <TagList>
+  <TagGroup>
     <Tag size="sm">Cosmetic</Tag>
     <Tag size="sm">Implants</Tag>
-  </TagList>
+  </TagGroup>
 </Field>
 
 // Value with a bullet list

--- a/components/ui/Field/Field.tsx
+++ b/components/ui/Field/Field.tsx
@@ -7,7 +7,7 @@ export type FieldLayout = 'stacked' | 'inline';
 export interface FieldProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Field label — rendered above (stacked) or beside (inline) the value. */
   label: string;
-  /** Value content — text, <TagList>, <BulletList>, <a>, or any ReactNode. */
+  /** Value content — text, <TagGroup>, <BulletList>, <a>, or any ReactNode. */
   children?: ReactNode;
   /** Stacked = label above value (default). Inline = label / value on one row. */
   layout?: FieldLayout;

--- a/components/ui/Sheet/Sheet.mdx
+++ b/components/ui/Sheet/Sheet.mdx
@@ -122,7 +122,7 @@ The Sheet body is a composition surface — but the blocks you compose from are 
 | [`SheetSection`](/?path=/docs/displays-sheet-sheet-section--docs) | Named section wrapper (uppercase heading + content). One per logical grouping of fields. |
 | [`Field`](/?path=/docs/displays-sheet-field--docs) | Label + value pair. Value can be text, tags, URLs, lists — any ReactNode. |
 | [`FieldGrid`](/?path=/docs/displays-sheet-field-grid--docs) | 2 / 3 / 4-column grid of Fields or Cards. Stat-tile rows. |
-| [`TagList`](/?path=/docs/displays-sheet-tag-list--docs) | Horizontal cluster of `<Tag>` elements inside a Field. |
+| [`TagGroup`](/?path=/docs/components-indicator-tag-group--docs) | Horizontal cluster of `<Tag>` elements inside a Field. |
 | [`BulletList`](/?path=/docs/displays-sheet-bullet-list--docs) | Short-item lists (anti-messages, proof points, approved CTAs). |
 | [`Card`](/?path=/docs/displays-card-card--docs) / [`CardList`](/?path=/docs/displays-card-card-list--docs) / [`CardDisplay`](/?path=/docs/displays-card-card-display--docs) | Entity rows (contacts, services, scraped pages, linked records). |
 | [`Table`](/?path=/docs/displays-table-table--docs) | Tabular data (strategy tables, typography rows, schedules). |

--- a/components/ui/SheetSection/SheetSection.mdx
+++ b/components/ui/SheetSection/SheetSection.mdx
@@ -7,7 +7,7 @@ import * as Stories from './SheetSection.stories';
 
 The named wrapper for a block of content inside a `<Sheet>` body. Pairs an uppercase section heading with its content and locks the vertical rhythm between sections.
 
-Replaces ad-hoc flex-column + raw `<h3>` + `detail.sectionHeading` patterns. Inside a Sheet body, `SheetSection` is the only structural wrapper you should need — compose `Field`, `FieldGrid`, `Card`, `CardList`, `Table`, `TagList`, or `BulletList` inside it.
+Replaces ad-hoc flex-column + raw `<h3>` + `detail.sectionHeading` patterns. Inside a Sheet body, `SheetSection` is the only structural wrapper you should need — compose `Field`, `FieldGrid`, `Card`, `CardList`, `Table`, `TagGroup`, or `BulletList` inside it.
 
 ---
 

--- a/components/ui/SheetSection/SheetSection.tsx
+++ b/components/ui/SheetSection/SheetSection.tsx
@@ -9,7 +9,7 @@ export interface SheetSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'ti
   heading?: string;
   /** Optional lead paragraph rendered under the heading. */
   description?: ReactNode;
-  /** Section content — Field, FieldGrid, Card, CardList, Table, TagList, BulletList, etc. */
+  /** Section content — Field, FieldGrid, Card, CardList, Table, TagGroup, BulletList, etc. */
   children?: ReactNode;
   /** Vertical rhythm between this section and the next. Default `lg`. */
   spacing?: SheetSectionSpacing;

--- a/components/ui/TagGroup/TagGroup.css
+++ b/components/ui/TagGroup/TagGroup.css
@@ -1,33 +1,33 @@
 @layer bds-components {
-/* ─── TagList ──────────────────────────────────────────────────── */
+/* ─── TagGroup ──────────────────────────────────────────────────── */
 
-.bds-tag-list {
+.bds-tag-group {
   display: flex;
   align-items: center;
 }
 
 /* ─── Wrap ──────────────────────────────────────────────────── */
 
-.bds-tag-list--wrap {
+.bds-tag-group--wrap {
   flex-wrap: wrap;
 }
 
-.bds-tag-list--nowrap {
+.bds-tag-group--nowrap {
   flex-wrap: nowrap;
   overflow: hidden;
 }
 
 /* ─── Gap ───────────────────────────────────────────────────── */
 
-.bds-tag-list--gap-xs {
+.bds-tag-group--gap-xs {
   gap: var(--gap-xs);
 }
 
-.bds-tag-list--gap-sm {
+.bds-tag-group--gap-sm {
   gap: var(--gap-sm);
 }
 
-.bds-tag-list--gap-md {
+.bds-tag-group--gap-md {
   gap: var(--gap-md);
 }
 }

--- a/components/ui/TagGroup/TagGroup.mdx
+++ b/components/ui/TagGroup/TagGroup.mdx
@@ -1,9 +1,9 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
-import * as Stories from './TagList.stories';
+import * as Stories from './TagGroup.stories';
 
 <Meta of={Stories} />
 
-# TagList
+# TagGroup
 
 Horizontal cluster of `<Tag>` elements with locked spacing. Replaces the `<div style={{ display: 'flex', gap, flexWrap }}>` wrapper that had grown around tag arrays across the portal.
 
@@ -44,18 +44,18 @@ Several fields each rendering a tag cluster — the recurring "brand personality
 ## Usage
 
 ```tsx
-import { TagList, Tag, Field } from '@brikdesigns/bds';
+import { TagGroup, Tag, Field } from '@brikdesigns/bds';
 
 <Field label="Services offered">
-  <TagList>
+  <TagGroup>
     <Tag size="sm">Cosmetic</Tag>
     <Tag size="sm">General</Tag>
     <Tag size="sm">Implants</Tag>
-  </TagList>
+  </TagGroup>
 </Field>
 ```
 
 ## Rules
 
 - **Don't wrap a single Tag.** If there's only one, just use `<Tag>` directly inside the Field.
-- **Use `Tag` children, not arbitrary nodes.** TagList locks spacing for Tag's specific footprint; other content will misalign.
+- **Use `Tag` children, not arbitrary nodes.** TagGroup locks spacing for Tag's specific footprint; other content will misalign.

--- a/components/ui/TagGroup/TagGroup.stories.tsx
+++ b/components/ui/TagGroup/TagGroup.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { TagList } from './TagList';
+import { TagGroup } from './TagGroup';
 import { Tag } from '../Tag';
 import { Field } from '../Field';
 
-const meta: Meta<typeof TagList> = {
-  title: 'Displays/Sheet/tag-list',
-  component: TagList,
+const meta: Meta<typeof TagGroup> = {
+  title: 'Components/Indicator/tag-group',
+  component: TagGroup,
   parameters: { layout: 'padded' },
   argTypes: {
     gap: { control: 'select', options: ['xs', 'sm', 'md'] },
@@ -14,7 +14,7 @@ const meta: Meta<typeof TagList> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof TagList>;
+type Story = StoryObj<typeof TagGroup>;
 
 const Frame = ({ width = '360px', children }: { width?: string; children: React.ReactNode }) => (
   <div style={{ width, padding: 'var(--padding-lg)', background: 'var(--surface-primary)' }}>
@@ -31,12 +31,12 @@ export const Playground: Story = {
   },
   render: (args) => (
     <Frame>
-      <TagList {...args}>
+      <TagGroup {...args}>
         <Tag size="sm">Cosmetic</Tag>
         <Tag size="sm">General</Tag>
         <Tag size="sm">Implants</Tag>
         <Tag size="sm">Invisalign</Tag>
-      </TagList>
+      </TagGroup>
     </Frame>
   ),
 };
@@ -47,23 +47,23 @@ export const Gaps: Story = {
   render: () => (
     <Frame>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)' }}>
-        <TagList gap="xs">
+        <TagGroup gap="xs">
           <Tag size="sm">xs gap</Tag>
           <Tag size="sm">tight</Tag>
           <Tag size="sm">cluster</Tag>
-        </TagList>
+        </TagGroup>
 
-        <TagList gap="sm">
+        <TagGroup gap="sm">
           <Tag size="sm">sm gap</Tag>
           <Tag size="sm">standard</Tag>
           <Tag size="sm">list</Tag>
-        </TagList>
+        </TagGroup>
 
-        <TagList gap="md">
+        <TagGroup gap="md">
           <Tag size="md">md gap</Tag>
           <Tag size="md">roomy</Tag>
           <Tag size="md">display</Tag>
-        </TagList>
+        </TagGroup>
       </div>
     </Frame>
   ),
@@ -75,13 +75,13 @@ export const InsideField: Story = {
   render: () => (
     <Frame>
       <Field label="Services offered">
-        <TagList>
+        <TagGroup>
           <Tag size="sm">Cosmetic</Tag>
           <Tag size="sm">General</Tag>
           <Tag size="sm">Implants</Tag>
           <Tag size="sm">Invisalign</Tag>
           <Tag size="sm">Whitening</Tag>
-        </TagList>
+        </TagGroup>
       </Field>
     </Frame>
   ),
@@ -94,27 +94,27 @@ export const Patterns: Story = {
     <Frame>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
         <Field label="Industries">
-          <TagList>
+          <TagGroup>
             <Tag size="sm">Dental</Tag>
             <Tag size="sm">Medical</Tag>
             <Tag size="sm">Legal</Tag>
-          </TagList>
+          </TagGroup>
         </Field>
 
         <Field label="Voice traits">
-          <TagList>
+          <TagGroup>
             <Tag size="sm">Warm</Tag>
             <Tag size="sm">Authoritative</Tag>
             <Tag size="sm">Clear</Tag>
-          </TagList>
+          </TagGroup>
         </Field>
 
         <Field label="Brand personality">
-          <TagList>
+          <TagGroup>
             <Tag size="sm">Sophisticated</Tag>
             <Tag size="sm">Approachable</Tag>
             <Tag size="sm">Trustworthy</Tag>
-          </TagList>
+          </TagGroup>
         </Field>
       </div>
     </Frame>

--- a/components/ui/TagGroup/TagGroup.tsx
+++ b/components/ui/TagGroup/TagGroup.tsx
@@ -1,12 +1,12 @@
 import { type HTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
-import './TagList.css';
+import './TagGroup.css';
 
-export type TagListGap = 'xs' | 'sm' | 'md';
+export type TagGroupGap = 'xs' | 'sm' | 'md';
 
-export interface TagListProps extends HTMLAttributes<HTMLDivElement> {
+export interface TagGroupProps extends HTMLAttributes<HTMLDivElement> {
   /** Gap between tags. Default `xs` (matches tight tag clusters). */
-  gap?: TagListGap;
+  gap?: TagGroupGap;
   /** When true, tags wrap to additional rows. Default true. */
   wrap?: boolean;
   /** `<Tag>` children, or anything with tag-sized footprint. */
@@ -14,26 +14,26 @@ export interface TagListProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * TagList — horizontal cluster of `<Tag>` elements with locked spacing.
+ * TagGroup — horizontal cluster of `<Tag>` elements with locked spacing.
  *
  * Replaces ad-hoc `<div style={{ display: 'flex', gap, flexWrap }}>`
  * wrappers around tag arrays. Use as a Field value, inside a table cell,
  * or standalone inside a SheetSection.
  */
-export function TagList({
+export function TagGroup({
   gap = 'xs',
   wrap = true,
   className,
   style,
   children,
   ...props
-}: TagListProps) {
+}: TagGroupProps) {
   return (
     <div
       className={bdsClass(
-        'bds-tag-list',
-        `bds-tag-list--gap-${gap}`,
-        wrap ? 'bds-tag-list--wrap' : 'bds-tag-list--nowrap',
+        'bds-tag-group',
+        `bds-tag-group--gap-${gap}`,
+        wrap ? 'bds-tag-group--wrap' : 'bds-tag-group--nowrap',
         className,
       )}
       style={style}
@@ -44,4 +44,4 @@ export function TagList({
   );
 }
 
-export default TagList;
+export default TagGroup;

--- a/components/ui/TagGroup/index.ts
+++ b/components/ui/TagGroup/index.ts
@@ -1,0 +1,6 @@
+export {
+  TagGroup,
+  type TagGroupProps,
+  type TagGroupGap,
+} from './TagGroup';
+export { default } from './TagGroup';

--- a/components/ui/TagList/index.ts
+++ b/components/ui/TagList/index.ts
@@ -1,6 +1,0 @@
-export {
-  TagList,
-  type TagListProps,
-  type TagListGap,
-} from './TagList';
-export { default } from './TagList';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -79,7 +79,7 @@ export * from './Switch';
 export * from './TabBar';
 export * from './Table';
 export * from './Tag';
-export * from './TagList';
+export * from './TagGroup';
 export * from './TextArea';
 export * from './TextInput';
 export * from './TimePicker';


### PR DESCRIPTION
## Summary
- feat(content-system): add real-estate-commercial industry pack + navigationIA audience accents (0.35.0) (#216)
- chore(storybook): update favicon to filled orange Brik mark (#219)
- feat(schema): add optional compliance field to IndustryPack (#221)
- docs(compliance): ban accessibility overlay widgets (ADR-002) (#220)
- chore(claude): add PreToolUse Bash hook blocking secret-capture patterns (#225)
- chore(storybook): consolidate sidebar — Typography → Sheet, Patterns → component folders (#226)
- refactor(tag-group)!: rename TagList → TagGroup, move to Components/Indicator

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)