### PR TITLE
bds: deprecated manifest tags

### DIFF
--- a/components/ui/AlertBanner/AlertBanner.stories.tsx
+++ b/components/ui/AlertBanner/AlertBanner.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof AlertBanner> = {
   title: 'Components/Feedback/alert-banner',
   component: AlertBanner,
+  tags: ['!manifest'], // deprecated — hide from MCP discovery (use Banner)
   parameters: { layout: 'padded' },
   argTypes: {
     title: { control: 'text' },

--- a/components/ui/Dialog/Dialog.stories.tsx
+++ b/components/ui/Dialog/Dialog.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof Dialog> = {
   title: 'Displays/Overlay/dialog',
   component: Dialog,
+  tags: ['!manifest'], // deprecated — hide from MCP discovery (use Modal preset="confirm")
   parameters: { layout: 'centered' },
   argTypes: {
     variant: { control: 'select', options: ['default', 'destructive'] },


### PR DESCRIPTION
## Summary
- chore(stories): hide deprecated AlertBanner + Dialog from MCP manifest

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)