### PR TITLE
chore(release): v0.40.0 — AddableFieldRowList + addable family cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.39.0",
+      "version": "0.40.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Cuts BDS v0.40.0 — bundles the addable family follow-up sequence (PRs #249–#254) on top of v0.39.0's audit cleanup. **Unblocks the portal migrations queued behind it.**

`dist/` is gitignored; `prepublishOnly` regenerates at `npm publish` time. This PR is just the version bump + lockfile (3 insertions, 3 deletions).

## What ships in v0.40.0

| PR | Scope |
|---|---|
| **#253** | `AddableFieldRowList` — new BDS primitive for multi-field row collections (per ADR-005). Render-prop API with generic `<T>`. 4 Storybook stories. |
| **#250** | Addable family composition + remove-pattern fixes — drops rolled-own `<input>` from ComboList + EntryList suggestion mode (replaces with TextInput), unifies remove pattern on `IconButton`. Storybook moves 3 stories `Components/Form` → `Displays/Form`. |
| **#254** | `AddableEntryList` per-row remove icon `ph:x` → `ph:dash-circle` per ADR-005's icon semantic rule. |
| **#251** | Survey doc — 5 distinct portal addable shapes catalogued. |
| **#252** | ADR-005 — `AddableFieldRowList` design decision. |
| **#249** | `CardControl` un-deprecation per user decision. |

## What this enables for consumers

Portal can now migrate three onboarding sheets to `AddableFieldRowList`:

- `onboarding-software-sheet.tsx` — Phone System / Other Tools
- `onboarding-listing-sheet.tsx` — holiday hours
- `onboarding-competitors-sheet.tsx` — Competitive Positioning frames

(plus the previously-queued migrations from v0.39.0: Dialog, AlertBanner, ServiceBadge, CardSummary, CardControl-stays).

## Process note (preventability)

This release captures three rounds of cleanup work that piled up because **v0.39.0 was bumped + merged (PR #247) but the actual `npm publish` step was deferred.** I built dependent features (AddableFieldRowList, icon swap, etc.) without verifying the publish gate.

Saved a feedback memory: [`feedback_release_publish_gate.md`](file:///Users/nickstanerson/.claude/projects/-Users-nickstanerson-Documents-GitHub-brik-brik-bds/memory/feedback_release_publish_gate.md). Rule: after a release PR merges, verify publish ran AND consumer picked it up before building features that depend on consumer imports. `main ≠ published ≠ installed`.

If this happens again at scale, escalate to a `chore(release)` PR template with a "publish completed: yes/no" gate, or move publish to GitHub Actions.

## Test plan

- [x] Build clean (`npm run build:lib` ran locally; manifest at 81 components, 426 tokens)
- [x] Typecheck clean (pre-commit)
- [x] Anti-slop scan skipped (build-artifacts-only commit)
- [ ] Reviewer: confirm changelog covers everything since 0.39.0 (run `git log v0.39.0..HEAD --oneline -- '*.tsx' '*.css' docs/ | head -30` to verify)
- [ ] After merge: **`npm publish` from local at the merged main SHA**
- [ ] After publish: portal `npm update @brikdesigns/bds` (caret bump from `^0.38.0` → `^0.40.0` as well, since portal lockfile shows 0.35.0 actually installed)

## Followups after publish

| Repo | Files | Branch |
|---|---|---|
| portal | software-sheet | `task/portal-software-sheet-to-addable-field-row-list` |
| portal | listing-sheet (holiday hours) | `task/portal-listing-sheet-holiday-to-addable-field-row-list` |
| portal | competitors-sheet (frames) | `task/portal-competitors-frames-to-addable-field-row-list` |
| portal | (queued from v0.39.0) Dialog → Modal preset, AlertBanner → Banner tone, CardSummary → Card preset, ServiceBadge → ServiceTag | various |

🤖 Generated with [Claude Code](https://claude.com/claude-code)