### PR TITLE
docs(jsdoc): add @summary to 79 component main exports

### DIFF
--- a/components/ui/Accordion/Accordion.tsx
+++ b/components/ui/Accordion/Accordion.tsx
@@ -64,6 +64,8 @@ function AccordionItem({ item, isOpen, onToggle }: AccordionItemProps) {
 
 /**
  * Accordion — collapsible content sections with plus/minus icons.
+ *
+ * @summary Collapsible content sections with single/multi-open
  */
 export function Accordion({
   items,

--- a/components/ui/ActivityTimeline/ActivityTimeline.tsx
+++ b/components/ui/ActivityTimeline/ActivityTimeline.tsx
@@ -43,6 +43,8 @@ export interface ActivityTimelineProps {
  *   { icon: <Icon icon="ph:check-circle" />, label: 'Completed', timestamp: 'Apr 13, 2026' },
  * ]} />
  * ```
+ *
+ * @summary Vertical timeline of dated events
  */
 export function ActivityTimeline({ events, className = '' }: ActivityTimelineProps) {
   if (events.length === 0) return null;

--- a/components/ui/AddableComboList/AddableComboList.tsx
+++ b/components/ui/AddableComboList/AddableComboList.tsx
@@ -70,6 +70,8 @@ const INPUT_SIZE: Record<AddableComboListSize, TextInputSize> = { sm: 'sm', md: 
  *   placeholder="Search or add a service…"
  * />
  * ```
+ *
+ * @summary Suggestion-driven combobox tag input (multi-select)
  */
 export function AddableComboList({
   values,

--- a/components/ui/AddableEntryList/AddableEntryList.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.tsx
@@ -142,6 +142,8 @@ const TEXTAREA_SIZE: Record<AddableEntryListSize, TextAreaSize> = { sm: 'sm', md
  *   addLabel="Add Service"
  * />
  * ```
+ *
+ * @summary Add-edit list of label+text entry rows
  */
 export function AddableEntryList({
   entries,

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.tsx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.tsx
@@ -126,6 +126,8 @@ const BUTTON_SIZE: Record<AddableFieldRowListSize, ButtonSize> = {
  *   )}
  * </AddableFieldRowList>
  * ```
+ *
+ * @summary Add-edit list of multi-field rows
  */
 export function AddableFieldRowList<T>({
   values,

--- a/components/ui/AddableTextList/AddableTextList.tsx
+++ b/components/ui/AddableTextList/AddableTextList.tsx
@@ -72,6 +72,8 @@ function warnStructuredContent(value: string, label?: string) {
  *   placeholder="e.g. Dental cleaning"
  * />
  * ```
+ *
+ * @summary Reveal-on-click list of single-line text entries
  */
 export function AddableTextList({
   values,

--- a/components/ui/AddressInput/AddressInput.tsx
+++ b/components/ui/AddressInput/AddressInput.tsx
@@ -271,6 +271,8 @@ const suggestionDescriptionStyles: CSSProperties = {
  *   onSuggestionSelect={(s) => console.log(s)}
  * />
  * ```
+ *
+ * @summary Location input with autocomplete suggestions
  */
 export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
   (

--- a/components/ui/AlertBanner/AlertBanner.tsx
+++ b/components/ui/AlertBanner/AlertBanner.tsx
@@ -54,6 +54,8 @@ const iconMap: Record<AlertBannerVariant, string> = {
  * ```
  *
  * Tracked under ADR-004 — see docs/adrs/ADR-004-component-bloat-guardrails.md.
+ *
+ * @summary Status banner (deprecated — use Banner)
  */
 export function AlertBanner({
   title,

--- a/components/ui/AnimatedIcon/AnimatedIcon.tsx
+++ b/components/ui/AnimatedIcon/AnimatedIcon.tsx
@@ -31,6 +31,8 @@ export interface AnimatedIconProps {
  * import checkAnimation from '@/animations/checkbox.json';
  * <AnimatedIcon animationData={checkAnimation} trigger="once" size={32} label="Completed" />
  * ```
+ *
+ * @summary Lottie wrapper for animated icon states
  */
 export function AnimatedIcon({
   animationData,

--- a/components/ui/Avatar/Avatar.tsx
+++ b/components/ui/Avatar/Avatar.tsx
@@ -34,6 +34,8 @@ function getInitials(name: string): string {
  * <Avatar src="/user.jpg" alt="John Doe" />
  * <Avatar name="John Doe" size="lg" status="online" />
  * ```
+ *
+ * @summary Profile image with initials fallback + status dot
  */
 export function Avatar({
   src,

--- a/components/ui/Badge/Badge.tsx
+++ b/components/ui/Badge/Badge.tsx
@@ -49,6 +49,8 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
  * <Badge status="warning" size="sm" appearance="subtle">Pending</Badge>
  * <Badge status="error" size="lg">Failed</Badge>
  * ```
+ *
+ * @summary Status indicator with semantic tones and sizes
  */
 export function Badge({
   status = 'info',

--- a/components/ui/BadgeGroup/BadgeGroup.tsx
+++ b/components/ui/BadgeGroup/BadgeGroup.tsx
@@ -21,6 +21,8 @@ export interface BadgeGroupProps extends HTMLAttributes<HTMLDivElement> {
  * or standalone inside a SheetSection.
  *
  * Sibling of `TagGroup` — same API shape, different child indicator.
+ *
+ * @summary Horizontal cluster of Badges with locked spacing
  */
 export function BadgeGroup({
   gap = 'xs',

--- a/components/ui/Banner/Banner.tsx
+++ b/components/ui/Banner/Banner.tsx
@@ -50,6 +50,8 @@ const STATUS_BADGE: Record<Exclude<BannerTone, 'announcement'>, 'warning' | 'err
  *   leading status Badge icon and primary text. Renders with `role="alert"`.
  *   Replaces the legacy `AlertBanner` component (per ADR-004 §3 — same
  *   shape, different presets = one component with a tone prop).
+ *
+ * @summary Full-width banner — announcement or status tones
  */
 export function Banner({
   title,

--- a/components/ui/Board/Board.tsx
+++ b/components/ui/Board/Board.tsx
@@ -22,6 +22,9 @@ export interface BoardProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 }
 
+/**
+ * @summary Horizontal kanban container of BoardColumns
+ */
 export function Board({ children, className, style, ...props }: BoardProps) {
   return (
     <div

--- a/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -23,6 +23,8 @@ const SEPARATOR_CHARS: Record<BreadcrumbSeparator, string> = {
 
 /**
  * Breadcrumb — navigation breadcrumb trail with separator variants.
+ *
+ * @summary Navigation breadcrumb trail with separator variants
  */
 export function Breadcrumb({
   items,

--- a/components/ui/BrikDevBar/BrikDevBar.tsx
+++ b/components/ui/BrikDevBar/BrikDevBar.tsx
@@ -62,6 +62,8 @@ declare global {
  * Render this once in your DevTools layout (or any high-level layout component).
  * Both scripts must be present in the app's public/ directory — see the sync
  * script at brik-llm/scripts/brik-dev-tool/sync-downstream.sh.
+ *
+ * @summary Dev-only inspection bar (loads devbar/inspect scripts)
  */
 export function BrikDevBar() {
   useEffect(() => {

--- a/components/ui/BulletList/BulletList.tsx
+++ b/components/ui/BulletList/BulletList.tsx
@@ -21,6 +21,8 @@ export interface BulletListProps extends Omit<HTMLAttributes<HTMLUListElement>, 
  * pattern used across sheets for anti-messages, proof points, brand
  * rules, and other short-item lists. Pass `marker="decimal"` for
  * numbered lists; the underlying element switches to `<ol>` automatically.
+ *
+ * @summary Structured list of short text items with markers
  */
 export function BulletList({
   items,

--- a/components/ui/Button/Button.tsx
+++ b/components/ui/Button/Button.tsx
@@ -98,6 +98,8 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * <Button variant="danger" size="md">Delete account</Button>
  * <Button variant="outline" iconAfter={<ArrowRight />}>Continue</Button>
  * ```
+ *
+ * @summary Primary action component with variants and sizes
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (

--- a/components/ui/ButtonGroup/ButtonGroup.tsx
+++ b/components/ui/ButtonGroup/ButtonGroup.tsx
@@ -23,6 +23,8 @@ export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
  *   <Button variant="ghost">Cancel</Button>
  * </ButtonGroup>
  * ```
+ *
+ * @summary Group related Buttons (orientation + full-width)
  */
 export function ButtonGroup({
   children,

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -138,6 +138,8 @@ function formatSummaryValue(value: string | number, type: CardSummaryType): stri
  *   textLink={{ label: 'Details', href: '/revenue' }}
  * />
  * ```
+ *
+ * @summary Flexible content container with presets
  */
 export function Card(props: CardProps) {
   if (props.preset === 'control') {

--- a/components/ui/CardControl/CardControl.tsx
+++ b/components/ui/CardControl/CardControl.tsx
@@ -28,6 +28,8 @@ export interface CardControlProps extends HTMLAttributes<HTMLDivElement> {
  * 2026-04-24 — CardControl stays as a first-class component. The
  * 2026-Q2 audit's recommendation to retire it is logged but not in
  * effect; see docs/audits/2026-Q2-component-bloat-audit.md.
+ *
+ * @summary Settings card — title, description, badge, action
  */
 export function CardControl({
   title,

--- a/components/ui/CardList/CardList.tsx
+++ b/components/ui/CardList/CardList.tsx
@@ -18,6 +18,8 @@ export interface CardListProps extends HTMLAttributes<HTMLUListElement> {
 
 /**
  * CardList — layout wrapper that stacks card components vertically or horizontally.
+ *
+ * @summary Stack of cards (vertical or horizontal)
  */
 export function CardList({
   orientation = 'vertical',

--- a/components/ui/CardTestimonial/CardTestimonial.tsx
+++ b/components/ui/CardTestimonial/CardTestimonial.tsx
@@ -20,6 +20,8 @@ export interface CardTestimonialProps extends HTMLAttributes<HTMLElement> {
 
 /**
  * CardTestimonial — customer testimonial card with quote, attribution, and stars.
+ *
+ * @summary Customer testimonial card with quote and stars
  */
 export function CardTestimonial({
   quote,

--- a/components/ui/CatalogPicker/CatalogPicker.tsx
+++ b/components/ui/CatalogPicker/CatalogPicker.tsx
@@ -151,6 +151,8 @@ function matchCatalogEntry(
  *   emptyDescriptionLabel="No description set"
  * />
  * ```
+ *
+ * @summary Industry-aware multi-pick input with custom escape
  */
 export function CatalogPicker({
   catalog,

--- a/components/ui/Checkbox/Checkbox.tsx
+++ b/components/ui/Checkbox/Checkbox.tsx
@@ -17,6 +17,8 @@ export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement
 
 /**
  * Checkbox — themed checkbox with label text.
+ *
+ * @summary Themed checkbox with adjacent label
  */
 export function Checkbox({
   label,

--- a/components/ui/Chip/Chip.tsx
+++ b/components/ui/Chip/Chip.tsx
@@ -60,6 +60,8 @@ export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childre
  * <Chip label="Status: Active" onRemove={() => removeFilter('status')} />
  * <Chip label="Selected" variant="primary" appearance="solid" onChipClick={toggle} />
  * ```
+ *
+ * @summary Compact interactive pill for filtering or selection
  */
 export function Chip({
   label,

--- a/components/ui/CollapsibleCard/CollapsibleCard.tsx
+++ b/components/ui/CollapsibleCard/CollapsibleCard.tsx
@@ -50,6 +50,8 @@ export interface CollapsibleCardProps extends HTMLAttributes<HTMLDivElement> {
  *   <p>Content goes here</p>
  * </CollapsibleCard>
  * ```
+ *
+ * @summary Card with expand/collapse content section
  */
 export function CollapsibleCard({
   sectionLabel,

--- a/components/ui/Counter/Counter.tsx
+++ b/components/ui/Counter/Counter.tsx
@@ -24,6 +24,8 @@ export interface CounterProps extends HTMLAttributes<HTMLSpanElement> {
  * <Counter count={5} status="success" />
  * <Counter count={150} max={99} status="error" size="lg" />
  * ```
+ *
+ * @summary Numeric count indicator with status colors
  */
 export function Counter({
   count,

--- a/components/ui/DataSection/DataSection.tsx
+++ b/components/ui/DataSection/DataSection.tsx
@@ -38,6 +38,7 @@ export interface DataSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'tit
  *
  * The title is a real heading node in the page outline — default `<h2>`,
  * rendered with heading-tier typography. It is NOT an uppercase label.
+ * @summary Page-side wrapper for read-mode data sections
  *
  * @see Displays/Form/Read-Mode Page — composition with FieldGrid + Field + ButtonGroup.
  */

--- a/components/ui/DatePicker/DatePicker.tsx
+++ b/components/ui/DatePicker/DatePicker.tsx
@@ -235,6 +235,8 @@ function Calendar({
  * <DatePicker size="md" label="Due date" helperText="Task must be completed by this date" />
  * <DatePicker size="lg" label="Appointment" error="Date is required" />
  * ```
+ *
+ * @summary Themed date picker (Radix Popover + calendar grid)
  */
 export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
   (

--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
@@ -71,6 +71,9 @@ export interface DevFeedbackWidgetProps {
 }
 
 // ── Component ───────────────────────────────────────────────────────────
+/**
+ * @summary Floating dev-only feedback capture widget
+ */
 export function DevFeedbackWidget({
   endpoint = '/api/feedback',
   contextLabel = 'Page',

--- a/components/ui/Dialog/Dialog.tsx
+++ b/components/ui/Dialog/Dialog.tsx
@@ -51,6 +51,8 @@ export interface DialogProps {
  * ```
  *
  * Tracked under ADR-004 — see docs/adrs/ADR-004-component-bloat-guardrails.md.
+ *
+ * @summary Confirm dialog (deprecated — use Modal preset=confirm)
  */
 export function Dialog({
   isOpen,

--- a/components/ui/Divider/Divider.tsx
+++ b/components/ui/Divider/Divider.tsx
@@ -21,6 +21,8 @@ export interface DividerProps extends HTMLAttributes<HTMLHRElement> {
  * <Divider spacing="lg" />
  * <Divider orientation="vertical" />
  * ```
+ *
+ * @summary Visual separator line for content sections
  */
 export function Divider({
   orientation = 'horizontal',

--- a/components/ui/Dot/Dot.tsx
+++ b/components/ui/Dot/Dot.tsx
@@ -22,6 +22,8 @@ export interface DotProps extends HTMLAttributes<HTMLSpanElement> {
  * <Dot status="positive" />
  * <Dot status="error" size="lg" />
  * ```
+ *
+ * @summary Small status indicator circle
  */
 export function Dot({
   status = 'default',

--- a/components/ui/EmptyState/EmptyState.tsx
+++ b/components/ui/EmptyState/EmptyState.tsx
@@ -20,6 +20,8 @@ export interface EmptyStateProps extends Omit<HTMLAttributes<HTMLDivElement>, 't
  *
  * Displays a centered title, optional description, and optional
  * action button within a bordered surface container.
+ *
+ * @summary Empty/zero-state messaging with optional action
  */
 export function EmptyState({
   title,

--- a/components/ui/Field/Field.tsx
+++ b/components/ui/Field/Field.tsx
@@ -30,6 +30,8 @@ function isEmpty(value: ReactNode): boolean {
  * The single biggest win over ad-hoc markup: one API covers text,
  * tags, URLs, bullet lists, and empty states. Locks label typography,
  * value spacing, and the "Not set" empty treatment.
+ *
+ * @summary Read-mode label + value pair for use inside a Sheet
  */
 export function Field({
   label,

--- a/components/ui/FieldGrid/FieldGrid.tsx
+++ b/components/ui/FieldGrid/FieldGrid.tsx
@@ -21,6 +21,8 @@ export interface FieldGridProps extends HTMLAttributes<HTMLDivElement> {
  * pattern scattered across portal sheets. Primary use: pair `Field`
  * components in a stacked sheet body. Also works for `Card`, `Tag`,
  * or any equal-weight row of content.
+ *
+ * @summary Equal-column grid for laying out Fields side by side
  */
 export function FieldGrid({
   columns = 2,

--- a/components/ui/FileUploader/FileUploader.tsx
+++ b/components/ui/FileUploader/FileUploader.tsx
@@ -43,6 +43,8 @@ export interface FileUploaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 
  *   onChange={(files) => console.log(files)}
  * />
  * ```
+ *
+ * @summary Drag-and-drop file upload zone with progress
  */
 export function FileUploader({
   accept,

--- a/components/ui/FilterBar/FilterBar.tsx
+++ b/components/ui/FilterBar/FilterBar.tsx
@@ -46,6 +46,8 @@ export interface FilterBarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'ti
  *   <FilterButton label="Status" value={statusFilter} onChange={setStatusFilter} options={...} />
  * </FilterBar>
  * ```
+ *
+ * @summary Heading + counter + filter controls row for list views
  */
 export function FilterBar({
   total,

--- a/components/ui/FilterButton/FilterButton.tsx
+++ b/components/ui/FilterButton/FilterButton.tsx
@@ -66,6 +66,8 @@ export interface FilterButtonProps extends Omit<HTMLAttributes<HTMLDivElement>, 
  *   ]}
  * />
  * ```
+ *
+ * @summary Dropdown filter trigger for filter bars
  */
 export function FilterButton({
   label,

--- a/components/ui/FilterToggle/FilterToggle.tsx
+++ b/components/ui/FilterToggle/FilterToggle.tsx
@@ -38,6 +38,8 @@ export interface FilterToggleProps
  *   onToggle={() => setShowArchived((prev) => !prev)}
  * />
  * ```
+ *
+ * @summary Binary on/off filter pill for filter bars
  */
 export function FilterToggle({
   label,

--- a/components/ui/Footer/Footer.tsx
+++ b/components/ui/Footer/Footer.tsx
@@ -52,6 +52,8 @@ export type FooterVariant = 'default' | 'brand';
  *   copyright="2026 Brik Designs. All rights reserved."
  * />
  * ```
+ *
+ * @summary Page footer with link columns and brand block
  */
 export function Footer({
   logo,

--- a/components/ui/Form/Form.tsx
+++ b/components/ui/Form/Form.tsx
@@ -48,6 +48,8 @@ export interface FormProps extends FormHTMLAttributes<HTMLFormElement> {
  *   <TextArea label="Message" placeholder="How can we help?" />
  * </Form>
  * ```
+ *
+ * @summary Form container with layout and inline messaging
  */
 export function Form({
   children,

--- a/components/ui/Menu/Menu.tsx
+++ b/components/ui/Menu/Menu.tsx
@@ -94,6 +94,8 @@ export function MenuItem({ item, isActive, className, style, ...props }: MenuIte
  *   />
  * </div>
  * ```
+ *
+ * @summary Dropdown menu with items and keyboard nav
  */
 export function Menu({
   items,

--- a/components/ui/Meter/Meter.tsx
+++ b/components/ui/Meter/Meter.tsx
@@ -56,6 +56,8 @@ function defaultFormatter(value: number, max: number): string {
  * <Meter value={3} max={10} status="warning" label="Fair" size="lg" />
  * <Meter value={1} max={5} status="error" label="Fail" showValue={false} />
  * ```
+ *
+ * @summary Horizontal gauge bar for scores and ratings
  */
 export function Meter({
   value,

--- a/components/ui/Modal/Modal.tsx
+++ b/components/ui/Modal/Modal.tsx
@@ -107,6 +107,8 @@ export type ModalProps = ModalDefaultProps | ModalConfirmPresetProps;
  *   onConfirm={handleDelete}
  * />
  * ```
+ *
+ * @summary Portal-rendered overlay with backdrop and escape
  */
 export function Modal(props: ModalProps) {
   const {

--- a/components/ui/MultiSelect/MultiSelect.tsx
+++ b/components/ui/MultiSelect/MultiSelect.tsx
@@ -83,6 +83,8 @@ export interface MultiSelectProps {
  *   onChange={setSelected}
  * />
  * ```
+ *
+ * @summary Themed multi-select dropdown with chip values
  */
 export function MultiSelect({
   options,

--- a/components/ui/NavBar/NavBar.tsx
+++ b/components/ui/NavBar/NavBar.tsx
@@ -46,6 +46,8 @@ export interface NavBarProps extends HTMLAttributes<HTMLElement> {
  *   actions={<Button size="sm">Get Started</Button>}
  * />
  * ```
+ *
+ * @summary Horizontal top navigation bar with brand and links
  */
 export function NavBar({
   logo,

--- a/components/ui/NotificationList/NotificationList.tsx
+++ b/components/ui/NotificationList/NotificationList.tsx
@@ -91,6 +91,8 @@ export interface NotificationListProps {
  *   onItemClick={(n) => console.log(n.id)}
  * />
  * ```
+ *
+ * @summary Scrollable list of notification items
  */
 export function NotificationList({
   notifications,

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -34,6 +34,8 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
 
 /**
  * PageHeader — composable page-level header with breadcrumbs, badge, actions, metadata, stats, and tabs.
+ *
+ * @summary Page-level header — title, breadcrumbs, actions, tabs
  */
 export function PageHeader({
   title,

--- a/components/ui/Pagination/Pagination.tsx
+++ b/components/ui/Pagination/Pagination.tsx
@@ -91,6 +91,8 @@ function getPageNumbers(
  *   position="center"
  * />
  * ```
+ *
+ * @summary Page-navigation controls with page numbers
  */
 export function Pagination({
   currentPage,

--- a/components/ui/PasswordInput/PasswordInput.tsx
+++ b/components/ui/PasswordInput/PasswordInput.tsx
@@ -86,6 +86,8 @@ const EyeClosedIcon = () => (
  * <PasswordInput label="Password" size="sm" helperText="Must be at least 8 characters" />
  * <PasswordInput label="Password" error="Password is required" fullWidth />
  * ```
+ *
+ * @summary TextInput with show/hide password toggle
  */
 export const PasswordInput = ({
   id,

--- a/components/ui/Popover/Popover.tsx
+++ b/components/ui/Popover/Popover.tsx
@@ -32,6 +32,8 @@ export interface PopoverProps extends Omit<HTMLAttributes<HTMLDivElement>, 'cont
  *
  * Supports click or hover triggering, 4 placements, and controlled/uncontrolled modes.
  * Uses click-outside pattern from Menu and positioning from Tooltip.
+ *
+ * @summary Floating content panel anchored to a trigger
  */
 export function Popover({
   children,

--- a/components/ui/PricingCard/PricingCard.tsx
+++ b/components/ui/PricingCard/PricingCard.tsx
@@ -43,6 +43,8 @@ export interface PricingCardProps extends HTMLAttributes<HTMLDivElement> {
  *   highlighted
  * />
  * ```
+ *
+ * @summary Pricing tier card with feature list
  */
 export function PricingCard({
   title,

--- a/components/ui/ProgressBar/ProgressBar.tsx
+++ b/components/ui/ProgressBar/ProgressBar.tsx
@@ -24,6 +24,8 @@ export interface ProgressBarProps extends Omit<HTMLAttributes<HTMLDivElement>, '
  * ```tsx
  * <ProgressBar value={35} label="Upload progress" />
  * ```
+ *
+ * @summary Themed linear progress indicator
  */
 export function ProgressBar({
   value,

--- a/components/ui/ProgressStepper/ProgressStepper.tsx
+++ b/components/ui/ProgressStepper/ProgressStepper.tsx
@@ -102,6 +102,8 @@ function getStepStatus(index: number, activeStep: number): StepStatus {
  *   onStepClick={setStep}
  * />
  * ```
+ *
+ * @summary Multi-step progress indicator (numbered or dots)
  */
 export function ProgressStepper(props: ProgressStepperProps) {
   if (props.variant === 'dots') {

--- a/components/ui/Radio/Radio.tsx
+++ b/components/ui/Radio/Radio.tsx
@@ -36,6 +36,8 @@ export interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
  * <Radio name="plan" value="pro" label="Pro Plan" checked />
  * <Radio name="plan" value="enterprise" label="Enterprise" disabled />
  * ```
+ *
+ * @summary Themed radio button (single-select group member)
  */
 export function Radio({
   label,

--- a/components/ui/SegmentedControl/SegmentedControl.tsx
+++ b/components/ui/SegmentedControl/SegmentedControl.tsx
@@ -107,6 +107,8 @@ const activeSegmentStyles: CSSProperties = {
  *   ]}
  * />
  * ```
+ *
+ * @summary Toggle between mutually-exclusive views or modes
  */
 export function SegmentedControl({
   items,

--- a/components/ui/Select/Select.tsx
+++ b/components/ui/Select/Select.tsx
@@ -50,6 +50,8 @@ function isOptionGroup(opt: SelectOption | SelectOptionGroup): opt is SelectOpti
 
 /**
  * Select — themed select dropdown with label, helper text, and error state.
+ *
+ * @summary Themed native select with label, helper, error
  */
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   (

--- a/components/ui/ServiceBadge/ServiceBadge.tsx
+++ b/components/ui/ServiceBadge/ServiceBadge.tsx
@@ -111,6 +111,8 @@ const boxSizeMap: Record<ServiceBadgeSize, number> = { sm: 20, md: 28, lg: 40 };
  * // Migration: replace ServiceBadge with ServiceTag
  * // Old: <ServiceBadge category="brand" serviceName="Brand Identity Bundle" size="lg" />
  * // New: <ServiceTag category="brand" variant="icon" serviceName="Brand Identity Bundle" size="lg" />
+ *
+ * @summary Brik service category icon (deprecated — use ServiceTag)
  */
 export function ServiceBadge({
   category,

--- a/components/ui/Sheet/Sheet.tsx
+++ b/components/ui/Sheet/Sheet.tsx
@@ -123,6 +123,8 @@ export interface SheetProps {
  * exposes a primary Edit action in the footer. Pass `mode="edit"` with `onSave`
  * to switch into form state with Cancel / Save actions. Custom `footer` always
  * wins when supplied.
+ *
+ * @summary Sliding panel overlay for contextual content
  */
 export function Sheet({
   isOpen,

--- a/components/ui/SheetSection/SheetSection.tsx
+++ b/components/ui/SheetSection/SheetSection.tsx
@@ -23,6 +23,8 @@ export interface SheetSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'ti
  * raw `<h3>` + `detail.sectionHeading` patterns.
  *
  * Composes inside `<Sheet>` — one section per logical grouping of fields.
+ *
+ * @summary Named block wrapper for content inside a Sheet body
  */
 export function SheetSection({
   heading,

--- a/components/ui/SidebarNavigation/SidebarNavigation.tsx
+++ b/components/ui/SidebarNavigation/SidebarNavigation.tsx
@@ -26,6 +26,8 @@ export interface SidebarNavigationProps {
  * SidebarNavigation — fixed sidebar with logo, nav items, footer, and user section.
  *
  * Width is a runtime prop passed via inline style.
+ *
+ * @summary Fixed app sidebar — logo, nav, footer, user
  */
 export function SidebarNavigation({
   logo,

--- a/components/ui/Skeleton/Skeleton.tsx
+++ b/components/ui/Skeleton/Skeleton.tsx
@@ -22,6 +22,8 @@ export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
  * <Skeleton variant="circular" width={48} height={48} />
  * <Skeleton variant="rectangular" width="300px" height="200px" />
  * ```
+ *
+ * @summary Loading placeholder with shimmer animation
  */
 export function Skeleton({
   variant = 'text',

--- a/components/ui/Slider/Slider.tsx
+++ b/components/ui/Slider/Slider.tsx
@@ -128,6 +128,8 @@ const valueStyles: CSSProperties = {
  *   showValue
  * />
  * ```
+ *
+ * @summary Themed range input with track and thumb
  */
 export function Slider({
   value,

--- a/components/ui/Spinner/Spinner.tsx
+++ b/components/ui/Spinner/Spinner.tsx
@@ -13,6 +13,8 @@ export interface SpinnerProps extends HTMLAttributes<HTMLDivElement> {
  * Spinner — circular loading indicator with CSS animation
  *
  * Uses BDS tokens for colors and follows the existing animation pattern.
+ *
+ * @summary Circular loading indicator with CSS animation
  */
 export function Spinner({
   size = 'sm',

--- a/components/ui/Stepper/Stepper.tsx
+++ b/components/ui/Stepper/Stepper.tsx
@@ -59,6 +59,8 @@ const sizeConfig: Record<StepperSize, {
  * Figma: bds-stepper (node 26432:14777)
  * - Two icon buttons (- / +) flanking a numeric display
  * - Respects min/max bounds
+ *
+ * @summary Numeric input with increment/decrement buttons
  */
 export function Stepper({
   value,

--- a/components/ui/Switch/Switch.tsx
+++ b/components/ui/Switch/Switch.tsx
@@ -34,6 +34,8 @@ const sizes = {
  *
  * Track/knob dimensions are size-dependent (runtime-calculated inline styles).
  * Colors and typography are in Switch.css.
+ *
+ * @summary Toggle control for binary on/off states
  */
 export function Switch({
   label,

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -164,6 +164,8 @@ const styleBuilders: Record<TabBarVariant, (active: boolean, onColor: boolean) =
  *   ]}
  * />
  * ```
+ *
+ * @summary Horizontal tab navigation with active indicator
  */
 export function TabBar({
   items,

--- a/components/ui/Table/Table.tsx
+++ b/components/ui/Table/Table.tsx
@@ -30,6 +30,8 @@ export interface TableProps extends HTMLAttributes<HTMLTableElement> {
  * Size is propagated via `data-size` attribute on the table element.
  * CSS uses `[data-size]` selectors for cell padding, eliminating the
  * need for React context.
+ *
+ * @summary Themed data table with striped + size variants
  */
 export function Table({
   striped = false,

--- a/components/ui/Tag/Tag.tsx
+++ b/components/ui/Tag/Tag.tsx
@@ -57,6 +57,8 @@ export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
  * <Tag size="lg" icon={<Icon />}>With Icon</Tag>
  * <Tag appearance="subtle">Outlined</Tag>
  * ```
+ *
+ * @summary Categorization label for content
  */
 export function Tag({
   children,

--- a/components/ui/TagGroup/TagGroup.tsx
+++ b/components/ui/TagGroup/TagGroup.tsx
@@ -19,6 +19,8 @@ export interface TagGroupProps extends HTMLAttributes<HTMLDivElement> {
  * Replaces ad-hoc `<div style={{ display: 'flex', gap, flexWrap }}>`
  * wrappers around tag arrays. Use as a Field value, inside a table cell,
  * or standalone inside a SheetSection.
+ *
+ * @summary Horizontal cluster of Tags with locked spacing
  */
 export function TagGroup({
   gap = 'xs',

--- a/components/ui/TaskConsole/TaskConsole.tsx
+++ b/components/ui/TaskConsole/TaskConsole.tsx
@@ -73,6 +73,8 @@ function StatusIcon({ status }: { status: TaskItemStatus }) {
  * upload progress widget.
  *
  * Category: Feedback (alongside Toast)
+ *
+ * @summary Floating progress overlay for long-running operations
  */
 export function TaskConsole({
   title,

--- a/components/ui/TextArea/TextArea.tsx
+++ b/components/ui/TextArea/TextArea.tsx
@@ -137,6 +137,8 @@ const textareaDisabledStyles: CSSProperties = {
  * <TextArea label="Description" error="Required" rows={3} fullWidth />
  * <TextArea placeholder="Comments" rows={6} resize="none" />
  * ```
+ *
+ * @summary Themed multi-line text input with label/helper/error
  */
 export function TextArea({
   size = 'md',

--- a/components/ui/TextInput/TextInput.tsx
+++ b/components/ui/TextInput/TextInput.tsx
@@ -141,6 +141,8 @@ const sizeStyles: Record<TextInputSize, { input: CSSProperties }> = {
  * <TextInput size="md" label="Password" type="password" helperText="Must be at least 8 characters" />
  * <TextInput size="lg" label="Search" error="Required field" />
  * ```
+ *
+ * @summary Themed single-line text input with label/helper/error
  */
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   (

--- a/components/ui/TextLink/TextLink.tsx
+++ b/components/ui/TextLink/TextLink.tsx
@@ -32,6 +32,8 @@ export interface TextLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
  * <TextLink href="/about">Learn More</TextLink>
  * <TextLink href="/contact" size="small">Contact Us</TextLink>
  * ```
+ *
+ * @summary Themed inline link with size + variant options
  */
 export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
   (

--- a/components/ui/TimePicker/TimePicker.tsx
+++ b/components/ui/TimePicker/TimePicker.tsx
@@ -157,6 +157,8 @@ function ScrollColumn({
  * <TimePicker size="md" label="End Time" value="14:30" minuteStep={5} />
  * <TimePicker size="lg" label="Appointment" use24Hour error="Time is required" />
  * ```
+ *
+ * @summary Themed time picker (12h/24h, configurable step)
  */
 export const TimePicker = forwardRef<HTMLButtonElement, TimePickerProps>(
   (

--- a/components/ui/Toast/Toast.tsx
+++ b/components/ui/Toast/Toast.tsx
@@ -30,6 +30,8 @@ const variantBadge: Record<Exclude<ToastVariant, 'default'>, { status: 'positive
  *
  * The surface NEVER changes color — only the badge communicates
  * success, error, warning, or info status.
+ *
+ * @summary White-surface notification with optional Badge
  */
 export function Toast({
   title,

--- a/components/ui/Tooltip/Tooltip.tsx
+++ b/components/ui/Tooltip/Tooltip.tsx
@@ -42,6 +42,8 @@ export interface TooltipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'cont
  *   <span>?</span>
  * </Tooltip>
  * ```
+ *
+ * @summary Themed hover tooltip anchored to a trigger element
  */
 export function Tooltip({
   content,


### PR DESCRIPTION
## Summary
- docs(jsdoc): add @summary to 79 component main exports

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)