### PR TITLE
feat(card): add preset='control' and deprecate CardControl

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -71,4 +71,63 @@
   margin-top: auto;
   padding-top: var(--padding-sm);
 }
+
+/* ─── Preset: control ─────────────────────────────────────────── */
+/* Settings/control card layout — replaces the legacy CardControl
+ * component. Badge + (title + description) on the left, action on the
+ * right. Surface uses primary background + muted border + small shadow
+ * regardless of `variant` (variant is ignored for this preset). */
+
+.bds-card--preset-control {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--padding-xl);
+  padding: var(--padding-xl);
+  background-color: var(--surface-primary);
+  border: var(--border-width-md) solid var(--border-muted);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-sm);
+  width: 100%;
+  box-sizing: border-box;
+  flex-wrap: wrap;
+}
+
+.bds-card--preset-control-action-center { align-items: center; }
+.bds-card--preset-control-action-top    { align-items: flex-start; }
+
+.bds-card__preset-control-content {
+  display: flex;
+  align-items: center;
+  gap: var(--padding-lg);
+  flex: 1;
+  min-width: 0;
+}
+
+.bds-card__preset-control-text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  min-width: 0;
+}
+
+.bds-card__preset-control-title {
+  font-family: var(--font-family-label);
+  font-size: var(--label-lg);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.bds-card__preset-control-description {
+  font-family: var(--font-family-body);
+  font-size: var(--body-md);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.bds-card__preset-control-action {
+  flex-shrink: 0;
+}
 }

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -25,6 +25,24 @@ All visual variants, padding sizes, interactive, and link modes.
 - **`brand`** — Primary-color border for emphasis
 - **`elevated`** — Shadow for visual prominence
 
+## Control preset
+
+`preset="control"` collapses the legacy `CardControl` component into Card as a locked-down settings/control layout (per [ADR-004](../../docs/adrs/ADR-004-component-bloat-guardrails.md)). Renders: leading badge + (title + description) on the left, action slot on the right.
+
+<Canvas of={Stories.ControlPreset} />
+
+```tsx
+<Card
+  preset="control"
+  badge={<Badge status="positive">On</Badge>}
+  title="Email notifications"
+  description="Send a weekly digest to your inbox."
+  action={<Button variant="outline" size="sm">Configure</Button>}
+/>
+```
+
+The standalone `CardControl` component is `@deprecated` and slated for deletion in a future major version. Migrate to `Card preset="control"` — same prop names, same behavior. See [ADR-004](../../docs/adrs/ADR-004-component-bloat-guardrails.md).
+
 ## Patterns
 
 Real-world usage: service grids and feature cards with actions.

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -102,6 +102,52 @@ export const Variants: Story = {
   ),
 };
 
+/* ─── Control preset ─────────────────────────────────────────── */
+
+/**
+ * `preset="control"` — locked-down settings/control card layout.
+ * Replaces the legacy `CardControl` component (per ADR-004).
+ *
+ * Renders: leading badge + (title + description) on the left, action
+ * slot on the right. Use `actionAlign="top"` to anchor the action to
+ * the upper-right corner instead of the vertical midline.
+ */
+export const ControlPreset = () => (
+  <Stack>
+    <SectionLabel>Default — center-aligned action</SectionLabel>
+    <div style={{ width: 560 }}>
+      <Card
+        preset="control"
+        badge={<Badge status="positive">On</Badge>}
+        title="Email notifications"
+        description="Send a weekly digest to your inbox."
+        action={<Button variant="outline" size="sm">Configure</Button>}
+      />
+    </div>
+
+    <SectionLabel>Top-aligned action</SectionLabel>
+    <div style={{ width: 560 }}>
+      <Card
+        preset="control"
+        actionAlign="top"
+        badge={<Badge status="warning">Off</Badge>}
+        title="Two-factor authentication"
+        description="Add a second layer of security by requiring a code from your phone when signing in. Strongly recommended for accounts with admin access."
+        action={<Button variant="primary" size="sm">Enable</Button>}
+      />
+    </div>
+
+    <SectionLabel>No badge, no action</SectionLabel>
+    <div style={{ width: 560 }}>
+      <Card
+        preset="control"
+        title="Account name"
+        description="The display name shown to your team and on shared documents."
+      />
+    </div>
+  </Stack>
+);
+
 /* ─── Patterns ───────────────────────────────────────────────── */
 
 export const Patterns: Story = {

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -4,19 +4,95 @@ import './Card.css';
 
 export type CardVariant = 'outlined' | 'brand' | 'elevated';
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
+export type CardPreset = 'control';
+export type CardControlActionAlign = 'center' | 'top';
 
-export interface CardProps extends HTMLAttributes<HTMLDivElement> {
-  variant?: CardVariant;
-  children: ReactNode;
-  interactive?: boolean;
-  href?: string;
-  padding?: CardPadding;
+interface CardBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  /**
+   * Optional class name applied to the root element.
+   */
+  className?: string;
 }
 
+interface CardDefaultProps extends CardBaseProps {
+  /** No preset — default flexible Card with `children` content slot. */
+  preset?: undefined;
+  /** Visual variant — outlined / brand / elevated (default `outlined`). */
+  variant?: CardVariant;
+  /** Padding scale (default `md`). */
+  padding?: CardPadding;
+  /** Render with hover affordance — adds cursor + interaction styles. */
+  interactive?: boolean;
+  /** Render as `<a>` instead of `<div>`. */
+  href?: string;
+  /** Card content — composes `<CardTitle>`, `<CardDescription>`, `<CardFooter>`, etc. */
+  children: ReactNode;
+}
+
+interface CardControlPresetProps extends CardBaseProps {
+  /**
+   * Control preset — locked-down settings/control card layout. Replaces the
+   * legacy `CardControl` component (per ADR-004 §"Resolve the existing
+   * instances"). Renders: badge + (title + description) on the left,
+   * action on the right.
+   */
+  preset: 'control';
+  /** Bold control label */
+  title: string;
+  /** Helper text under the title */
+  description?: string;
+  /** Optional leading badge (e.g. status icon, ServiceTag) */
+  badge?: ReactNode;
+  /** Optional trailing action element (Button, Switch, Link) */
+  action?: ReactNode;
+  /**
+   * Vertical alignment of the action slot. `top` anchors the action to the
+   * upper-right corner; `center` (default) aligns to the vertical midline.
+   */
+  actionAlign?: CardControlActionAlign;
+}
+
+export type CardProps = CardDefaultProps | CardControlPresetProps;
+
 /**
- * Card — flexible content container with variant styles
+ * Card — flexible content container.
+ *
+ * Two shapes share the same primitive:
+ *
+ * - **Default** (no `preset`) — flexible content slot. Compose with
+ *   `<CardTitle>`, `<CardDescription>`, `<CardFooter>` subcomponents.
+ *   Visual variants: `outlined` (default) / `brand` / `elevated`.
+ * - **`preset="control"`** — settings/control card with locked-down
+ *   badge + title + description + action layout. Replaces the legacy
+ *   `CardControl` component.
+ *
+ * @example Default
+ * ```tsx
+ * <Card variant="elevated" padding="lg">
+ *   <CardTitle>Quarterly report</CardTitle>
+ *   <CardDescription>Summary of Q1 performance.</CardDescription>
+ *   <CardFooter><Button>View</Button></CardFooter>
+ * </Card>
+ * ```
+ *
+ * @example Control preset
+ * ```tsx
+ * <Card
+ *   preset="control"
+ *   title="Email notifications"
+ *   description="Send weekly digest to your inbox."
+ *   action={<Switch checked={enabled} onChange={setEnabled} />}
+ * />
+ * ```
  */
-export function Card({
+export function Card(props: CardProps) {
+  if (props.preset === 'control') {
+    return renderControlPreset(props);
+  }
+  return renderDefault(props);
+}
+
+function renderDefault({
   variant = 'outlined',
   children,
   interactive = false,
@@ -24,8 +100,9 @@ export function Card({
   padding = 'md',
   className,
   style,
-  ...props
-}: CardProps) {
+  preset: _preset,
+  ...rest
+}: CardDefaultProps) {
   const classes = bdsClass(
     'bds-card',
     `bds-card--${variant}`,
@@ -37,20 +114,54 @@ export function Card({
 
   if (href) {
     return (
-      <a href={href} className={classes} style={style} {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
+      <a href={href} className={classes} style={style} {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
         {children}
       </a>
     );
   }
 
   return (
-    <div className={classes} style={style} {...props}>
+    <div className={classes} style={style} {...rest}>
       {children}
     </div>
   );
 }
 
-/* ─── Subcomponents ──────────────────────────────────────────── */
+function renderControlPreset({
+  title,
+  description,
+  badge,
+  action,
+  actionAlign = 'center',
+  className,
+  style,
+  preset: _preset,
+  ...rest
+}: CardControlPresetProps) {
+  return (
+    <div
+      className={bdsClass(
+        'bds-card',
+        'bds-card--preset-control',
+        `bds-card--preset-control-action-${actionAlign}`,
+        className,
+      )}
+      style={style}
+      {...rest}
+    >
+      <div className="bds-card__preset-control-content">
+        {badge}
+        <div className="bds-card__preset-control-text">
+          <p className="bds-card__preset-control-title">{title}</p>
+          {description && <p className="bds-card__preset-control-description">{description}</p>}
+        </div>
+      </div>
+      {action && <div className="bds-card__preset-control-action">{action}</div>}
+    </div>
+  );
+}
+
+/* ─── Subcomponents (default Card composition) ────────────────── */
 
 export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {
   children: ReactNode;

--- a/components/ui/CardControl/CardControl.tsx
+++ b/components/ui/CardControl/CardControl.tsx
@@ -15,6 +15,23 @@ export interface CardControlProps extends HTMLAttributes<HTMLDivElement> {
 
 /**
  * CardControl — settings control card with badge, title, description, and action.
+ *
+ * @deprecated Use `<Card preset="control">` instead. Same prop names, same
+ * layout, same visual treatment. Slated for deletion in a future major
+ * version once the 1 portal consumer migrates.
+ *
+ * Migration:
+ * ```tsx
+ * // before
+ * <CardControl title="Email notifications" description="Send weekly digest"
+ *   action={<Switch />} actionAlign="top" />
+ *
+ * // after
+ * <Card preset="control" title="Email notifications" description="Send weekly digest"
+ *   action={<Switch />} actionAlign="top" />
+ * ```
+ *
+ * Tracked under ADR-004 — see docs/adrs/ADR-004-component-bloat-guardrails.md.
  */
 export function CardControl({
   title,


### PR DESCRIPTION
## Summary

Punch-list item #7b from the [2026-Q2 component bloat audit](docs/audits/2026-Q2-component-bloat-audit.md). Per [ADR-004](docs/adrs/ADR-004-component-bloat-guardrails.md): `CardControl` is a fixed badge + title + description + action layout that shares ~70% CSS with `Card` itself.

Same additive-deprecate pattern as PR #236 (Modal/Dialog) and PR #237 (Banner/AlertBanner). CardControl has 1 portal consumer, so this PR adds `preset="control"` to Card and `@deprecated`s CardControl without deleting it.

## What changed

### Card (additive)
- New discriminated union: `{ preset?: 'control' }` enables locked-down badge + title + description + action layout
- Control preset props: `title` (required), `description?`, `badge?`, `action?`, `actionAlign?: 'center' | 'top'`
- TypeScript narrows on `preset` so control-variant props only appear when `preset="control"` is set
- Default Card API completely unchanged (`children`, `variant`, `padding`, `interactive`, `href`)
- CSS: migrated CardControl's layout into `.bds-card--preset-control` selectors in Card.css

### CardControl (deprecation only — file preserved)
- `@deprecated` JSDoc on the component with migration code
- 1 portal consumer file queued for follow-up migration before deletion

### Stories + docs
- New `ControlPreset` story with three sub-cases: default (center action), top-aligned action, no-badge-no-action
- `Card.mdx` documents the preset and links to ADR-004

## Migration

```tsx
// before
<CardControl
  title="Email notifications"
  description="Send a weekly digest"
  badge={<Badge status="positive">On</Badge>}
  action={<Button variant="outline" size="sm">Configure</Button>}
  actionAlign="top"
/>

// after
<Card
  preset="control"
  title="Email notifications"
  description="Send a weekly digest"
  badge={<Badge status="positive">On</Badge>}
  action={<Button variant="outline" size="sm">Configure</Button>}
  actionAlign="top"
/>
```

Same prop names. Same layout. Same visual treatment.

## Consumer migration (follow-up tasks)

| Repo | Files | Branch |
|---|---|---|
| portal | companies/[slug]/page.tsx (1 file) | `task/portal-card-control-to-card-preset` |
| bds | Delete CardControl folder + remove export, major bump | `task/bds-card-control-deletion` |

## Test plan

- [x] Token linter clean (pre-commit)
- [x] TypeScript typecheck clean — discriminated union narrows correctly
- [x] Anti-slop scan clean (pre-commit)
- [ ] Reviewer: visual diff `Card preset="control"` vs the existing `CardControl` baseline (Chromatic) — should match
- [ ] Reviewer: confirm default Card unchanged

## Audit progress

| # | Item | Status |
|---|---|---|
| 1–6, 7a, 8, 9 | Original 9 items | All closed (PR #243 closes the last two) |
| 7b | CardControl → Card preset | **This PR** (additive) |
| 7c | CardSummary → Card variant (12 consumers) | Queued |

🤖 Generated with [Claude Code](https://claude.com/claude-code)