### PR TITLE
docs(jsdoc): backfill prop descriptions on 5 product components

### DIFF
--- a/components/ui/Board/Board.tsx
+++ b/components/ui/Board/Board.tsx
@@ -18,6 +18,7 @@ import './Board.css';
  * ```
  */
 export interface BoardProps extends HTMLAttributes<HTMLDivElement> {
+  /** `BoardColumn` elements. Columns flex equally and respect their min/max widths. */
   children: ReactNode;
 }
 

--- a/components/ui/FieldGrid/FieldGrid.tsx
+++ b/components/ui/FieldGrid/FieldGrid.tsx
@@ -10,6 +10,7 @@ export interface FieldGridProps extends HTMLAttributes<HTMLDivElement> {
   columns?: FieldGridColumns;
   /** Gap between cells. Default `xl` (matches existing portal field grids). */
   gap?: FieldGridGap;
+  /** Cells to lay out side by side — typically `Field` components, but works for any equal-weight content. */
   children?: ReactNode;
 }
 

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -8,13 +8,19 @@ export interface MetadataItem {
 }
 
 export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  /** Page title — rendered as the H1. */
   title: string;
+  /** Optional subtitle paragraph rendered under the title. */
   subtitle?: string;
   /** Badge displayed to the left of the title (e.g. ServiceBadge) */
   badge?: ReactNode;
+  /** Breadcrumb element (typically a `Breadcrumb` component) rendered above the title row. */
   breadcrumbs?: ReactNode;
+  /** Right-aligned action element(s) (primary `Button`, dropdown menu, etc.). */
   actions?: ReactNode;
+  /** Optional `TabBar` (or equivalent) rendered at the bottom of the header — page-level navigation. */
   tabs?: ReactNode;
+  /** Key/value pairs rendered below the title row (e.g. Owner, Status, Updated). */
   metadata?: MetadataItem[];
   /** Summary content (e.g. stat cards) rendered between metadata and tabs. */
   stats?: ReactNode;

--- a/components/ui/Sheet/Sheet.tsx
+++ b/components/ui/Sheet/Sheet.tsx
@@ -33,10 +33,15 @@ export interface SheetSecondaryAction {
 }
 
 export interface SheetProps {
+  /** Whether the sheet is rendered. Returns `null` when false (no animation; pair with `closeOnBackdrop` / `closeOnEscape` for dismissal UX). */
   isOpen: boolean;
+  /** Called when the sheet should close — fired by backdrop click, Escape key, the close button, and the auto-footer Cancel/Close actions. */
   onClose: () => void;
+  /** Body content rendered in the sheet. Ignored when `tabs` is provided (tabs render their own content). */
   children?: ReactNode;
+  /** Edge the sheet anchors to. Default `right`. `bottom` becomes a full-width drawer. */
   side?: SheetSide;
+  /** Heading rendered as `<h2>` in the sheet header. */
   title?: ReactNode;
   /**
    * Eyebrow label rendered above the title in `text-muted`. Use for short
@@ -57,8 +62,11 @@ export interface SheetProps {
    * - `floating` — rounded floating panel with elevation, no backdrop (read-only detail views)
    */
   variant?: SheetVariant;
+  /** Close when the backdrop is clicked. Default `true`. Has no effect when `variant="floating"` (no backdrop). */
   closeOnBackdrop?: boolean;
+  /** Close on `Escape` keypress. Default `true`. */
   closeOnEscape?: boolean;
+  /** Render the X close button in the header. Default `true`. Disable when the sheet has its own dismissal UX. */
   showCloseButton?: boolean;
   /**
    * When set, renders a back button in the header for nested sheet navigation.
@@ -77,9 +85,13 @@ export interface SheetProps {
   onSave?: () => void;
   /** Triggered from the secondary action in edit mode. Falls back to `onClose`. */
   onCancel?: () => void;
+  /** Label for the auto-rendered Edit button when `mode="read"`. Default `"Edit"`. */
   editLabel?: string;
+  /** Label for the auto-rendered Save button when `mode="edit"`. Default `"Save"`. */
   saveLabel?: string;
+  /** Label for the auto-rendered Cancel button when `mode="edit"`. Default `"Cancel"`. */
   cancelLabel?: string;
+  /** Label for the auto-rendered Close button when `mode="read"` (no `onEdit`) or as the dismissal verb in the auto-footer. Default `"Close"`. */
   closeLabel?: string;
   /** Disable the save button (e.g. while form is invalid) */
   saveDisabled?: boolean;

--- a/components/ui/SidebarNavigation/SidebarNavigation.tsx
+++ b/components/ui/SidebarNavigation/SidebarNavigation.tsx
@@ -10,9 +10,13 @@ export interface SidebarNavItem {
 }
 
 export interface SidebarNavigationProps {
+  /** Logo node rendered at the top of the sidebar (typically a brand mark or `<img>`). */
   logo: ReactNode;
+  /** Primary navigation items. Each renders as an anchor with an optional icon and active state. */
   navItems: SidebarNavItem[];
+  /** Optional content rendered above the user section (e.g. settings link, theme toggle). */
   footerActions?: ReactNode;
+  /** Bottom section with user identity / account controls (e.g. avatar + email + sign-out). */
   userSection?: ReactNode;
   /** Custom width (default: 260px) — runtime-configurable, stays inline */
   width?: string;


### PR DESCRIPTION
## Summary
- docs(claude-md): swap stale per-build Chromatic URL for stable branch alias (#262)
- docs(jsdoc): backfill prop descriptions on 5 product components

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)