### PR TITLE
feat(modal): add preset='confirm' and deprecate Dialog

### DIFF
--- a/components/ui/Dialog/Dialog.tsx
+++ b/components/ui/Dialog/Dialog.tsx
@@ -22,6 +22,25 @@ export interface DialogProps {
  * Dialog — focused confirmation overlay for user decisions.
  *
  * Simpler than Modal — intended for confirm/cancel flows.
+ *
+ * @deprecated Use `<Modal preset="confirm">` instead. Same behavior, same
+ * API (title, description, confirmLabel, cancelLabel, onConfirm), with
+ * `confirmVariant="destructive"` covering this component's `variant="destructive"`.
+ * Slated for deletion in a future major version once consumers migrate.
+ *
+ * Migration:
+ * ```tsx
+ * // before
+ * <Dialog isOpen={open} onClose={close} title="Delete?" description="..."
+ *   confirmLabel="Delete" onConfirm={handleDelete} variant="destructive" />
+ *
+ * // after
+ * <Modal isOpen={open} onClose={close} preset="confirm" title="Delete?"
+ *   description="..." confirmLabel="Delete" onConfirm={handleDelete}
+ *   confirmVariant="destructive" />
+ * ```
+ *
+ * Tracked under ADR-004 — see docs/adrs/ADR-004-component-bloat-guardrails.md.
  */
 export function Dialog({
   isOpen,

--- a/components/ui/Modal/Modal.css
+++ b/components/ui/Modal/Modal.css
@@ -116,4 +116,45 @@
   flex-wrap: wrap;
   flex-shrink: 0;
 }
+
+/* ─── Preset: confirm ────────────────────────────────────────── */
+/* Compact alertdialog layout — replaces the legacy Dialog component.
+ * No header bar; title + description + auto-rendered footer share one
+ * padded surface. */
+
+/* bds-lint-ignore — design-spec max-width for confirmation dialogs */
+.bds-modal--preset-confirm {
+  max-width: 440px;
+  padding: var(--padding-xl);
+  gap: var(--gap-lg);
+  overflow: visible;
+}
+
+@media (min-width: 768px) {
+  .bds-modal--preset-confirm { min-width: 0; }
+}
+
+.bds-modal__confirm-title {
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-sm);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--font-line-height-snug);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.bds-modal__confirm-description {
+  font-family: var(--font-family-body);
+  font-size: var(--body-md);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.bds-modal__confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--gap-md);
+  flex-wrap: wrap;
+}
 }

--- a/components/ui/Modal/Modal.mdx
+++ b/components/ui/Modal/Modal.mdx
@@ -27,6 +27,36 @@ Size variants, scrolling content, and no close button.
 - **`xl`** — Extra large, data-heavy views
 - **`full`** — Full screen
 
+## Confirm preset
+
+`preset="confirm"` collapses the legacy `Dialog` component into Modal as a compact `alertdialog` shape with auto-rendered confirm/cancel buttons. Use `confirmVariant="destructive"` for delete-type actions.
+
+The preset:
+- sets `role="alertdialog"` and a tighter 440px width
+- hides the X close button (footer is the dismissal surface)
+- auto-renders Cancel / Confirm buttons from `confirmLabel` / `cancelLabel` / `onConfirm`
+- supports `confirmVariant: 'primary' | 'destructive'` for destructive flows
+- accepts `confirmDisabled` and `confirmLoading` for in-flight requests
+
+Pass a custom `footer` to override the auto-rendered actions while keeping the rest of the preset.
+
+<Canvas of={Stories.ConfirmPreset} />
+
+```tsx
+<Modal
+  isOpen={open}
+  onClose={close}
+  preset="confirm"
+  title="Delete this item?"
+  description="This action cannot be undone."
+  confirmLabel="Delete"
+  confirmVariant="destructive"
+  onConfirm={handleDelete}
+/>
+```
+
+The standalone `Dialog` component is `@deprecated` and slated for deletion in a future major version. Migrate to `Modal preset="confirm"` — same prop names, same behavior. See [ADR-004](../../docs/adrs/ADR-004-component-bloat-guardrails.md).
+
 ## Patterns
 
 Confirm delete and form in modal.

--- a/components/ui/Modal/Modal.stories.tsx
+++ b/components/ui/Modal/Modal.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { Meta } from '@storybook/react-vite';
 import { expect, userEvent, within } from 'storybook/test';
 import { useState } from 'react';
 import { Modal } from './Modal';
@@ -17,7 +17,6 @@ const meta: Meta<typeof Modal> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
 
 /* ─── Layout helpers ─────────────────────────────────────────── */
 
@@ -41,16 +40,17 @@ const Row = ({ children }: { children: React.ReactNode }) => (
 
 /* ─── Playground ─────────────────────────────────────────────── */
 
-export const Playground: Story = {
-  render: (args) => {
+export const Playground = {
+  render: () => {
     const [isOpen, setIsOpen] = useState(false);
     return (
       <>
         <Button onClick={() => setIsOpen(true)}>Open modal</Button>
         <Modal
-          {...args}
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
+          title="Title goes here"
+          size="md"
           footer={
             <>
               <Button variant="ghost" onClick={() => setIsOpen(false)}>Cancel</Button>
@@ -63,14 +63,7 @@ export const Playground: Story = {
       </>
     );
   },
-  args: {
-    isOpen: false,
-    onClose: () => {},
-    children: null,
-    title: 'Title goes here',
-    size: 'md',
-  },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
     const trigger = canvas.getByRole('button', { name: 'Open modal' });
 
@@ -89,8 +82,7 @@ export const Playground: Story = {
 
 /* ─── Variants ───────────────────────────────────────────────── */
 
-export const Variants: Story = {
-  render: () => {
+export const Variants = () => {
     const [openId, setOpenId] = useState<string | null>(null);
     const open = (id: string) => setOpenId(id);
     const close = () => setOpenId(null);
@@ -156,13 +148,63 @@ export const Variants: Story = {
         </Row>
       </Stack>
     );
-  },
+};
+
+/* ─── Confirm preset ─────────────────────────────────────────── */
+
+/**
+ * `preset="confirm"` — compact alertdialog with auto-rendered confirm/cancel
+ * footer. Replaces the legacy `Dialog` component (per ADR-004).
+ *
+ * Use `confirmVariant="destructive"` for delete-type actions; the confirm
+ * button switches to the danger color while keeping the same shape.
+ */
+export const ConfirmPreset = () => {
+    const [openId, setOpenId] = useState<string | null>(null);
+    const open = (id: string) => setOpenId(id);
+    const close = () => setOpenId(null);
+
+    return (
+      <Stack>
+        <SectionLabel>Default confirm</SectionLabel>
+        <Row>
+          <div>
+            <Button onClick={() => open('default')}>Confirm action</Button>
+            <Modal
+              isOpen={openId === 'default'}
+              onClose={close}
+              preset="confirm"
+              title="Save changes?"
+              description="Your edits will be applied to the live record."
+              confirmLabel="Save"
+              onConfirm={close}
+            />
+          </div>
+        </Row>
+
+        <SectionLabel>Destructive confirm</SectionLabel>
+        <Row>
+          <div>
+            <Button variant="destructive" onClick={() => open('destructive')}>Delete item</Button>
+            <Modal
+              isOpen={openId === 'destructive'}
+              onClose={close}
+              preset="confirm"
+              title="Delete this item?"
+              description="This action cannot be undone."
+              confirmLabel="Delete"
+              confirmVariant="destructive"
+              onConfirm={close}
+            />
+          </div>
+        </Row>
+      </Stack>
+    );
 };
 
 /* ─── Patterns ───────────────────────────────────────────────── */
 
-export const Patterns: Story = {
-  render: () => {
+export const Patterns = () => {
     const [openId, setOpenId] = useState<string | null>(null);
     const open = (id: string) => setOpenId(id);
     const close = () => setOpenId(null);
@@ -219,5 +261,4 @@ export const Patterns: Story = {
         </Row>
       </Stack>
     );
-  },
 };

--- a/components/ui/Modal/Modal.tsx
+++ b/components/ui/Modal/Modal.tsx
@@ -1,39 +1,123 @@
-import { type ReactNode, useEffect, useRef } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Icon } from '@iconify/react';
 import { X } from '../../icons';
+import { Button } from '../Button';
 import { bdsClass } from '../../utils';
 import './Modal.css';
 
 export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
+export type ModalPreset = 'confirm';
+export type ModalConfirmVariant = 'primary' | 'destructive';
 
-export interface ModalProps {
+interface ModalBaseProps {
   isOpen: boolean;
   onClose: () => void;
   title?: ReactNode;
-  children: ReactNode;
-  footer?: ReactNode;
   size?: ModalSize;
   closeOnBackdrop?: boolean;
   closeOnEscape?: boolean;
+}
+
+interface ModalDefaultProps extends ModalBaseProps {
+  /**
+   * Default modal — flexible header / body / footer layout.
+   *
+   * Provide `children` for the body and an optional `footer` slot for
+   * actions. Pair with `showCloseButton={false}` if the footer alone
+   * should be the dismissal surface.
+   */
+  preset?: undefined;
+  /** Body content */
+  children: ReactNode;
+  /** Optional footer ReactNode (typically Button(s)) */
+  footer?: ReactNode;
+  /** Show the X close button in the header (default true) */
   showCloseButton?: boolean;
 }
 
+interface ModalConfirmPresetProps extends ModalBaseProps {
+  /**
+   * Confirm preset — compact alertdialog with title + description + locked
+   * confirm/cancel footer. Replaces the legacy `Dialog` component
+   * (per ADR-004 §"Resolve the existing instances").
+   *
+   * The preset:
+   *   - sets `role="alertdialog"` and a tighter 440px width
+   *   - hides the X close button (footer is the dismissal surface)
+   *   - auto-renders Cancel / Confirm buttons from `confirmLabel`,
+   *     `cancelLabel`, `onConfirm`
+   *   - supports `confirmVariant="destructive"` for delete-type actions
+   *
+   * Pass a custom `footer` to override the auto-rendered actions while
+   * keeping the rest of the preset.
+   */
+  preset: 'confirm';
+  /** Description text rendered under the title */
+  description?: ReactNode;
+  /** Optional override for the auto-rendered footer */
+  footer?: ReactNode;
+  /** Confirm button label (default "Confirm") */
+  confirmLabel?: string;
+  /** Cancel button label (default "Cancel") */
+  cancelLabel?: string;
+  /** Confirm action — required for the auto-rendered footer */
+  onConfirm?: () => void;
+  /** Visual treatment of the confirm button (default 'primary') */
+  confirmVariant?: ModalConfirmVariant;
+  /** Disable the confirm button (e.g. while a request is in flight) */
+  confirmDisabled?: boolean;
+  /** Show loading state on the confirm button */
+  confirmLoading?: boolean;
+  /** Optional extra body content rendered between description and footer */
+  children?: ReactNode;
+}
+
+export type ModalProps = ModalDefaultProps | ModalConfirmPresetProps;
+
 /**
- * Modal — portal-rendered dialog with backdrop, escape key, and scroll lock.
+ * Modal — portal-rendered overlay with backdrop, escape key, and scroll lock.
+ *
+ * Two shapes share the same primitive:
+ *
+ * - **Default** (no `preset`) — flexible header / body / footer layout.
+ *   Use for forms, multi-step flows, content viewers.
+ * - **`preset="confirm"`** — compact `alertdialog` with auto-rendered
+ *   confirm/cancel buttons. Replaces the legacy `Dialog` component.
+ *
+ * @example Default
+ * ```tsx
+ * <Modal isOpen={open} onClose={close} title="Edit profile" size="md"
+ *   footer={<><Button variant="ghost" onClick={close}>Cancel</Button>
+ *            <Button variant="primary" onClick={save}>Save</Button></>}>
+ *   <ProfileForm />
+ * </Modal>
+ * ```
+ *
+ * @example Confirm preset
+ * ```tsx
+ * <Modal
+ *   isOpen={open}
+ *   onClose={close}
+ *   preset="confirm"
+ *   title="Delete this item?"
+ *   description="This action cannot be undone."
+ *   confirmLabel="Delete"
+ *   confirmVariant="destructive"
+ *   onConfirm={handleDelete}
+ * />
+ * ```
  */
-export function Modal({
-  isOpen,
-  onClose,
-  title,
-  children,
-  footer,
-  size = 'md',
-  closeOnBackdrop = true,
-  closeOnEscape = true,
-  showCloseButton = true,
-}: ModalProps) {
-  const modalRef = useRef<HTMLDivElement>(null);
+export function Modal(props: ModalProps) {
+  const {
+    isOpen,
+    onClose,
+    size = 'md',
+    closeOnBackdrop = true,
+    closeOnEscape = true,
+  } = props;
+
+  const isConfirmPreset = props.preset === 'confirm';
 
   useEffect(() => {
     if (!isOpen || !closeOnEscape) return;
@@ -57,36 +141,104 @@ export function Modal({
 
   if (!isOpen) return null;
 
-  const modal = (
+  const modal = isConfirmPreset
+    ? renderConfirmPreset(props as ModalConfirmPresetProps, onClose)
+    : renderDefault(props as ModalDefaultProps, onClose, size);
+
+  return createPortal(
     <div className="bds-modal-backdrop" onClick={handleBackdropClick}>
-      <div
-        ref={modalRef}
-        className={bdsClass('bds-modal', `bds-modal--${size}`)}
-        role="dialog"
-        aria-modal="true"
+      {modal}
+    </div>,
+    document.body,
+  );
+}
+
+function renderDefault(
+  { title, children, footer, showCloseButton = true }: ModalDefaultProps,
+  onClose: () => void,
+  size: ModalSize,
+) {
+  return (
+    <div
+      className={bdsClass('bds-modal', `bds-modal--${size}`)}
+      role="dialog"
+      aria-modal="true"
+    >
+      {(title || showCloseButton) && (
+        <div className="bds-modal__header">
+          {title && <h2 className="bds-modal__title">{title}</h2>}
+          {showCloseButton && (
+            <button
+              type="button"
+              className="bds-modal__close"
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <Icon icon={X} />
+            </button>
+          )}
+        </div>
+      )}
+      <div className="bds-modal__body">{children}</div>
+      {footer && <div className="bds-modal__footer">{footer}</div>}
+    </div>
+  );
+}
+
+function renderConfirmPreset(
+  {
+    title,
+    description,
+    children,
+    footer,
+    confirmLabel = 'Confirm',
+    cancelLabel = 'Cancel',
+    onConfirm,
+    confirmVariant = 'primary',
+    confirmDisabled,
+    confirmLoading,
+  }: ModalConfirmPresetProps,
+  onClose: () => void,
+) {
+  const titleId = 'bds-modal-confirm-title';
+  const descId = description ? 'bds-modal-confirm-desc' : undefined;
+
+  const autoFooter = (
+    <>
+      <Button variant="secondary" onClick={onClose}>
+        {cancelLabel}
+      </Button>
+      <Button
+        variant={confirmVariant === 'destructive' ? 'destructive' : 'primary'}
+        onClick={() => onConfirm?.()}
+        disabled={confirmDisabled}
+        loading={confirmLoading}
       >
-        {(title || showCloseButton) && (
-          <div className="bds-modal__header">
-            {title && <h2 className="bds-modal__title">{title}</h2>}
-            {showCloseButton && (
-              <button
-                type="button"
-                className="bds-modal__close"
-                onClick={onClose}
-                aria-label="Close"
-              >
-                <Icon icon={X} />
-              </button>
-            )}
-          </div>
-        )}
-        <div className="bds-modal__body">{children}</div>
-        {footer && <div className="bds-modal__footer">{footer}</div>}
+        {confirmLabel}
+      </Button>
+    </>
+  );
+
+  return (
+    <div
+      className={bdsClass('bds-modal', 'bds-modal--preset-confirm')}
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby={title ? titleId : undefined}
+      aria-describedby={descId}
+    >
+      {title && (
+        <h2 id={titleId} className="bds-modal__confirm-title">{title}</h2>
+      )}
+      {description && (
+        <p id={descId} className="bds-modal__confirm-description">{description}</p>
+      )}
+      {children}
+      <div className="bds-modal__confirm-actions">
+        {footer ?? autoFooter}
       </div>
     </div>
   );
-
-  return createPortal(modal, document.body);
 }
 
 export default Modal;


### PR DESCRIPTION
## Summary

Punch-list item #3 from the [2026-Q2 component bloat audit](docs/audits/2026-Q2-component-bloat-audit.md). Per [ADR-004](docs/adrs/ADR-004-component-bloat-guardrails.md): `Dialog` replicates `Modal`'s lifecycle line-for-line and hardcodes a confirm/cancel layout — exactly the forks-as-components pattern.

**Different from PRs #234 and #235**: Dialog has 5 active consumers (portal: 3, renew-pms: 2) so this PR is **additive only** — no breakage. Dialog stays exported, just `@deprecated`. Consumer migration happens in follow-up task branches before the component is deleted.

## What changed

### Modal (additive)
- New discriminated union: `{ preset?: 'confirm' }` enables a compact `alertdialog` (440px) with auto-rendered confirm/cancel footer built on BDS Button (`variant='primary'|'destructive'`)
- New props on the confirm preset: `description`, `confirmLabel`, `cancelLabel`, `onConfirm`, `confirmVariant`, `confirmDisabled`, `confirmLoading`
- Custom `footer` overrides the auto-rendered actions while keeping the preset's compact shape and `alertdialog` role
- Default Modal API unchanged — existing consumers unaffected

### Dialog (deprecation only — file preserved)
- `@deprecated` JSDoc on the component with migration code
- 5 consumer files queued for follow-up migration before deletion

### Stories + docs
- New `ConfirmPreset` story showing default + destructive variants
- `Modal.mdx` documents the preset and links to ADR-004
- Story-typed exports converted to plain functions where the discriminated union breaks the strict `args` inference

## Migration

```tsx
// before
<Dialog
  isOpen={open}
  onClose={close}
  title="Delete this item?"
  description="This cannot be undone."
  confirmLabel="Delete"
  onConfirm={handleDelete}
  variant="destructive"
/>

// after
<Modal
  isOpen={open}
  onClose={close}
  preset="confirm"
  title="Delete this item?"
  description="This cannot be undone."
  confirmLabel="Delete"
  onConfirm={handleDelete}
  confirmVariant="destructive"
/>
```

## Consumer migration (follow-up tasks)

These are queued as separate task branches — **not part of this PR**:

| Repo | Files | Branch |
|---|---|---|
| portal | task-table.tsx, task-console-provider.tsx, audit-competitor-button.tsx | `task/portal-dialog-to-modal-confirm` |
| renew-pms | ConfirmDeleteDialog.tsx, ViewRequestSheet.tsx | `task/renew-pms-dialog-to-modal-confirm` |
| bds | Delete Dialog folder + remove export, major version bump | `task/bds-dialog-deletion` |

## Test plan

- [x] Token linter clean (pre-commit)
- [x] TypeScript typecheck clean — discriminated union narrows correctly
- [x] Anti-slop scan clean (pre-commit)
- [x] Storybook MCP confirms ConfirmPreset story renders
- [ ] Reviewer: visual diff `Modal preset='confirm'` vs the existing `Dialog` baseline (Chromatic)
- [ ] Reviewer: confirm destructive variant button color matches Dialog's existing destructive style

## Preview

- [Confirm Preset](http://localhost:6006/?path=/story/displays-overlay-modal--confirm-preset) — default + destructive
- [Variants](http://localhost:6006/?path=/story/displays-overlay-modal--variants) — confirm existing Modal API still works

## Audit progress

| # | Item | Status |
|---|---|---|
| 1 | EmailInput / SearchInput | Merged |
| 2 | ProgressDots → ProgressStepper | Merged |
| 3 | Dialog → Modal preset | **This PR — additive** |
| 4 | AlertBanner ↔ Banner | Next |
| 5 | Snackbar ↔ Toast | Queued |
| 6 | Menu → Popover preset | Queued |
| 7 | Card variants consolidation | Queued |
| 8 | ServiceBadge REVIEW | Queued |
| 9 | CardList REVIEW | Queued |

🤖 Generated with [Claude Code](https://claude.com/claude-code)