### PR TITLE
bds: storybook taxonomy addables

### DIFF
--- a/components/ui/AddableComboList/AddableComboList.stories.tsx
+++ b/components/ui/AddableComboList/AddableComboList.stories.tsx
@@ -81,7 +81,7 @@ const DENTAL_INSURANCE = [
 // ── Storybook meta ────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof AddableComboList> = {
-  title: 'Displays/Form/addable-combo-list',
+  title: 'Components/Addables/addable-combo-list',
   component: AddableComboList,
   parameters: { layout: 'centered' },
   argTypes: {

--- a/components/ui/AddableEntryList/AddableEntryList.stories.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.stories.tsx
@@ -59,7 +59,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 // ── Storybook meta ────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof AddableEntryList> = {
-  title: 'Displays/Form/addable-entry-list',
+  title: 'Components/Addables/addable-entry-list',
   component: AddableEntryList,
   parameters: { layout: 'centered' },
   argTypes: {

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.mdx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.mdx
@@ -12,9 +12,9 @@ Distinct from the rest of the addable family:
 | Component | Item shape |
 |---|---|
 | [`MultiSelect`](/?path=/docs/components-form-multi-select--docs) | Selected enum values rendered as Tags |
-| [`AddableTextList`](/?path=/docs/displays-form-addable-text-list--docs) | Single string per item (free-form) |
-| [`AddableComboList`](/?path=/docs/displays-form-addable-combo-list--docs) | Single string per item, suggestion-driven |
-| [`AddableEntryList`](/?path=/docs/displays-form-addable-entry-list--docs) | Title + description card |
+| [`AddableTextList`](/?path=/docs/components-addables-addable-text-list--docs) | Single string per item (free-form) |
+| [`AddableComboList`](/?path=/docs/components-addables-addable-combo-list--docs) | Single string per item, suggestion-driven |
+| [`AddableEntryList`](/?path=/docs/components-addables-addable-entry-list--docs) | Title + description card |
 | **`AddableFieldRowList`** | **Arbitrary multi-field row** |
 
 Per [ADR-005](../../docs/adrs/ADR-005-addable-field-row-list.md). Replaces three hand-rolled patterns identified in the [2026-Q2 portal addable survey](../../docs/audits/2026-Q2-portal-addable-survey.md).
@@ -128,6 +128,6 @@ interface Tool {
 
 ## When NOT to use
 
-- Single-string-per-item — use [`AddableTextList`](/?path=/docs/displays-form-addable-text-list--docs) or [`AddableComboList`](/?path=/docs/displays-form-addable-combo-list--docs)
-- Title + description per item — use [`AddableEntryList`](/?path=/docs/displays-form-addable-entry-list--docs)
+- Single-string-per-item — use [`AddableTextList`](/?path=/docs/components-addables-addable-text-list--docs) or [`AddableComboList`](/?path=/docs/components-addables-addable-combo-list--docs)
+- Title + description per item — use [`AddableEntryList`](/?path=/docs/components-addables-addable-entry-list--docs)
 - Pick from a fixed enum — use [`MultiSelect`](/?path=/docs/components-form-multi-select--docs) (renders Tags)

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx
@@ -7,7 +7,7 @@ import { Select } from '../Select';
 import { Checkbox } from '../Checkbox';
 
 const meta: Meta<typeof AddableFieldRowList> = {
-  title: 'Displays/Form/addable-field-row-list',
+  title: 'Components/Addables/addable-field-row-list',
   component: AddableFieldRowList,
   parameters: { layout: 'padded' },
 };

--- a/components/ui/AddableTextList/AddableTextList.stories.tsx
+++ b/components/ui/AddableTextList/AddableTextList.stories.tsx
@@ -23,7 +23,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 );
 
 const meta: Meta<typeof AddableTextList> = {
-  title: 'Displays/Form/addable-text-list',
+  title: 'Components/Addables/addable-text-list',
   component: AddableTextList,
   parameters: { layout: 'centered' },
   argTypes: {


### PR DESCRIPTION
## Summary
- refactor(storybook): move addable family to Components/Addables

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)