### PR TITLE
docs(audit): portal addable-pattern survey (PR 2 of cleanup sequence)

### DIFF
--- a/docs/audits/2026-Q2-portal-addable-survey.md
+++ b/docs/audits/2026-Q2-portal-addable-survey.md
@@ -1,0 +1,141 @@
+# 2026-Q2 Portal Addable-Pattern Survey
+
+**Date:** 2026-04-25
+**Surveyor:** Nick Stanerson + Claude
+**Scope:** PR 2 of the addable-cleanup sequence — research only, no code. Reads all six onboarding sheets in `brik-client-portal/src/components/sheets/` plus the Brand Identity flow, inventories every "add/remove items" pattern, and produces a punch-list to inform PR 3 (consolidation decision).
+**Predecessor:** [PR #250](https://github.com/brikdesigns/brik-bds/pull/250) — composition + remove-pattern fix in BDS.
+
+## Headline
+
+The portal has **5 distinct shapes** for "user manages a list of items" — three are BDS-correct (using `MultiSelect`, `AddableTextList`, `AddableComboList`, `AddableEntryList`, `CatalogPicker`), and **three are hand-rolled local clones** that reimplement the pattern with no BDS-level abstraction.
+
+The hand-rolled clones share a structural shape (multi-field row with a remove affordance) that no BDS component covers today. **PR 3 should decide whether to introduce a BDS primitive for that shape OR force migration to existing primitives.**
+
+## Inventory — patterns by sheet
+
+### Sheets using BDS components correctly
+
+| Sheet | Pattern(s) | BDS components used |
+|---|---|---|
+| `onboarding-billing-sheet.tsx` | CTAs, services, payment types, payment-policy notes, pricing tiers | `CatalogPicker` ×2, `AddableComboList`, `MultiSelect` |
+| `onboarding-visual-sheet.tsx` | Reference sites, image moods, vibe descriptors | `AddableEntryList` ×2, `MultiSelect` |
+| `onboarding-industry-details-sheet.tsx` | Services offered, locations, certifications, compliance | `AddableComboList` ×4 |
+| `onboarding-brand-sheet.tsx` | Approved/rejected CTAs, personality, voice | `CatalogPicker` ×2, `MultiSelect` |
+| `onboarding-competitors-sheet.tsx` (competitor list) | Competitor URLs + notes | `AddableEntryList` ×2 (read + edit modes) |
+
+These six BDS-correct usages span 4 of the 5 BDS-shipped Addable/Multi components — `MultiSelect`, `AddableComboList`, `AddableEntryList`, `CatalogPicker`. (The 5th, `AddableTextList`, doesn't appear in onboarding sheets — checked.)
+
+### Sheets with hand-rolled local clones
+
+These are the divergence cases. Each reimplements the add/remove flow with custom JSX rather than using a BDS component.
+
+#### Pattern A — Multi-field row + trash IconButton
+
+Two sheets. Same structural shape. Different hand-roll.
+
+**`onboarding-software-sheet.tsx`** — [lines 170-227](https://github.com/brikdesigns/brik-client-portal/blob/main/src/components/sheets/onboarding-software-sheet.tsx#L170-L227)
+- Per item: `TextInput` (Name) + `TextInput` (Purpose) + `Select` (Category) + `IconButton` (`ph:trash-fill`, `variant="secondary"`)
+- Inline `<div>` with `gridTemplateColumns: '1fr 1fr 160px auto'`
+- "Add X" Button below rows
+- Used for: Phone System, Other Tools (sectioned by category)
+
+**`onboarding-listing-sheet.tsx`** — [lines ~370-400](https://github.com/brikdesigns/brik-client-portal/blob/main/src/components/sheets/onboarding-listing-sheet.tsx#L370-L400)
+- Per item: holiday-name `TextInput` + open-time `TextInput` + close-time `TextInput` + closed `Checkbox` + `IconButton` (`ph:trash-fill`, `variant="secondary"`)
+- Inline grid layout (different column template)
+- "Add Holiday" Button below
+- Used for: holiday hours
+
+**Same shape, different JSX, different field sets, no shared abstraction.**
+
+#### Pattern B — Frame/card with text "Remove" Button
+
+One sheet.
+
+**`onboarding-competitors-sheet.tsx`** — [lines 150-200](https://github.com/brikdesigns/brik-client-portal/blob/main/src/components/sheets/onboarding-competitors-sheet.tsx#L150-L200)
+- Per item: header row (`#1` index + text "Remove" Button) + `TextInput` (Competitor) + `TextArea` (Gap) + `TextArea` (Copy implication)
+- Inline-styled `<div>` with `padding`, `border`, `borderRadius` from `@/lib/tokens` — local CSS-in-JS
+- "+ Add frame" Button at top
+- Used for: Competitive Positioning "frames"
+
+**Note**: This sheet ALSO uses BDS `AddableEntryList` correctly elsewhere ([line 104, 232](https://github.com/brikdesigns/brik-client-portal/blob/main/src/components/sheets/onboarding-competitors-sheet.tsx#L104)) for the actual competitor list. The hand-roll is for a separate "frames" data shape (Competitor + Gap + Copy implication = three fields per item).
+
+## Comparison table — five distinct shapes
+
+| Shape | Field count | Field types | Add affordance | Remove affordance | Wrapping container | BDS abstraction? |
+|---|---|---|---|---|---|---|
+| **MultiSelect + Tag** | 1 (locked enum) | dropdown pick | dropdown selection | Tag `onRemove ×` | inline | ✅ `MultiSelect` |
+| **Free-form tag list** | 1 (free string) | TextInput in reveal-form | "Add new" Button | Tag `onRemove ×` | inline | ✅ `AddableTextList` |
+| **Suggestion-driven tag list** | 1 (string + suggestions) | TextInput combobox + dropdown | combobox commit | Tag `onRemove ×` | inline | ✅ `AddableComboList` |
+| **Title + description card** | 2 (primary + secondary) | TextInput + TextArea | row append OR reveal-form | text "Remove" Button OR IconButton `ph:x` (after PR #250) | bordered card | ✅ `AddableEntryList` (and `CatalogPicker` for the suggestion case) |
+| **Multi-field row** (3+ fields) | 3+ | TextInput / Select / Checkbox / TimePicker / etc. | "Add X" Button below rows | IconButton `ph:trash-fill` (or text "Remove" in one case) | inline grid | ❌ **none — hand-rolled in 3 sheets** |
+
+The fifth shape — the multi-field row — has no BDS abstraction. Three sheets reinvent it.
+
+## Punch-list (input for PR 3)
+
+Ordered by impact × design-clarity:
+
+### 1. Decide on the multi-field-row shape
+
+**Question:** Should BDS introduce a primitive for the multi-field row pattern, or should the three offending sheets converge on something existing?
+
+Three options:
+
+**Option A — Introduce `AddableFieldRowList` in BDS.** Generic primitive for "user manages a list of N-field rows." Props sketch: `rows`, `onChange`, `fields: Array<{ key, label, render: (value, onChange) => ReactNode }>`, `addLabel`, `removeLabel`. Renders rows + add button + IconButton trash per row. Net: −300 LOC across the three sheets, +~150 LOC in BDS.
+
+**Option B — `AddableEntryList` grows multi-field support.** Extend `AddableEntry` shape from `{ primary, secondary }` to `Record<string, string>` with field config. Net: stretches a 2-field shape into N-field territory; risks forks-as-component-with-discriminated-union complexity.
+
+**Option C — Defer.** Mark the three sheets as "tolerated divergence" and move on. Punt the abstraction until a 4th instance shows up.
+
+**Honest take**: 3 instances meets ADR-004's "three uses test" — Option A is justified. The shape is genuinely useful (Phone System, Holiday Hours, Competitive Frames are all reasonable use cases). But the API design is non-trivial (how to declare fields? type-safe values? validation?) and warrants its own focused design pass.
+
+### 2. Settle the × vs trash semantic question
+
+| Affordance | Where used today | Semantic |
+|---|---|---|
+| Tag `onRemove ×` (`ph:x`) | MultiSelect, AddableTextList, AddableComboList, AddableEntryList (post-PR #250) | "remove from this list" — non-destructive |
+| `IconButton ph:trash-fill` | onboarding-software-sheet, onboarding-listing-sheet | "delete this row" — destructive intent |
+| Text `<Button>Remove</Button>` | onboarding-competitors-sheet local clone (not BDS) | inconsistent with both above |
+
+Two patterns are arguably semantically distinct: removing a *tag* (light) vs deleting a *row of structured data* (heavier, signals data loss). But there's no documented rule, and PR #250 just unified everything in BDS to `ph:x`.
+
+**Question:** Does `ph:trash-fill` belong on multi-field rows because they're "more destructive"? Or should the new `AddableFieldRowList` (if Option A wins) also use `ph:x`?
+
+**Honest take**: lean toward `ph:x` everywhere for visual consistency. Trash-as-icon is a strong destructive cue that may overstate the gravity of removing one row from a list — and tags vs rows isn't a meaningful semantic distinction at the user level. But the user (operator) should make this call; there's no objectively right answer.
+
+### 3. Settle the competitors-sheet "frames" shape
+
+The frames shape (Competitor + Gap + Copy implication) is technically a 3-field card, not a tag list. It's currently hand-rolled in `onboarding-competitors-sheet.tsx`. Options:
+
+- **A.** It becomes the canonical example of `AddableFieldRowList` (if introduced).
+- **B.** It collapses into `AddableEntryList` plain mode if the third field (Copy implication) gets dropped or merged into the secondary.
+- **C.** It stays hand-rolled.
+
+Same axis as #1 — depends on whether BDS gains the multi-field primitive.
+
+### 4. Migration scope summary (post PR 3 decisions)
+
+If BDS introduces `AddableFieldRowList` (Option A on #1):
+- Migrate `onboarding-software-sheet.tsx` Phone System / Other Tools (1 sheet)
+- Migrate `onboarding-listing-sheet.tsx` holiday hours (1 sheet)
+- Possibly migrate `onboarding-competitors-sheet.tsx` competitive frames (1 sheet) — depends on #3
+
+If BDS doesn't introduce the primitive:
+- No migrations. Tolerated divergence; document as known.
+
+## Out of scope (already addressed)
+
+- Composition fixes for AddableComboList + AddableEntryList — landed in PR #250
+- Remove-pattern unification across BDS Addables — landed in PR #250
+- Storybook taxonomy moves — landed in PR #250
+- Dialog / AlertBanner / CardSummary / CardControl deprecations — separate audit punch-list (already shipped via PRs #236, #237, #244, #246)
+
+## Recommendation for PR 3
+
+**Don't decide #1 in a vacuum.** The right format is a short ADR proposing `AddableFieldRowList` (or rejecting it) with concrete API sketch + migration estimate. That ADR becomes PR 3.
+
+If the ADR accepts the new primitive, BDS implementation + portal migration follow as separate PRs (same additive-deprecate-migrate-delete pattern as Modal/Dialog, Banner/AlertBanner, Card/CardSummary).
+
+If the ADR rejects (defers), document the rationale in the audit doc's "Rejected recommendations" section like #5 Snackbar and #6 Menu/Popover were.
+
+Either way, PR 3 starts with the ADR — not code.


### PR DESCRIPTION
## Summary

Research-only PR. Read all six portal onboarding sheets, inventoried every "add/remove items" pattern, produced a punch-list to inform PR 3 (consolidation decision).

**No code changes.** Output is a single doc at [`docs/audits/2026-Q2-portal-addable-survey.md`](docs/audits/2026-Q2-portal-addable-survey.md) (141 lines).

## Headline findings

The portal has **5 distinct shapes** for "user manages a list of items":

| # | Shape | BDS abstraction? |
|---|---|---|
| 1 | MultiSelect + Tag (locked enum) | ✅ MultiSelect |
| 2 | Free-form tag list | ✅ AddableTextList |
| 3 | Suggestion-driven tag list | ✅ AddableComboList |
| 4 | Title + description card (with optional suggestions) | ✅ AddableEntryList / CatalogPicker |
| 5 | **Multi-field row (3+ fields)** | ❌ **none — hand-rolled in 3 sheets** |

The fifth shape has no BDS abstraction. **Three sheets reinvent it independently:**

- `onboarding-software-sheet.tsx` — Phone System / Other Tools (Name + Purpose + Category Select + trash IconButton)
- `onboarding-listing-sheet.tsx` — holiday hours (open + close + closed Checkbox + trash IconButton)
- `onboarding-competitors-sheet.tsx` — Competitive Positioning frames (Competitor + Gap + Copy implication + text "Remove" Button — different remove pattern)

Three instances meets ADR-004's three-uses test. The shape is a real candidate for a new BDS primitive.

## Punch-list (input for PR 3)

The survey doc identifies four open decisions:

1. **Multi-field-row shape**: introduce `AddableFieldRowList` in BDS (Option A), extend `AddableEntryList` (Option B), or defer (Option C)
2. **× vs trash semantic**: settle whether the new primitive uses `ph:x` (consistency with PR #250's BDS-wide unification) or `ph:trash-fill` (current portal convention for "delete row")
3. **Competitors-sheet frames**: collapse into the new primitive, or leave hand-rolled
4. **Migration scope**: 0–3 sheets depending on #1 and #3

## Recommendation

PR 3 should start with **an ADR proposing `AddableFieldRowList` (or rejecting it)** — not code. The API design is non-trivial (how to declare fields? type-safety? validation?) and warrants a focused design pass before implementation.

If accepted: BDS implementation + portal migration follow as separate PRs (same additive-deprecate-migrate-delete pattern as Modal/Dialog, Banner/AlertBanner, Card presets).

If rejected: document under "Rejected recommendations" in the audit doc, like #5 Snackbar and #6 Menu/Popover were.

## Sheets that are clean (no follow-up needed)

- `onboarding-billing-sheet.tsx` — `CatalogPicker` ×2, `AddableComboList`, `MultiSelect`
- `onboarding-visual-sheet.tsx` — `AddableEntryList` ×2, `MultiSelect`
- `onboarding-industry-details-sheet.tsx` — `AddableComboList` ×4
- `onboarding-brand-sheet.tsx` — `CatalogPicker` ×2, `MultiSelect` (Brand Identity will render correctly once portal picks up v0.39.0+ — PR #250 fixed the source bug)
- `onboarding-competitors-sheet.tsx` competitor list — `AddableEntryList` ×2 (note: same sheet has the hand-rolled "frames" pattern flagged above)

## Test plan

- [x] Survey doc lints clean (Markdown only)
- [ ] Reviewer: confirm the 5-shape inventory matches your mental model
- [ ] Reviewer: pick a direction on punch-list item #1 (Option A / B / C) so PR 3 can target a specific ADR

## Sequencing recap

| PR | Status | Scope |
|---|---|---|
| #250 (PR 1) | ✓ merged | BDS composition + remove-pattern fixes |
| **This PR (PR 2)** | open | Portal survey |
| PR 3 | next | ADR for AddableFieldRowList (or rejection) |
| PR 4+ | future | Implementation + portal migrations (if PR 3 accepts) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)