### PR TITLE
docs(audit): close out items #8 (ServiceBadge) and #9 (CardList)

### DIFF
--- a/components/ui/ServiceBadge/ServiceBadge.tsx
+++ b/components/ui/ServiceBadge/ServiceBadge.tsx
@@ -96,7 +96,13 @@ const iconScaleMap: Record<ServiceBadgeSize, number> = { sm: 0.55, md: 0.6, lg: 
 const boxSizeMap: Record<ServiceBadgeSize, number> = { sm: 20, md: 28, lg: 40 };
 
 /**
- * @deprecated Use `ServiceTag variant="icon"` instead. ServiceBadge is kept for backwards compatibility only.
+ * @deprecated Use `ServiceTag variant="icon"` instead. ServiceBadge has zero
+ * external consumers (verified during 2026-Q2 component bloat audit) and is
+ * slated for deletion in a future major version.
+ *
+ * Full deletion is blocked on extracting `categoryConfig` and
+ * `getServiceIconPath` (currently exported from this file and consumed by
+ * `ServiceTag`) into a shared utility module. Tracked as a follow-up task.
  *
  * ServiceBadge — icon-only colored square badge for a Brik service category.
  * The `mode="label"` prop is no longer supported; use `ServiceTag` for text labels.

--- a/docs/audits/2026-Q2-component-bloat-audit.md
+++ b/docs/audits/2026-Q2-component-bloat-audit.md
@@ -108,7 +108,7 @@ Plus the bloat already booked in [ADR-003](../adrs/ADR-003-addable-list-family.m
 - `Skeleton` — content placeholder shimmer. No overlap.
 - `Spinner` — rotating loader. No overlap with Skeleton (loader vs placeholder).
 - `Badge` — already consolidated with Chip/Tag in [PR #229](https://github.com/brikdesigns/brik-bds/pull/229). Out of scope.
-- `ServiceBadge` — domain-specific (Brik service-category icon). The `mode` prop is `@deprecated` ([ServiceBadge.tsx:7](../../components/ui/ServiceBadge/ServiceBadge.tsx#L7)) pointing to `ServiceTag`. The component itself isn't deprecated, but the deprecation note hints that `ServiceTag variant="icon"` may already cover its visual. **Flag as REVIEW** — confirm whether ServiceBadge has any callers that ServiceTag can't serve; if not, retire it.
+- `ServiceBadge` — domain-specific (Brik service-category icon). The `mode` prop is `@deprecated` ([ServiceBadge.tsx:7](../../components/ui/ServiceBadge/ServiceBadge.tsx#L7)) pointing to `ServiceTag`. **Reviewed 2026-04-24** — component-level `@deprecated` JSDoc added; ServiceTag's `variant="icon"` fully covers the use case. Full deletion queued (blocked on shared utility extraction; see punch-list item #8).
 
 ## Prioritized punch-list
 
@@ -124,8 +124,8 @@ Ordered by leverage × low-risk-first:
     - **7a.** ~~CardDisplay + CardFeature deletion (zero consumers)~~ — completed in PR #241.
     - **7b.** CardControl → Card variant — 1 portal consumer; small additive PR + 1-file portal migration.
     - **7c.** CardSummary → Card variant — 12 portal consumers; full additive-deprecate-migrate-delete cycle.
-8. **`ServiceBadge` REVIEW** — verify ServiceTag coverage before retiring.
-9. **`CardList` REVIEW** — assess demotion to CSS utility class vs keeping as layout primitive.
+8. ~~**`ServiceBadge` REVIEW** — verify ServiceTag coverage before retiring.~~ **Reviewed 2026-04-24** — ServiceTag fully covers ServiceBadge via `variant="icon"` (ServiceTag's own docstring already says "replaces ServiceBadge"). Both have zero external consumers. Component-level `@deprecated` JSDoc updated; full deletion queued as `task/bds-service-badge-deletion` (blocked on extracting shared `categoryConfig` + `getServiceIconPath` utilities from ServiceBadge.tsx into a shared module that ServiceTag can continue to import).
+9. ~~**`CardList` REVIEW** — assess demotion to CSS utility class vs keeping as layout primitive.~~ **Reviewed 2026-04-24** — Keep as-is. CardList is 51 LOC + 59 LOC CSS that provides a discoverable, semantic-list (`<ul>` + `<li>`) layout for the common "stack of cards" pattern. Zero external consumers today, but BDS has no general layout primitives (no Stack/Cluster/Box) — CardList fills the closest equivalent. **Future watch:** if BDS introduces general layout primitives, revisit whether CardList becomes redundant. For now: honest, justified.
 
 Each numbered item should be its own task branch + PR (per CLAUDE.md scope rule: "one concern per PR").
 


### PR DESCRIPTION
## Summary

Final two REVIEW items from the 2026-Q2 component bloat audit. Closes out the original 9-item punch-list.

**Net: 2 files changed, 10 insertions, 4 deletions.**

## Item #8 — ServiceBadge

**Decision: keep `@deprecated`, queue full deletion.**

- `ServiceTag variant="icon"` fully replaces ServiceBadge — confirmed by reading both components. ServiceTag's own docstring already says: *"icon — colored square with service icon only (replaces ServiceBadge)"*.
- Both have **zero external consumers** (verified via grep across portal, renew-pms, brikdesigns).
- ServiceBadge already had `@deprecated` JSDoc, but the comment said "kept for backwards compatibility only" — misleading since there's no compat to preserve. Updated to accurately explain the real blocker.

**Blocker for full deletion:** `ServiceBadge.tsx` exports `categoryConfig` and `getServiceIconPath` which `ServiceTag.tsx` imports. Full deletion requires extracting those utilities into a shared module first. Queued as `task/bds-service-badge-deletion`.

## Item #9 — CardList

**Decision: keep as-is.**

- 51 LOC component + 59 LOC CSS — modest size for what it provides.
- Renders semantic `<ul>` with `<li>` items + token-driven gap and orientation. Not a wrapper around inline styles; provides a discoverable + semantic API.
- Zero external consumers today, but **BDS has no general layout primitives** (no Stack, Cluster, Box, Inline). CardList is the closest thing.
- Audit's "demote to CSS utility class" suggestion would regress DX without a real replacement.

**Future watch:** If BDS introduces general layout primitives, revisit whether CardList becomes redundant or should be repointed at a Stack primitive internally.

## What changed

| File | Action |
|---|---|
| `components/ui/ServiceBadge/ServiceBadge.tsx` | Updated `@deprecated` JSDoc — replaced stale "backwards compatibility" note with accurate blocker context |
| `docs/audits/2026-Q2-component-bloat-audit.md` | Items #8 and #9 marked reviewed with decision rationale; ServiceBadge "Honest" entry updated to reflect deprecated status |

## Audit progress — closed

| # | Item | Status |
|---|---|---|
| 1 | EmailInput / SearchInput | Merged |
| 2 | ProgressDots → ProgressStepper | Merged |
| 3 | Dialog → Modal preset | Merged |
| 4 | AlertBanner ↔ Banner | Merged |
| 5 | Snackbar deletion | Merged |
| 6 | Menu → Popover | Merged (rejection logged) |
| 7a | CardDisplay + CardFeature deletion | Merged |
| 7b | CardControl → Card variant | Queued (own session) |
| 7c | CardSummary → Card variant | Queued (own session) |
| 8 | ServiceBadge | **This PR** (deprecated; deletion queued) |
| 9 | CardList | **This PR** (keep) |

## Pass 1 outcome

The original 9-item audit is closed out. Net component reduction from pass 1:

- **−6 components hard-deleted**: EmailInput, SearchInput, ProgressDots, Snackbar, CardDisplay, CardFeature
- **−2 components consolidated as variants**: Dialog (→ Modal preset), AlertBanner (→ Banner tone)
- **−1 deprecated, deletion queued**: ServiceBadge
- **2 components in-flight as queued migrations**: CardControl, CardSummary

Combined with ADRs 003 + 004 cleanups (Addable* split, SheetTypography fold-in), the forward path retires ~16 components — roughly 19% off the original 84-component surface.

## Pass 2 (still queued for 2026-Q4 per ADR-004)

Navigation family, Form atomic, Filter family. No work needed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)