### PR TITLE
feat(bds): promote BrikDevBar React shell to BDS (v0.41.0)

### DIFF
--- a/components/ui/BrikDevBar/BrikDevBar.stories.tsx
+++ b/components/ui/BrikDevBar/BrikDevBar.stories.tsx
@@ -1,0 +1,216 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect, useState } from 'react';
+import { BrikDevBar, useDevBarSlot, useDevBarApi } from './BrikDevBar';
+import type { DevBarSlotDef } from './BrikDevBar';
+
+const meta: Meta<typeof BrikDevBar> = {
+  title: 'Dev Tools/BrikDevBar',
+  component: BrikDevBar,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof BrikDevBar>;
+
+// ── Icon helpers ────────────────────────────────────────────────────────────
+
+const PERSONAS_ICON =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>';
+
+const THEME_ICON =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2v20M2 12h20" opacity=".4"/><path d="M12 2a10 10 0 0 1 0 20V2z" fill="currentColor" stroke="none"/></svg>';
+
+const GRID_ICON =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>';
+
+// ── Story components ─────────────────────────────────────────────────────────
+
+/**
+ * Demonstrates BrikDevBar loading devbar.js + two registered slots.
+ * The brik-devbar.js script is served from Storybook's /public directory.
+ */
+function DevBarWithSlots() {
+  const [personasOpen, setPersonasOpen] = useState(false);
+  const [themeOpen, setThemeOpen] = useState(false);
+
+  const personasSlot: DevBarSlotDef = {
+    id: 'personas',
+    label: 'Personas',
+    icon: PERSONAS_ICON,
+    order: 20,
+    onActivate: () => setPersonasOpen(true),
+    onDeactivate: () => setPersonasOpen(false),
+  };
+
+  const themeSlot: DevBarSlotDef = {
+    id: 'theme',
+    label: 'Theme',
+    icon: THEME_ICON,
+    order: 30,
+    onActivate: () => setThemeOpen(true),
+    onDeactivate: () => setThemeOpen(false),
+  };
+
+  useDevBarSlot(personasSlot);
+  useDevBarSlot(themeSlot);
+
+  return (
+    <>
+      <BrikDevBar />
+      <div style={{ padding: 'var(--padding-xl)', fontFamily: 'var(--font-family-body)' }}>
+        <p style={{ color: 'var(--text-primary)', marginBottom: 'var(--gap-md)' }}>
+          BrikDevBar has been mounted. The DevBar shell loads from{' '}
+          <code>/brik-devbar.js</code> and two slots have been registered via{' '}
+          <code>useDevBarSlot</code>: <strong>Personas</strong> and <strong>Theme</strong>.
+        </p>
+        <p style={{ color: 'var(--text-muted)', fontSize: 'var(--body-sm)' }}>
+          If the DevBar shell is available (brik-devbar.js loaded), you should see the
+          toolbar appear at the bottom of the preview. The slots below reflect local
+          open/close state driven by <code>onActivate</code> / <code>onDeactivate</code>.
+        </p>
+        <div style={{ marginTop: 'var(--gap-lg)', display: 'flex', gap: 'var(--gap-md)', flexWrap: 'wrap' }}>
+          <SlotIndicator id="personas" open={personasOpen} label="Personas slot" />
+          <SlotIndicator id="theme" open={themeOpen} label="Theme slot" />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function SlotIndicator({ id, open, label }: { id: string; open: boolean; label: string }) {
+  const BDS_POPPY = '#e35335';
+  const BDS_GRAY = '#e0e0e0';
+  return (
+    <div
+      style={{
+        padding: '12px 16px',
+        borderRadius: '8px',
+        border: `2px solid ${open ? BDS_POPPY : BDS_GRAY}`,
+        background: open ? '#fff5f3' : '#fafafa',
+        fontFamily: 'var(--font-family-label)',
+        fontSize: 'var(--label-sm)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        minWidth: 160,
+        transition: 'border-color 0.15s, background 0.15s',
+      }}
+    >
+      <span
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          background: open ? BDS_POPPY : BDS_GRAY,
+          flexShrink: 0,
+          transition: 'background 0.15s',
+        }}
+      />
+      <div>
+        <div style={{ fontWeight: 600, color: 'var(--text-primary)' }}>
+          {label}
+        </div>
+        <div
+          style={{
+            color: open ? BDS_POPPY : 'var(--text-muted)',
+            fontSize: '11px',
+            marginTop: 2,
+          }}
+        >
+          {open ? 'active' : 'inactive'} · id: {id}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Demonstrates useDevBarApi() returning the imperative API handle.
+ */
+function DevBarApiDemo() {
+  const api = useDevBarApi();
+  const [gridOpen, setGridOpen] = useState(false);
+  const [registered, setRegistered] = useState(false);
+
+  const gridSlot: DevBarSlotDef = {
+    id: 'grid',
+    label: 'Grid',
+    icon: GRID_ICON,
+    order: 40,
+    onActivate: () => setGridOpen(true),
+    onDeactivate: () => setGridOpen(false),
+  };
+
+  useDevBarSlot(gridSlot);
+
+  // Demonstrate imperative setBadge when panel is open
+  useEffect(() => {
+    if (!api) return;
+    api.setBadge('grid', gridOpen ? 'ON' : null);
+    api.setActive('grid', gridOpen);
+  }, [api, gridOpen]);
+
+  // Check registration status
+  useEffect(() => {
+    if (!api) return;
+    const iv = setInterval(() => {
+      setRegistered(api.isRegistered('grid'));
+    }, 200);
+    return () => clearInterval(iv);
+  }, [api]);
+
+  return (
+    <>
+      <BrikDevBar />
+      <div style={{ padding: 'var(--padding-xl)', fontFamily: 'var(--font-family-body)' }}>
+        <p style={{ color: 'var(--text-primary)', marginBottom: 'var(--gap-md)' }}>
+          Demonstrates <code>useDevBarApi()</code> — imperative access for setting
+          badges and toggling active state from outside the hook lifecycle.
+        </p>
+        <div style={{ marginTop: 'var(--gap-lg)', display: 'flex', flexDirection: 'column', gap: 'var(--gap-sm)' }}>
+          <ApiRow label="window.BrikDevBar present" value={api !== null} />
+          <ApiRow label="grid slot registered" value={registered} />
+          <ApiRow label="grid slot active" value={gridOpen} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ApiRow({ label, value }: { label: string; value: boolean }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--gap-md)',
+        fontFamily: 'var(--font-family-label)',
+        fontSize: 'var(--label-sm)',
+        color: 'var(--text-primary)',
+      }}
+    >
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: value ? '#22c55e' : '#e0e0e0',
+          flexShrink: 0,
+        }}
+      />
+      {label}
+    </div>
+  );
+}
+
+// ── Stories ──────────────────────────────────────────────────────────────────
+
+export const WithSlots: Story = {
+  name: 'With Registered Slots',
+  render: () => <DevBarWithSlots />,
+};
+
+export const ImperativeApi: Story = {
+  name: 'Imperative API (useDevBarApi)',
+  render: () => <DevBarApiDemo />,
+};

--- a/components/ui/BrikDevBar/BrikDevBar.tsx
+++ b/components/ui/BrikDevBar/BrikDevBar.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Brik DevBar — React bootstrap.
+ *
+ * Mounts the canonical vanilla devbar.js (public/brik-devbar.js) once per page
+ * and exposes typed React hooks so other dev widgets can register slots.
+ *
+ * The underlying shell is the same code that powers mockup deploys, the
+ * Brik Client Portal, and Renew PMS — that's the point: one visual source of
+ * truth, identical across all Brik surfaces.
+ *
+ * Source: brik-llm/scripts/brik-dev-tool/widgets/devbar.js (synced via sync-downstream.sh)
+ *
+ * Promoted from brik-client-portal/src/components/BrikDevBar.tsx on 2026-04-25.
+ * DevBarSlotDef + DevBarApi types moved here from DevFeedbackWidget.tsx
+ * (they are DevBar API types, not feedback types — they ended up in
+ * DevFeedbackWidget historically because that was the first consumer).
+ */
+
+// ── DevBar integration types ────────────────────────────────────────────────
+/** A slot definition registered with the DevBar shell. */
+export interface DevBarSlotDef {
+  id: string;
+  label: string;
+  icon: string;
+  order?: number;
+  badge?: string | number | null;
+  onActivate?: (api: DevBarApi) => void;
+  onDeactivate?: (api: DevBarApi) => void;
+}
+
+/** Imperative API exposed by the DevBar shell on window.BrikDevBar. */
+export interface DevBarApi {
+  register: (def: DevBarSlotDef) => DevBarApi;
+  unregister: (id: string) => void;
+  setBadge: (id: string, value: string | number | null) => void;
+  setActive: (id: string, active: boolean) => void;
+  isRegistered: (id: string) => boolean;
+  getBarRect: () => DOMRect | null;
+  getSlotRect: (id: string) => DOMRect | null;
+}
+
+declare global {
+  interface Window {
+    BrikDevBar?: DevBarApi;
+    BrikDevBarQueue?: DevBarSlotDef[];
+  }
+}
+
+// ── BrikDevBar component ─────────────────────────────────────────────────────
+
+/**
+ * Loads brik-devbar.js + brik-inspect.js once. Idempotent.
+ *
+ * - `brik-devbar.js` — always loaded. Provides the shell other widgets register into.
+ * - `brik-inspect.js` — always loaded in dev; registers its own Inspect + Scan slots.
+ *   The BDS token auditor works against any BDS-built page, not just mockups.
+ *
+ * Render this once in your DevTools layout (or any high-level layout component).
+ * Both scripts must be present in the app's public/ directory — see the sync
+ * script at brik-llm/scripts/brik-dev-tool/sync-downstream.sh.
+ */
+export function BrikDevBar() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const inject = (src: string, marker: string, attrs: Record<string, string> = {}) => {
+      if (document.querySelector(`script[${marker}]`)) return;
+      const s = document.createElement('script');
+      s.src = src;
+      s.async = false;
+      s.setAttribute(marker, '');
+      for (const [k, v] of Object.entries(attrs)) s.setAttribute(k, v);
+      document.head.appendChild(s);
+    };
+
+    if (!window.BrikDevBar) inject('/brik-devbar.js', 'data-brik-devbar-loader');
+    // Inspect auto-enables via data-attr → toolbar loads but hover is off
+    // until the user clicks the Inspect slot.
+    inject('/brik-inspect.js', 'data-brik-inspect-loader', { 'data-auto-enable': '1' });
+  }, []);
+
+  return null;
+}
+
+// ── Hooks ────────────────────────────────────────────────────────────────────
+
+/**
+ * Register a slot with the DevBar. The slot disappears when this hook unmounts.
+ *
+ * The slot is queued if the DevBar shell hasn't loaded yet, and flushed as
+ * soon as it becomes available — so render order doesn't matter.
+ *
+ * @example
+ * useDevBarSlot({
+ *   id: 'persona',
+ *   label: 'Personas',
+ *   icon: '<svg…/>',
+ *   order: 30,
+ *   onActivate: () => setOpen(true),
+ *   onDeactivate: () => setOpen(false),
+ * });
+ */
+export function useDevBarSlot(def: DevBarSlotDef | null) {
+  const registeredRef = useRef(false);
+
+  useEffect(() => {
+    if (!def) return;
+    if (typeof window === 'undefined') return;
+
+    const register = () => {
+      if (!window.BrikDevBar) return false;
+      window.BrikDevBar.register(def);
+      registeredRef.current = true;
+      return true;
+    };
+
+    if (register()) {
+      // Registered synchronously — nothing more to do.
+    } else {
+      // Queue for when devbar.js loads.
+      window.BrikDevBarQueue = window.BrikDevBarQueue || [];
+      window.BrikDevBarQueue.push(def);
+      // Poll briefly for late-load.
+      const iv = setInterval(() => {
+        if (register()) clearInterval(iv);
+      }, 50);
+      // Give up after 2s — devbar.js probably wasn't loaded on this page.
+      setTimeout(() => clearInterval(iv), 2000);
+    }
+
+    return () => {
+      if (registeredRef.current && window.BrikDevBar) {
+        window.BrikDevBar.unregister(def.id);
+        registeredRef.current = false;
+      } else if (window.BrikDevBarQueue) {
+        window.BrikDevBarQueue = window.BrikDevBarQueue.filter((d) => d.id !== def.id);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [def?.id, def?.label]);
+}
+
+/**
+ * Imperative access to the DevBar API, for widgets that need to toggle
+ * active/badge state outside a hook.
+ *
+ * Returns null when called server-side or before devbar.js has loaded.
+ */
+export function useDevBarApi(): DevBarApi | null {
+  if (typeof window === 'undefined') return null;
+  return window.BrikDevBar ?? null;
+}

--- a/components/ui/BrikDevBar/index.ts
+++ b/components/ui/BrikDevBar/index.ts
@@ -1,0 +1,2 @@
+export { BrikDevBar, useDevBarSlot, useDevBarApi } from './BrikDevBar';
+export type { DevBarSlotDef, DevBarApi } from './BrikDevBar';

--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
@@ -53,32 +53,8 @@ const FEEDBACK_TYPES = [
 ] as const;
 
 // ── DevBar integration types ────────────────────────────────────────────
-/** Single source of truth for DevBar types. Portal's BrikDevBar loader
- *  imports these rather than redeclaring, to avoid global Window collisions. */
-export interface DevBarSlotDef {
-  id: string;
-  label: string;
-  icon: string;
-  order?: number;
-  badge?: string | number | null;
-  onActivate?: (api: DevBarApi) => void;
-  onDeactivate?: (api: DevBarApi) => void;
-}
-export interface DevBarApi {
-  register: (def: DevBarSlotDef) => DevBarApi;
-  unregister: (id: string) => void;
-  setBadge: (id: string, value: string | number | null) => void;
-  setActive: (id: string, active: boolean) => void;
-  isRegistered: (id: string) => boolean;
-  getBarRect: () => DOMRect | null;
-  getSlotRect: (id: string) => DOMRect | null;
-}
-declare global {
-  interface Window {
-    BrikDevBar?: DevBarApi;
-    BrikDevBarQueue?: DevBarSlotDef[];
-  }
-}
+// Types live in BrikDevBar — imported here to avoid duplicate declarations.
+import type { DevBarSlotDef } from '../BrikDevBar';
 
 // ── Public props ────────────────────────────────────────────────────────
 export interface DevFeedbackWidgetProps {

--- a/components/ui/DevFeedbackWidget/index.ts
+++ b/components/ui/DevFeedbackWidget/index.ts
@@ -1,6 +1,3 @@
 export { DevFeedbackWidget } from './DevFeedbackWidget';
-export type {
-  DevFeedbackWidgetProps,
-  DevBarSlotDef,
-  DevBarApi,
-} from './DevFeedbackWidget';
+export type { DevFeedbackWidgetProps } from './DevFeedbackWidget';
+// DevBarSlotDef + DevBarApi now live in BrikDevBar — re-exported from there.

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -13,6 +13,7 @@ export * from './Badge';
 export * from './BadgeGroup';
 export * from './Board';
 export * from './Banner';
+export * from './BrikDevBar';
 export * from './Breadcrumb';
 export * from './BulletList';
 export * from './Button';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Context

This is **PR 1 of 4** in the BrikDevBar promotion sequence:

| PR | Repo | What |
|----|------|------|
| **1 (this)** | brik-bds | Promote BrikDevBar component + hooks into BDS |
| 2 | brik-client-portal | Swap `BrikDevBar.tsx` for `import { BrikDevBar } from '@brikdesigns/bds'` |
| 3 | renew-pms | Wire BrikDevBar into DevTools layout using the BDS import |
| 4 | brik-llm submodule | Update submodule pointer after merge |

Portal and renew-pms PRs are blocked on this one merging and `@brikdesigns/bds@0.41.0` being published.

## What changed

- **New: `components/ui/BrikDevBar/`** — the React bootstrap shell, ported verbatim from `brik-client-portal/src/components/BrikDevBar.tsx`:
  - `BrikDevBar` — loads `/brik-devbar.js` + `/brik-inspect.js` once (idempotent, client-only)
  - `useDevBarSlot(def)` — registers a slot; queues if shell hasn't loaded; cleans up on unmount
  - `useDevBarApi()` — imperative handle to `window.BrikDevBar` for badge/active state control
  - `DevBarSlotDef` + `DevBarApi` types + `declare global { interface Window … }` (moved here from DevFeedbackWidget)
- **Updated: `DevFeedbackWidget/DevFeedbackWidget.tsx`** — imports `DevBarSlotDef` from `../BrikDevBar` instead of redeclaring inline
- **Updated: `DevFeedbackWidget/index.ts`** — no longer re-exports `DevBarSlotDef`/`DevBarApi` (those now come from BrikDevBar)
- **Updated: `components/ui/index.ts`** — `export * from './BrikDevBar'` added in alphabetical position
- **Version bump: `0.40.0 → 0.41.0`** (minor — net-new component, additive)

## What did NOT change

- The vanilla JS widgets (`devbar.js`, `inspect-widget.js`, etc.) stay in brik-llm. Not touched.
- `DevFeedbackWidget` behavior is identical — only the type import source changed.
- No loader behavior changes — the `BrikDevBar` component is a line-for-line port.

## Storybook

Two stories under `Dev Tools/BrikDevBar`:
- **WithSlots** — mounts the bar + Personas and Theme slots; shows active/inactive state
- **ImperativeApi** — demonstrates `useDevBarApi()` for badge/active control

The Storybook public dir already has `brik-devbar.js` — runtime is available in the story preview.

## Verification checklist

- [x] TypeScript: `tsc --noEmit` clean (0 errors)
- [x] Token lint: PASS
- [x] Storybook build: PASS
- [x] `BrikDevBar`, `useDevBarSlot`, `useDevBarApi` exported from `@brikdesigns/bds`
- [x] `DevBarSlotDef`, `DevBarApi` exported from `@brikdesigns/bds`
- [x] `DevFeedbackWidget` unchanged in behavior; types re-imported from `../BrikDevBar`
- [x] No breaking changes to any existing export surface
- [ ] Portal can swap `import { BrikDevBar } from '@/components/BrikDevBar'` → `import { BrikDevBar } from '@brikdesigns/bds'` (PR 2)
- [ ] renew-pms can adopt after PR 2 lands

## Known gap / log

`brik-inspect.js` is not yet in `.storybook/public/` — only `brik-devbar.js` is synced. The `BrikDevBar` component will attempt to inject `brik-inspect.js` and silently no-op if the file isn't present (404, script never executes). This is correct existing behavior from the portal port — not introduced by this PR. The fix is to add `brik-inspect.js` to the sync script, tracked separately.