### PR TITLE
feat(addable-field-row-list): add multi-field row primitive (ADR-005)

### DIFF
--- a/components/ui/AddableFieldRowList/AddableFieldRowList.css
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.css
@@ -1,0 +1,69 @@
+@layer bds-components {
+/**
+ * BDS AddableFieldRowList — multi-field row collection primitive.
+ *
+ * Owns add/remove handlers, grid layout, label/helper/empty surface.
+ * Consumer supplies per-row field markup via the children render-prop;
+ * grid columns come from the `columns` prop (set as inline style).
+ *
+ * Naming: BEM-lite — .bds-addable-field-row-list, __row, etc.
+ */
+
+/* ─── Root ────────────────────────────────────────────────── */
+
+.bds-addable-field-row-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  width: 100%;
+}
+
+/* ─── Label ───────────────────────────────────────────────── */
+
+.bds-addable-field-row-list__label {
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+/* ─── Row list ────────────────────────────────────────────── */
+
+.bds-addable-field-row-list__rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* ─── Row ─────────────────────────────────────────────────── */
+/* grid-template-columns is set inline via `columns` prop + auto track for
+ * the remove IconButton. align-items: end keeps fields aligned along their
+ * baselines when the consumer's fields have labels of varying heights. */
+
+.bds-addable-field-row-list__row {
+  display: grid;
+  gap: var(--gap-sm);
+  align-items: end;
+}
+
+/* ─── Empty state ─────────────────────────────────────────── */
+
+.bds-addable-field-row-list__empty {
+  font-family: var(--font-family-body);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ─── Helper text ─────────────────────────────────────────── */
+
+.bds-addable-field-row-list__helper {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+}
+}

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.mdx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.mdx
@@ -1,0 +1,133 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './AddableFieldRowList.stories';
+
+<Meta of={Stories} />
+
+# AddableFieldRowList
+
+Multi-field row collection primitive. Use when the user manages a list where each item has 2+ structured fields (e.g. Name + Purpose + Category, open time + close time + closed-checkbox).
+
+Distinct from the rest of the addable family:
+
+| Component | Item shape |
+|---|---|
+| [`MultiSelect`](/?path=/docs/components-form-multi-select--docs) | Selected enum values rendered as Tags |
+| [`AddableTextList`](/?path=/docs/displays-form-addable-text-list--docs) | Single string per item (free-form) |
+| [`AddableComboList`](/?path=/docs/displays-form-addable-combo-list--docs) | Single string per item, suggestion-driven |
+| [`AddableEntryList`](/?path=/docs/displays-form-addable-entry-list--docs) | Title + description card |
+| **`AddableFieldRowList`** | **Arbitrary multi-field row** |
+
+Per [ADR-005](../../docs/adrs/ADR-005-addable-field-row-list.md). Replaces three hand-rolled patterns identified in the [2026-Q2 portal addable survey](../../docs/audits/2026-Q2-portal-addable-survey.md).
+
+---
+
+## Phone System
+
+Three real-world fields: TextInput + TextInput + Select. Mirrors the Phone System / Other Tools section of the portal's Software sheet.
+
+<Canvas of={Stories.PhoneSystem} />
+
+## Holiday hours (cross-field disabling)
+
+The render-prop API supports cross-field interactions naturally — the consumer reads `row.closed` and conditionally sets `disabled` on the time inputs. No special primitive support needed.
+
+<Canvas of={Stories.HolidayHours} />
+
+## Competitive Positioning (3 TextAreas)
+
+Same primitive, taller content. Three TextArea fields per row in a `1fr 1fr 1fr` grid.
+
+<Canvas of={Stories.CompetitiveFrames} />
+
+## Empty state + maxItems
+
+When `values.length === 0`, the optional `emptyLabel` shows in place of the row list. When `values.length >= maxItems`, the Add button hides automatically.
+
+<Canvas of={Stories.EmptyAndMaxItems} />
+
+---
+
+## API
+
+### Props
+
+<ArgTypes of={Stories} />
+
+### Render-prop context
+
+The `children` render-prop receives `{ row, index, update }`:
+
+- **`row: T`** — current row data, typed via the generic `<T>` parameter
+- **`index: number`** — zero-indexed row position
+- **`update: (patch: Partial<T>) => void`** — patches the row, merging into current values
+
+### `columns` prop
+
+CSS `grid-template-columns` value for the field columns. The primitive automatically appends an `auto` track for the per-row remove `IconButton`.
+
+```tsx
+columns="1fr 1fr 160px"   // 2 flexible + 1 fixed-width
+columns="1fr 1fr 1fr"     // 3 equal columns
+columns="1fr"             // single full-width field
+```
+
+### Remove icon
+
+Per-row remove uses `IconButton variant="ghost"` with `ph:dash-circle`. The icon choice carries a semantic distinction (per ADR-005):
+
+- `ph:dash-circle` (this primitive) = **remove from list** (subtract)
+- `ph:x` ([Tag](/?path=/docs/components-indicator-tag--docs) `onRemove`) = **dismiss selection** (close)
+- `ph:trash-fill` (page-level destructive actions) = **delete record** (permanent)
+
+---
+
+## Usage
+
+```tsx
+import { AddableFieldRowList, TextInput, Select } from '@brikdesigns/bds';
+
+interface Tool {
+  name: string;
+  purpose: string;
+  category: 'phone' | 'crm' | 'other';
+}
+
+<AddableFieldRowList<Tool>
+  values={tools}
+  onChange={setTools}
+  newRow={() => ({ name: '', purpose: '', category: 'other' })}
+  columns="1fr 1fr 160px"
+  addLabel="Add tool"
+  removeLabel="Remove tool"
+>
+  {({ row, update }) => (
+    <>
+      <TextInput
+        value={row.name}
+        onChange={(e) => update({ name: e.target.value })}
+      />
+      <TextInput
+        value={row.purpose}
+        onChange={(e) => update({ purpose: e.target.value })}
+      />
+      <Select
+        options={CATEGORY_OPTIONS}
+        value={row.category}
+        onChange={(e) => update({ category: e.target.value as Tool['category'] })}
+      />
+    </>
+  )}
+</AddableFieldRowList>
+```
+
+## When to use
+
+- The user adds/removes a list of items where **each item has 2+ structured fields**
+- Field types may vary (TextInput, Select, Checkbox, TextArea, etc.) and you want type-safe row data
+- Cross-field interactions are needed (e.g. one field disables another)
+
+## When NOT to use
+
+- Single-string-per-item — use [`AddableTextList`](/?path=/docs/displays-form-addable-text-list--docs) or [`AddableComboList`](/?path=/docs/displays-form-addable-combo-list--docs)
+- Title + description per item — use [`AddableEntryList`](/?path=/docs/displays-form-addable-entry-list--docs)
+- Pick from a fixed enum — use [`MultiSelect`](/?path=/docs/components-form-multi-select--docs) (renders Tags)

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx
@@ -1,0 +1,250 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AddableFieldRowList } from './AddableFieldRowList';
+import { TextInput } from '../TextInput';
+import { TextArea } from '../TextArea';
+import { Select } from '../Select';
+import { Checkbox } from '../Checkbox';
+
+const meta: Meta<typeof AddableFieldRowList> = {
+  title: 'Displays/Form/addable-field-row-list',
+  component: AddableFieldRowList,
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ─── Story 1: Phone System (3-text + Select) ─────────────────
+ * Mirrors onboarding-software-sheet.tsx — Name + Purpose + Category Select.
+ * Demonstrates the typical multi-field row use case.
+ */
+
+interface Tool {
+  name: string;
+  purpose: string;
+  category: 'phone' | 'crm' | 'other';
+}
+
+const CATEGORY_OPTIONS = [
+  { value: 'phone', label: 'Phone System' },
+  { value: 'crm', label: 'CRM' },
+  { value: 'other', label: 'Other Tools' },
+];
+
+export const PhoneSystem: Story = {
+  name: 'Phone System (3 fields)',
+  render: () => {
+    const [tools, setTools] = useState<Tool[]>([
+      { name: 'HubSpot', purpose: 'CRM and pipeline tracking', category: 'crm' },
+      { name: 'Office 365', purpose: 'email platform', category: 'other' },
+    ]);
+
+    return (
+      <div style={{ width: 720 }}>
+        <AddableFieldRowList<Tool>
+          label="Software stack"
+          values={tools}
+          onChange={setTools}
+          newRow={() => ({ name: '', purpose: '', category: 'other' })}
+          columns="1fr 1fr 160px"
+          addLabel="Add tool"
+          removeLabel="Remove tool"
+          emptyLabel="No tools added yet."
+        >
+          {({ row, update }) => (
+            <>
+              <TextInput
+                value={row.name}
+                onChange={(e) => update({ name: e.target.value })}
+                placeholder="e.g. HubSpot"
+                fullWidth
+              />
+              <TextInput
+                value={row.purpose}
+                onChange={(e) => update({ purpose: e.target.value })}
+                placeholder="What this tool is used for"
+                fullWidth
+              />
+              <Select
+                options={CATEGORY_OPTIONS}
+                value={row.category}
+                onChange={(e) => update({ category: e.target.value as Tool['category'] })}
+              />
+            </>
+          )}
+        </AddableFieldRowList>
+      </div>
+    );
+  },
+};
+
+/* ─── Story 2: Holiday hours (cross-field disabling) ──────────
+ * Mirrors onboarding-listing-sheet.tsx — open + close TextInput
+ * (disabled when closed) + Closed Checkbox. Demonstrates that the
+ * render-prop API supports cross-field interactions naturally.
+ */
+
+interface Holiday {
+  open: string;
+  close: string;
+  closed: boolean;
+}
+
+export const HolidayHours: Story = {
+  name: 'Holiday hours (cross-field disabling)',
+  render: () => {
+    const [holidays, setHolidays] = useState<Holiday[]>([
+      { open: '09:00', close: '17:00', closed: false },
+      { open: '', close: '', closed: true },
+    ]);
+
+    return (
+      <div style={{ width: 640 }}>
+        <AddableFieldRowList<Holiday>
+          label="Holiday hours"
+          values={holidays}
+          onChange={setHolidays}
+          newRow={() => ({ open: '', close: '', closed: false })}
+          columns="1fr 1fr 100px"
+          addLabel="Add holiday"
+          removeLabel="Remove holiday"
+          emptyLabel="No holidays configured."
+          helperText="Mark Closed to disable open/close times for that day."
+        >
+          {({ row, update }) => (
+            <>
+              <TextInput
+                type="time"
+                value={row.open}
+                onChange={(e) => update({ open: e.target.value })}
+                disabled={row.closed}
+                fullWidth
+              />
+              <TextInput
+                type="time"
+                value={row.close}
+                onChange={(e) => update({ close: e.target.value })}
+                disabled={row.closed}
+                fullWidth
+              />
+              <Checkbox
+                label="Closed"
+                checked={row.closed}
+                onChange={(e) => update({ closed: e.target.checked })}
+              />
+            </>
+          )}
+        </AddableFieldRowList>
+      </div>
+    );
+  },
+};
+
+/* ─── Story 3: Competitive Positioning (3 TextAreas) ──────────
+ * Mirrors onboarding-competitors-sheet.tsx — Competitor + Gap +
+ * Copy implication. Demonstrates wider rows with TextArea fields
+ * and the same 3-column grid working for taller content.
+ */
+
+interface CompetitiveFrame {
+  competitor: string;
+  gap: string;
+  copyImplication: string;
+}
+
+export const CompetitiveFrames: Story = {
+  name: 'Competitive Positioning (3 textareas)',
+  render: () => {
+    const [frames, setFrames] = useState<CompetitiveFrame[]>([
+      {
+        competitor: 'DSO-affiliated practices',
+        gap: 'Patient experience feels transactional and rushed.',
+        copyImplication: 'Lead with longer appointment times and named-clinician continuity.',
+      },
+    ]);
+
+    return (
+      <div style={{ width: 880 }}>
+        <AddableFieldRowList<CompetitiveFrame>
+          label="Competitive Positioning"
+          values={frames}
+          onChange={setFrames}
+          newRow={() => ({ competitor: '', gap: '', copyImplication: '' })}
+          columns="1fr 1fr 1fr"
+          addLabel="Add frame"
+          removeLabel="Remove frame"
+          emptyLabel="No frames. Click Add frame to create one."
+        >
+          {({ row, update }) => (
+            <>
+              <TextArea
+                value={row.competitor}
+                onChange={(e) => update({ competitor: e.target.value })}
+                placeholder="Name or archetype"
+                rows={3}
+                fullWidth
+              />
+              <TextArea
+                value={row.gap}
+                onChange={(e) => update({ gap: e.target.value })}
+                placeholder="What they lack that this client can claim"
+                rows={3}
+                fullWidth
+              />
+              <TextArea
+                value={row.copyImplication}
+                onChange={(e) => update({ copyImplication: e.target.value })}
+                placeholder="How this should shape on-site copy"
+                rows={3}
+                fullWidth
+              />
+            </>
+          )}
+        </AddableFieldRowList>
+      </div>
+    );
+  },
+};
+
+/* ─── Story 4: Empty state + maxItems gating ──────────────────
+ * Demonstrates the empty state and maxItems behavior — Add button
+ * disappears once the cap is reached.
+ */
+
+interface SimpleNote {
+  text: string;
+}
+
+export const EmptyAndMaxItems: Story = {
+  name: 'Empty state + maxItems',
+  render: () => {
+    const [notes, setNotes] = useState<SimpleNote[]>([]);
+
+    return (
+      <div style={{ width: 480, display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)' }}>
+        <AddableFieldRowList<SimpleNote>
+          label="Quick notes (max 3)"
+          values={notes}
+          onChange={setNotes}
+          newRow={() => ({ text: '' })}
+          columns="1fr"
+          addLabel="Add note"
+          removeLabel="Remove note"
+          emptyLabel="No notes yet — click Add note to start."
+          maxItems={3}
+          helperText="Add up to 3 quick notes. The Add button disappears at the cap."
+        >
+          {({ row, update }) => (
+            <TextInput
+              value={row.text}
+              onChange={(e) => update({ text: e.target.value })}
+              placeholder="Type a quick note…"
+              fullWidth
+            />
+          )}
+        </AddableFieldRowList>
+      </div>
+    );
+  },
+};

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.tsx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.tsx
@@ -1,0 +1,221 @@
+import { type CSSProperties, type HTMLAttributes, type ReactNode } from 'react';
+import { Icon } from '@iconify/react';
+import { bdsClass } from '../../utils';
+import { Button, type ButtonSize } from '../Button';
+import { IconButton } from '../Button';
+import './AddableFieldRowList.css';
+
+export type AddableFieldRowListSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Render context passed to the children render-prop on each row.
+ */
+export interface AddableFieldRowContext<T> {
+  /** Current row data */
+  row: T;
+  /** Zero-indexed row position */
+  index: number;
+  /** Patch the row — merges into the current row data */
+  update: (patch: Partial<T>) => void;
+}
+
+export interface AddableFieldRowListProps<T>
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'> {
+  /** Current list of rows */
+  values: T[];
+  /** Called when rows change (add / update / remove) */
+  onChange: (next: T[]) => void;
+  /**
+   * Factory for a new empty row when the user clicks "Add".
+   * Called once per add — the returned object is appended to `values`.
+   */
+  newRow: () => T;
+  /**
+   * Render-prop for the row's field markup. Receives the current row,
+   * its index, and an `update` helper for patching the row. The remove
+   * IconButton is rendered automatically by the primitive.
+   */
+  children: (ctx: AddableFieldRowContext<T>) => ReactNode;
+  /**
+   * CSS `grid-template-columns` value for the row's field columns.
+   * The primitive appends an `auto` track for the remove button. Default `1fr`.
+   *
+   * @example "1fr 1fr 160px"   (3-text + Select)
+   * @example "1fr"             (single full-width field)
+   */
+  columns?: string;
+  /** Optional field label rendered above the list */
+  label?: string;
+  /** Optional helper text rendered below the list */
+  helperText?: string;
+  /** Empty-state message shown when `values.length === 0` */
+  emptyLabel?: string;
+  /** Add button label (default "Add row") */
+  addLabel?: string;
+  /** Accessible label for the per-row remove button (default "Remove row") */
+  removeLabel?: string;
+  /**
+   * Maximum number of rows. When reached, the Add button is hidden.
+   * Omitted = unlimited.
+   */
+  maxItems?: number;
+  /** Size variant — controls Button + IconButton sizing. Default `md`. */
+  size?: AddableFieldRowListSize;
+}
+
+const BUTTON_SIZE: Record<AddableFieldRowListSize, ButtonSize> = {
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+};
+
+/**
+ * AddableFieldRowList — multi-field row collection primitive.
+ *
+ * Replaces hand-rolled "add/remove rows of structured data" patterns with a
+ * type-safe render-prop API. The consumer supplies the per-row field markup
+ * (TextInput, Select, Checkbox, etc.); the primitive owns add/remove
+ * handlers, grid layout, and the per-row remove IconButton.
+ *
+ * Per ADR-005, this is the canonical primitive for the multi-field row
+ * shape — distinct from `AddableTextList` (single-string tag list),
+ * `AddableComboList` (suggestion-driven tag list), and `AddableEntryList`
+ * (title + description card).
+ *
+ * @example Phone System / Other Tools (3-text + Select)
+ * ```tsx
+ * <AddableFieldRowList<Tool>
+ *   values={tools}
+ *   onChange={setTools}
+ *   newRow={() => ({ name: '', purpose: '', category: 'other' })}
+ *   columns="1fr 1fr 160px"
+ *   addLabel="Add Phone System"
+ *   removeLabel="Remove tool"
+ * >
+ *   {({ row, update }) => (
+ *     <>
+ *       <TextInput value={row.name} onChange={(e) => update({ name: e.target.value })} />
+ *       <TextInput value={row.purpose} onChange={(e) => update({ purpose: e.target.value })} />
+ *       <Select value={row.category} options={CATEGORY_OPTIONS}
+ *         onChange={(e) => update({ category: e.target.value as ToolCategory })} />
+ *     </>
+ *   )}
+ * </AddableFieldRowList>
+ * ```
+ *
+ * @example Holiday hours with cross-field disabling
+ * ```tsx
+ * <AddableFieldRowList<Holiday>
+ *   values={holidays}
+ *   onChange={setHolidays}
+ *   newRow={() => ({ open: '', close: '', closed: false })}
+ *   columns="1fr 1fr 100px"
+ *   addLabel="Add Holiday"
+ * >
+ *   {({ row, update }) => (
+ *     <>
+ *       <TextInput type="time" value={row.open}
+ *         onChange={(e) => update({ open: e.target.value })}
+ *         disabled={row.closed} />
+ *       <TextInput type="time" value={row.close}
+ *         onChange={(e) => update({ close: e.target.value })}
+ *         disabled={row.closed} />
+ *       <Checkbox label="Closed" checked={row.closed}
+ *         onChange={(e) => update({ closed: e.target.checked })} />
+ *     </>
+ *   )}
+ * </AddableFieldRowList>
+ * ```
+ */
+export function AddableFieldRowList<T>({
+  values,
+  onChange,
+  newRow,
+  children,
+  columns = '1fr',
+  label,
+  helperText,
+  emptyLabel,
+  addLabel = 'Add row',
+  removeLabel = 'Remove row',
+  maxItems,
+  size = 'md',
+  className,
+  style,
+  ...props
+}: AddableFieldRowListProps<T>) {
+  const atLimit = typeof maxItems === 'number' && values.length >= maxItems;
+
+  const update = (index: number, patch: Partial<T>) => {
+    onChange(values.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+  };
+
+  const remove = (index: number) => {
+    onChange(values.filter((_, i) => i !== index));
+  };
+
+  const append = () => {
+    onChange([...values, newRow()]);
+  };
+
+  const showEmpty = values.length === 0 && emptyLabel;
+
+  // Each row is a CSS grid: consumer columns + auto track for the remove button.
+  const rowStyle: CSSProperties = {
+    gridTemplateColumns: `${columns} auto`,
+  };
+
+  return (
+    <div
+      className={bdsClass('bds-addable-field-row-list', className)}
+      style={style}
+      {...props}
+    >
+      {label && <span className="bds-addable-field-row-list__label">{label}</span>}
+
+      {values.length > 0 && (
+        <ul className="bds-addable-field-row-list__rows" role="list">
+          {values.map((row, index) => (
+            <li
+              key={index}
+              className="bds-addable-field-row-list__row"
+              style={rowStyle}
+              role="listitem"
+            >
+              {children({
+                row,
+                index,
+                update: (patch) => update(index, patch),
+              })}
+              <IconButton
+                size={BUTTON_SIZE[size]}
+                variant="ghost"
+                icon={<Icon icon="ph:dash-circle" />}
+                label={removeLabel}
+                onClick={() => remove(index)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showEmpty && (
+        <span className="bds-addable-field-row-list__empty">{emptyLabel}</span>
+      )}
+
+      {!atLimit && (
+        <div>
+          <Button size={BUTTON_SIZE[size]} variant="secondary" onClick={append}>
+            {addLabel}
+          </Button>
+        </div>
+      )}
+
+      {helperText && (
+        <span className="bds-addable-field-row-list__helper">{helperText}</span>
+      )}
+    </div>
+  );
+}
+
+export default AddableFieldRowList;

--- a/components/ui/AddableFieldRowList/index.ts
+++ b/components/ui/AddableFieldRowList/index.ts
@@ -1,0 +1,6 @@
+export {
+  AddableFieldRowList,
+  type AddableFieldRowListProps,
+  type AddableFieldRowListSize,
+  type AddableFieldRowContext,
+} from './AddableFieldRowList';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -3,6 +3,7 @@ export * from './Accordion';
 export * from './ActivityTimeline';
 export * from './AddableComboList';
 export * from './AddableEntryList';
+export * from './AddableFieldRowList';
 export * from './AddableTextList';
 export * from './AddressInput';
 export * from './AnimatedIcon';


### PR DESCRIPTION
## Summary

Implements [ADR-005](docs/adrs/ADR-005-addable-field-row-list.md) — new BDS primitive for the multi-field row pattern hand-rolled in three portal sheets.

**+680 LOC, 0 deletions, 0 public API changes to existing components.** Pure addition — three portal sheets and the per-row icon re-standardization migrate in subsequent PRs.

## What landed

| File | Purpose |
|---|---|
| `components/ui/AddableFieldRowList/AddableFieldRowList.tsx` (221 LOC) | Render-prop component with generic `<T>` |
| `components/ui/AddableFieldRowList/AddableFieldRowList.css` (69 LOC) | Grid layout + list semantics |
| `components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx` (250 LOC) | 4 stories matching the 3 real uses + an empty/maxItems demo |
| `components/ui/AddableFieldRowList/AddableFieldRowList.mdx` (133 LOC) | Docs + when-to-use guidance |
| `components/ui/AddableFieldRowList/index.ts` (6 LOC) | Barrel export |
| `components/ui/index.ts` | +1 line |

## API shape (per ADR-005)

Render-prop with generic `<T>`:

```tsx
<AddableFieldRowList<Tool>
  values={tools}
  onChange={setTools}
  newRow={() => ({ name: '', purpose: '', category: 'other' })}
  columns="1fr 1fr 160px"
  addLabel="Add tool"
  removeLabel="Remove tool"
>
  {({ row, update }) => (
    <>
      <TextInput value={row.name} onChange={(e) => update({ name: e.target.value })} />
      <TextInput value={row.purpose} onChange={(e) => update({ purpose: e.target.value })} />
      <Select options={CATEGORY_OPTIONS} value={row.category}
        onChange={(e) => update({ category: e.target.value as Tool['category'] })} />
    </>
  )}
</AddableFieldRowList>
```

Per-row remove rendered by the primitive: `<IconButton variant="ghost" icon={<Icon icon="ph:dash-circle" />} />`.

## Stories cover all three real use cases

| Story | Maps to | Demonstrates |
|---|---|---|
| `PhoneSystem` | software-sheet (Phone System / Other Tools) | 3-text + Select, the typical case |
| `HolidayHours` | listing-sheet | TextInput time + Checkbox with **cross-field disabling** — render-prop reads `row.closed` and conditionally disables the time inputs, no special primitive support |
| `CompetitiveFrames` | competitors-sheet | 3 TextAreas in `1fr 1fr 1fr` grid — same primitive, taller content |
| `EmptyAndMaxItems` | (synthetic) | `emptyLabel` rendering + Add-button gating at `maxItems` |

## Design notes

- **No special primitive support for cross-field interactions.** The render-prop pattern means consumers read `row` and conditionally set `disabled` (or any other prop) directly on their fields. Listing-sheet's "closed disables open/close" is naturally expressible.
- **Layout is a CSS grid** with consumer-supplied `columns` + an `auto` track for the remove IconButton. `align-items: end` keeps fields aligned along their baselines when labels vary in height.
- **Storybook taxonomy** lives at `Displays/Form/addable-field-row-list` — alongside the migrated addable family.

## Test plan

- [x] Token linter clean (pre-commit)
- [x] TypeScript typecheck clean — generic `<T>` infers correctly through the render-prop
- [x] Anti-slop scan clean (pre-commit)
- [ ] Reviewer: confirm the API matches the ADR sketch
- [ ] Reviewer: confirm the four stories render as expected (Chromatic visual diff)
- [ ] Reviewer: spot-check the `HolidayHours` story for the cross-field-disabling behavior

## Forward scope (separate PRs after merge)

| PR | Scope | Status |
|---|---|---|
| Per-row remove icon re-standardization | `AddableEntryList` `ph:x` → `ph:dash-circle` per-row remove. Revises PR #250 for the per-row case; `Tag.onRemove` unchanged. | Next |
| Portal migration: software-sheet | `AddableFieldRowList` for Phone System / Other Tools | Queued |
| Portal migration: listing-sheet | `AddableFieldRowList` for holiday hours | Queued |
| Portal migration: competitors-sheet | `AddableFieldRowList` for Competitive Positioning frames | Queued |
| BDS v0.40.0 release | Bundles the above | Queued |

🤖 Generated with [Claude Code](https://claude.com/claude-code)