### PR TITLE
revert(card-control): undo deprecation per user decision

### DIFF
--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -41,7 +41,7 @@ All visual variants, padding sizes, interactive, and link modes.
 />
 ```
 
-The standalone `CardControl` component is `@deprecated` and slated for deletion in a future major version. Migrate to `Card preset="control"` — same prop names, same behavior. See [ADR-004](../../docs/adrs/ADR-004-component-bloat-guardrails.md).
+Both `<Card preset="control">` and the standalone `<CardControl>` ship as first-class APIs in v0.39.0 — pick whichever fits the call site. The audit recommended folding CardControl into Card; the user reversed that decision 2026-04-24 to preserve optionality. See [audit doc](../../docs/audits/2026-Q2-component-bloat-audit.md).
 
 ## Summary preset
 

--- a/components/ui/CardControl/CardControl.tsx
+++ b/components/ui/CardControl/CardControl.tsx
@@ -16,22 +16,14 @@ export interface CardControlProps extends HTMLAttributes<HTMLDivElement> {
 /**
  * CardControl — settings control card with badge, title, description, and action.
  *
- * @deprecated Use `<Card preset="control">` instead. Same prop names, same
- * layout, same visual treatment. Slated for deletion in a future major
- * version once the 1 portal consumer migrates.
+ * Equivalent to `<Card preset="control">` (added in v0.39.0). Both APIs are
+ * supported and ship the same layout / visual treatment; pick whichever
+ * fits the call site.
  *
- * Migration:
- * ```tsx
- * // before
- * <CardControl title="Email notifications" description="Send weekly digest"
- *   action={<Switch />} actionAlign="top" />
- *
- * // after
- * <Card preset="control" title="Email notifications" description="Send weekly digest"
- *   action={<Switch />} actionAlign="top" />
- * ```
- *
- * Tracked under ADR-004 — see docs/adrs/ADR-004-component-bloat-guardrails.md.
+ * The earlier deprecation marker (PR #244) was reversed by user decision
+ * 2026-04-24 — CardControl stays as a first-class component. The
+ * 2026-Q2 audit's recommendation to retire it is logged but not in
+ * effect; see docs/audits/2026-Q2-component-bloat-audit.md.
  */
 export function CardControl({
   title,

--- a/docs/audits/2026-Q2-component-bloat-audit.md
+++ b/docs/audits/2026-Q2-component-bloat-audit.md
@@ -27,7 +27,7 @@ Plus the bloat already booked in [ADR-003](../adrs/ADR-003-addable-list-family.m
 | Component | Evidence | Fold into | Status |
 |---|---|---|---|
 | `CardSummary` | 85% CSS overlap with `Card`. Fixed template (label + large-value + optional link) plus `formatValue()` helper. No use of Card's subcomponent slots. | `<Card variant="summary" formatValue="price\|numeric" />` | 12 portal consumers — pending #7c |
-| `CardControl` | [CardControl.tsx](../../components/ui/CardControl/CardControl.tsx) — same base flex/border/padding-xl/surface as Card. Fixed layout (badge + title/description left, action right). No Card subcomponent reuse. | `<Card variant="control" />` | 1 portal consumer — pending #7b |
+| `CardControl` | [CardControl.tsx](../../components/ui/CardControl/CardControl.tsx) — same base flex/border/padding-xl/surface as Card. Fixed layout (badge + title/description left, action right). No Card subcomponent reuse. | `<Card variant="control" />` | **Kept 2026-04-24** by user decision — Card preset added (PR #244) for new uses, but CardControl stays as a first-class component for current and future settings/control surfaces. |
 | `CardDisplay` | ~80% CSS overlap. Fixed image-header + content-body template. | `<Card variant="display" image={...} />` | **Deleted in PR #241** (zero consumers) |
 | `CardFeature` | ~75% CSS overlap. Fixed icon + title/description + action with `align` control. | `<Card variant="feature" icon={...} align="left\|center" />` | **Deleted in PR #241** (zero consumers) |
 
@@ -122,7 +122,7 @@ Ordered by leverage × low-risk-first:
 6. ~~**Overlay `Menu` → `Popover preset="menu"`** — Menu's hardcoded item rendering needs to become a slot. Larger refactor than #3.~~ **Rejected** — see "Rejected recommendations" section. Different patterns, not forks.
 7. **Card variant consolidation** — biggest scope. Split into sub-tasks during execution based on consumer footprint:
     - **7a.** ~~CardDisplay + CardFeature deletion (zero consumers)~~ — completed in PR #241.
-    - **7b.** CardControl → Card variant — 1 portal consumer; small additive PR + 1-file portal migration.
+    - ~~**7b.** CardControl → Card variant — 1 portal consumer; small additive PR + 1-file portal migration.~~ **Card preset added (PR #244) but CardControl kept** — user decision 2026-04-24 to preserve CardControl as a first-class component. Both APIs supported; deprecation reversed.
     - **7c.** CardSummary → Card variant — 12 portal consumers; full additive-deprecate-migrate-delete cycle.
 8. **`ServiceBadge` REVIEW** — verify ServiceTag coverage before retiring.
 9. **`CardList` REVIEW** — assess demotion to CSS utility class vs keeping as layout primitive.
@@ -136,6 +136,12 @@ After consumer-impact review during execution, two original audit recommendation
 ### #5 Snackbar ↔ Toast merge — **rejected, deleted instead** (PR #238)
 
 The audit recommended merging Snackbar into Toast with `{ isPortal, position, autoDismissMs, statusSurface, showBadge }` props. On execution, Snackbar had **zero consumers**. Adding three orthogonal behavioral flags to Toast for zero current benefit was prop-bag bloat — exactly what ADR-004 §3 forbids. Outcome: deleted Snackbar entirely. If floating + auto-dismissing notifications are needed later, build a dedicated `Toaster` manager component (Sonner / react-hot-toast pattern) rather than overloading Toast.
+
+### #7b CardControl deletion — **reversed after Card preset added**
+
+PR #244 added `<Card preset="control">` and marked CardControl `@deprecated` ahead of a planned consumer migration + deletion cycle. On 2026-04-24 the user reversed the deprecation: *"hold off on cardcontrol as there may be a need for that in the future."* Both APIs ship in v0.39.0 — Card preset for new uses, CardControl for existing and future settings/control surfaces. The `@deprecated` JSDoc on CardControl was removed in PR #248.
+
+This is a soft no-op for the audit: the bloat-reduction case for folding CardControl into Card was real (~70% CSS overlap), but the operator decision is to keep optionality. If at a future audit pass CardControl is genuinely unused, revisit.
 
 ### #6 Menu → Popover preset — **rejected outright**
 


### PR DESCRIPTION
## Summary

Reverses the `@deprecated` marker added to `CardControl` in PR #244. User decision 2026-04-24:

> "hold off on cardcontrol as there may be a need for that in the future"

Both APIs ship in v0.39.0 going forward — pick whichever fits:
- `<Card preset="control">` (added PR #244, additive)
- `<CardControl>` (preserved as first-class component)

## What changed

| File | Change |
|---|---|
| `components/ui/CardControl/CardControl.tsx` | Replace `@deprecated` JSDoc with neutral note that both APIs are equivalent and supported |
| `components/ui/Card/Card.mdx` | Replace "CardControl is deprecated" line with "both ship as first-class APIs" |
| `docs/audits/2026-Q2-component-bloat-audit.md` | Card-family table marks CardControl "Kept"; punch-list #7b struck through; new "#7b reversed" entry under Rejected recommendations |

The `<Card preset="control">` API itself is unchanged — it's still available. This PR only un-deprecates the standalone `CardControl`.

## Why

The bloat-reduction case was real (~70% CSS overlap). Operator preference is to keep optionality; if a future audit pass finds CardControl genuinely unused, revisit.

## Test plan

- [x] Token linter clean (pre-commit)
- [x] TypeScript typecheck clean
- [x] Anti-slop scan clean (pre-commit)
- [ ] Reviewer: confirm both Card preset and standalone CardControl render correctly (no behavior change in either)

🤖 Generated with [Claude Code](https://claude.com/claude-code)