### PR TITLE
refactor(addable): use BDS primitives + unify remove pattern + relocate stories

### DIFF
--- a/components/ui/AddableComboList/AddableComboList.css
+++ b/components/ui/AddableComboList/AddableComboList.css
@@ -78,51 +78,6 @@
   min-width: 0;
 }
 
-/* ─── Native input (styled to match TextInput) ────────────── */
-
-.bds-addable-combo-list__input {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-family: var(--font-family-body);
-  color: var(--text-primary);
-  background-color: var(--background-primary);
-  border: var(--border-width-md) solid var(--border-primary);
-  border-radius: var(--border-radius-md);
-  outline: none;
-  transition:
-    border-color var(--duration-fast) var(--ease-out),
-    box-shadow var(--duration-fast) var(--ease-out);
-}
-
-.bds-addable-combo-list__input::placeholder {
-  color: var(--text-muted);
-}
-
-.bds-addable-combo-list__input:focus {
-  border-color: var(--border-brand-primary);
-  box-shadow: 0 0 0 3px var(--surface-brand-primary);
-}
-
-/* Sizes — match TextInput */
-.bds-addable-combo-list__input--sm {
-  padding: var(--padding-tiny) var(--padding-sm);
-  font-size: var(--body-sm);
-  height: 32px;
-}
-
-.bds-addable-combo-list__input--md {
-  padding: var(--padding-sm) var(--padding-md);
-  font-size: var(--body-md);
-  height: 40px;
-}
-
-.bds-addable-combo-list__input--lg {
-  padding: var(--padding-sm) var(--padding-md);
-  font-size: var(--body-lg);
-  height: 48px;
-}
-
 /* ─── Dropdown ─────────────────────────────────────────────── */
 
 @keyframes bds-combo-dropdown-enter {

--- a/components/ui/AddableComboList/AddableComboList.stories.tsx
+++ b/components/ui/AddableComboList/AddableComboList.stories.tsx
@@ -81,7 +81,7 @@ const DENTAL_INSURANCE = [
 // ── Storybook meta ────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof AddableComboList> = {
-  title: 'Components/Form/addable-combo-list',
+  title: 'Displays/Form/addable-combo-list',
   component: AddableComboList,
   parameters: { layout: 'centered' },
   argTypes: {

--- a/components/ui/AddableComboList/AddableComboList.tsx
+++ b/components/ui/AddableComboList/AddableComboList.tsx
@@ -7,6 +7,7 @@ import { Icon } from '@iconify/react';
 import { bdsClass } from '../../utils';
 import { Button, type ButtonSize } from '../Button';
 import { Tag, type TagSize } from '../Tag';
+import { TextInput, type TextInputSize } from '../TextInput';
 import { useSuggestionFilter } from '../shared/useSuggestionFilter';
 import './AddableComboList.css';
 
@@ -45,6 +46,7 @@ export interface AddableComboListProps {
 
 const TAG_SIZE: Record<AddableComboListSize, TagSize> = { sm: 'sm', md: 'md', lg: 'md' };
 const BUTTON_SIZE: Record<AddableComboListSize, ButtonSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+const INPUT_SIZE: Record<AddableComboListSize, TextInputSize> = { sm: 'sm', md: 'md', lg: 'lg' };
 
 /**
  * AddableComboList — suggestion-driven combobox for tag-style multi-select
@@ -178,9 +180,10 @@ export function AddableComboList({
         >
           <div className="bds-addable-combo-list__input-row">
             <div className="bds-addable-combo-list__input-wrap" style={{ position: 'relative' }}>
-              <input
+              <TextInput
                 ref={inputRef}
                 id={combo.comboId}
+                size={INPUT_SIZE[size]}
                 role="combobox"
                 aria-expanded={combo.isOpen}
                 aria-haspopup="listbox"
@@ -189,10 +192,6 @@ export function AddableComboList({
                 aria-label={label ? `Add ${label}` : 'Add item'}
                 aria-autocomplete="list"
                 autoComplete="off"
-                className={bdsClass(
-                  'bds-addable-combo-list__input',
-                  `bds-addable-combo-list__input--${size}`,
-                )}
                 value={combo.query}
                 onChange={combo.handleInputChange}
                 onKeyDown={combo.handleKeyDown}
@@ -200,6 +199,7 @@ export function AddableComboList({
                   if (combo.query.trim() && combo.filtered.length > 0) combo.openList();
                 }}
                 placeholder={placeholder}
+                fullWidth
               />
 
               {combo.isOpen && combo.filtered.length > 0 && (

--- a/components/ui/AddableEntryList/AddableEntryList.css
+++ b/components/ui/AddableEntryList/AddableEntryList.css
@@ -119,6 +119,7 @@
 }
 
 .bds-addable-entry-list__item-primary {
+  display: block;
   font-family: var(--font-family-body);
   font-weight: var(--font-weight-semi-bold);
   color: var(--text-primary);
@@ -126,6 +127,7 @@
 }
 
 .bds-addable-entry-list__item-secondary {
+  display: block;
   font-family: var(--font-family-body);
   font-size: var(--body-sm);
   color: var(--text-secondary);
@@ -136,36 +138,6 @@
 .bds-addable-entry-list__item-secondary--empty {
   color: var(--text-muted);
   font-style: italic;
-}
-
-.bds-addable-entry-list__remove {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  border-radius: var(--border-radius-sm);
-  flex-shrink: 0;
-  transition: background 120ms ease, color 120ms ease;
-}
-
-.bds-addable-entry-list__remove:hover {
-  background: var(--background-muted);
-  color: var(--text-primary);
-}
-
-.bds-addable-entry-list__remove:focus-visible {
-  outline: var(--border-width-md) solid var(--border-focus);
-  outline-offset: 2px;
-}
-
-.bds-addable-entry-list__remove svg {
-  width: 1rem;
-  height: 1rem;
 }
 
 .bds-addable-entry-list__empty {
@@ -208,60 +180,6 @@
 .bds-addable-entry-list__primary-combo-field {
   position: relative;
   width: 100%;
-}
-
-/* Label above the combobox input — mirrors BDS TextInput label style */
-.bds-addable-entry-list__input-label {
-  font-family: var(--font-family-label);
-  font-size: var(--body-sm);
-  font-weight: var(--font-weight-semi-bold);
-  line-height: var(--font-line-height-tight);
-  color: var(--text-primary);
-}
-
-/* ─── Native combobox input (styled to match TextInput) ─────── */
-
-.bds-addable-entry-list__primary-input {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  font-family: var(--font-family-body);
-  color: var(--text-primary);
-  background-color: var(--background-primary);
-  border: var(--border-width-md) solid var(--border-primary);
-  border-radius: var(--border-radius-md);
-  outline: none;
-  transition:
-    border-color var(--duration-fast) var(--ease-out),
-    box-shadow var(--duration-fast) var(--ease-out);
-}
-
-.bds-addable-entry-list__primary-input::placeholder {
-  color: var(--text-muted);
-}
-
-.bds-addable-entry-list__primary-input:focus {
-  border-color: var(--border-brand-primary);
-  box-shadow: 0 0 0 3px var(--surface-brand-primary);
-}
-
-/* Sizes — match TextInput */
-.bds-addable-entry-list__primary-input--sm {
-  padding: var(--padding-tiny) var(--padding-sm);
-  font-size: var(--body-sm);
-  height: 32px;
-}
-
-.bds-addable-entry-list__primary-input--md {
-  padding: var(--padding-sm) var(--padding-md);
-  font-size: var(--body-md);
-  height: 40px;
-}
-
-.bds-addable-entry-list__primary-input--lg {
-  padding: var(--padding-sm) var(--padding-md);
-  font-size: var(--body-lg);
-  height: 48px;
 }
 
 /* ─── Dropdown ──────────────────────────────────────────────── */

--- a/components/ui/AddableEntryList/AddableEntryList.stories.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.stories.tsx
@@ -59,7 +59,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 // ── Storybook meta ────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof AddableEntryList> = {
-  title: 'Components/Form/addable-entry-list',
+  title: 'Displays/Form/addable-entry-list',
   component: AddableEntryList,
   parameters: { layout: 'centered' },
   argTypes: {

--- a/components/ui/AddableEntryList/AddableEntryList.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, type KeyboardEvent } from 'react';
 import { Icon } from '@iconify/react';
 import { bdsClass } from '../../utils';
-import { Button, type ButtonSize } from '../Button';
+import { Button, IconButton, type ButtonSize } from '../Button';
 import { TextInput, type TextInputSize } from '../TextInput';
 import { TextArea, type TextAreaSize } from '../TextArea';
 import { useSuggestionFilter } from '../shared/useSuggestionFilter';
@@ -282,14 +282,13 @@ export function AddableEntryList({
             >
               <div className="bds-addable-entry-list__row-header">
                 <span className="bds-addable-entry-list__row-index">#{index + 1}</span>
-                <Button
+                <IconButton
                   size={BUTTON_SIZE[size]}
-                  variant="secondary"
+                  variant="ghost"
+                  icon={<Icon icon="ph:x" />}
+                  label={removeLabel}
                   onClick={() => remove(index)}
-                  aria-label={removeLabel}
-                >
-                  Remove
-                </Button>
+                />
               </div>
               <TextInput
                 size={INPUT_SIZE[size]}
@@ -499,14 +498,13 @@ function SuggestionModeEdit({
                   </span>
                 ) : null}
               </div>
-              <button
-                type="button"
-                className="bds-addable-entry-list__remove"
+              <IconButton
+                size={BUTTON_SIZE[size]}
+                variant="ghost"
+                icon={<Icon icon="ph:x" />}
+                label={removeLabel}
                 onClick={() => remove(index)}
-                aria-label={removeLabel}
-              >
-                <Icon icon="ph:x" />
-              </button>
+              />
             </div>
           ))}
         </div>
@@ -521,18 +519,12 @@ function SuggestionModeEdit({
             className="bds-addable-entry-list__primary-combo"
             onBlur={handleComboBlur}
           >
-            {primaryLabel && (
-              <label
-                htmlFor={combo.comboId}
-                className="bds-addable-entry-list__input-label"
-              >
-                {primaryLabel}
-              </label>
-            )}
             <div className="bds-addable-entry-list__primary-combo-field">
-              <input
+              <TextInput
                 ref={primaryInputRef}
                 id={combo.comboId}
+                size={INPUT_SIZE[size]}
+                label={primaryLabel}
                 role="combobox"
                 aria-expanded={combo.isOpen}
                 aria-haspopup="listbox"
@@ -541,10 +533,6 @@ function SuggestionModeEdit({
                 aria-label={primaryLabel ?? (label ? `Add ${label}` : 'New entry')}
                 aria-autocomplete="list"
                 autoComplete="off"
-                className={bdsClass(
-                  'bds-addable-entry-list__primary-input',
-                  `bds-addable-entry-list__primary-input--${size}`,
-                )}
                 value={primaryDraft}
                 onChange={handleComboPrimaryChange}
                 onKeyDown={handleComboPrimaryKey}
@@ -552,6 +540,7 @@ function SuggestionModeEdit({
                   if (combo.query.trim() && combo.filtered.length > 0) combo.openList();
                 }}
                 placeholder={primaryPlaceholder}
+                fullWidth
               />
 
               {combo.isOpen && combo.filtered.length > 0 && (

--- a/components/ui/AddableTextList/AddableTextList.stories.tsx
+++ b/components/ui/AddableTextList/AddableTextList.stories.tsx
@@ -23,7 +23,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 );
 
 const meta: Meta<typeof AddableTextList> = {
-  title: 'Components/Form/addable-text-list',
+  title: 'Displays/Form/addable-text-list',
   component: AddableTextList,
   parameters: { layout: 'centered' },
   argTypes: {


### PR DESCRIPTION
## Summary

PR 1 of the addable-cleanup sequence. Per the deep-look findings — the Addable family had two divergence problems independent of any consolidation question, both worth fixing now before the consolidation decision.

**Net: 7 files changed, 26 insertions, 164 deletions (−138 LOC).** No public API change.

## What changed

### Composition fix — drop rolled-own `<input>` in favor of `<TextInput>`

Two of the three Addable components were rolling their own `<input>` element with the comment *"styled to match TextInput"* and ~45-60 lines each of duplicate CSS replicating TextInput's surface tokens.

| Component | Before | After |
|---|---|---|
| `AddableComboList` | Custom `<input role="combobox">` + 45 lines duplicate CSS | `<TextInput role="combobox">` (ARIA spreads through TextInput's props passthrough) |
| `AddableEntryList` suggestion mode | Same custom-input pattern + 60 lines of duplicate CSS — **this is the source of the broken-text-input UI on Brand Identity via CatalogPicker** | `<TextInput>` |
| `AddableTextList` | Already used `<TextInput>` correctly | unchanged |

### Remove-pattern unification — converge on Tag's × affordance

The family had three different remove-button shapes:

| Pattern | Where | After this PR |
|---|---|---|
| `Tag onRemove ×` | `AddableTextList`, `AddableComboList` | unchanged (this was already correct) |
| `<Button variant="secondary">Remove</Button>` (text label) | `AddableEntryList` plain mode | replaced with `<IconButton variant="ghost" icon={<Icon icon="ph:x" />} />` |
| Custom gray-X icon button (`bds-addable-entry-list__remove` class) | `AddableEntryList` suggestion mode | replaced with `<IconButton variant="ghost" icon={<Icon icon="ph:x" />} />` |

Now all four remove affordances across the family use the same `ph:x` icon — matches what `Tag.onRemove` renders, matches what MultiSelect+Tag uses (the user's stated acceptable pattern). Drops 30 lines of custom remove-button CSS.

### Belt-and-suspenders for the broken-rendering screenshot

Added explicit `display: block` to `.bds-addable-entry-list__item-primary` and `__item-secondary`. The parent already uses `flex-direction: column`, but spans default to inline — the explicit block is defensive against any consumer-side flex override.

### Storybook taxonomy

Three story titles moved per your ask:

| Before | After |
|---|---|
| `Components/Form/addable-text-list` | `Displays/Form/addable-text-list` |
| `Components/Form/addable-combo-list` | `Displays/Form/addable-combo-list` |
| `Components/Form/addable-entry-list` | `Displays/Form/addable-entry-list` |

These are composed entry-management widgets, not atomic form inputs — `Displays/Form` is the right namespace.

## What this fixes downstream

- The "Start a ConversationNo context set" rendering on portal Brand Identity (CatalogPicker → AddableEntryList suggestion mode) — the broken text input is replaced with a real TextInput, and the gray-X is replaced with a proper IconButton
- TextInput style drift: changes to TextInput now propagate cleanly to ComboList and EntryList instead of needing parallel CSS edits
- Visual consistency for the × affordance across the Addable family

## What this does NOT do

This is not a consolidation. The three components still exist with their current public APIs unchanged. Consolidation (whether to keep all three, collapse to two with a `suggestions?` prop, or replace with MultiSelect-style elsewhere) is queued as PR 3 after the portal sheet survey (PR 2).

## Test plan

- [x] Token linter clean (pre-commit)
- [x] TypeScript typecheck clean
- [x] Anti-slop scan clean (pre-commit)
- [ ] Reviewer: visual diff in Chromatic — three stories should render identically minus the remove-button visual change
- [ ] Reviewer: confirm the broken Brand Identity rendering is fixed once portal picks up the next BDS release
- [ ] Reviewer: confirm sidebar shows Displays/Form/addable-* (not Components/Form/)

## Followups (separate PRs)

- PR 2 — Portal sheet survey: read the 5 unsurveyed onboarding-*-sheet.tsx files, document divergent local patterns (e.g. the hand-rolled multi-field-row in onboarding-software-sheet.tsx), produce a punch-list
- PR 3 — Consolidation decision: informed by PR 2's findings, decide whether to introduce `AddableTagList` per ADR-003, or align elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)