### PR TITLE
feat(card): add preset='summary' and deprecate CardSummary

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -130,4 +130,79 @@
 .bds-card__preset-control-action {
   flex-shrink: 0;
 }
+
+/* ─── Preset: summary ─────────────────────────────────────────── */
+/* Compact metric/stat card layout — replaces the legacy CardSummary
+ * component. Label (top) + large value (bottom) + optional secondary
+ * link to the right. Surface uses primary background + muted border;
+ * `variant` is ignored for this preset. */
+
+.bds-card--preset-summary {
+  background-color: var(--surface-primary);
+  border: var(--border-width-md) solid var(--border-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.bds-card__preset-summary-inner {
+  display: flex;
+  gap: var(--gap-md);
+  align-items: flex-start;
+  padding: var(--padding-lg);
+}
+
+.bds-card__preset-summary-content {
+  flex: 1 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  min-width: 0;
+}
+
+.bds-card__preset-summary-label {
+  font-family: var(--font-family-body);
+  font-size: var(--body-lg);
+  color: var(--text-secondary);
+  line-height: var(--font-line-height-normal);
+  margin: 0;
+  text-transform: capitalize;
+}
+
+.bds-card__preset-summary-value {
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  line-height: var(--font-line-height-tight);
+  margin: 0;
+}
+
+.bds-card__preset-summary-link-area {
+  flex: 1 0 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  min-width: 0;
+}
+
+.bds-card__preset-summary-link {
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  font-weight: var(--font-weight-semi-bold);
+  color: var(--text-brand-primary);
+  line-height: var(--font-line-height-tight);
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: center;
+}
+
+.bds-card__preset-summary-link:hover {
+  text-decoration: underline;
+}
 }

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -43,6 +43,24 @@ All visual variants, padding sizes, interactive, and link modes.
 
 The standalone `CardControl` component is `@deprecated` and slated for deletion in a future major version. Migrate to `Card preset="control"` — same prop names, same behavior. See [ADR-004](../../docs/adrs/ADR-004-component-bloat-guardrails.md).
 
+## Summary preset
+
+`preset="summary"` collapses the legacy `CardSummary` component into Card as a compact metric/stat layout (per [ADR-004](../../docs/adrs/ADR-004-component-bloat-guardrails.md)). Renders: label (top) + large value (bottom) + optional text link to the right. Numeric values format as locale integers; pass `type="price"` for USD currency.
+
+<Canvas of={Stories.SummaryPreset} />
+
+```tsx
+<Card
+  preset="summary"
+  label="Q1 revenue"
+  value={48250.75}
+  type="price"
+  textLink={{ label: 'Details', href: '/revenue' }}
+/>
+```
+
+The standalone `CardSummary` component is `@deprecated` and slated for deletion in a future major version. Migrate to `Card preset="summary"` — same prop names, same number formatting, same layout. See [ADR-004](../../docs/adrs/ADR-004-component-bloat-guardrails.md).
+
 ## Patterns
 
 Real-world usage: service grids and feature cards with actions.

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -148,6 +148,62 @@ export const ControlPreset = () => (
   </Stack>
 );
 
+/* ─── Summary preset ─────────────────────────────────────────── */
+
+/**
+ * `preset="summary"` — compact metric/stat card with label, large value,
+ * and optional text link. Replaces the legacy `CardSummary` component
+ * (per ADR-004).
+ *
+ * `value` accepts a string or number. Numbers are formatted via
+ * `Intl.NumberFormat` based on `type`:
+ * - `numeric` (default): locale integer formatting (e.g. 1,234)
+ * - `price`: USD currency (e.g. $48,250.75)
+ */
+export const SummaryPreset = () => (
+  <Stack>
+    <SectionLabel>Numeric — with text link</SectionLabel>
+    <div style={{ width: 320 }}>
+      <Card
+        preset="summary"
+        label="Active companies"
+        value={42}
+        textLink={{ label: 'View all', href: '#' }}
+      />
+    </div>
+
+    <SectionLabel>Price — formatted as USD currency</SectionLabel>
+    <div style={{ width: 320 }}>
+      <Card
+        preset="summary"
+        label="Q1 revenue"
+        value={48250.75}
+        type="price"
+        textLink={{ label: 'Details', href: '#' }}
+      />
+    </div>
+
+    <SectionLabel>String value (no formatting)</SectionLabel>
+    <div style={{ width: 320 }}>
+      <Card
+        preset="summary"
+        label="Plan"
+        value="Pro Annual"
+      />
+    </div>
+
+    <SectionLabel>Button-style link (no href)</SectionLabel>
+    <div style={{ width: 320 }}>
+      <Card
+        preset="summary"
+        label="Pending tasks"
+        value={7}
+        textLink={{ label: 'Review', onClick: () => {} }}
+      />
+    </div>
+  </Stack>
+);
+
 /* ─── Patterns ───────────────────────────────────────────────── */
 
 export const Patterns: Story = {

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -4,8 +4,15 @@ import './Card.css';
 
 export type CardVariant = 'outlined' | 'brand' | 'elevated';
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
-export type CardPreset = 'control';
+export type CardPreset = 'control' | 'summary';
 export type CardControlActionAlign = 'center' | 'top';
+export type CardSummaryType = 'numeric' | 'price';
+
+export interface CardSummaryTextLink {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+}
 
 interface CardBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /**
@@ -52,7 +59,40 @@ interface CardControlPresetProps extends CardBaseProps {
   actionAlign?: CardControlActionAlign;
 }
 
-export type CardProps = CardDefaultProps | CardControlPresetProps;
+interface CardSummaryPresetProps extends CardBaseProps {
+  /**
+   * Summary preset — compact metric/stat card with label, large value, and
+   * optional text link. Replaces the legacy `CardSummary` component (per
+   * ADR-004 §"Resolve the existing instances").
+   */
+  preset: 'summary';
+  /** Stat label rendered above the value */
+  label: string;
+  /**
+   * Stat value. Numbers are formatted via `Intl.NumberFormat` based on
+   * `type`; strings render verbatim.
+   */
+  value: string | number;
+  /**
+   * Number formatting:
+   * - `numeric` (default): locale-formatted integer (e.g. 1,234)
+   * - `price`: USD currency (e.g. $1,234.50)
+   * Ignored when `value` is a string.
+   */
+  type?: CardSummaryType;
+  /** Optional secondary action rendered to the right of the value */
+  textLink?: CardSummaryTextLink;
+}
+
+export type CardProps = CardDefaultProps | CardControlPresetProps | CardSummaryPresetProps;
+
+function formatSummaryValue(value: string | number, type: CardSummaryType): string {
+  if (typeof value === 'string') return value;
+  if (type === 'price') {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+  }
+  return value.toLocaleString();
+}
 
 /**
  * Card — flexible content container.
@@ -65,6 +105,9 @@ export type CardProps = CardDefaultProps | CardControlPresetProps;
  * - **`preset="control"`** — settings/control card with locked-down
  *   badge + title + description + action layout. Replaces the legacy
  *   `CardControl` component.
+ * - **`preset="summary"`** — compact metric/stat card with label,
+ *   large value, and optional text link. Replaces the legacy
+ *   `CardSummary` component.
  *
  * @example Default
  * ```tsx
@@ -84,10 +127,24 @@ export type CardProps = CardDefaultProps | CardControlPresetProps;
  *   action={<Switch checked={enabled} onChange={setEnabled} />}
  * />
  * ```
+ *
+ * @example Summary preset
+ * ```tsx
+ * <Card
+ *   preset="summary"
+ *   label="Total revenue"
+ *   value={48250.75}
+ *   type="price"
+ *   textLink={{ label: 'Details', href: '/revenue' }}
+ * />
+ * ```
  */
 export function Card(props: CardProps) {
   if (props.preset === 'control') {
     return renderControlPreset(props);
+  }
+  if (props.preset === 'summary') {
+    return renderSummaryPreset(props);
   }
   return renderDefault(props);
 }
@@ -157,6 +214,55 @@ function renderControlPreset({
         </div>
       </div>
       {action && <div className="bds-card__preset-control-action">{action}</div>}
+    </div>
+  );
+}
+
+function renderSummaryPreset({
+  label,
+  value,
+  type = 'numeric',
+  textLink,
+  className,
+  style,
+  preset: _preset,
+  ...rest
+}: CardSummaryPresetProps) {
+  const formatted = formatSummaryValue(value, type);
+
+  return (
+    <div
+      className={bdsClass('bds-card', 'bds-card--preset-summary', className)}
+      style={style}
+      {...rest}
+    >
+      <div className="bds-card__preset-summary-inner">
+        <div className="bds-card__preset-summary-content">
+          <p className="bds-card__preset-summary-label">{label}</p>
+          <p className="bds-card__preset-summary-value">{formatted}</p>
+        </div>
+        {textLink && (
+          <div className="bds-card__preset-summary-link-area">
+            {textLink.href ? (
+              <a
+                href={textLink.href}
+                className="bds-card__preset-summary-link"
+                onClick={textLink.onClick}
+              >
+                {textLink.label}
+              </a>
+            ) : (
+              <button
+                type="button"
+                className="bds-card__preset-summary-link"
+                onClick={textLink.onClick}
+              >
+                {textLink.label}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/ui/Card/CardSummary.tsx
+++ b/components/ui/Card/CardSummary.tsx
@@ -27,6 +27,25 @@ function formatValue(value: string | number, type: CardSummaryType): string {
 
 /**
  * CardSummary — compact metric/stat card with label, large value, and optional text link.
+ *
+ * @deprecated Use `<Card preset="summary">` instead. Same prop names
+ * (`label`, `value`, `type`, `textLink`), same layout, same number
+ * formatting (currency for `type="price"`, locale-formatted otherwise).
+ * Slated for deletion in a future major version once the 12 portal
+ * consumers migrate.
+ *
+ * Migration:
+ * ```tsx
+ * // before
+ * <CardSummary label="Revenue" value={48250.75} type="price"
+ *   textLink={{ label: 'Details', href: '/revenue' }} />
+ *
+ * // after
+ * <Card preset="summary" label="Revenue" value={48250.75} type="price"
+ *   textLink={{ label: 'Details', href: '/revenue' }} />
+ * ```
+ *
+ * Tracked under ADR-004 — see docs/adrs/ADR-004-component-bloat-guardrails.md.
  */
 export function CardSummary({
   label,


### PR DESCRIPTION
## Summary

Punch-list item #7c — the **biggest** consolidation item — from the [2026-Q2 component bloat audit](docs/audits/2026-Q2-component-bloat-audit.md). Per [ADR-004](docs/adrs/ADR-004-component-bloat-guardrails.md): `CardSummary` shares ~85% CSS with Card itself, plus an Intl.NumberFormat helper for currency/integer formatting.

**12 portal consumers** — same additive-deprecate pattern as PR #244 (CardControl), PR #237 (Banner/AlertBanner), PR #236 (Modal/Dialog).

## What changed

### Card (additive — extends the discriminated union added in PR #244)
- `preset?: 'control' | 'summary'` now supports two preset shapes
- Summary preset props: `label` (required), `value: string | number`, `type?: 'numeric' | 'price'`, `textLink?: { label, href?, onClick? }`
- `formatSummaryValue` helper migrated from CardSummary.tsx — handles `Intl.NumberFormat` for USD currency vs locale integer formatting; strings pass through verbatim
- TypeScript narrows on `preset` so summary-variant props only appear when `preset="summary"` is set
- CSS: migrated CardSummary's layout into `.bds-card--preset-summary` selectors in Card.css
- Default Card and `preset="control"` paths unchanged

### CardSummary (deprecation only — file preserved)
- `@deprecated` JSDoc on the component with migration code
- 12 portal consumer files queued for follow-up migration before deletion
- CardSummary.css remains alongside (temporary CSS duplication during deprecation; resolved when CardSummary is deleted)

### Stories + docs
- New `SummaryPreset` story with four sub-cases: numeric+link, price+link, string value, button-style link (no href)
- `Card.mdx` documents the preset, links to ADR-004, notes the CardSummary deprecation

## Migration

```tsx
// before
<CardSummary
  label="Q1 revenue"
  value={48250.75}
  type="price"
  textLink={{ label: 'Details', href: '/revenue' }}
/>

// after
<Card
  preset="summary"
  label="Q1 revenue"
  value={48250.75}
  type="price"
  textLink={{ label: 'Details', href: '/revenue' }}
/>
```

Same prop names. Same `Intl.NumberFormat` behavior. Same surface + layout.

## Consumer migration (follow-up tasks)

| Repo | Files | Branch |
|---|---|---|
| portal | 12 files (admin/page, reporting, contacts, agreements, companies/[slug], services, services/stripe-sync, proposals, dashboard, dashboard/payments, dashboard/services, billing-tab-content) | `task/portal-card-summary-to-card-preset` |
| bds | Delete `components/ui/Card/CardSummary.{tsx,css,mdx,stories.tsx}`, remove from index.ts, major bump | `task/bds-card-summary-deletion` |

## Test plan

- [x] Token linter clean (pre-commit)
- [x] TypeScript typecheck clean — discriminated union narrows correctly across both presets (`control` and `summary`)
- [x] Anti-slop scan clean (pre-commit)
- [ ] Reviewer: visual diff `Card preset="summary"` vs the existing `CardSummary` baseline (Chromatic) — should match
- [ ] Reviewer: confirm both `preset="control"` and default Card paths still render correctly

## Audit progress — closed except for execution tail

| # | Status |
|---|---|
| 1–6, 7a, 8, 9 | All addressed (some merged, audit overrides logged) |
| 7b | CardControl → preset (merged in PR #244) |
| 7c | CardSummary → preset (**this PR**) |

## What's left after this lands

- **5 consumer migration PRs** (Dialog → Modal preset, AlertBanner → Banner tone, ServiceBadge → ServiceTag, CardControl → Card preset, CardSummary → Card preset)
- **5 BDS deletion PRs** (one per migrated component, after consumers ship)
- **ADR-003 implementation** (Addable* family split, 3 → 2 components)
- **ADR-004 implementation** (SheetTypography fold-in)
- **Pass 2 audit** (Q4 — Navigation, Form atomic, Filter family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)