### PR TITLE
bds: appearance vocabulary

### DIFF
--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -88,66 +88,66 @@
   font-size: var(--label-xl);
 }
 
-/* ─── Status × Dark (default) ─────────────────────────────────── */
+/* ─── Status × Solid (default, saturated bg) ─────────────────── */
 
-.bds-badge--dark.bds-badge--positive {
+.bds-badge--solid.bds-badge--positive {
   background-color: var(--background-positive);
   color: var(--text-on-color-dark);
 }
 
-.bds-badge--dark.bds-badge--warning {
+.bds-badge--solid.bds-badge--warning {
   background-color: var(--background-warning);
   color: var(--text-status-neutral);
 }
 
-.bds-badge--dark.bds-badge--error {
+.bds-badge--solid.bds-badge--error {
   background-color: var(--background-negative);
   color: var(--text-on-color-dark);
 }
 
-.bds-badge--dark.bds-badge--info {
+.bds-badge--solid.bds-badge--info {
   background-color: var(--background-status-neutral);
   color: var(--text-status-neutral);
 }
 
-.bds-badge--dark.bds-badge--progress {
+.bds-badge--solid.bds-badge--progress {
   background-color: var(--background-status-info);
   color: var(--text-on-color-dark);
 }
 
-.bds-badge--dark.bds-badge--brand {
+.bds-badge--solid.bds-badge--brand {
   background-color: var(--background-brand-primary);
   color: var(--text-on-color-dark);
 }
 
-/* ─── Status × Light (pastel bg, saturated text) ─────────────── */
+/* ─── Status × Subtle (pastel bg, saturated text) ────────────── */
 
-.bds-badge--light.bds-badge--positive {
+.bds-badge--subtle.bds-badge--positive {
   background-color: var(--background-status-success-subtle);
   color: var(--text-positive);
 }
 
-.bds-badge--light.bds-badge--warning {
+.bds-badge--subtle.bds-badge--warning {
   background-color: var(--background-status-warning-subtle);
   color: var(--text-status-neutral);
 }
 
-.bds-badge--light.bds-badge--error {
+.bds-badge--subtle.bds-badge--error {
   background-color: var(--background-status-error-subtle);
   color: var(--text-negative);
 }
 
-.bds-badge--light.bds-badge--info {
+.bds-badge--subtle.bds-badge--info {
   background-color: var(--background-status-neutral);
   color: var(--text-status-neutral);
 }
 
-.bds-badge--light.bds-badge--progress {
+.bds-badge--subtle.bds-badge--progress {
   background-color: var(--background-status-info-subtle);
   color: var(--text-status-info);
 }
 
-.bds-badge--light.bds-badge--brand {
+.bds-badge--subtle.bds-badge--brand {
   background-color: var(--background-brand-secondary);
   color: var(--text-brand-primary);
 }

--- a/components/ui/Badge/Badge.mdx
+++ b/components/ui/Badge/Badge.mdx
@@ -5,7 +5,7 @@ import * as Stories from './Badge.stories';
 
 # Badge
 
-Status indicators and labels for displaying contextual information. Badges use semantic system colors to communicate status at a glance, with dark (saturated) and light (pastel) visual variants.
+Status indicators and labels for displaying contextual information. Badges use semantic system colors to communicate status at a glance, with `solid` (saturated bg) and `subtle` (pastel bg) appearance values.
 
 ---
 
@@ -32,7 +32,7 @@ Use the Controls panel to explore all props interactively.
 
 ## Variants
 
-Five status variants across four sizes, each available in dark and light styles. The `xs` size renders a compact icon-only badge.
+Five status variants across four sizes, each available in `solid` and `subtle` appearances. The `xs` size renders a compact icon-only badge.
 
 <Canvas of={Stories.Variants} />
 
@@ -44,14 +44,14 @@ Five status variants across four sizes, each available in dark and light styles.
 - **`info`** — Neutral. Informational, neutral notifications.
 - **`progress`** — Blue. In-progress states, active processes.
 
-**Appearance:**
+**Appearance:** (shared axis with Chip and Tag — see [Vocabulary › Axes](/?path=/docs/foundations-vocabulary--overview))
 
-- **`dark`** (default) — High emphasis, standalone badges, dark backgrounds.
-- **`light`** — Lower emphasis, inline with content, table cells, cards.
+- **`solid`** (default) — High emphasis, standalone badges, dark backgrounds.
+- **`subtle`** — Lower emphasis pastel fill, inline with content, table cells, cards.
 
 ## Icons
 
-Badges can include a leading icon alongside text, shown in both dark and light variants.
+Badges can include a leading icon alongside text, shown in both `solid` and `subtle` appearances.
 
 <Canvas of={Stories.Icons} />
 
@@ -74,14 +74,14 @@ Real-world compositions for common badge use cases.
 ```tsx
 import { Badge } from '@brik/bds';
 
-// Dark variant (default)
+// Solid appearance (default)
 <Badge status="positive">Done</Badge>
 <Badge status="warning">Needs Attention</Badge>
 <Badge status="error">Canceled</Badge>
 
-// Light variant
-<Badge status="positive" variant="light">Done</Badge>
-<Badge status="progress" variant="light">In Progress</Badge>
+// Subtle appearance (pastel fill)
+<Badge status="positive" appearance="subtle">Done</Badge>
+<Badge status="progress" appearance="subtle">In Progress</Badge>
 
 // With icon
 <Badge status="positive" icon={<Icon icon="ph:check" />}>

--- a/components/ui/Badge/Badge.stories.tsx
+++ b/components/ui/Badge/Badge.stories.tsx
@@ -20,9 +20,9 @@ const meta: Meta<typeof Badge> = {
       control: 'select',
       options: ['xs', 'sm', 'md', 'lg'],
     },
-    variant: {
+    appearance: {
       control: 'select',
-      options: ['dark', 'light'],
+      options: ['solid', 'subtle'],
     },
   },
 };
@@ -60,43 +60,43 @@ const statuses = ['positive', 'warning', 'error', 'info', 'progress'] as const;
    ═══════════════════════════════════════════════════════════════ */
 
 export const Playground: Story = {
-  args: { children: 'New', status: 'info', size: 'md', variant: 'dark' },
+  args: { children: 'New', status: 'info', size: 'md', appearance: 'solid' },
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Dark and light styles × all statuses × all sizes
+   2. VARIANTS — Solid and subtle appearances × all statuses × all sizes
    ═══════════════════════════════════════════════════════════════ */
 
 export const Variants: Story = {
   render: () => (
     <Stack>
-      {/* Dark variant */}
+      {/* Solid appearance */}
       <div>
-        <SectionLabel>Dark (default)</SectionLabel>
+        <SectionLabel>Solid (default)</SectionLabel>
         <Stack gap="var(--gap-lg)">
           {(['sm', 'md', 'lg'] as const).map((size) => (
             <Row key={size}>
               {statuses.map((s) => (
-                <Badge key={s} size={size} status={s} variant="dark">{s}</Badge>
+                <Badge key={s} size={size} status={s} appearance="solid">{s}</Badge>
               ))}
             </Row>
           ))}
         </Stack>
       </div>
-      {/* Light variant */}
+      {/* Subtle appearance */}
       <div>
-        <SectionLabel>Light</SectionLabel>
+        <SectionLabel>Subtle</SectionLabel>
         <Stack gap="var(--gap-lg)">
           {(['sm', 'md', 'lg'] as const).map((size) => (
             <Row key={size}>
               {statuses.map((s) => (
-                <Badge key={s} size={size} status={s} variant="light">{s}</Badge>
+                <Badge key={s} size={size} status={s} appearance="subtle">{s}</Badge>
               ))}
             </Row>
           ))}
         </Stack>
       </div>
-      {/* xs icon-only — both variants */}
+      {/* xs icon-only — both appearances */}
       <div>
         <SectionLabel>xs icon-only</SectionLabel>
         <Stack gap="var(--gap-lg)">
@@ -108,11 +108,11 @@ export const Variants: Story = {
             <Badge size="xs" status="progress" icon={<Icon icon="ph:arrows-clockwise" />} />
           </Row>
           <Row>
-            <Badge size="xs" status="positive" variant="light" icon={<Icon icon="ph:check" />} />
-            <Badge size="xs" status="warning" variant="light" icon={<Icon icon="ph:warning" />} />
-            <Badge size="xs" status="error" variant="light" icon={<Icon icon="ph:x-circle" />} />
-            <Badge size="xs" status="info" variant="light" icon={<Icon icon="ph:info" />} />
-            <Badge size="xs" status="progress" variant="light" icon={<Icon icon="ph:arrows-clockwise" />} />
+            <Badge size="xs" status="positive" appearance="subtle" icon={<Icon icon="ph:check" />} />
+            <Badge size="xs" status="warning" appearance="subtle" icon={<Icon icon="ph:warning" />} />
+            <Badge size="xs" status="error" appearance="subtle" icon={<Icon icon="ph:x-circle" />} />
+            <Badge size="xs" status="info" appearance="subtle" icon={<Icon icon="ph:info" />} />
+            <Badge size="xs" status="progress" appearance="subtle" icon={<Icon icon="ph:arrows-clockwise" />} />
           </Row>
         </Stack>
       </div>
@@ -128,7 +128,7 @@ export const Icons: Story = {
   render: () => (
     <Stack>
       <div>
-        <SectionLabel>Dark with icons</SectionLabel>
+        <SectionLabel>Solid with icons</SectionLabel>
         <Row>
           <Badge status="positive" icon={<Icon icon="ph:check" />}>Done</Badge>
           <Badge status="error" icon={<Icon icon="ph:warning-circle" />}>Canceled</Badge>
@@ -138,13 +138,13 @@ export const Icons: Story = {
         </Row>
       </div>
       <div>
-        <SectionLabel>Light with icons</SectionLabel>
+        <SectionLabel>Subtle with icons</SectionLabel>
         <Row>
-          <Badge status="positive" variant="light" icon={<Icon icon="ph:check" />}>Done</Badge>
-          <Badge status="error" variant="light" icon={<Icon icon="ph:warning-circle" />}>Canceled</Badge>
-          <Badge status="progress" variant="light" icon={<Icon icon="ph:spinner" />}>In Progress</Badge>
-          <Badge status="info" variant="light" icon={<Icon icon="ph:info" />}>Neutral</Badge>
-          <Badge status="warning" variant="light" icon={<Icon icon="ph:warning" />}>Needs Attention</Badge>
+          <Badge status="positive" appearance="subtle" icon={<Icon icon="ph:check" />}>Done</Badge>
+          <Badge status="error" appearance="subtle" icon={<Icon icon="ph:warning-circle" />}>Canceled</Badge>
+          <Badge status="progress" appearance="subtle" icon={<Icon icon="ph:spinner" />}>In Progress</Badge>
+          <Badge status="info" appearance="subtle" icon={<Icon icon="ph:info" />}>Neutral</Badge>
+          <Badge status="warning" appearance="subtle" icon={<Icon icon="ph:warning" />}>Needs Attention</Badge>
         </Row>
       </div>
       <div>
@@ -210,7 +210,7 @@ export const Patterns: Story = {
   render: () => (
     <Stack>
       <div>
-        <SectionLabel>Content status (dark)</SectionLabel>
+        <SectionLabel>Content status (solid)</SectionLabel>
         <Stack gap="var(--gap-lg)">
           {([
             { status: 'positive' as const, label: 'Published', desc: 'Article is live and visible' },
@@ -228,7 +228,7 @@ export const Patterns: Story = {
         </Stack>
       </div>
       <div>
-        <SectionLabel>Content status (light)</SectionLabel>
+        <SectionLabel>Content status (subtle)</SectionLabel>
         <Stack gap="var(--gap-lg)">
           {([
             { status: 'positive' as const, label: 'Published', desc: 'Article is live and visible' },
@@ -236,8 +236,8 @@ export const Patterns: Story = {
             { status: 'warning' as const, label: 'Draft', desc: 'Saved but not published' },
             { status: 'error' as const, label: 'Archived', desc: 'Has been removed' },
           ]).map(({ status, label, desc }) => (
-            <div key={`${status}-light`} style={{ display: 'flex', gap: 'var(--gap-md)', alignItems: 'center' }}>
-              <Badge status={status} variant="light">{label}</Badge>
+            <div key={`${status}-subtle`} style={{ display: 'flex', gap: 'var(--gap-md)', alignItems: 'center' }}>
+              <Badge status={status} appearance="subtle">{label}</Badge>
               <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-sm)', color: 'var(--text-secondary)' }}>
                 {desc}
               </span>

--- a/components/ui/Badge/Badge.tsx
+++ b/components/ui/Badge/Badge.tsx
@@ -8,8 +8,13 @@ export type BadgeStatus = 'positive' | 'warning' | 'error' | 'info' | 'progress'
 /** Badge size variants — shared scale with Tag */
 export type BadgeSize = 'xs' | 'sm' | 'md' | 'lg';
 
-/** Badge visual style — dark (saturated bg) or light (pastel bg) */
-export type BadgeVariant = 'dark' | 'light';
+/**
+ * Badge fill appearance — shared axis with Chip (`solid | outline`) and
+ * Tag (`solid | subtle`). Badge supports the two pastel-capable values.
+ * - `solid`  — saturated status-color background, high emphasis.
+ * - `subtle` — pastel status-color background, saturated text, lower emphasis.
+ */
+export type BadgeAppearance = 'solid' | 'subtle';
 
 /** Badge component props */
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
@@ -17,8 +22,8 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   status?: BadgeStatus;
   /** Size variant — xs is icon-only (no text) */
   size?: BadgeSize;
-  /** Visual style — dark uses saturated bg, light uses pastel bg */
-  variant?: BadgeVariant;
+  /** Fill appearance — solid (saturated bg) or subtle (pastel bg). */
+  appearance?: BadgeAppearance;
   /** Children content (optional for xs/icon-only size) */
   children?: ReactNode;
   /** Optional icon before text (required for xs size) */
@@ -41,14 +46,14 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
  * @example
  * ```tsx
  * <Badge status="positive">Success</Badge>
- * <Badge status="warning" size="sm">Pending</Badge>
+ * <Badge status="warning" size="sm" appearance="subtle">Pending</Badge>
  * <Badge status="error" size="lg">Failed</Badge>
  * ```
  */
 export function Badge({
   status = 'info',
   size = 'md',
-  variant = 'dark',
+  appearance = 'solid',
   children,
   icon,
   className,
@@ -61,7 +66,7 @@ export function Badge({
     'bds-badge',
     `bds-badge--${status}`,
     `bds-badge--${size}`,
-    `bds-badge--${variant}`,
+    `bds-badge--${appearance}`,
     className
   );
 

--- a/components/ui/Badge/index.ts
+++ b/components/ui/Badge/index.ts
@@ -1,2 +1,2 @@
-export { Badge, type BadgeProps, type BadgeStatus, type BadgeSize, type BadgeVariant } from './Badge';
+export { Badge, type BadgeProps, type BadgeStatus, type BadgeSize, type BadgeAppearance } from './Badge';
 export { default } from './Badge';

--- a/components/ui/BadgeGroup/BadgeGroup.mdx
+++ b/components/ui/BadgeGroup/BadgeGroup.mdx
@@ -27,9 +27,9 @@ Badge clusters work well as `Field` values when multiple statuses need to be sho
 
 <Canvas of={Stories.InsideField} />
 
-## Variant mix
+## Appearance mix
 
-Compare dark and light Badge variants inside the same group container. Pick one variant per cluster for visual consistency — BadgeGroup does not enforce this at the API level.
+Compare `solid` and `subtle` Badge appearances inside the same group container. Pick one appearance per cluster for visual consistency — BadgeGroup does not enforce this at the API level.
 
 <Canvas of={Stories.VariantMix} />
 

--- a/components/ui/BadgeGroup/BadgeGroup.stories.tsx
+++ b/components/ui/BadgeGroup/BadgeGroup.stories.tsx
@@ -86,27 +86,28 @@ export const InsideField: Story = {
   ),
 };
 
-/* ─── 4. Variant mix ─────────────────────────────────────────── */
+/* ─── 4. Appearance mix ──────────────────────────────────────── */
 
 export const VariantMix: Story = {
+  name: 'Appearance mix',
   render: () => (
     <Frame width="480px">
       <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
-        <Field label="Dark variants">
+        <Field label="Solid appearance">
           <BadgeGroup>
-            <Badge status="positive" size="sm" variant="dark">Paid</Badge>
-            <Badge status="warning" size="sm" variant="dark">Overdue</Badge>
-            <Badge status="error" size="sm" variant="dark">Failed</Badge>
-            <Badge status="info" size="sm" variant="dark">Scheduled</Badge>
+            <Badge status="positive" size="sm" appearance="solid">Paid</Badge>
+            <Badge status="warning" size="sm" appearance="solid">Overdue</Badge>
+            <Badge status="error" size="sm" appearance="solid">Failed</Badge>
+            <Badge status="info" size="sm" appearance="solid">Scheduled</Badge>
           </BadgeGroup>
         </Field>
 
-        <Field label="Light variants">
+        <Field label="Subtle appearance">
           <BadgeGroup>
-            <Badge status="positive" size="sm" variant="light">Paid</Badge>
-            <Badge status="warning" size="sm" variant="light">Overdue</Badge>
-            <Badge status="error" size="sm" variant="light">Failed</Badge>
-            <Badge status="info" size="sm" variant="light">Scheduled</Badge>
+            <Badge status="positive" size="sm" appearance="subtle">Paid</Badge>
+            <Badge status="warning" size="sm" appearance="subtle">Overdue</Badge>
+            <Badge status="error" size="sm" appearance="subtle">Failed</Badge>
+            <Badge status="info" size="sm" appearance="subtle">Scheduled</Badge>
           </BadgeGroup>
         </Field>
       </div>

--- a/components/ui/Chip/Chip.css
+++ b/components/ui/Chip/Chip.css
@@ -66,28 +66,23 @@
 
 /* ─── Variant + Appearance ────────────────────────────────────── */
 
-.bds-chip--primary-dark {
-  background-color: var(--background-inverse);
-  color: var(--text-inverse);
-}
-
-.bds-chip--primary-light {
-  background-color: transparent;
-  color: var(--text-brand-primary);
-  border: var(--border-width-md) solid var(--border-brand-primary);
-}
-
 .bds-chip--primary-solid {
   background-color: var(--background-inverse);
   color: var(--text-inverse);
 }
 
-.bds-chip--secondary-dark {
+.bds-chip--primary-outline {
+  background-color: transparent;
+  color: var(--text-brand-primary);
+  border: var(--border-width-md) solid var(--border-brand-primary);
+}
+
+.bds-chip--secondary-solid {
   background-color: var(--background-secondary);
   color: var(--text-primary);
 }
 
-.bds-chip--secondary-light {
+.bds-chip--secondary-outline {
   background-color: var(--background-primary);
   color: var(--text-primary);
   border: var(--border-width-md) solid var(--border-secondary);

--- a/components/ui/Chip/Chip.mdx
+++ b/components/ui/Chip/Chip.mdx
@@ -40,10 +40,12 @@ All variant, appearance, size, and state combinations.
 
 <Canvas of={Stories.Variants} />
 
-- **`secondary` + `dark`** — Default filter chip. High contrast.
-- **`secondary` + `light`** — Softer filter chip. Secondary contexts.
-- **`primary` + `dark`** — Active/selected filter. Brand emphasis.
-- **`primary` + `light`** — Active filter with softer appearance.
+- **`secondary` + `solid`** — Default filter chip. High contrast fill.
+- **`secondary` + `outline`** — Softer filter chip. Transparent with neutral border.
+- **`primary` + `solid`** — Active/selected filter. Brand emphasis fill.
+- **`primary` + `outline`** — Active filter with lower-emphasis brand border.
+
+**Appearance** is a shared axis across Badge/Chip/Tag — see [Vocabulary › Axes](/?path=/docs/foundations-vocabulary--overview).
 
 ## Patterns
 
@@ -92,8 +94,8 @@ import { Chip } from '@brik/bds';
 // Removable chip (active filter)
 <Chip label="Status: Active" onRemove={() => removeFilter('status')} />
 
-// Size and variant
-<Chip label="Active" size="sm" variant="primary" appearance="light" />
+// Size, variant, and appearance
+<Chip label="Active" size="sm" variant="primary" appearance="outline" />
 
 // Disabled
 <Chip label="Archived" disabled />

--- a/components/ui/Chip/Chip.stories.tsx
+++ b/components/ui/Chip/Chip.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof Chip> = {
     },
     appearance: {
       control: 'select',
-      options: ['dark', 'light'],
+      options: ['solid', 'outline'],
     },
     showDropdown: { control: 'boolean' },
     disabled: { control: 'boolean' },
@@ -76,10 +76,10 @@ export const Variants: Story = {
       <div>
         <SectionLabel>Variant + Appearance</SectionLabel>
         <Row>
-          <Chip label="Secondary Dark" variant="secondary" appearance="dark" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Secondary Light" variant="secondary" appearance="light" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Primary Dark" variant="primary" appearance="dark" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Primary Light" variant="primary" appearance="light" icon={<Icon icon="ph:funnel" />} showDropdown />
+          <Chip label="Secondary Solid" variant="secondary" appearance="solid" icon={<Icon icon="ph:funnel" />} showDropdown />
+          <Chip label="Secondary Outline" variant="secondary" appearance="outline" icon={<Icon icon="ph:funnel" />} showDropdown />
+          <Chip label="Primary Solid" variant="primary" appearance="solid" icon={<Icon icon="ph:funnel" />} showDropdown />
+          <Chip label="Primary Outline" variant="primary" appearance="outline" icon={<Icon icon="ph:funnel" />} showDropdown />
         </Row>
       </div>
       <div>
@@ -113,7 +113,7 @@ export const Patterns: Story = {
       <div>
         <SectionLabel>Active filters</SectionLabel>
         <Row>
-          <Chip label="Status: Active" variant="primary" appearance="light" onRemove={() => {}} />
+          <Chip label="Status: Active" variant="primary" appearance="outline" onRemove={() => {}} />
           <Chip label="Category: Design" onRemove={() => {}} />
           <Chip label="Date: This week" onRemove={() => {}} />
         </Row>

--- a/components/ui/Chip/Chip.tsx
+++ b/components/ui/Chip/Chip.tsx
@@ -5,17 +5,26 @@ import { bdsClass } from '../../utils';
 import './Chip.css';
 
 export type ChipSize = 'sm' | 'md' | 'lg';
+
+/** Chip hierarchy variant — how much attention the chip commands in a cluster. */
 export type ChipVariant = 'primary' | 'secondary';
-export type ChipAppearance = 'dark' | 'light' | 'solid';
+
+/**
+ * Chip fill appearance — shared axis with Badge (`solid | subtle`) and
+ * Tag (`solid | subtle`). Chip supports the two filled-vs-outlined values.
+ * - `solid`   — filled background, no border.
+ * - `outline` — transparent background with a border in the variant color.
+ */
+export type ChipAppearance = 'solid' | 'outline';
 
 export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Chip label text */
   label: string;
   /** Size variant */
   size?: ChipSize;
-  /** Color variant */
+  /** Hierarchy variant — primary (emphasized) or secondary (neutral). */
   variant?: ChipVariant;
-  /** Filled (dark) or outlined (light) appearance */
+  /** Fill appearance — solid (filled) or outline (transparent + border). */
   appearance?: ChipAppearance;
   /** Optional leading icon */
   icon?: ReactNode;
@@ -35,7 +44,7 @@ export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childre
  * Chip — compact interactive pill for filtering, selection, or input.
  *
  * Pill-shaped with two variants (primary/secondary) and two appearances
- * (dark/light).
+ * (solid/outline).
  *
  * **Action, not indicator.** Chip always represents user-initiated
  * state: filter toggles, selection chips, removable tokens, dropdown
@@ -49,14 +58,14 @@ export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childre
  * ```tsx
  * <Chip label="All statuses" showDropdown onChipClick={openMenu} />
  * <Chip label="Status: Active" onRemove={() => removeFilter('status')} />
- * <Chip label="Selected" variant="primary" appearance="dark" onChipClick={toggle} />
+ * <Chip label="Selected" variant="primary" appearance="solid" onChipClick={toggle} />
  * ```
  */
 export function Chip({
   label,
   size = 'md',
   variant = 'secondary',
-  appearance = 'dark',
+  appearance = 'solid',
   icon,
   avatar,
   showDropdown = false,

--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -18,7 +18,6 @@
   font-weight: var(--font-weight-semi-bold);
   line-height: 1; /* bds-lint-ignore — collapse line box so padding controls spacing symmetrically */
   color: var(--text-primary);
-  background-color: var(--background-secondary);
   text-decoration: none;
   white-space: nowrap;
   text-transform: uppercase;
@@ -28,6 +27,17 @@
   overflow: clip;
   transition: background-color var(--duration-normal) var(--ease-out);
   box-sizing: border-box;
+}
+
+/* ─── Appearance (shared axis with Badge/Chip) ───────────────── */
+
+.bds-tag--solid {
+  background-color: var(--background-secondary);
+}
+
+.bds-tag--subtle {
+  background-color: transparent;
+  border: var(--border-width-md) solid var(--border-secondary);
 }
 
 /* ─── Sizes (shared scale with Badge) ────────────────────────── */

--- a/components/ui/Tag/Tag.mdx
+++ b/components/ui/Tag/Tag.mdx
@@ -32,9 +32,14 @@ Use the Controls panel to explore all props interactively.
 
 ## Variants
 
-Sizes, icon positions, and states in one view.
+Sizes, appearances, icon positions, and states in one view.
 
 <Canvas of={Stories.Variants} />
+
+**Appearance** (shared axis with Badge and Chip — see [Vocabulary › Axes](/?path=/docs/foundations-vocabulary--overview)):
+
+- **`solid`** (default) — Neutral filled background. Matches existing Tag styling.
+- **`subtle`** — Transparent background with a hairline border. Lower visual weight when Tags sit on a colored surface.
 
 ## Patterns
 

--- a/components/ui/Tag/Tag.stories.tsx
+++ b/components/ui/Tag/Tag.stories.tsx
@@ -16,6 +16,10 @@ const meta: Meta<typeof Tag> = {
       control: 'select',
       options: ['xs', 'sm', 'md', 'lg'],
     },
+    appearance: {
+      control: 'select',
+      options: ['solid', 'subtle'],
+    },
     disabled: { control: 'boolean' },
     onRemove: { action: 'removed' },
   },
@@ -69,6 +73,15 @@ export const Variants: Story = {
           <Tag size="sm">Small</Tag>
           <Tag size="md">Medium</Tag>
           <Tag size="lg">Large</Tag>
+        </Row>
+      </div>
+      <div>
+        <SectionLabel>Appearance</SectionLabel>
+        <Row>
+          <Tag appearance="solid">Solid (default)</Tag>
+          <Tag appearance="subtle">Subtle</Tag>
+          <Tag appearance="solid" icon={<Icon icon="ph:tag" />}>Solid + icon</Tag>
+          <Tag appearance="subtle" icon={<Icon icon="ph:tag" />}>Subtle + icon</Tag>
         </Row>
       </div>
       <div>

--- a/components/ui/Tag/Tag.tsx
+++ b/components/ui/Tag/Tag.tsx
@@ -7,12 +7,22 @@ import './Tag.css';
 /** Tag size variants — shared scale with Badge */
 export type TagSize = 'xs' | 'sm' | 'md' | 'lg';
 
+/**
+ * Tag fill appearance — shared axis with Badge (`solid | subtle`) and
+ * Chip (`solid | outline`). Tag supports the two pastel-capable values.
+ * - `solid`  — neutral filled background (current default styling).
+ * - `subtle` — transparent background with a hairline border.
+ */
+export type TagAppearance = 'solid' | 'subtle';
+
 /** Tag component props */
 export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
   /** Tag label content (optional for xs/icon-only size) */
   children?: ReactNode;
   /** Size variant — xs is icon-only (no text) */
   size?: TagSize;
+  /** Fill appearance — solid (neutral fill) or subtle (transparent + border). */
+  appearance?: TagAppearance;
   /** Optional leading icon (left) — required for xs size */
   icon?: ReactNode;
   /** Optional trailing icon (right) */
@@ -45,11 +55,13 @@ export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
  * <Tag>Category</Tag>
  * <Tag size="xs" icon={<Icon />} />
  * <Tag size="lg" icon={<Icon />}>With Icon</Tag>
+ * <Tag appearance="subtle">Outlined</Tag>
  * ```
  */
 export function Tag({
   children,
   size = 'md',
+  appearance = 'solid',
   icon,
   trailingIcon,
   onRemove,
@@ -63,6 +75,7 @@ export function Tag({
   const classes = bdsClass(
     'bds-tag',
     `bds-tag--${size}`,
+    `bds-tag--${appearance}`,
     disabled && 'bds-tag--disabled',
     className
   );

--- a/components/ui/Tag/index.ts
+++ b/components/ui/Tag/index.ts
@@ -1,2 +1,2 @@
-export { Tag, type TagProps, type TagSize } from './Tag';
+export { Tag, type TagProps, type TagSize, type TagAppearance } from './Tag';
 export { default } from './Tag';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Brik Design System \u2014 React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",

--- a/stories/foundation/Vocabulary.mdx
+++ b/stories/foundation/Vocabulary.mdx
@@ -141,3 +141,62 @@ Quick reference. HTML element shown first — it is the load-bearing fact.
 | `<div>` | Slots, containers, wrappers | `__actions`, `__content`, `__header`, `__titles` |
 
 Screen readers walk `<h*>` elements to build the outline. Every `<h*>` decision is an a11y decision. Don't reach for `<h3>` because it "looks right" — use outline position.
+
+---
+
+## Axes — shared prop vocabulary across components
+
+Components with overlapping visual concerns share the same prop names and values. A prop is an **axis** when more than one component exposes it — the axis names belong to the system, not any single component.
+
+| Axis | Values | Meaning | Components |
+|---|---|---|---|
+| `size` | `xs` · `sm` · `md` · `lg` | Physical dimensions on a shared scale (e.g. Badge + Tag + Chip align by height at every tier). | Badge, Tag, Chip, Badge­Group, Tag­Group, Button, IconButton, Field, Sheet, most form controls |
+| `status` | `positive` · `warning` · `error` · `info` · `progress` · `brand` | Semantic value judgment — which system color tier applies. Indicator-only. | Badge, AlertBanner, Dot |
+| `variant` (hierarchy) | `primary` · `secondary` | How much attention the element commands inside a cluster. Not a fill style. | Chip, Button |
+| `appearance` (fill) | `solid` · `subtle` · `outline` | How the shape is filled vs. bordered. Each component supports the subset that has a real visual meaning. | Badge (`solid` / `subtle`), Chip (`solid` / `outline`), Tag (`solid` / `subtle`) |
+
+### The rule
+
+> `variant` describes **hierarchy**. `appearance` describes **fill**. Never conflate them — a chip can be both `variant="primary"` and `appearance="outline"`, and the combination is meaningful.
+
+### Why `solid | subtle | outline` (not `dark | light`)
+
+The older `dark | light` vocabulary was ambiguous with dark-mode theming — `--dark` could mean either "saturated fill" or "variant used on dark themes." `solid | subtle | outline` names the *fill form* explicitly and never collides with the theme axis:
+
+- **`solid`** — filled background, typically saturated or neutral.
+- **`subtle`** — filled with a pastel or tinted background, lower emphasis.
+- **`outline`** — transparent background, visible border.
+
+### Axis coverage matrix
+
+| Component | `variant` | `appearance` values | `status` | Notes |
+|---|---|---|---|---|
+| Badge | — | `solid` (default) · `subtle` | required axis | Outline never made sense for status indicators — low contrast. |
+| Tag | — | `solid` (default) · `subtle` | — | Neutral categorization — no status axis. |
+| Chip | `primary` · `secondary` | `solid` (default) · `outline` | — | Two axes: hierarchy (variant) × fill (appearance). |
+
+Adding a new pill component? Reuse the axis names above. Don't invent `kind`, `style`, `flavor`, etc. — the axes exist so a reader knows what to expect.
+
+---
+
+## Elements — no unclassed wrappers
+
+The element/BEM table above lists which HTML elements each role maps to. The implicit rule is that **every element in a BDS component tree carries a role name** — either a `bds-*` class (when the element belongs to the system) or a `data-*` attribute (when the consumer needs to override something). A `<div>` with no class and no role is drift: it tells the next reader nothing about why the element exists.
+
+### The rule
+
+> Every element in a BDS component tree names its role. Bare `<div>` with no class, no role, no reason to exist is drift — replace it with the correct BEM slot (`__content`, `__actions`, `__header`, etc.) or remove it.
+
+**Acceptable unclassed elements:**
+
+- Short-lived rendering helpers inside a Storybook story file (they don't ship).
+- Children passed in by the consumer (`{children}`) — the consumer owns those names.
+- Fragments (`<>...</>`) — no wrapper exists.
+
+**Not acceptable:**
+
+- `<div>` wrapping a component's output because "it needs a flex container" — name the slot.
+- `<span>` around an icon + label pair — use `__icon` / `__label`.
+- `<div className={classes}>` where `classes` is empty or conditionally empty — ship the class or don't ship the wrapper.
+
+This is a discipline rule, not a build-time lint (yet). If a wrapper is ambiguous about its role, add a BEM class with the role name before you add any CSS.


### PR DESCRIPTION
## Summary
- refactor(vocabulary)!: unify Badge/Chip/Tag fill axis as appearance (solid|subtle|outline)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)