### PR TITLE
feat(banner): add tone prop and deprecate AlertBanner

### DIFF
--- a/components/ui/AlertBanner/AlertBanner.tsx
+++ b/components/ui/AlertBanner/AlertBanner.tsx
@@ -35,6 +35,25 @@ const iconMap: Record<AlertBannerVariant, string> = {
  *
  * Uses a secondary surface background with an icon-only Badge,
  * title, description, and optional action button.
+ *
+ * @deprecated Use `<Banner tone="warning|error|information">` instead.
+ * Same shape, same visual treatment, with `tone="information"` covering
+ * the previous `variant="information"` default. The consolidated Banner
+ * component also supports `onDismiss` for a close button. Slated for
+ * deletion in a future major version once consumers migrate.
+ *
+ * Migration:
+ * ```tsx
+ * // before
+ * <AlertBanner variant="warning" title="Heads up" description="..."
+ *   action={<Button>Review</Button>} />
+ *
+ * // after
+ * <Banner tone="warning" title="Heads up" description="..."
+ *   action={<Button>Review</Button>} />
+ * ```
+ *
+ * Tracked under ADR-004 — see docs/adrs/ADR-004-component-bloat-guardrails.md.
  */
 export function AlertBanner({
   title,

--- a/components/ui/Banner/Banner.css
+++ b/components/ui/Banner/Banner.css
@@ -1,5 +1,5 @@
 @layer bds-components {
-/* ─── Banner ─────────────────────────────────────────────────── */
+/* ─── Banner — base layout (shared across tones) ──────────────── */
 
 .bds-banner {
   display: flex;
@@ -7,15 +7,21 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--gap-lg);
-  background-color: var(--surface-brand-primary);
-  color: var(--text-on-color-dark);
-  padding: var(--padding-md) var(--padding-huge);
-  border-radius: var(--border-radius-100);
   width: 100%;
   box-sizing: border-box;
 }
 
-/* ─── Content — title stacked above description ────────────────── */
+/* ─── Inner — optional leading badge + content ───────────────── */
+
+.bds-banner__inner {
+  display: flex;
+  gap: var(--gap-sm);
+  align-items: center;
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+/* ─── Content — title stacked above description ───────────────── */
 
 .bds-banner__content {
   display: flex;
@@ -23,6 +29,7 @@
   align-items: flex-start;
   gap: var(--gap-xs);
   min-width: 0;
+  flex: 1 1 0;
 }
 
 /* ─── Title ──────────────────────────────────────────────────── */
@@ -70,5 +77,40 @@
 
 .bds-banner__close:hover {
   opacity: 1;
+}
+
+/* ─── Tone: announcement (brand-primary surface) ──────────────── */
+
+.bds-banner--tone-announcement {
+  background-color: var(--surface-brand-primary);
+  color: var(--text-on-color-dark);
+  padding: var(--padding-md) var(--padding-huge);
+  border-radius: var(--border-radius-100);
+}
+
+/* ─── Tones: warning / error / information (status surfaces) ──── */
+/* Replaces the legacy AlertBanner styling. Secondary surface, primary
+ * text, leading Badge icon. Wider stack gap matches the alert hierarchy. */
+
+.bds-banner--tone-warning,
+.bds-banner--tone-error,
+.bds-banner--tone-information {
+  background-color: var(--surface-secondary);
+  color: var(--text-primary);
+  padding: var(--padding-lg);
+  border-radius: var(--border-radius-sm);
+  align-items: flex-start;
+}
+
+.bds-banner--tone-warning .bds-banner__inner,
+.bds-banner--tone-error .bds-banner__inner,
+.bds-banner--tone-information .bds-banner__inner {
+  align-items: flex-start;
+}
+
+.bds-banner--tone-warning .bds-banner__content,
+.bds-banner--tone-error .bds-banner__content,
+.bds-banner--tone-information .bds-banner__content {
+  gap: var(--gap-sm);
 }
 }

--- a/components/ui/Banner/Banner.mdx
+++ b/components/ui/Banner/Banner.mdx
@@ -3,9 +3,12 @@ import * as Stories from './Banner.stories';
 
 <Meta of={Stories} />
 
-# Marketing banner
+# Banner
 
-Full-width branded banner for announcements, promotions, and site-wide notices. Uses brand-primary background with inverse text.
+Full-width contextual banner. One component covers two visual modes via the `tone` prop:
+
+- **`tone="announcement"`** (default) — brand-primary surface with inverse text. Use for marketing notices, promotions, and site-wide announcements.
+- **`tone="warning" | "error" | "information"`** — secondary surface with a leading status Badge and `role="alert"`. Replaces the legacy `AlertBanner` component (per [ADR-004](../../docs/adrs/ADR-004-component-bloat-guardrails.md)).
 
 ---
 
@@ -15,11 +18,17 @@ Use the Controls panel to explore all props interactively.
 
 <Canvas of={Stories.Playground} />
 
-## Variants
+## Announcement variants
 
-Action, title-only, and dismissible configurations.
+Action, title-only, and dismissible configurations on the brand surface.
 
 <Canvas of={Stories.Variants} />
+
+## Status tones
+
+Information / warning / error tones with leading status Badge.
+
+<Canvas of={Stories.Tones} />
 
 ## Patterns
 
@@ -40,10 +49,21 @@ Real-world usage: announcements and dismissible notices.
 ```tsx
 import { Banner, Button } from '@brik/bds';
 
+// Announcement
 <Banner
   title="New feature"
   description="Check out our latest update"
   action={<Button variant="secondary" size="sm">Learn more</Button>}
   onDismiss={() => setVisible(false)}
 />
+
+// Status alert (replaces AlertBanner)
+<Banner
+  tone="warning"
+  title="Heads up"
+  description="Your trial ends in 7 days."
+  action={<Button size="sm">Upgrade</Button>}
+/>
 ```
+
+The standalone `AlertBanner` component is `@deprecated` and slated for deletion in a future major version. Migrate `<AlertBanner variant="warning">` to `<Banner tone="warning">` — same shape, same Badge, same surface.

--- a/components/ui/Banner/Banner.stories.tsx
+++ b/components/ui/Banner/Banner.stories.tsx
@@ -4,12 +4,13 @@ import { Banner } from './Banner';
 import { Button } from '../Button';
 
 const meta: Meta<typeof Banner> = {
-  title: 'Components/Feedback/marketing-banner',
+  title: 'Components/Feedback/banner',
   component: Banner,
   parameters: { layout: 'padded' },
   argTypes: {
     title: { control: 'text' },
     description: { control: 'text' },
+    tone: { control: 'select', options: ['announcement', 'warning', 'error', 'information'] },
   },
 };
 
@@ -49,7 +50,7 @@ export const Playground: Story = {
 export const Variants: Story = {
   render: () => (
     <Stack>
-      <SectionLabel>With action</SectionLabel>
+      <SectionLabel>Announcement (default — brand surface)</SectionLabel>
       <Banner
         title="Limited time offer"
         description="Save 20% on all plans this month"
@@ -64,6 +65,51 @@ export const Variants: Story = {
         title="Cookie notice"
         description="We use cookies to improve your experience"
         action={<BannerAction>Accept</BannerAction>}
+        onDismiss={() => {}}
+      />
+    </Stack>
+  ),
+};
+
+/* ─── Tones (replaces AlertBanner) ───────────────────────────── */
+
+/**
+ * The status tones — `warning`, `error`, `information` — replace the
+ * legacy `AlertBanner` component (per ADR-004 §3). Same shape as the
+ * announcement tone, with a leading status Badge and an `alert` ARIA
+ * role for assistive tech.
+ */
+export const Tones: Story = {
+  render: () => (
+    <Stack>
+      <SectionLabel>Information</SectionLabel>
+      <Banner
+        tone="information"
+        title="Heads up"
+        description="Your trial period ends in 7 days. Upgrade to keep access."
+        action={<Button size="sm">Upgrade</Button>}
+      />
+
+      <SectionLabel>Warning</SectionLabel>
+      <Banner
+        tone="warning"
+        title="Slow connection detected"
+        description="Some features may take longer to respond."
+      />
+
+      <SectionLabel>Error</SectionLabel>
+      <Banner
+        tone="error"
+        title="Sync failed"
+        description="We couldn't reach the server. Check your connection and try again."
+        action={<Button size="sm" variant="secondary">Retry</Button>}
+      />
+
+      <SectionLabel>Status banner with dismiss</SectionLabel>
+      <Banner
+        tone="information"
+        title="What&apos;s new in v2.0"
+        description="Auto-saving drafts, faster search, and dark mode."
         onDismiss={() => {}}
       />
     </Stack>

--- a/components/ui/Banner/Banner.tsx
+++ b/components/ui/Banner/Banner.tsx
@@ -1,38 +1,90 @@
 import { type ReactNode, type HTMLAttributes } from 'react';
+import { Icon } from '@iconify/react';
+import { Warning, Info } from '../../icons';
+import { Badge } from '../Badge';
 import { bdsClass } from '../../utils';
 import './Banner.css';
+
+export type BannerTone = 'announcement' | 'warning' | 'error' | 'information';
 
 export interface BannerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /** Bold title text */
   title: ReactNode;
-  /** Description text beside the title */
+  /** Description text beside or below the title */
   description?: ReactNode;
+  /**
+   * Visual tone:
+   * - `announcement` (default) — brand-primary surface for marketing notices
+   * - `warning` / `error` / `information` — secondary surface with leading
+   *   status Badge icon. Switches `role` to `alert` for assistive tech.
+   *   Replaces the legacy `AlertBanner` component.
+   */
+  tone?: BannerTone;
   /** Action element (e.g. Button) aligned to the right */
   action?: ReactNode;
   /** Dismissible — shows close button and calls onDismiss */
   onDismiss?: () => void;
 }
 
+const STATUS_ICON: Record<Exclude<BannerTone, 'announcement'>, string> = {
+  warning: Warning,
+  error: Warning,
+  information: Info,
+};
+
+const STATUS_BADGE: Record<Exclude<BannerTone, 'announcement'>, 'warning' | 'error' | 'info'> = {
+  warning: 'warning',
+  error: 'error',
+  information: 'info',
+};
+
 /**
- * Banner — full-width branded banner for announcements
+ * Banner — full-width contextual banner.
  *
- * Uses brand-primary surface with inverse text. Ideal for
- * announcements, promotions, or site-wide notices.
+ * Two tone families share the same component:
+ *
+ * - **`announcement`** (default) — brand-primary surface with inverse text.
+ *   Use for site-wide announcements, promotions, or marketing notices.
+ *   Renders with `role="banner"`.
+ * - **`warning` / `error` / `information`** — secondary surface with a
+ *   leading status Badge icon and primary text. Renders with `role="alert"`.
+ *   Replaces the legacy `AlertBanner` component (per ADR-004 §3 — same
+ *   shape, different presets = one component with a tone prop).
  */
 export function Banner({
   title,
   description,
+  tone = 'announcement',
   action,
   onDismiss,
   className,
   style,
   ...props
 }: BannerProps) {
+  const isStatus = tone !== 'announcement';
+  const role = isStatus ? 'alert' : 'banner';
+
+  const badge = isStatus ? (
+    <Badge
+      size="xs"
+      status={STATUS_BADGE[tone]}
+      icon={<Icon icon={STATUS_ICON[tone]} />}
+    />
+  ) : null;
+
   return (
-    <div role="banner" className={bdsClass('bds-banner', className)} style={style} {...props}>
-      <div className="bds-banner__content">
-        <span className="bds-banner__title">{title}</span>
-        {description && <span className="bds-banner__description">{description}</span>}
+    <div
+      role={role}
+      className={bdsClass('bds-banner', `bds-banner--tone-${tone}`, className)}
+      style={style}
+      {...props}
+    >
+      <div className="bds-banner__inner">
+        {badge}
+        <div className="bds-banner__content">
+          <span className="bds-banner__title">{title}</span>
+          {description && <span className="bds-banner__description">{description}</span>}
+        </div>
       </div>
       {(action || onDismiss) && (
         <div className="bds-banner__actions">


### PR DESCRIPTION
## Summary

Punch-list item #4 from the [2026-Q2 component bloat audit](docs/audits/2026-Q2-component-bloat-audit.md). Per [ADR-004 §3](docs/adrs/ADR-004-component-bloat-guardrails.md): `AlertBanner` and `Banner` share the same `{title, description, action}` shape; their differences are presets (brand surface vs status surface, optional Badge, ARIA role).

Same pattern as PR #236 — **additive only**. AlertBanner has 2 portal consumers, so this PR adds `tone` to Banner and `@deprecated`s AlertBanner without deleting it.

## What changed

### Banner (additive)
- New `tone: 'announcement' | 'warning' | 'error' | 'information'` prop
- `tone="announcement"` (default) preserves the existing brand-primary surface — zero visual change for existing Banner consumers
- Status tones render a leading status Badge (info/warning/error icon) and switch ARIA role to `alert` for assistive tech
- `onDismiss` now works across all tones — previously announcement-only
- Sidebar moved `Components/Feedback/marketing-banner` → `Components/Feedback/banner` (the "marketing" qualifier was misleading once Banner covers status alerts too)

### AlertBanner (deprecation only — file preserved)
- `@deprecated` JSDoc on the component with migration code
- 2 portal consumer files queued for follow-up migration before deletion

### Stories + docs
- New `Tones` story showing information/warning/error + dismissible variant
- `Banner.mdx` documents both modes and links to ADR-004

## Migration

```tsx
// before
<AlertBanner
  variant="warning"
  title="Heads up"
  description="Your trial ends in 7 days."
  action={<Button>Upgrade</Button>}
/>

// after
<Banner
  tone="warning"
  title="Heads up"
  description="Your trial ends in 7 days."
  action={<Button>Upgrade</Button>}
/>
```

Same prop names, same shape, same Badge.

## Consumer migration (follow-up tasks)

Queued as a separate branch — **not in this PR**:

| Repo | Files | Branch |
|---|---|---|
| portal | sections-view.tsx, run-analysis-button.tsx | `task/portal-alert-banner-to-banner-tone` |
| bds | Delete AlertBanner folder + remove export, major bump | `task/bds-alert-banner-deletion` |

## Test plan

- [x] Token linter clean (pre-commit)
- [x] TypeScript typecheck clean
- [x] Anti-slop scan clean (pre-commit)
- [x] Storybook MCP confirms `Tones` story renders
- [ ] Reviewer: visual diff `Banner tone="warning"` vs the existing `AlertBanner variant="warning"` (should match)
- [ ] Reviewer: confirm announcement tone unchanged (no visual regression for current Banner consumers)

## Preview

- [Banner — Variants (announcement)](http://localhost:6006/?path=/story/components-feedback-banner--variants)
- [Banner — Tones (replaces AlertBanner)](http://localhost:6006/?path=/story/components-feedback-banner--tones)

## Audit progress

| # | Item | Status |
|---|---|---|
| 1 | EmailInput / SearchInput | Merged |
| 2 | ProgressDots → ProgressStepper | Merged |
| 3 | Dialog → Modal preset | PR #236 (open, additive) |
| 4 | AlertBanner ↔ Banner | **This PR** (additive) |
| 5 | Snackbar ↔ Toast | Next |
| 6 | Menu → Popover preset | Queued |
| 7 | Card variants consolidation | Queued |
| 8 | ServiceBadge REVIEW | Queued |
| 9 | CardList REVIEW | Queued |

🤖 Generated with [Claude Code](https://claude.com/claude-code)