### PR TITLE
refactor(addable-entry-list): per-row remove ph:x → ph:dash-circle

### DIFF
--- a/components/ui/AddableEntryList/AddableEntryList.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.tsx
@@ -285,7 +285,7 @@ export function AddableEntryList({
                 <IconButton
                   size={BUTTON_SIZE[size]}
                   variant="ghost"
-                  icon={<Icon icon="ph:x" />}
+                  icon={<Icon icon="ph:dash-circle" />}
                   label={removeLabel}
                   onClick={() => remove(index)}
                 />
@@ -501,7 +501,7 @@ function SuggestionModeEdit({
               <IconButton
                 size={BUTTON_SIZE[size]}
                 variant="ghost"
-                icon={<Icon icon="ph:x" />}
+                icon={<Icon icon="ph:dash-circle" />}
                 label={removeLabel}
                 onClick={() => remove(index)}
               />


### PR DESCRIPTION
## Summary

Tiny PR — 2 lines changed. Re-standardizes `AddableEntryList`'s per-row remove IconButton to `ph:dash-circle` per [ADR-005](docs/adrs/ADR-005-addable-field-row-list.md)'s icon semantic distinction.

## What changed

| Location | Before | After |
|---|---|---|
| Plain mode row-header IconButton | `ph:x` | `ph:dash-circle` |
| Suggestion mode card IconButton | `ph:x` | `ph:dash-circle` |

Both were `ph:x` as a result of PR #250's family-wide unification. ADR-005 introduced the semantic distinction that re-orders the right defaults:

| Icon | Semantic | Where |
|---|---|---|
| `ph:dash-circle` | "remove from list" (subtract — composing a collection) | Per-row remove in editable list components |
| `ph:x` | "dismiss selection" (close — selection has happened) | `Tag.onRemove` |
| `ph:trash-fill` | destructive permanent delete | Reserved for hard-delete flows (e.g. record deletion) |

## What this does NOT change

- `Tag.onRemove` keeps `ph:x` — the dismiss-selection semantic is correct there
- `AddableTextList` and `AddableComboList` use Tag's `onRemove`, so they're already on the right icon by virtue of that
- The newly-shipped `AddableFieldRowList` (PR #253) is already on `ph:dash-circle`
- No public API change

## Test plan

- [x] Token linter clean (pre-commit)
- [x] TypeScript typecheck clean
- [x] Anti-slop scan clean (pre-commit)
- [ ] Reviewer: confirm visual change in Chromatic — `Displays/Form/addable-entry-list` per-row remove now shows dash-circle in both plain and suggestion modes

## Forward scope (separate PRs)

| PR | Scope |
|---|---|
| Portal migration: software-sheet | Phone System / Other Tools → AddableFieldRowList |
| Portal migration: listing-sheet | Holiday hours → AddableFieldRowList |
| Portal migration: competitors-sheet | Competitive Positioning frames → AddableFieldRowList |
| v0.40.0 release | Bundles PR #253 (AddableFieldRowList) + this icon swap |

🤖 Generated with [Claude Code](https://claude.com/claude-code)