### PR TITLE
feat(storybook): components manifest + surface taxonomy for MCP

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -38,6 +38,7 @@ const config: StorybookConfig = {
   },
   features: {
     experimentalCodeExamples: true,
+    experimentalComponentsManifest: true,
   },
   docs: {
     defaultName: 'Overview',

--- a/components/ui/Accordion/Accordion.stories.tsx
+++ b/components/ui/Accordion/Accordion.stories.tsx
@@ -37,6 +37,7 @@ const faqItems = [
 const meta: Meta<typeof Accordion> = {
   title: 'Displays/Accordion/accordion',
   component: Accordion,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     allowMultiple: { control: 'boolean', description: 'Allow multiple items open simultaneously' },

--- a/components/ui/ActivityTimeline/ActivityTimeline.stories.tsx
+++ b/components/ui/ActivityTimeline/ActivityTimeline.stories.tsx
@@ -5,6 +5,7 @@ import { ActivityTimeline } from './ActivityTimeline';
 const meta: Meta<typeof ActivityTimeline> = {
   title: 'Displays/Timeline/activity-timeline',
   component: ActivityTimeline,
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
 };
 

--- a/components/ui/AddableComboList/AddableComboList.stories.tsx
+++ b/components/ui/AddableComboList/AddableComboList.stories.tsx
@@ -83,6 +83,7 @@ const DENTAL_INSURANCE = [
 const meta: Meta<typeof AddableComboList> = {
   title: 'Components/Addables/addable-combo-list',
   component: AddableComboList,
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/AddableEntryList/AddableEntryList.stories.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.stories.tsx
@@ -61,6 +61,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof AddableEntryList> = {
   title: 'Components/Addables/addable-entry-list',
   component: AddableEntryList,
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx
@@ -9,6 +9,7 @@ import { Checkbox } from '../Checkbox';
 const meta: Meta<typeof AddableFieldRowList> = {
   title: 'Components/Addables/addable-field-row-list',
   component: AddableFieldRowList,
+  tags: ['surface-product'],
   parameters: { layout: 'padded' },
 };
 

--- a/components/ui/AddableTextList/AddableTextList.stories.tsx
+++ b/components/ui/AddableTextList/AddableTextList.stories.tsx
@@ -25,6 +25,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof AddableTextList> = {
   title: 'Components/Addables/addable-text-list',
   component: AddableTextList,
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/AddressInput/AddressInput.stories.tsx
+++ b/components/ui/AddressInput/AddressInput.stories.tsx
@@ -38,6 +38,7 @@ const mockSuggestions: AddressSuggestion[] = [
 const meta: Meta<typeof AddressInput> = {
   title: 'Components/Input/address-input',
   component: AddressInput,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   decorators: [
     (Story) => (

--- a/components/ui/AlertBanner/AlertBanner.stories.tsx
+++ b/components/ui/AlertBanner/AlertBanner.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof AlertBanner> = {
   title: 'Components/Feedback/alert-banner',
   component: AlertBanner,
-  tags: ['!manifest'], // deprecated — hide from MCP discovery (use Banner)
+  tags: ['!manifest', 'surface-shared'], // deprecated — hide from MCP discovery (use Banner)
   parameters: { layout: 'padded' },
   argTypes: {
     title: { control: 'text' },

--- a/components/ui/Avatar/Avatar.stories.tsx
+++ b/components/ui/Avatar/Avatar.stories.tsx
@@ -6,6 +6,7 @@ import { Avatar } from './Avatar';
 const meta: Meta<typeof Avatar> = {
   title: 'Foundations/Assets/avatar',
   component: Avatar,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/Badge/Badge.stories.tsx
+++ b/components/ui/Badge/Badge.stories.tsx
@@ -8,6 +8,7 @@ import { Tag } from '../Tag/Tag';
 const meta: Meta<typeof Badge> = {
   title: 'Components/Indicator/badge',
   component: Badge,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/BadgeGroup/BadgeGroup.stories.tsx
+++ b/components/ui/BadgeGroup/BadgeGroup.stories.tsx
@@ -6,6 +6,7 @@ import { Field } from '../Field';
 const meta: Meta<typeof BadgeGroup> = {
   title: 'Components/Indicator/badge-group',
   component: BadgeGroup,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     gap: { control: 'select', options: ['xs', 'sm', 'md'] },

--- a/components/ui/Banner/Banner.stories.tsx
+++ b/components/ui/Banner/Banner.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof Banner> = {
   title: 'Components/Feedback/banner',
   component: Banner,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     title: { control: 'text' },

--- a/components/ui/Board/Board.stories.tsx
+++ b/components/ui/Board/Board.stories.tsx
@@ -10,6 +10,7 @@ import { Badge } from '../Badge';
 const meta: Meta<typeof Board> = {
   title: 'Displays/Board/board',
   component: Board,
+  tags: ['surface-product'],
   parameters: {
     layout: 'padded',
   },

--- a/components/ui/Breadcrumb/Breadcrumb.stories.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.stories.tsx
@@ -26,6 +26,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof Breadcrumb> = {
   title: 'Navigation/Secondary/breadcrumb',
   component: Breadcrumb,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     separator: { control: 'select', options: ['slash', 'chevron'] },

--- a/components/ui/BrikDevBar/BrikDevBar.stories.tsx
+++ b/components/ui/BrikDevBar/BrikDevBar.stories.tsx
@@ -6,6 +6,7 @@ import type { DevBarSlotDef } from './BrikDevBar';
 const meta: Meta<typeof BrikDevBar> = {
   title: 'Dev Tools/BrikDevBar',
   component: BrikDevBar,
+  tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },
 };
 

--- a/components/ui/BulletList/BulletList.stories.tsx
+++ b/components/ui/BulletList/BulletList.stories.tsx
@@ -5,6 +5,7 @@ import { Field } from '../Field';
 const meta: Meta<typeof BulletList> = {
   title: 'Components/List/bullet-list',
   component: BulletList,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     marker: { control: 'select', options: ['disc', 'decimal', 'none'] },

--- a/components/ui/Button/Button.stories.tsx
+++ b/components/ui/Button/Button.stories.tsx
@@ -11,6 +11,7 @@ import { IconButton } from './IconButton';
 const meta: Meta<typeof Button> = {
   title: 'Components/Action/button',
   component: Button,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/ButtonGroup/ButtonGroup.stories.tsx
+++ b/components/ui/ButtonGroup/ButtonGroup.stories.tsx
@@ -7,6 +7,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof ButtonGroup> = {
   title: 'Components/Action/button-group',
   component: ButtonGroup,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/Calendar/Calendar.stories.tsx
+++ b/components/ui/Calendar/Calendar.stories.tsx
@@ -14,7 +14,7 @@ const CalendarPlaceholder = () => (
 const meta: Meta<typeof CalendarPlaceholder> = {
   title: 'Displays/Calendar/calendar',
   component: CalendarPlaceholder,
-  tags: ['wip'],
+  tags: ['wip', 'surface-shared'],
 };
 
 export default meta;

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -6,6 +6,7 @@ import { Badge } from '../Badge';
 const meta: Meta<typeof Card> = {
   title: 'Displays/Card/card',
   component: Card,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     variant: { control: 'select', options: ['outlined', 'brand', 'elevated'] },

--- a/components/ui/Card/CardSummary.stories.tsx
+++ b/components/ui/Card/CardSummary.stories.tsx
@@ -4,6 +4,7 @@ import { CardSummary } from './CardSummary';
 const meta: Meta<typeof CardSummary> = {
   title: 'Displays/Card/card-summary',
   component: CardSummary,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     type: { control: 'select', options: ['numeric', 'price'] },

--- a/components/ui/CardControl/CardControl.stories.tsx
+++ b/components/ui/CardControl/CardControl.stories.tsx
@@ -9,6 +9,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof CardControl> = {
   title: 'Displays/Card/card-control',
   component: CardControl,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     title: { control: 'text' },

--- a/components/ui/CardList/CardList.stories.tsx
+++ b/components/ui/CardList/CardList.stories.tsx
@@ -8,6 +8,7 @@ import { Badge } from '../Badge';
 const meta: Meta<typeof CardList> = {
   title: 'Displays/Card/card-list',
   component: CardList,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     orientation: { control: 'inline-radio', options: ['vertical', 'horizontal'] },

--- a/components/ui/CardTestimonial/CardTestimonial.stories.tsx
+++ b/components/ui/CardTestimonial/CardTestimonial.stories.tsx
@@ -4,6 +4,7 @@ import { CardTestimonial } from './CardTestimonial';
 const meta: Meta<typeof CardTestimonial> = {
   title: 'Displays/Card/card-testimonial',
   component: CardTestimonial,
+  tags: ['surface-web'],
   parameters: { layout: 'centered' },
   argTypes: {
     variant: { control: 'select', options: ['brand', 'outlined'] },

--- a/components/ui/CatalogPicker/CatalogPicker.stories.tsx
+++ b/components/ui/CatalogPicker/CatalogPicker.stories.tsx
@@ -93,6 +93,7 @@ const SectionLabel = ({ children }: { children: string }) => (
 const meta: Meta<typeof CatalogPicker> = {
   title: 'Components/Form/catalog-picker',
   component: CatalogPicker,
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/Checkbox/Checkbox.stories.tsx
+++ b/components/ui/Checkbox/Checkbox.stories.tsx
@@ -30,6 +30,7 @@ const Row = ({ children, gap = 'var(--padding-sm)' }: { children: React.ReactNod
 const meta: Meta<typeof Checkbox> = {
   title: 'Components/Form/checkbox',
   component: Checkbox,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     label: { control: 'text' },

--- a/components/ui/Chip/Chip.stories.tsx
+++ b/components/ui/Chip/Chip.stories.tsx
@@ -7,6 +7,7 @@ import { Chip } from './Chip';
 const meta: Meta<typeof Chip> = {
   title: 'Components/Indicator/chip',
   component: Chip,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/CollapsibleCard/CollapsibleCard.stories.tsx
+++ b/components/ui/CollapsibleCard/CollapsibleCard.stories.tsx
@@ -26,6 +26,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof CollapsibleCard> = {
   title: 'Displays/Card/collapsible-card',
   component: CollapsibleCard,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   decorators: [(Story) => <div style={{ maxWidth: 640 }}><Story /></div>],
   argTypes: {

--- a/components/ui/Counter/Counter.stories.tsx
+++ b/components/ui/Counter/Counter.stories.tsx
@@ -6,6 +6,7 @@ import { Counter } from './Counter';
 const meta: Meta<typeof Counter> = {
   title: 'Components/Indicator/counter',
   component: Counter,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/DataSection/DataSection.stories.tsx
+++ b/components/ui/DataSection/DataSection.stories.tsx
@@ -9,6 +9,7 @@ import { ButtonGroup } from '../ButtonGroup';
 const meta: Meta<typeof DataSection> = {
   title: 'Displays/Data/data-section',
   component: DataSection,
+  tags: ['surface-product'],
   parameters: { layout: 'padded' },
   argTypes: {
     title: { control: 'text' },

--- a/components/ui/DatePicker/DatePicker.stories.tsx
+++ b/components/ui/DatePicker/DatePicker.stories.tsx
@@ -31,6 +31,7 @@ const Row = ({ children, gap = 'var(--padding-sm)' }: { children: React.ReactNod
 const meta: Meta<typeof DatePicker> = {
   title: 'Components/Form/date-picker',
   component: DatePicker,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/Dialog/Dialog.stories.tsx
+++ b/components/ui/Dialog/Dialog.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof Dialog> = {
   title: 'Displays/Overlay/dialog',
   component: Dialog,
-  tags: ['!manifest'], // deprecated — hide from MCP discovery (use Modal preset="confirm")
+  tags: ['!manifest', 'surface-shared'], // deprecated — hide from MCP discovery (use Modal preset="confirm")
   parameters: { layout: 'centered' },
   argTypes: {
     variant: { control: 'select', options: ['default', 'destructive'] },

--- a/components/ui/Divider/Divider.stories.tsx
+++ b/components/ui/Divider/Divider.stories.tsx
@@ -6,6 +6,7 @@ import { Divider } from './Divider';
 const meta: Meta<typeof Divider> = {
   title: 'Components/Structure/divider',
   component: Divider,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'padded',
   },

--- a/components/ui/Dot/Dot.stories.tsx
+++ b/components/ui/Dot/Dot.stories.tsx
@@ -6,6 +6,7 @@ import { Dot } from './Dot';
 const meta: Meta<typeof Dot> = {
   title: 'Components/Indicator/dot',
   component: Dot,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/EmptyState/EmptyState.stories.tsx
+++ b/components/ui/EmptyState/EmptyState.stories.tsx
@@ -4,6 +4,7 @@ import { EmptyState } from './EmptyState';
 const meta: Meta<typeof EmptyState> = {
   title: 'Components/Feedback/empty-state',
   component: EmptyState,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     title: { control: 'text' },

--- a/components/ui/Field/Field.stories.tsx
+++ b/components/ui/Field/Field.stories.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from '../EmptyState';
 const meta: Meta<typeof Field> = {
   title: 'Components/Form/field',
   component: Field,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     label: { control: 'text' },

--- a/components/ui/FieldGrid/FieldGrid.stories.tsx
+++ b/components/ui/FieldGrid/FieldGrid.stories.tsx
@@ -6,6 +6,7 @@ import { Card } from '../Card';
 const meta: Meta<typeof FieldGrid> = {
   title: 'Components/Form/field-grid',
   component: FieldGrid,
+  tags: ['surface-product'],
   parameters: { layout: 'padded' },
   argTypes: {
     columns: { control: 'select', options: [2, 3, 4] },

--- a/components/ui/FileUploader/FileUploader.stories.tsx
+++ b/components/ui/FileUploader/FileUploader.stories.tsx
@@ -27,6 +27,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof FileUploader> = {
   title: 'Components/Control/file-uploader',
   component: FileUploader,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   decorators: [(Story) => <div style={{ width: 400 }}><Story /></div>],
 } satisfies Meta<typeof FileUploader>;

--- a/components/ui/FilterBar/FilterBar.stories.tsx
+++ b/components/ui/FilterBar/FilterBar.stories.tsx
@@ -38,6 +38,7 @@ const statusOptions = [
 const meta = {
   title: 'Components/Action/filter-bar',
   component: FilterBar,
+  tags: ['surface-product'],
   parameters: { layout: 'padded' },
   decorators: [
     (Story) => (

--- a/components/ui/FilterButton/FilterButton.stories.tsx
+++ b/components/ui/FilterButton/FilterButton.stories.tsx
@@ -56,6 +56,7 @@ const tagOptions = [
 const meta = {
   title: 'Components/Action/filter-button',
   component: FilterButton,
+  tags: ['surface-product'],
   parameters: { layout: 'padded' },
   decorators: [
     (Story) => (

--- a/components/ui/FilterToggle/FilterToggle.stories.tsx
+++ b/components/ui/FilterToggle/FilterToggle.stories.tsx
@@ -32,6 +32,7 @@ const Row = ({ children, gap = 'var(--gap-lg)' }: { children: React.ReactNode; g
 const meta = {
   title: 'Components/Action/filter-toggle',
   component: FilterToggle,
+  tags: ['surface-product'],
   parameters: { layout: 'padded' },
   decorators: [
     (Story) => (

--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -75,6 +75,7 @@ const socialLinks = (
 const meta: Meta<typeof Footer> = {
   title: 'Navigation/Primary/footer',
   component: Footer,
+  tags: ['surface-web'],
   parameters: { layout: 'fullscreen' },
   argTypes: {
     variant: { control: 'select', options: ['default', 'brand'] },

--- a/components/ui/Form/Form.stories.tsx
+++ b/components/ui/Form/Form.stories.tsx
@@ -35,6 +35,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof Form> = {
   title: 'Components/Form/form',
   component: Form,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     layout: { control: 'select', options: ['vertical', 'horizontal'] },

--- a/components/ui/Icons/Icons.stories.tsx
+++ b/components/ui/Icons/Icons.stories.tsx
@@ -62,6 +62,7 @@ const IconsReference = () => <div />;
 const meta: Meta<typeof IconsReference> = {
   title: 'Foundations/Assets/icons',
   component: IconsReference,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'padded',
     docs: { toc: true },

--- a/components/ui/Menu/Menu.stories.tsx
+++ b/components/ui/Menu/Menu.stories.tsx
@@ -47,6 +47,7 @@ const filterOptions = sampleItems.map((item) => ({
 const meta = {
   title: 'Navigation/Menu/menu',
   component: Menu,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   decorators: [
     (Story) => (

--- a/components/ui/Meter/Meter.stories.tsx
+++ b/components/ui/Meter/Meter.stories.tsx
@@ -4,6 +4,7 @@ import { Meter } from './Meter';
 const meta: Meta<typeof Meter> = {
   title: 'Displays/Charts/meter',
   component: Meter,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/Modal/Modal.stories.tsx
+++ b/components/ui/Modal/Modal.stories.tsx
@@ -7,6 +7,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof Modal> = {
   title: 'Displays/Overlay/modal',
   component: Modal,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg', 'xl', 'full'] },

--- a/components/ui/MultiSelect/MultiSelect.stories.tsx
+++ b/components/ui/MultiSelect/MultiSelect.stories.tsx
@@ -27,6 +27,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof MultiSelect> = {
   title: 'Components/Form/multi-select',
   component: MultiSelect,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   decorators: [(Story) => <div style={{ maxWidth: 480 }}><Story /></div>],
   argTypes: {

--- a/components/ui/NavBar/NavBar.stories.tsx
+++ b/components/ui/NavBar/NavBar.stories.tsx
@@ -48,6 +48,7 @@ const LogoPlaceholder = () => (
 const meta: Meta<typeof NavBar> = {
   title: 'Navigation/Primary/nav-bar',
   component: NavBar,
+  tags: ['surface-web'],
   parameters: { layout: 'fullscreen' },
 } satisfies Meta<typeof NavBar>;
 

--- a/components/ui/NotificationList/NotificationList.stories.tsx
+++ b/components/ui/NotificationList/NotificationList.stories.tsx
@@ -6,6 +6,7 @@ import type { NotificationItemData } from './NotificationList';
 const meta: Meta<typeof NotificationList> = {
   title: 'Displays/Notifications/notification-list',
   component: NotificationList,
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
 };
 

--- a/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/components/ui/PageHeader/PageHeader.stories.tsx
@@ -48,6 +48,7 @@ const sampleBreadcrumbs = [
 const meta: Meta<typeof PageHeader> = {
   title: 'Navigation/Secondary/page-header',
   component: PageHeader,
+  tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },
   argTypes: {
     title: { control: 'text' },

--- a/components/ui/Pagination/Pagination.stories.tsx
+++ b/components/ui/Pagination/Pagination.stories.tsx
@@ -27,6 +27,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta = {
   title: 'Components/Control/pagination',
   component: Pagination,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     position: {

--- a/components/ui/PasswordInput/PasswordInput.stories.tsx
+++ b/components/ui/PasswordInput/PasswordInput.stories.tsx
@@ -26,6 +26,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof PasswordInput> = {
   title: 'Components/Input/password-input',
   component: PasswordInput,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   decorators: [(Story) => <div style={{ width: 320 }}><Story /></div>],
   argTypes: {

--- a/components/ui/Popover/Popover.stories.tsx
+++ b/components/ui/Popover/Popover.stories.tsx
@@ -51,6 +51,7 @@ const sampleContent = (
 const meta: Meta<typeof Popover> = {
   title: 'Displays/Overlay/popover',
   component: Popover,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   decorators: [
     (Story) => (

--- a/components/ui/PricingCard/PricingCard.stories.tsx
+++ b/components/ui/PricingCard/PricingCard.stories.tsx
@@ -28,6 +28,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof PricingCard> = {
   title: 'Displays/Card/pricing-card',
   component: PricingCard,
+  tags: ['surface-web'],
   parameters: { layout: 'centered' },
   decorators: [(Story) => <div style={{ width: 320 }}><Story /></div>],
   argTypes: {

--- a/components/ui/ProgressBar/ProgressBar.stories.tsx
+++ b/components/ui/ProgressBar/ProgressBar.stories.tsx
@@ -27,6 +27,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof ProgressBar> = {
   title: 'Components/Feedback/progress-bar',
   component: ProgressBar,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   decorators: [(Story) => <div style={{ width: 400 }}><Story /></div>],
   argTypes: {

--- a/components/ui/ProgressStepper/ProgressStepper.stories.tsx
+++ b/components/ui/ProgressStepper/ProgressStepper.stories.tsx
@@ -5,6 +5,7 @@ import { ProgressStepper, type ProgressStep } from './ProgressStepper';
 const meta: Meta<typeof ProgressStepper> = {
   title: 'Navigation/Stepper/progress-stepper',
   component: ProgressStepper,
+  tags: ['surface-product'],
   parameters: {
     layout: 'padded',
   },

--- a/components/ui/Radio/Radio.stories.tsx
+++ b/components/ui/Radio/Radio.stories.tsx
@@ -31,6 +31,7 @@ const Row = ({ children, gap = 'var(--gap-lg)' }: { children: React.ReactNode; g
 const meta = {
   title: 'Components/Form/radio',
   component: Radio,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
 } satisfies Meta<typeof Radio>;
 

--- a/components/ui/SegmentedControl/SegmentedControl.stories.tsx
+++ b/components/ui/SegmentedControl/SegmentedControl.stories.tsx
@@ -56,6 +56,7 @@ function InteractiveSegmentedControl({
 const meta: Meta<typeof SegmentedControl> = {
   title: 'Components/Control/segmented-control',
   component: SegmentedControl,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/Select/Select.stories.tsx
+++ b/components/ui/Select/Select.stories.tsx
@@ -55,6 +55,7 @@ const groupedOptions = [
 const meta: Meta<typeof Select> = {
   title: 'Components/Form/select',
   component: Select,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     placeholder: { control: 'text' },

--- a/components/ui/ServiceBadge/ServiceTag.stories.tsx
+++ b/components/ui/ServiceBadge/ServiceTag.stories.tsx
@@ -8,6 +8,7 @@ import type { ServiceCategory } from './ServiceBadge';
 const meta: Meta<typeof ServiceTag> = {
   title: 'Components/Indicator/service-tag',
   component: ServiceTag,
+  tags: ['surface-web'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/Sheet/Sheet.stories.tsx
+++ b/components/ui/Sheet/Sheet.stories.tsx
@@ -8,6 +8,7 @@ import { Field } from '../Field';
 const meta: Meta<typeof Sheet> = {
   title: 'Displays/Sheet/sheet',
   component: Sheet,
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
     side: { control: 'select', options: ['right', 'left', 'bottom'] },

--- a/components/ui/SheetSection/SheetSection.stories.tsx
+++ b/components/ui/SheetSection/SheetSection.stories.tsx
@@ -4,6 +4,7 @@ import { SheetSection } from './SheetSection';
 const meta: Meta<typeof SheetSection> = {
   title: 'Displays/Sheet/sheet-section',
   component: SheetSection,
+  tags: ['surface-product'],
   parameters: { layout: 'padded' },
   argTypes: {
     heading: { control: 'text' },

--- a/components/ui/SheetTypography/SheetTypography.stories.tsx
+++ b/components/ui/SheetTypography/SheetTypography.stories.tsx
@@ -39,6 +39,7 @@ const Section = ({ children }: { children: React.ReactNode }) => (
 
 const meta: Meta = {
   title: 'Displays/Sheet/sheet-typography',
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
 };
 

--- a/components/ui/SidebarNavigation/SidebarNavigation.stories.tsx
+++ b/components/ui/SidebarNavigation/SidebarNavigation.stories.tsx
@@ -73,6 +73,7 @@ const userSection = (
 const meta: Meta<typeof SidebarNavigation> = {
   title: 'Navigation/Primary/sidebar-navigation',
   component: SidebarNavigation,
+  tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },
 };
 

--- a/components/ui/Skeleton/Skeleton.stories.tsx
+++ b/components/ui/Skeleton/Skeleton.stories.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from './Skeleton';
 const meta: Meta<typeof Skeleton> = {
   title: 'Components/Indicator/skeleton',
   component: Skeleton,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'padded',
   },

--- a/components/ui/Slider/Slider.stories.tsx
+++ b/components/ui/Slider/Slider.stories.tsx
@@ -27,6 +27,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof Slider> = {
   title: 'Components/Control/slider',
   component: Slider,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/Spinner/Spinner.stories.tsx
+++ b/components/ui/Spinner/Spinner.stories.tsx
@@ -4,6 +4,7 @@ import { Spinner } from './Spinner';
 const meta: Meta<typeof Spinner> = {
   title: 'Components/Indicator/spinner',
   component: Spinner,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'lg'] },

--- a/components/ui/Stepper/Stepper.stories.tsx
+++ b/components/ui/Stepper/Stepper.stories.tsx
@@ -31,6 +31,7 @@ const Row = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; g
 const meta: Meta<typeof Stepper> = {
   title: 'Components/Control/stepper',
   component: Stepper,
+  tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/Switch/Switch.stories.tsx
+++ b/components/ui/Switch/Switch.stories.tsx
@@ -27,6 +27,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof Switch> = {
   title: 'Components/Control/switch',
   component: Switch,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     label: { control: 'text' },

--- a/components/ui/TabBar/TabBar.stories.tsx
+++ b/components/ui/TabBar/TabBar.stories.tsx
@@ -61,6 +61,7 @@ function InteractiveTabBar({
 const meta: Meta<typeof TabBar> = {
   title: 'Navigation/Secondary/tab-bar',
   component: TabBar,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     variant: { control: 'select', options: ['text', 'tab', 'box'] },

--- a/components/ui/Table/Table.stories.tsx
+++ b/components/ui/Table/Table.stories.tsx
@@ -74,6 +74,7 @@ const statusLabel = (s: string) =>
 const meta: Meta<typeof Table> = {
   title: 'Displays/Table/table',
   component: Table,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     striped: { control: 'boolean' },

--- a/components/ui/Tag/Tag.stories.tsx
+++ b/components/ui/Tag/Tag.stories.tsx
@@ -8,6 +8,7 @@ import { Badge } from '../Badge/Badge';
 const meta: Meta<typeof Tag> = {
   title: 'Components/Indicator/tag',
   component: Tag,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/TagGroup/TagGroup.stories.tsx
+++ b/components/ui/TagGroup/TagGroup.stories.tsx
@@ -6,6 +6,7 @@ import { Field } from '../Field';
 const meta: Meta<typeof TagGroup> = {
   title: 'Components/Indicator/tag-group',
   component: TagGroup,
+  tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
     gap: { control: 'select', options: ['xs', 'sm', 'md'] },

--- a/components/ui/TaskConsole/TaskConsole.stories.tsx
+++ b/components/ui/TaskConsole/TaskConsole.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof TaskConsole> = {
   title: 'Components/Feedback/task-console',
   component: TaskConsole,
+  tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },
   argTypes: {
     position: { control: 'select', options: ['bottom-right', 'bottom-left'] },

--- a/components/ui/TextArea/TextArea.stories.tsx
+++ b/components/ui/TextArea/TextArea.stories.tsx
@@ -30,6 +30,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta = {
   title: 'Components/Form/text-area',
   component: TextArea,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/TextInput/TextInput.stories.tsx
+++ b/components/ui/TextInput/TextInput.stories.tsx
@@ -32,6 +32,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 const meta: Meta<typeof TextInput> = {
   title: 'Components/Form/text-input',
   component: TextInput,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/TextLink/TextLink.stories.tsx
+++ b/components/ui/TextLink/TextLink.stories.tsx
@@ -4,6 +4,7 @@ import { TextLink } from './TextLink';
 const meta: Meta<typeof TextLink> = {
   title: 'Components/Action/text-link',
   component: TextLink,
+  tags: ['surface-shared'],
   parameters: {
     layout: 'centered',
   },

--- a/components/ui/TimePicker/TimePicker.stories.tsx
+++ b/components/ui/TimePicker/TimePicker.stories.tsx
@@ -31,6 +31,7 @@ const Row = ({ children, gap = 'var(--padding-sm)' }: { children: React.ReactNod
 const meta: Meta<typeof TimePicker> = {
   title: 'Components/Form/time-picker',
   component: TimePicker,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },

--- a/components/ui/Toast/Toast.stories.tsx
+++ b/components/ui/Toast/Toast.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 const meta: Meta<typeof Toast> = {
   title: 'Components/Feedback/toast',
   component: Toast,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
     title: { control: 'text' },

--- a/components/ui/Tooltip/Tooltip.stories.tsx
+++ b/components/ui/Tooltip/Tooltip.stories.tsx
@@ -31,6 +31,7 @@ const Row = ({ children, gap = 'var(--gap-lg)' }: { children: React.ReactNode; g
 const meta: Meta<typeof Tooltip> = {
   title: 'Components/Feedback/tooltip',
   component: Tooltip,
+  tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   decorators: [
     (Story) => (

--- a/docs/STORYBOOK-WRITING-GUIDE.md
+++ b/docs/STORYBOOK-WRITING-GUIDE.md
@@ -89,6 +89,42 @@ Never combine two prop axes in one story. Write `Sizes` and `Variants` as
 separate stories — never `SizesAndVariants`. If a story name needs "and"
 to describe it, split it.
 
+### Surface taxonomy — every story declares one
+
+Every component story carries exactly one surface tag in its meta:
+
+| Tag | Meaning | Examples |
+| --- | --- | --- |
+| `surface-web` | Marketing / site surfaces — brikdesigns.com and Webflow client sites | `Footer`, `NavBar`, `PricingCard`, `CardTestimonial`, `ServiceBadge` |
+| `surface-product` | Product app surfaces — `brik-client-portal`, `renew-pms`, `freedom-client-portal` | `AddableEntryList`, `FieldGrid`, `FilterBar`, `Sheet`, `SidebarNavigation`, `BrikDevBar` |
+| `surface-shared` | Used in both contexts (the default for primitives) | `Button`, `Badge`, `Field`, `Modal`, `Toast` |
+
+```tsx
+const meta: Meta<typeof Button> = {
+  title: 'Components/Action/button',
+  component: Button,
+  tags: ['surface-shared'],
+  // …
+};
+```
+
+**Why this exists.** Agents querying `list-all-documentation` via the
+Storybook MCP get every BDS component back with no signal about which
+surface it belongs on. Without this tag, an agent building a portal
+dashboard can pattern-match on `PricingCard` (a marketing component) or
+suggest `FilterBar` on a brikdesigns.com landing page. The surface tag
+lets the agent — and the consumer-repo `CLAUDE.md` system prompts —
+filter to relevant primitives only.
+
+**Reclassifying.** If a `surface-shared` component starts being used
+heavily on one surface only, leave it `shared`. Move it to a specific
+surface only when the component's *API* assumes that surface (e.g. a
+component that requires a marketing-only prop or a product-only context
+provider). Surface is about API affordance, not adoption count.
+
+**New components default to `surface-shared`** unless you can name a
+specific reason it can't render on the other surface.
+
 ### Deprecated stories must hide from agents
 
 When a component is deprecated (`@deprecated` JSDoc), the same PR adds


### PR DESCRIPTION
## Summary
- feat(storybook): add components manifest + surface taxonomy for MCP

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)