### PR TITLE
docs(jsdoc): close Track D — explicit exempt + multi-export linter handling

### DIFF
--- a/components/ui/SheetTypography/SheetFieldLabel.tsx
+++ b/components/ui/SheetTypography/SheetFieldLabel.tsx
@@ -14,6 +14,8 @@ export interface SheetFieldLabelProps
 }
 
 /**
+ * @summary Field label above a Sheet value or input
+ *
  * Field label inside a Sheet body. Sits one tier below `<SheetSectionTitle>`
  * — label family, `--label-sm`, semibold, muted text, Title Case transform.
  * Use above `<SheetFieldValue>` in read mode, or above a `<TextInput>` /

--- a/components/ui/SheetTypography/SheetFieldValue.tsx
+++ b/components/ui/SheetTypography/SheetFieldValue.tsx
@@ -12,6 +12,8 @@ export interface SheetFieldValueProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
+ * @summary Read-mode display of a field value in a Sheet
+ *
  * Read-mode display of a field value inside a Sheet body. Body family,
  * `--body-md`, regular weight, primary text, preserves whitespace so
  * multi-line values render correctly. Pair with `<SheetFieldLabel>` above.

--- a/components/ui/SheetTypography/SheetHelperText.tsx
+++ b/components/ui/SheetTypography/SheetHelperText.tsx
@@ -13,6 +13,8 @@ export interface SheetHelperTextProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 /**
+ * @summary Helper or error text below a Sheet field
+ *
  * Small hint or error text in a Sheet body. Label family, `--label-xs`,
  * regular weight, muted text. Always smaller than `<SheetFieldLabel>`, so
  * the reading order is preserved: section title → field label → value →

--- a/components/ui/SheetTypography/SheetSectionTitle.tsx
+++ b/components/ui/SheetTypography/SheetSectionTitle.tsx
@@ -12,6 +12,8 @@ export interface SheetSectionTitleProps extends HTMLAttributes<HTMLHeadingElemen
 }
 
 /**
+ * @summary Section heading inside a Sheet body
+ *
  * Top-of-section heading inside a Sheet body. Locks to the Sheet-context
  * section-heading tier — heading family, `--heading-sm`, semibold, primary
  * text, no uppercase transform. Always renders larger than `<SheetFieldLabel>`

--- a/docs/AUDIT-FOLLOWUPS.md
+++ b/docs/AUDIT-FOLLOWUPS.md
@@ -127,31 +127,25 @@ templates, not lint rules.
 
 ---
 
-### 3. Track D — non-conforming components (low ROI)
+### 3. Track D — non-conforming components — closed 2026-04-25
 
-**Status:** Not started. The three components listed below don't follow the
-`<Name>/<Name>.tsx` shape, so [`scripts/lint-jsdoc.js`](../scripts/lint-jsdoc.js)
-skips them automatically and the JSDoc audit script lists them as
-"_missing file_".
+**Status:** Done. The three components are now handled explicitly by
+[`scripts/lint-jsdoc.js`](../scripts/lint-jsdoc.js) instead of being
+silently skipped via the missing-file path:
 
-**Components:**
+- `Calendar` — `EXEMPT_COMPONENTS` entry. `index.ts` documents it as
+  "placeholder, component not yet implemented" — no React export to summarize.
+- `Icons` — `EXEMPT_COMPONENTS` entry. `index.ts` documents it as
+  "reference page only, no exported component" — Storybook docs only.
+- `SheetTypography` — `MULTI_EXPORT` entry listing the four sub-components
+  (`SheetSectionTitle`, `SheetFieldLabel`, `SheetFieldValue`, `SheetHelperText`).
+  The linter scans each sub-component file individually for rules 1 + 2,
+  and an `@summary` line was added to each.
 
-| Component | Why it's non-conforming | Hint for the pass |
-|---|---|---|
-| `Calendar` | No top-level `Calendar.tsx`; rendering is split across sub-files. | Pick the canonical component to receive the `@summary` (probably the one re-exported from `index.ts`) and document. |
-| `Icons` | Module of icon constants, not a single React component. | Audit doesn't really apply — consider exempting via an inline note in the linter's skip-list comment. |
-| `SheetTypography` | Covers four sub-components (`SheetSectionTitle`, `SheetFieldLabel`, `SheetFieldValue`, `SheetHelperText`) — meta has no `component:` line. | Add `@summary` to each sub-component export. The story file already has a `surface-product` tag. |
-
-**Pickup details:**
-
-- Run `node /tmp/jsdoc-audit.mjs $(pwd)` to confirm these three are still
-  the only "_missing_" rows.
-- Decide for each: skip (Icons), document the canonical export (Calendar),
-  document each sub-component (SheetTypography).
-- Consider extending the linter's component-export detection to handle these
-  shapes, then remove them from the implicit skip-list.
-- This is purely cosmetic completionism — consumer agents don't typically pull
-  these. Don't prioritize.
+**Behavior change:** the linter no longer silently skips when `<Name>.tsx`
+is missing — it errors with "expected component file not found (not in
+EXEMPT_COMPONENTS or MULTI_EXPORT)". Adding a new non-conforming component
+now requires an explicit decision about which set it belongs in.
 
 ---
 

--- a/scripts/lint-jsdoc.js
+++ b/scripts/lint-jsdoc.js
@@ -17,9 +17,12 @@
  *   4. Every story file's `meta` has one of `surface-web`, `surface-product`,
  *      or `surface-shared` in its `tags` array.
  *
- * Components that don't follow the `<Name>/<Name>.tsx` shape (currently
- * Calendar, Icons, SheetTypography) are skipped automatically — they're
- * tracked separately as Track D of the JSDoc audit.
+ * Two categories of non-conforming components are handled explicitly:
+ *   - `EXEMPT_COMPONENTS` — Storybook reference pages with no real React
+ *     export (Calendar, Icons). Skipped without error.
+ *   - `MULTI_EXPORT` — directories whose `index.ts` re-exports several
+ *     named sub-components instead of a single `<Name>.tsx` (SheetTypography).
+ *     Each sub-component file is checked individually for rules 1 + 2.
  *
  * Usage:
  *   node scripts/lint-jsdoc.js          # check everything, exit 1 on any violation
@@ -71,9 +74,44 @@ const componentDirs = fs
   .map((d) => d.name)
   .filter((n) => n !== 'shared');
 
-for (const name of componentDirs) {
-  const file = path.join(COMPONENTS_DIR, name, `${name}.tsx`);
-  if (!fs.existsSync(file)) continue; // Calendar / Icons / SheetTypography
+// Storybook reference pages — no exported React component, nothing to check.
+const EXEMPT_COMPONENTS = new Set([
+  'Calendar', // index.ts: "Calendar — placeholder, component not yet implemented"
+  'Icons', // index.ts: "Icons — reference page only, no exported component"
+]);
+
+// Directories whose `index.ts` re-exports several named sub-components.
+// For these, we scan each sub-component file individually instead of looking
+// for a single `<Name>.tsx`.
+const MULTI_EXPORT = {
+  SheetTypography: ['SheetSectionTitle', 'SheetFieldLabel', 'SheetFieldValue', 'SheetHelperText'],
+};
+
+// Build the (file, exportName) scan tasks.
+const scanTasks = [];
+for (const dirName of componentDirs) {
+  if (EXEMPT_COMPONENTS.has(dirName)) continue;
+  const subs = MULTI_EXPORT[dirName];
+  if (subs) {
+    for (const subName of subs) {
+      scanTasks.push({
+        file: path.join(COMPONENTS_DIR, dirName, `${subName}.tsx`),
+        name: subName,
+      });
+    }
+    continue;
+  }
+  scanTasks.push({
+    file: path.join(COMPONENTS_DIR, dirName, `${dirName}.tsx`),
+    name: dirName,
+  });
+}
+
+for (const { file, name } of scanTasks) {
+  if (!fs.existsSync(file)) {
+    errors.push(`${path.relative(ROOT, file)}: expected component file not found (not in EXEMPT_COMPONENTS or MULTI_EXPORT)`);
+    continue;
+  }
   const src = fs.readFileSync(file, 'utf8');
   const lines = src.split('\n');
 


### PR DESCRIPTION
## Summary

Closes item #3 (Track D) from `docs/AUDIT-FOLLOWUPS.md`. The three components that don't follow the `<Name>/<Name>.tsx` shape are now handled explicitly by `scripts/lint-jsdoc.js` instead of being silently skipped via a missing-file check.

- **Calendar** + **Icons** — added to `EXEMPT_COMPONENTS`. Both are Storybook reference pages with no React export (verified in each `index.ts`).
- **SheetTypography** — added to `MULTI_EXPORT` mapping `SheetSectionTitle`, `SheetFieldLabel`, `SheetFieldValue`, `SheetHelperText`. The linter now scans each sub-component file individually for rules 1 + 2. `@summary` line added to each sub-component's existing JSDoc.
- **Behavior change**: missing `<Name>.tsx` is now an error (not a silent skip) — adding a new non-conforming component requires an explicit decision about which set it belongs in.

JSDoc-only diff; no runtime, no CSS, no public API changes. No consumer-repo sync needed.

## Test plan

- [x] `npm run lint-jsdoc` passes (was 4 errors before adding `@summary` to SheetTypography sub-components, now clean).
- [x] `npm run validate` full suite passes locally (token lint, JSDoc lint, blueprints, typecheck, Storybook build).
- [ ] Reviewer: confirm the four `@summary` strings (≤60 chars each) read accurately for SheetSectionTitle / SheetFieldLabel / SheetFieldValue / SheetHelperText.
- [ ] Reviewer: confirm Calendar + Icons are correctly classified as "no React export" (each `index.ts` has the `export {};` + comment to that effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)