### PR TITLE
chore(release): v0.39.0 — 2026-Q2 component bloat audit cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.38.0",
-  "description": "Brik Design System \u2014 React components, Figma-synced tokens, and Content System (BCS) vocabulary",
+  "version": "0.39.0",
+  "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Summary

Cuts BDS v0.39.0 to bundle and ship the 2026-Q2 component bloat audit cleanup. **Unblocks consumer migrations** in portal + renew-pms.

`dist/` is gitignored (since PR #201) — `prepublishOnly` regenerates it at `npm publish` time. This PR is just the version bump + lockfile.

## Hard deletions (BREAKING — verified zero consumers)

| PR | Components | Replacement |
|---|---|---|
| #234 | `EmailInput`, `SearchInput` | `<TextInput type="email\|search" iconBefore={...} />` |
| #235 | `ProgressDots` | `<ProgressStepper variant="dots" />` |
| #238 | `Snackbar` | (use Toast for inline, future Toaster for floating — out of scope) |
| #241 | `CardDisplay`, `CardFeature` | (no replacement — were ~80% Card overlap with no unique behavior) |

## New presets (additive, replace soon-to-be-deleted components)

| PR | New API | Deprecates |
|---|---|---|
| #236 | `<Modal preset="confirm">` | `Dialog` |
| #237 | `<Banner tone="warning\|error\|information">` | `AlertBanner` |
| #244 | `<Card preset="control">` | `CardControl` |
| #246 | `<Card preset="summary">` | `CardSummary` |

## Deprecations (still exported, deletion queued)

- `Dialog`, `AlertBanner`, `CardControl`, `CardSummary` — `@deprecated` JSDoc with migration code
- `ServiceBadge` — `@deprecated`; full deletion blocked on shared utility extraction (PR #243)

## Documentation

- [ADR-003](docs/adrs/ADR-003-addable-list-family.md) — Addable* split (implementation pending)
- [ADR-004](docs/adrs/ADR-004-component-bloat-guardrails.md) — bloat guardrails (first retroactive pass complete)
- [Audit findings doc](docs/audits/2026-Q2-component-bloat-audit.md) — includes "Rejected recommendations" section for #5 Snackbar prop-bag merge and #6 Menu/Popover merge (both overridden during execution; PR #239)

## Test plan

- [x] Typecheck clean (pre-commit)
- [x] Anti-slop scan skipped (build-artifacts-only commit per the existing `.husky/pre-commit` rule)
- [x] `npm run build:lib` ran clean locally — manifest at 80 components, 426 tokens
- [ ] Reviewer: confirm changelog/PR body covers everything since 0.38.0 (run `git log v0.38.0..HEAD --oneline -- '*.tsx' '*.css' docs/` to verify)
- [ ] After merge: `npm publish` from local at the merged main SHA

## Post-publish followups

Once 0.39.0 ships and portal/renew-pms `npm update`, the consumer migration PRs unblock:

| Migration | Files | Repo |
|---|---|---|
| Dialog → Modal preset | 5 | portal (3) + renew-pms (2) |
| AlertBanner → Banner tone | 2 | portal |
| CardControl → Card preset | 1 | portal |
| CardSummary → Card preset | 12 | portal |

After those land, BDS deletion PRs finalize the cleanup with a major version bump (since the removals are formally breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)