### PR TITLE
docs(jsdoc): backfill prop descriptions on 11 shared + web components

### DIFF
--- a/components/ui/Accordion/Accordion.tsx
+++ b/components/ui/Accordion/Accordion.tsx
@@ -16,10 +16,15 @@ export interface AccordionItemData {
 }
 
 export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
+  /** Sections to render. Each item supplies its own `id`, `title`, and `content`. */
   items: AccordionItemData[];
+  /** Whether multiple sections can be open at once. Default `false` (single-open accordion — opening a new section closes the previous one). */
   allowMultiple?: boolean;
+  /** Controlled open ids. When provided, internal state is ignored and `onOpenChange` is the only way state advances. */
   openItems?: string[];
+  /** Called with the next array of open ids whenever a section toggles. Required for controlled use. */
   onOpenChange?: (openItems: string[]) => void;
+  /** Initial open ids when uncontrolled. Default `[]` (all closed). */
   defaultOpenItems?: string[];
 }
 

--- a/components/ui/AnimatedIcon/AnimatedIcon.tsx
+++ b/components/ui/AnimatedIcon/AnimatedIcon.tsx
@@ -16,6 +16,7 @@ export interface AnimatedIconProps {
   loop?: boolean;
   /** aria-label for accessibility */
   label?: string;
+  /** Optional CSS class names appended to the wrapping `<span>`. */
   className?: string;
 }
 

--- a/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -10,7 +10,9 @@ export interface BreadcrumbItem {
 export type BreadcrumbSeparator = 'slash' | 'chevron';
 
 export interface BreadcrumbProps extends HTMLAttributes<HTMLElement> {
+  /** Crumb trail in order. The last item is rendered as plain text with `aria-current="page"`; earlier items render as `<a>` when `href` is set. */
   items: BreadcrumbItem[];
+  /** Visual separator between crumbs. Default `slash` (`/`); `chevron` renders `›`. */
   separator?: BreadcrumbSeparator;
 }
 

--- a/components/ui/ButtonGroup/ButtonGroup.tsx
+++ b/components/ui/ButtonGroup/ButtonGroup.tsx
@@ -5,7 +5,9 @@ import './ButtonGroup.css';
 export type ButtonGroupOrientation = 'horizontal' | 'vertical';
 
 export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
+  /** `Button` (or `IconButton`) elements to group. */
   children: ReactNode;
+  /** Stack direction. Default `horizontal`. */
   orientation?: ButtonGroupOrientation;
   /** When true, buttons stretch to fill the container equally */
   fullWidth?: boolean;

--- a/components/ui/CardControl/CardControl.tsx
+++ b/components/ui/CardControl/CardControl.tsx
@@ -5,9 +5,13 @@ import './CardControl.css';
 export type CardControlActionAlign = 'center' | 'top';
 
 export interface CardControlProps extends HTMLAttributes<HTMLDivElement> {
+  /** Setting / control name shown as the primary text. */
   title: string;
+  /** Optional supporting copy displayed below the title. */
   description?: string;
+  /** Optional leading element (typically a `Badge` or icon) rendered before the text block. */
   badge?: ReactNode;
+  /** Trailing action element (typically a `Switch`, `Button`, or link). */
   action?: ReactNode;
   /** Vertical alignment of the action slot. `top` anchors the CTA to the upper-right corner. */
   actionAlign?: CardControlActionAlign;

--- a/components/ui/CardList/CardList.tsx
+++ b/components/ui/CardList/CardList.tsx
@@ -6,10 +6,13 @@ export type CardListOrientation = 'vertical' | 'horizontal';
 export type CardListGap = 'sm' | 'md' | 'lg' | 'xl';
 
 export interface CardListProps extends HTMLAttributes<HTMLUListElement> {
+  /** Stacking direction. `vertical` (default) for column lists, `horizontal` for rows. */
   orientation?: CardListOrientation;
+  /** Spacing between items. Default `md`. */
   gap?: CardListGap;
   /** Horizontal only — when true, items size to their content instead of filling equal columns */
   fitContent?: boolean;
+  /** Child cards. Each is wrapped in an `<li>` automatically. */
   children: ReactNode;
 }
 

--- a/components/ui/CardTestimonial/CardTestimonial.tsx
+++ b/components/ui/CardTestimonial/CardTestimonial.tsx
@@ -6,10 +6,15 @@ import './CardTestimonial.css';
 export type CardTestimonialVariant = 'brand' | 'outlined';
 
 export interface CardTestimonialProps extends HTMLAttributes<HTMLElement> {
+  /** Testimonial body — the customer's quote. Rendered inside a `<blockquote>`. */
   quote: string;
+  /** Person attribution rendered under the quote (typically full name). */
   authorName: string;
+  /** Job title / company / context displayed beneath the author name. */
   authorRole?: string;
+  /** Optional 1–5 star rating rendered as filled stars at the bottom. */
   rating?: 1 | 2 | 3 | 4 | 5;
+  /** Visual variant. `brand` (default) uses the brand-tinted card surface; `outlined` swaps to a neutral surface with a border. */
   variant?: CardTestimonialVariant;
 }
 

--- a/components/ui/Checkbox/Checkbox.tsx
+++ b/components/ui/Checkbox/Checkbox.tsx
@@ -3,10 +3,15 @@ import { bdsClass } from '../../utils';
 import './Checkbox.css';
 
 export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /** Visible text rendered next to the checkbox. Clicking the label toggles the input. */
   label: ReactNode;
+  /** Controlled checked state. Pair with `onChange` — uncontrolled callers use `defaultChecked` instead. */
   checked?: boolean;
+  /** Initial checked state for uncontrolled use. */
   defaultChecked?: boolean;
+  /** Disable the input and apply muted styling. */
   disabled?: boolean;
+  /** Called when the checkbox toggles — receives the native change event. */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 

--- a/components/ui/Dialog/Dialog.tsx
+++ b/components/ui/Dialog/Dialog.tsx
@@ -6,15 +6,25 @@ import './Dialog.css';
 export type DialogVariant = 'default' | 'destructive';
 
 export interface DialogProps {
+  /** Whether the dialog is rendered. Returns `null` when false. */
   isOpen: boolean;
+  /** Called on backdrop click, Escape key, or the Cancel button. Caller is responsible for setting `isOpen` to false. */
   onClose: () => void;
+  /** Heading text rendered in the dialog. Required for accessible labelling. */
   title: string;
+  /** Body paragraph rendered under the title. Ignored when `children` is supplied. */
   description?: string;
+  /** Custom body content. Replaces `description` when provided. */
   children?: ReactNode;
+  /** Label for the primary action button. Default `"Confirm"`. */
   confirmLabel?: string;
+  /** Label for the secondary cancel button. Default `"Cancel"`. */
   cancelLabel?: string;
+  /** Called when the primary action is clicked. Caller is responsible for closing the dialog (typically by toggling `isOpen`). */
   onConfirm?: () => void;
+  /** Visual variant. `default` uses the brand-primary confirm button; `destructive` switches it to the destructive treatment for delete-style confirmations. */
   variant?: DialogVariant;
+  /** Close when the backdrop is clicked. Default `true`. */
   closeOnBackdrop?: boolean;
 }
 

--- a/components/ui/Select/Select.tsx
+++ b/components/ui/Select/Select.tsx
@@ -18,17 +18,29 @@ export interface SelectOptionGroup {
 export type SelectSize = 'sm' | 'md' | 'lg';
 
 export interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 'size'> {
+  /** Flat options or grouped option groups. Mix freely — entries with an `options` key render as `<optgroup>`, others as `<option>`. */
   options: (SelectOption | SelectOptionGroup)[];
+  /** Empty-value option text shown when no selection has been made. Renders as a placeholder-styled first option. */
   placeholder?: string;
+  /** Controlled selection. Pair with `onChange` — uncontrolled callers use `defaultValue`. */
   value?: string;
+  /** Initial selection for uncontrolled use. */
   defaultValue?: string;
+  /** Disable the select and apply muted styling. */
   disabled?: boolean;
+  /** Size variant. Default `md`; `sm` and `lg` adjust padding and font size. */
   size?: SelectSize;
+  /** Visible label rendered above the select. Auto-wires `htmlFor`/`id` for accessibility. */
   label?: string;
+  /** Small text shown below the select. Hidden when `error` is present. */
   helperText?: string;
+  /** Error message. Sets `aria-invalid` and replaces `helperText`. */
   error?: string;
+  /** Stretch the wrapper to its container width. Default `true`. */
   fullWidth?: boolean;
+  /** Optional leading icon rendered inside the select field (left of the value). */
   icon?: ReactNode;
+  /** Native change handler — receives the change event. */
   onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void;
 }
 

--- a/components/ui/Table/Table.tsx
+++ b/components/ui/Table/Table.tsx
@@ -14,10 +14,13 @@ import './Table.css';
 export type TableSize = 'default' | 'comfortable';
 
 export interface TableProps extends HTMLAttributes<HTMLTableElement> {
+  /** Apply alternating row backgrounds for readability on dense tables. Default `false`. */
   striped?: boolean;
+  /** Row density. `default` is the standard scale; `comfortable` adds extra cell padding for dense data tables. */
   size?: TableSize;
   /** Remove left padding on first cell, right padding on last cell */
   flush?: boolean;
+  /** Table content — typically `TableHead` and `TableBody` from this same module. */
   children: ReactNode;
 }
 


### PR DESCRIPTION
## Summary
- docs(jsdoc): backfill prop descriptions on 11 shared + web components

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)