### PR TITLE
badge: group component

### DIFF
--- a/components/ui/BadgeGroup/BadgeGroup.css
+++ b/components/ui/BadgeGroup/BadgeGroup.css
@@ -1,0 +1,33 @@
+@layer bds-components {
+/* ─── BadgeGroup ──────────────────────────────────────────────── */
+
+.bds-badge-group {
+  display: flex;
+  align-items: center;
+}
+
+/* ─── Wrap ──────────────────────────────────────────────────── */
+
+.bds-badge-group--wrap {
+  flex-wrap: wrap;
+}
+
+.bds-badge-group--nowrap {
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+/* ─── Gap ───────────────────────────────────────────────────── */
+
+.bds-badge-group--gap-xs {
+  gap: var(--gap-xs);
+}
+
+.bds-badge-group--gap-sm {
+  gap: var(--gap-sm);
+}
+
+.bds-badge-group--gap-md {
+  gap: var(--gap-md);
+}
+}

--- a/components/ui/BadgeGroup/BadgeGroup.mdx
+++ b/components/ui/BadgeGroup/BadgeGroup.mdx
@@ -1,0 +1,62 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './BadgeGroup.stories';
+
+<Meta of={Stories} />
+
+# BadgeGroup
+
+Horizontal cluster of `<Badge>` elements with locked spacing. The indicator-family sibling of `TagGroup` — same API shape, different child.
+
+Use when you need to display multiple status indicators side by side — integration health rows, payment state summaries, tag-like badges on an entity row.
+
+---
+
+## Playground
+
+<Canvas of={Stories.Playground} />
+
+## Gaps
+
+Three locked gap sizes — `xs` for tight clusters, `sm` for standard lists, `md` for roomy displays.
+
+<Canvas of={Stories.Gaps} />
+
+## Inside a Field
+
+Badge clusters work well as `Field` values when multiple statuses need to be shown at once — e.g. the health of several integrations on one line.
+
+<Canvas of={Stories.InsideField} />
+
+## Variant mix
+
+Compare dark and light Badge variants inside the same group container. Pick one variant per cluster for visual consistency — BadgeGroup does not enforce this at the API level.
+
+<Canvas of={Stories.VariantMix} />
+
+---
+
+## Props
+
+<ArgTypes of={Stories} />
+
+---
+
+## Usage
+
+```tsx
+import { BadgeGroup, Badge, Field } from '@brikdesigns/bds';
+
+<Field label="Integrations health">
+  <BadgeGroup>
+    <Badge status="positive" size="sm">Helicone</Badge>
+    <Badge status="positive" size="sm">Supabase</Badge>
+    <Badge status="warning" size="sm">Stripe</Badge>
+  </BadgeGroup>
+</Field>
+```
+
+## Rules
+
+- **Don't wrap a single Badge.** If there's only one, just use `<Badge>` directly inside the Field.
+- **Use `Badge` children, not arbitrary nodes.** BadgeGroup locks spacing for Badge's specific footprint; other content will misalign.
+- **Pair with `TagGroup`, not against it.** Use `TagGroup` for labels (category, filter, attribute). Use `BadgeGroup` for status indicators (live/active/paid). Both share the same API.

--- a/components/ui/BadgeGroup/BadgeGroup.stories.tsx
+++ b/components/ui/BadgeGroup/BadgeGroup.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { BadgeGroup } from './BadgeGroup';
+import { Badge } from '../Badge';
+import { Field } from '../Field';
+
+const meta: Meta<typeof BadgeGroup> = {
+  title: 'Components/Indicator/badge-group',
+  component: BadgeGroup,
+  parameters: { layout: 'padded' },
+  argTypes: {
+    gap: { control: 'select', options: ['xs', 'sm', 'md'] },
+    wrap: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BadgeGroup>;
+
+const Frame = ({ width = '360px', children }: { width?: string; children: React.ReactNode }) => (
+  <div style={{ width, padding: 'var(--padding-lg)', background: 'var(--surface-primary)' }}>
+    {children}
+  </div>
+);
+
+/* ─── 1. Playground ──────────────────────────────────────────── */
+
+export const Playground: Story = {
+  args: {
+    gap: 'xs',
+    wrap: true,
+  },
+  render: (args) => (
+    <Frame>
+      <BadgeGroup {...args}>
+        <Badge status="positive" size="sm">Active</Badge>
+        <Badge status="warning" size="sm">Pending</Badge>
+        <Badge status="info" size="sm">Draft</Badge>
+        <Badge status="error" size="sm">Blocked</Badge>
+      </BadgeGroup>
+    </Frame>
+  ),
+};
+
+/* ─── 2. Gaps ────────────────────────────────────────────────── */
+
+export const Gaps: Story = {
+  render: () => (
+    <Frame>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)' }}>
+        <BadgeGroup gap="xs">
+          <Badge status="positive" size="sm">xs gap</Badge>
+          <Badge status="info" size="sm">tight</Badge>
+          <Badge status="brand" size="sm">cluster</Badge>
+        </BadgeGroup>
+
+        <BadgeGroup gap="sm">
+          <Badge status="positive" size="sm">sm gap</Badge>
+          <Badge status="info" size="sm">standard</Badge>
+          <Badge status="brand" size="sm">list</Badge>
+        </BadgeGroup>
+
+        <BadgeGroup gap="md">
+          <Badge status="positive" size="md">md gap</Badge>
+          <Badge status="info" size="md">roomy</Badge>
+          <Badge status="brand" size="md">display</Badge>
+        </BadgeGroup>
+      </div>
+    </Frame>
+  ),
+};
+
+/* ─── 3. Inside a Field ──────────────────────────────────────── */
+
+export const InsideField: Story = {
+  render: () => (
+    <Frame>
+      <Field label="Integrations health">
+        <BadgeGroup>
+          <Badge status="positive" size="sm">Helicone</Badge>
+          <Badge status="positive" size="sm">Supabase</Badge>
+          <Badge status="warning" size="sm">Stripe</Badge>
+          <Badge status="error" size="sm">Twilio</Badge>
+        </BadgeGroup>
+      </Field>
+    </Frame>
+  ),
+};
+
+/* ─── 4. Variant mix ─────────────────────────────────────────── */
+
+export const VariantMix: Story = {
+  render: () => (
+    <Frame width="480px">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
+        <Field label="Dark variants">
+          <BadgeGroup>
+            <Badge status="positive" size="sm" variant="dark">Paid</Badge>
+            <Badge status="warning" size="sm" variant="dark">Overdue</Badge>
+            <Badge status="error" size="sm" variant="dark">Failed</Badge>
+            <Badge status="info" size="sm" variant="dark">Scheduled</Badge>
+          </BadgeGroup>
+        </Field>
+
+        <Field label="Light variants">
+          <BadgeGroup>
+            <Badge status="positive" size="sm" variant="light">Paid</Badge>
+            <Badge status="warning" size="sm" variant="light">Overdue</Badge>
+            <Badge status="error" size="sm" variant="light">Failed</Badge>
+            <Badge status="info" size="sm" variant="light">Scheduled</Badge>
+          </BadgeGroup>
+        </Field>
+      </div>
+    </Frame>
+  ),
+};

--- a/components/ui/BadgeGroup/BadgeGroup.tsx
+++ b/components/ui/BadgeGroup/BadgeGroup.tsx
@@ -1,0 +1,49 @@
+import { type HTMLAttributes, type ReactNode } from 'react';
+import { bdsClass } from '../../utils';
+import './BadgeGroup.css';
+
+export type BadgeGroupGap = 'xs' | 'sm' | 'md';
+
+export interface BadgeGroupProps extends HTMLAttributes<HTMLDivElement> {
+  /** Gap between badges. Default `xs` (matches tight badge clusters). */
+  gap?: BadgeGroupGap;
+  /** When true, badges wrap to additional rows. Default true. */
+  wrap?: boolean;
+  /** `<Badge>` children, or anything with badge-sized footprint. */
+  children?: ReactNode;
+}
+
+/**
+ * BadgeGroup — horizontal cluster of `<Badge>` elements with locked spacing.
+ *
+ * Replaces ad-hoc `<div style={{ display: 'flex', gap, flexWrap }}>`
+ * wrappers around badge arrays. Use as a Field value, inside a table cell,
+ * or standalone inside a SheetSection.
+ *
+ * Sibling of `TagGroup` — same API shape, different child indicator.
+ */
+export function BadgeGroup({
+  gap = 'xs',
+  wrap = true,
+  className,
+  style,
+  children,
+  ...props
+}: BadgeGroupProps) {
+  return (
+    <div
+      className={bdsClass(
+        'bds-badge-group',
+        `bds-badge-group--gap-${gap}`,
+        wrap ? 'bds-badge-group--wrap' : 'bds-badge-group--nowrap',
+        className,
+      )}
+      style={style}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default BadgeGroup;

--- a/components/ui/BadgeGroup/index.ts
+++ b/components/ui/BadgeGroup/index.ts
@@ -1,0 +1,6 @@
+export {
+  BadgeGroup,
+  type BadgeGroupProps,
+  type BadgeGroupGap,
+} from './BadgeGroup';
+export { default } from './BadgeGroup';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -9,6 +9,7 @@ export * from './AnimatedIcon';
 export * from './AlertBanner';
 export * from './Avatar';
 export * from './Badge';
+export * from './BadgeGroup';
 export * from './Board';
 export * from './Banner';
 export * from './Breadcrumb';


### PR DESCRIPTION
## Summary
- feat(content-system): add real-estate-commercial industry pack + navigationIA audience accents (0.35.0) (#216)
- chore(storybook): update favicon to filled orange Brik mark (#219)
- feat(schema): add optional compliance field to IndustryPack (#221)
- docs(compliance): ban accessibility overlay widgets (ADR-002) (#220)
- chore(claude): add PreToolUse Bash hook blocking secret-capture patterns (#225)
- chore(storybook): consolidate sidebar — Typography → Sheet, Patterns → component folders (#226)
- feat(badge-group): add BadgeGroup indicator component (0.36.0)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)