### PR TITLE
feat(docs-site): scaffold Fumadocs guidance site (foundations + Action group)

### DIFF
--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.source
+out
+*.tsbuildinfo
+next-env.d.ts
+.env*.local
+.DS_Store

--- a/docs-site/app/(home)/layout.tsx
+++ b/docs-site/app/(home)/layout.tsx
@@ -1,0 +1,7 @@
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { baseOptions } from '@/lib/layout.shared';
+import type { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <HomeLayout {...baseOptions}>{children}</HomeLayout>;
+}

--- a/docs-site/app/(home)/page.tsx
+++ b/docs-site/app/(home)/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main className="flex flex-1 flex-col items-center justify-center px-6 py-24 text-center">
+      <h1 className="mb-4 text-4xl font-semibold tracking-tight md:text-5xl">
+        Brik Design System
+      </h1>
+      <p className="mb-8 max-w-2xl text-lg text-fd-muted-foreground">
+        Foundations, components, and patterns for building Brik products and
+        client sites. Storybook is the playground; this is the guidance layer.
+      </p>
+      <div className="flex gap-3">
+        <Link
+          href="/docs"
+          className="rounded-md bg-fd-primary px-5 py-2.5 font-medium text-fd-primary-foreground transition hover:opacity-90"
+        >
+          Read the docs
+        </Link>
+        <a
+          href="https://storybook.brikdesigns.com"
+          className="rounded-md border border-fd-border px-5 py-2.5 font-medium transition hover:bg-fd-muted"
+        >
+          Open Storybook
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/docs-site/app/api/search/route.ts
+++ b/docs-site/app/api/search/route.ts
@@ -1,0 +1,4 @@
+import { source } from '@/lib/source';
+import { createFromSource } from 'fumadocs-core/search/server';
+
+export const { GET } = createFromSource(source);

--- a/docs-site/app/docs/[[...slug]]/page.tsx
+++ b/docs-site/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,46 @@
+import { source } from '@/lib/source';
+import {
+  DocsPage,
+  DocsBody,
+  DocsTitle,
+  DocsDescription,
+} from 'fumadocs-ui/page';
+import { notFound } from 'next/navigation';
+import { getMDXComponents } from '@/lib/mdx-components';
+
+export default async function Page(props: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const params = await props.params;
+  const page = source.getPage(params.slug);
+  if (!page) notFound();
+
+  const MDX = page.data.body;
+
+  return (
+    <DocsPage toc={page.data.toc} full={page.data.full}>
+      <DocsTitle>{page.data.title}</DocsTitle>
+      <DocsDescription>{page.data.description}</DocsDescription>
+      <DocsBody>
+        <MDX components={getMDXComponents()} />
+      </DocsBody>
+    </DocsPage>
+  );
+}
+
+export async function generateStaticParams() {
+  return source.generateParams();
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const params = await props.params;
+  const page = source.getPage(params.slug);
+  if (!page) notFound();
+
+  return {
+    title: page.data.title,
+    description: page.data.description,
+  };
+}

--- a/docs-site/app/docs/layout.tsx
+++ b/docs-site/app/docs/layout.tsx
@@ -1,0 +1,12 @@
+import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import { source } from '@/lib/source';
+import { baseOptions } from '@/lib/layout.shared';
+import type { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <DocsLayout tree={source.pageTree} {...baseOptions}>
+      {children}
+    </DocsLayout>
+  );
+}

--- a/docs-site/app/global.css
+++ b/docs-site/app/global.css
@@ -1,0 +1,27 @@
+@import 'tailwindcss';
+@import 'fumadocs-ui/css/neutral.css';
+@import 'fumadocs-ui/css/preset.css';
+
+/* Scan project files + Fumadocs UI dist (required so all fd-* utilities resolve). */
+@source "../app/**/*.{ts,tsx}";
+@source "../components/**/*.{ts,tsx}";
+@source "../content/**/*.{md,mdx}";
+@source "../lib/**/*.{ts,tsx}";
+@source "../node_modules/fumadocs-ui/dist/**/*.js";
+
+/* BDS token cascade — same order as consuming projects.
+ * Foundations → gap-fills → (client theme would slot here in real consumers).
+ * Live <ComponentPreview> blocks pick these up automatically. */
+@import '../../tokens/figma-tokens.css';
+@import '../../tokens/figma-tokens-dark.css';
+@import '../../tokens/gap-fills.css';
+@import '../../tokens/animations.css';
+@import '../../tokens/motion-classes.css';
+
+/* The docs site itself uses BDS tokens for branded surfaces (preview frames,
+ * code examples, callouts) so guidance and live demos stay visually coherent. */
+:root {
+  --docs-preview-bg: var(--surface-default, #ffffff);
+  --docs-preview-border: var(--border-default, #e5e5e5);
+  --docs-preview-radius: var(--radius-md, 8px);
+}

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -1,0 +1,19 @@
+import './global.css';
+import { RootProvider } from 'fumadocs-ui/provider/next';
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Brik Design System',
+  description:
+    'Guidance, foundations, and components for building Brik products and client sites.',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <RootProvider>{children}</RootProvider>
+      </body>
+    </html>
+  );
+}

--- a/docs-site/components/component-preview.tsx
+++ b/docs-site/components/component-preview.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+
+interface ComponentPreviewProps {
+  /** The live BDS component(s) to render in the preview frame. */
+  children: ReactNode;
+  /** Source code shown in the Code tab. Pass the literal JSX string. */
+  code: string;
+  /** Override the default 200px frame minimum height. */
+  minHeight?: number;
+}
+
+/**
+ * Two-tab preview: live render on the left, source code on the right.
+ * The frame uses BDS surface tokens so the preview canvas stays on-brand
+ * regardless of the docs site's own theme.
+ */
+export function ComponentPreview({
+  children,
+  code,
+  minHeight = 200,
+}: ComponentPreviewProps) {
+  const [tab, setTab] = useState<'preview' | 'code'>('preview');
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="my-6 overflow-hidden rounded-lg border border-fd-border">
+      <div className="flex items-center justify-between border-b border-fd-border bg-fd-muted/40 px-3 py-1.5">
+        <div className="flex gap-1">
+          <TabButton active={tab === 'preview'} onClick={() => setTab('preview')}>
+            Preview
+          </TabButton>
+          <TabButton active={tab === 'code'} onClick={() => setTab('code')}>
+            Code
+          </TabButton>
+        </div>
+        {tab === 'code' && (
+          <button
+            onClick={onCopy}
+            className="rounded px-2 py-0.5 text-xs font-medium text-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground"
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        )}
+      </div>
+
+      {tab === 'preview' ? (
+        <div
+          className="flex flex-wrap items-center gap-3 p-6"
+          style={{
+            minHeight,
+            background: 'var(--docs-preview-bg)',
+          }}
+        >
+          {children}
+        </div>
+      ) : (
+        <pre className="overflow-x-auto p-4 text-sm leading-relaxed">
+          <code>{code}</code>
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={
+        'rounded px-2.5 py-1 text-xs font-medium transition ' +
+        (active
+          ? 'bg-fd-background text-fd-foreground shadow-sm'
+          : 'text-fd-muted-foreground hover:text-fd-foreground')
+      }
+    >
+      {children}
+    </button>
+  );
+}

--- a/docs-site/components/mdx/comparison-grid.tsx
+++ b/docs-site/components/mdx/comparison-grid.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react';
+
+interface ComparisonItem {
+  /** Component or option name. */
+  title: string;
+  /** Optional live preview. Renders above the prose. */
+  preview?: ReactNode;
+  /** One-sentence "when to reach for this." */
+  whenToUse: string;
+  /** Optional "don't reach for this when..." line. */
+  whenNotToUse?: string;
+  /** Optional code snippet to copy. */
+  code?: string;
+}
+
+interface ComparisonGridProps {
+  items: ComparisonItem[];
+}
+
+/**
+ * Side-by-side "X vs Y vs Z" decision grid. The use-case for the moment a
+ * reader/agent has to pick between adjacent components — Button vs LinkButton
+ * vs IconButton, Switch vs Checkbox, AlertBanner vs Toast vs Tooltip.
+ *
+ * Three columns is the sweet spot. Two reads as a pair (use a table). Four+
+ * gets dense — split into two grids by category.
+ */
+export function ComparisonGrid({ items }: ComparisonGridProps) {
+  return (
+    <div
+      className="my-6 grid gap-4"
+      style={{
+        gridTemplateColumns: `repeat(${items.length}, minmax(0, 1fr))`,
+      }}
+    >
+      {items.map((item) => (
+        <div
+          key={item.title}
+          className="flex flex-col overflow-hidden rounded-lg border border-fd-border"
+        >
+          {item.preview && (
+            <div
+              className="flex min-h-[80px] items-center justify-center border-b border-fd-border p-4"
+              style={{ background: 'var(--surface-subtle, #fafafa)' }}
+            >
+              {item.preview}
+            </div>
+          )}
+          <div className="flex flex-1 flex-col gap-2 p-4">
+            <h4 className="m-0 text-sm font-semibold">{item.title}</h4>
+            <p className="m-0 text-sm text-fd-muted-foreground">
+              <strong className="text-fd-foreground">Use when:</strong> {item.whenToUse}
+            </p>
+            {item.whenNotToUse && (
+              <p className="m-0 text-sm text-fd-muted-foreground">
+                <strong className="text-fd-foreground">Don't:</strong> {item.whenNotToUse}
+              </p>
+            )}
+            {item.code && (
+              <pre className="m-0 mt-auto overflow-x-auto rounded bg-fd-muted px-2 py-1.5 text-xs">
+                <code>{item.code}</code>
+              </pre>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs-site/components/mdx/component-anatomy.tsx
+++ b/docs-site/components/mdx/component-anatomy.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+
+interface AnatomyPart {
+  /** Numeric label that appears on the diagram. */
+  number: number;
+  /** The named part. */
+  name: string;
+  /** What this part is responsible for. */
+  description: string;
+  /** Optional — mark this part as required. */
+  required?: boolean;
+}
+
+interface ComponentAnatomyProps {
+  /** Live render of the component to label. */
+  children: ReactNode;
+  /** Ordered list of parts; numbers should match callouts in `children` if you place them. */
+  parts: AnatomyPart[];
+}
+
+/**
+ * Side-by-side: live component preview (left) + numbered parts list (right).
+ * Replaces ASCII-art anatomy diagrams. Authors place numeric callouts in the
+ * preview JSX (small badge components or absolutely-positioned dots) that
+ * correspond to entries in `parts`.
+ *
+ * Goal: agents and humans can see what gets called what without the diagram
+ * silently rotting against component changes — because the diagram IS the
+ * component, rendered live.
+ */
+export function ComponentAnatomy({ children, parts }: ComponentAnatomyProps) {
+  return (
+    <div className="my-6 grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+      <div
+        className="flex items-center justify-center rounded-lg border border-fd-border p-8"
+        style={{ background: 'var(--surface-subtle, #fafafa)' }}
+      >
+        {children}
+      </div>
+      <ol className="m-0 flex flex-col gap-2 p-0">
+        {parts.map((part) => (
+          <li
+            key={part.number}
+            className="flex gap-3 rounded-md border border-fd-border bg-fd-card p-3"
+          >
+            <span
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+              style={{
+                background: 'var(--background-brand-primary, #111827)',
+                color: 'var(--text-on-brand, #ffffff)',
+              }}
+            >
+              {part.number}
+            </span>
+            <div className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                {part.name}
+                {part.required && (
+                  <span className="rounded bg-fd-muted px-1.5 py-0.5 text-[10px] font-normal uppercase tracking-wide text-fd-muted-foreground">
+                    required
+                  </span>
+                )}
+              </div>
+              <p className="m-0 text-sm text-fd-muted-foreground">
+                {part.description}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/docs-site/components/mdx/emphasis-ladder.tsx
+++ b/docs-site/components/mdx/emphasis-ladder.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+
+interface Rung {
+  /** The variant or option name. */
+  label: string;
+  /** Live element to display in the rung. Usually a BDS component. */
+  example: ReactNode;
+  /** When to reach for this rung. One sentence. */
+  use: string;
+}
+
+interface EmphasisLadderProps {
+  /** Top-of-ladder caption. e.g. "highest emphasis →  lowest" */
+  caption?: string;
+  /** Ordered list of rungs, highest-emphasis first. */
+  rungs: Rung[];
+}
+
+/**
+ * Visualizes an ordered ladder of variants from highest emphasis to lowest.
+ * Used for Button (primary → outline → secondary → ghost), alert variants,
+ * card surfaces, etc. The rung order is meaningful — agents and humans should
+ * pick top-down based on the action's importance.
+ */
+export function EmphasisLadder({ caption, rungs }: EmphasisLadderProps) {
+  return (
+    <div className="my-6 overflow-hidden rounded-lg border border-fd-border">
+      {caption && (
+        <div className="border-b border-fd-border bg-fd-muted/40 px-4 py-2 text-xs font-medium uppercase tracking-wide text-fd-muted-foreground">
+          {caption}
+        </div>
+      )}
+      <div className="divide-y divide-fd-border">
+        {rungs.map((rung, i) => (
+          <div
+            key={rung.label}
+            className="grid grid-cols-[auto_minmax(0,1fr)_minmax(0,2fr)] items-center gap-4 px-4 py-3"
+          >
+            <div
+              className="flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold"
+              style={{
+                background: 'var(--surface-subtle, #f3f4f6)',
+                color: 'var(--text-secondary, #6b7280)',
+              }}
+            >
+              {i + 1}
+            </div>
+            <div className="flex items-center gap-3">
+              {rung.example}
+              <code className="text-xs text-fd-muted-foreground">{rung.label}</code>
+            </div>
+            <p className="m-0 text-sm text-fd-muted-foreground">{rung.use}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs-site/components/mdx/foundation/color-grid.tsx
+++ b/docs-site/components/mdx/foundation/color-grid.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface ColorSwatchProps {
+  name: string;
+  cssVar: string;
+  isText?: boolean;
+}
+
+function ColorSwatch({ name, cssVar, isText }: ColorSwatchProps) {
+  const [resolved, setResolved] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const resolve = () => {
+      requestAnimationFrame(() => {
+        setResolved(getComputedStyle(document.body).getPropertyValue(cssVar).trim());
+      });
+    };
+    resolve();
+    const observer = new MutationObserver(resolve);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+    return () => observer.disconnect();
+  }, [cssVar]);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(`var(${cssVar})`);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <div
+      onClick={handleCopy}
+      style={{
+        cursor: 'pointer',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '4px',
+        minWidth: 0,
+      }}
+      title={`Click to copy var(${cssVar})`}
+    >
+      <div
+        style={{
+          width: '100%',
+          height: '56px',
+          backgroundColor: isText
+            ? 'var(--surface-primary, #ffffff)'
+            : `var(${cssVar})`,
+          borderRadius: 'var(--border-radius-sm, 2px)',
+          border: '1px solid var(--border-secondary, #e5e7eb)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {isText && (
+          <span style={{ color: `var(${cssVar})`, fontWeight: 700, fontSize: '1.5rem' }}>
+            Aa
+          </span>
+        )}
+      </div>
+      <div style={{ minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--text-primary, #111827)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {name}
+        </div>
+        <div
+          style={{
+            fontSize: '11px',
+            color: copied
+              ? 'var(--text-brand-primary, #e35335)'
+              : 'var(--text-muted, #6b7280)',
+            fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {copied ? 'Copied!' : resolved || '...'}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ColorGridProps {
+  title?: string;
+  colors: Array<{ name: string; cssVar: string; isText?: boolean }>;
+  columns?: number;
+}
+
+/**
+ * Live grid of resolved color tokens. Each swatch is click-to-copy and updates
+ * when the docs theme changes.
+ */
+export function ColorGrid({ title, colors, columns = 6 }: ColorGridProps) {
+  return (
+    <div className="my-6">
+      {title && (
+        <h3 className="mb-2 text-base font-semibold">{title}</h3>
+      )}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(auto-fill, minmax(${Math.floor(600 / columns)}px, 1fr))`,
+          gap: '8px',
+        }}
+      >
+        {colors.map((c) => (
+          <ColorSwatch key={c.cssVar} {...c} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface PaletteGridProps {
+  title?: string;
+  palette: Record<string, string>;
+  prefix: string;
+  columns?: number;
+}
+
+/**
+ * Render a flat palette object (grayscale, poppy, tan, etc.) as static swatches.
+ * The hex values are baked at build time — useful for primitive scales whose
+ * values don't change across themes.
+ */
+export function PaletteGrid({ title, palette, prefix, columns = 8 }: PaletteGridProps) {
+  const colors = Object.entries(palette).map(([name, hex]) => ({
+    name,
+    cssVar: `${prefix}-${name}`,
+    hex,
+  }));
+
+  return (
+    <div className="my-6">
+      {title && (
+        <h3 className="mb-2 text-base font-semibold">{title}</h3>
+      )}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(auto-fill, minmax(${Math.floor(600 / columns)}px, 1fr))`,
+          gap: '8px',
+        }}
+      >
+        {colors.map((c) => (
+          <div key={c.cssVar} style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            <div
+              style={{
+                width: '100%',
+                height: '56px',
+                backgroundColor: c.hex,
+                borderRadius: 'var(--border-radius-sm, 2px)',
+                border: '1px solid var(--border-secondary, #e5e7eb)',
+              }}
+            />
+            <div
+              style={{
+                fontSize: '11px',
+                fontWeight: 600,
+                color: 'var(--text-primary, #111827)',
+                fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {c.cssVar}
+            </div>
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--text-muted, #6b7280)',
+                fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+              }}
+            >
+              {c.hex}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs-site/components/mdx/foundation/radius-shadow.tsx
+++ b/docs-site/components/mdx/foundation/radius-shadow.tsx
@@ -1,0 +1,190 @@
+interface ScaleProps {
+  title?: string;
+  /** Map of step name → value (e.g. `{ "100": "4px", "200": "8px" }`). */
+  scale: Record<string, string>;
+  /** Token-name prefix for display labels (e.g. `--border-radius`). */
+  prefix: string;
+}
+
+/**
+ * Grid of squares with progressively rounded corners. Visualizes the
+ * border-radius primitive scale. Sorted by numeric value ascending — pill
+ * and circle land at the end.
+ */
+export function BorderRadiusPreview({ title, scale }: ScaleProps) {
+  const entries = Object.entries(scale).sort(
+    (a, b) => parseFloat(a[1]) - parseFloat(b[1])
+  );
+
+  return (
+    <div className="my-6">
+      {title && <h3 className="mb-2 text-base font-semibold">{title}</h3>}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(100px, 1fr))',
+          gap: '16px',
+        }}
+      >
+        {entries.map(([step, value]) => (
+          <div key={step} style={{ textAlign: 'center' }}>
+            <div
+              style={{
+                width: '72px',
+                height: '72px',
+                backgroundColor: 'var(--background-brand-primary, #e35335)',
+                borderRadius: value,
+                margin: '0 auto 8px',
+                opacity: 0.85,
+              }}
+            />
+            <div
+              style={{
+                fontSize: '12px',
+                fontWeight: 600,
+                color: 'var(--text-primary, #111827)',
+              }}
+            >
+              {step}
+            </div>
+            <code
+              style={{
+                fontSize: '11px',
+                color: 'var(--text-muted, #6b7280)',
+                fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+              }}
+            >
+              {value}
+            </code>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Horizontal border-width preview rows. Each row shows token name, a sample
+ * line at the actual width, and the value.
+ */
+export function BorderWidthPreview({ title, scale, prefix }: ScaleProps) {
+  const entries = Object.entries(scale).sort(
+    (a, b) => parseFloat(a[1]) - parseFloat(b[1])
+  );
+
+  return (
+    <div className="my-6">
+      {title && <h3 className="mb-2 text-base font-semibold">{title}</h3>}
+      <div className="flex flex-col gap-2">
+        {entries.map(([step, value]) => (
+          <div key={step} className="flex items-center gap-4 py-1">
+            <code
+              className="text-xs"
+              style={{
+                fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                width: '180px',
+                flexShrink: 0,
+                color: 'var(--text-muted, #6b7280)',
+              }}
+            >
+              {prefix}-{step}
+            </code>
+            <div
+              style={{
+                width: '200px',
+                height: 0,
+                borderTop: `${value} solid var(--border-brand-primary, #e35335)`,
+                flexShrink: 0,
+              }}
+            />
+            <span
+              className="text-xs"
+              style={{
+                color: 'var(--text-secondary, #374151)',
+                fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+              }}
+            >
+              {value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface ShadowScaleProps {
+  title?: string;
+  scale: Record<string, string>;
+  prefix: string;
+  /** Which shadow axis this scale represents. Drives the box-shadow composition. */
+  label: 'blur' | 'spread' | 'offset';
+}
+
+/**
+ * Grid of squares each rendering a synthetic shadow at the scale step's value.
+ * The label prop drives whether the value goes into blur, spread, or offset.
+ * For composed semantic tokens (--shadow-sm, --shadow-md, etc.) use a markdown
+ * table — those aren't on a single-axis scale.
+ */
+export function ShadowScale({ title, scale, prefix, label }: ShadowScaleProps) {
+  const entries = Object.entries(scale).sort(
+    (a, b) => parseFloat(a[1]) - parseFloat(b[1])
+  );
+
+  return (
+    <div className="my-6">
+      {title && <h3 className="mb-2 text-base font-semibold">{title}</h3>}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+          gap: '16px',
+        }}
+      >
+        {entries.map(([step, value]) => {
+          const px = parseFloat(value);
+          const shadow =
+            label === 'blur'
+              ? `0 4px ${px}px rgba(0,0,0,0.15)`
+              : label === 'spread'
+                ? `0 0 0 ${px}px rgba(0,0,0,0.1)`
+                : `0 ${px}px 8px rgba(0,0,0,0.15)`;
+
+          return (
+            <div key={step} style={{ textAlign: 'center' }}>
+              <div
+                style={{
+                  width: '80px',
+                  height: '80px',
+                  backgroundColor: 'var(--surface-primary, #ffffff)',
+                  borderRadius: '4px',
+                  boxShadow: shadow,
+                  margin: '16px auto',
+                }}
+              />
+              <div
+                style={{
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: 'var(--text-primary, #111827)',
+                }}
+              >
+                {prefix}-{step}
+              </div>
+              <code
+                style={{
+                  fontSize: '11px',
+                  color: 'var(--text-muted, #6b7280)',
+                  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                }}
+              >
+                {value}
+              </code>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/docs-site/components/mdx/foundation/spacing-scale.tsx
+++ b/docs-site/components/mdx/foundation/spacing-scale.tsx
@@ -1,0 +1,131 @@
+interface SpacingScaleProps {
+  title?: string;
+  /** Map of step name → value (e.g. `{ "100": "4px", "200": "8px" }`). */
+  scale: Record<string, string>;
+  /** CSS variable prefix used to render the token name (e.g. `--space`). */
+  prefix: string;
+}
+
+/**
+ * Visualizes a numeric spacing scale: token name + scaled bar + value.
+ * Sorted by numeric value ascending.
+ */
+export function SpacingScale({ title, scale, prefix }: SpacingScaleProps) {
+  const entries = Object.entries(scale).sort(
+    (a, b) => parseFloat(a[1]) - parseFloat(b[1])
+  );
+
+  return (
+    <div className="my-6">
+      {title && <h3 className="mb-2 text-base font-semibold">{title}</h3>}
+      <div className="flex flex-col gap-1">
+        {entries.map(([step, value]) => {
+          const px = parseFloat(value);
+          return (
+            <div key={step} className="flex items-center gap-3 py-1">
+              <code
+                className="text-xs"
+                style={{
+                  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                  width: '160px',
+                  flexShrink: 0,
+                  color: 'var(--text-muted, #6b7280)',
+                }}
+              >
+                {prefix}-{step}
+              </code>
+              <div
+                style={{
+                  width: `${Math.min(px, 300)}px`,
+                  height: '20px',
+                  backgroundColor: 'var(--background-brand-primary, #e35335)',
+                  borderRadius: '2px',
+                  opacity: 0.7,
+                  flexShrink: 0,
+                }}
+              />
+              <span
+                className="text-xs"
+                style={{
+                  color: 'var(--text-secondary, #374151)',
+                  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                  flexShrink: 0,
+                }}
+              >
+                {value}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface SemanticSpacingProps {
+  title?: string;
+  /** Map of token name → reference value (e.g. `{ "padding-md": "var(--space-400)" }`). */
+  tokens: Record<string, string>;
+  /** CSS variable prefix used for the rendered var (e.g. `--padding`). */
+  varPrefix: string;
+}
+
+/**
+ * Table of semantic spacing tokens with a live preview bar showing the
+ * resolved size. Used for padding-* and gap-* token tables.
+ */
+export function SemanticSpacing({ title, tokens, varPrefix }: SemanticSpacingProps) {
+  const entries = Object.entries(tokens);
+
+  return (
+    <div className="my-6">
+      {title && <h3 className="mb-2 text-base font-semibold">{title}</h3>}
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b-2 border-fd-border">
+            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+              Preview
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+              Token
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+              CSS Variable
+            </th>
+            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+              Maps to
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([name, value]) => {
+            const fullVar = `${varPrefix}-${name.replace(/^[a-z]+-/, '')}`;
+            return (
+              <tr key={name} className="border-b border-fd-border">
+                <td className="px-3 py-2 align-middle" style={{ width: '120px' }}>
+                  <div
+                    style={{
+                      width: `var(${fullVar}, 16px)`,
+                      maxWidth: '100px',
+                      height: '16px',
+                      backgroundColor: 'var(--background-brand-primary, #e35335)',
+                      borderRadius: '2px',
+                      opacity: 0.7,
+                    }}
+                  />
+                </td>
+                <td className="px-3 py-2 align-middle font-semibold">{name}</td>
+                <td className="px-3 py-2 align-middle">
+                  <code className="rounded bg-fd-muted px-1.5 py-0.5 text-xs">{fullVar}</code>
+                </td>
+                <td className="px-3 py-2 align-middle">
+                  <code className="rounded bg-fd-muted px-1.5 py-0.5 text-xs">{value}</code>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/docs-site/components/mdx/foundation/typography-scale.tsx
+++ b/docs-site/components/mdx/foundation/typography-scale.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface TypographyScaleProps {
+  title?: string;
+  /** Map of step name → value (e.g. `{ "100": "16px", "200": "18px" }`). */
+  scale: Record<string, string>;
+  /** CSS variable prefix used to render the token name (e.g. `--font-size`). */
+  prefix: string;
+}
+
+/**
+ * Live preview of a numeric font-size scale. Each row renders sample text
+ * sized at the actual value so the scale is comparable at a glance.
+ */
+export function TypographyScale({ title, scale, prefix }: TypographyScaleProps) {
+  const entries = Object.entries(scale).sort(
+    (a, b) => parseFloat(a[1]) - parseFloat(b[1])
+  );
+
+  return (
+    <div className="my-6">
+      {title && <h3 className="mb-2 text-base font-semibold">{title}</h3>}
+      <div className="flex flex-col gap-0.5">
+        {entries.map(([step, value]) => (
+          <div
+            key={step}
+            className="flex items-baseline gap-4 border-b border-fd-border py-1.5"
+          >
+            <code
+              className="text-xs"
+              style={{
+                fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                width: '140px',
+                flexShrink: 0,
+                color: 'var(--text-muted, #6b7280)',
+              }}
+            >
+              {prefix}-{step}
+            </code>
+            <span
+              style={{
+                fontSize: value,
+                lineHeight: 1.2,
+                fontFamily: 'var(--font-family-body, system-ui)',
+                color: 'var(--text-primary, #111827)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                maxWidth: '400px',
+              }}
+            >
+              {parseFloat(value) > 60 ? 'Ag' : 'The quick brown fox'}
+            </span>
+            <span
+              className="text-xs"
+              style={{
+                color: 'var(--text-muted, #6b7280)',
+                fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                flexShrink: 0,
+                marginLeft: 'auto',
+              }}
+            >
+              {value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface FontFamilyShowcaseProps {
+  families: Array<{ name: string; cssVar: string }>;
+}
+
+/**
+ * Renders sample text in each provided font-family CSS var. Resolves the
+ * computed value for display, so theme switches refresh the labels.
+ */
+export function FontFamilyShowcase({ families }: FontFamilyShowcaseProps) {
+  const [resolved, setResolved] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const update = () => {
+      requestAnimationFrame(() => {
+        const next: Record<string, string> = {};
+        families.forEach((f) => {
+          next[f.cssVar] = getComputedStyle(document.body)
+            .getPropertyValue(f.cssVar)
+            .trim();
+        });
+        setResolved(next);
+      });
+    };
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+    return () => observer.disconnect();
+  }, [families]);
+
+  return (
+    <div className="my-6 flex flex-col gap-4">
+      {families.map((f) => (
+        <div
+          key={f.cssVar}
+          className="rounded-md border border-fd-border p-4"
+          style={{ background: 'var(--surface-secondary, #f9fafb)' }}
+        >
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+            {f.name}
+          </div>
+          <div
+            style={{
+              fontFamily: `var(${f.cssVar})`,
+              fontSize: '28px',
+              color: 'var(--text-primary, #111827)',
+              marginBottom: '4px',
+            }}
+          >
+            ABCDEFGHIJKLM abcdefghijklm 0123456789
+          </div>
+          <code
+            className="text-[11px]"
+            style={{
+              fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+              color: 'var(--text-muted, #6b7280)',
+            }}
+          >
+            {f.cssVar}
+            {resolved[f.cssVar] ? ` → ${resolved[f.cssVar]}` : ''}
+          </code>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface SemanticTypographyTableProps {
+  title?: string;
+  /** List of semantic token names (e.g. `['heading-tiny', 'heading-sm']`). */
+  tokens: string[];
+}
+
+/**
+ * Render each named token at its actual font-size by reading `var(--{name})`.
+ * Each row resolves the computed value and shows it alongside the sample text.
+ */
+export function SemanticTypographyTable({ title, tokens }: SemanticTypographyTableProps) {
+  const [resolved, setResolved] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const update = () => {
+      requestAnimationFrame(() => {
+        const next: Record<string, string> = {};
+        tokens.forEach((name) => {
+          next[name] = getComputedStyle(document.body)
+            .getPropertyValue(`--${name}`)
+            .trim();
+        });
+        setResolved(next);
+      });
+    };
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+    return () => observer.disconnect();
+  }, [tokens]);
+
+  return (
+    <div className="my-6">
+      {title && <h3 className="mb-2 text-base font-semibold">{title}</h3>}
+      <div className="flex flex-col gap-0.5">
+        {tokens.map((name) => {
+          const cssVar = `--${name}`;
+          return (
+            <div
+              key={name}
+              className="flex items-baseline gap-4 border-b border-fd-border py-2"
+            >
+              <code
+                className="text-xs"
+                style={{
+                  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                  width: '200px',
+                  flexShrink: 0,
+                  color: 'var(--text-muted, #6b7280)',
+                }}
+              >
+                {cssVar}
+              </code>
+              <span
+                style={{
+                  fontSize: `var(${cssVar})`,
+                  lineHeight: 1.3,
+                  fontFamily: 'var(--font-family-body, system-ui)',
+                  color: 'var(--text-primary, #111827)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  flex: 1,
+                  minWidth: 0,
+                }}
+              >
+                The quick brown fox
+              </span>
+              <code
+                className="text-[11px]"
+                style={{
+                  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+                  color: 'var(--text-muted, #6b7280)',
+                  flexShrink: 0,
+                }}
+              >
+                {resolved[name] || '...'}
+              </code>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface FontWeightShowcaseProps {
+  /** Map of weight name → numeric value (e.g. `{ "regular": "400" }`). */
+  weights: Record<string, string>;
+}
+
+export function FontWeightShowcase({ weights }: FontWeightShowcaseProps) {
+  const entries = Object.entries(weights).sort((a, b) => parseInt(a[1]) - parseInt(b[1]));
+
+  return (
+    <div className="my-6 flex flex-col gap-0.5">
+      {entries.map(([name, value]) => (
+        <div
+          key={name}
+          className="flex items-baseline gap-4 border-b border-fd-border py-1.5"
+        >
+          <code
+            className="text-xs"
+            style={{
+              fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+              width: '200px',
+              flexShrink: 0,
+              color: 'var(--text-muted, #6b7280)',
+            }}
+          >
+            --font-weight-{name}
+          </code>
+          <span
+            style={{
+              fontWeight: parseInt(value),
+              fontSize: '18px',
+              fontFamily: 'var(--font-family-body, system-ui)',
+              color: 'var(--text-primary, #111827)',
+            }}
+          >
+            The quick brown fox ({value})
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs-site/components/mdx/metadata-strip.tsx
+++ b/docs-site/components/mdx/metadata-strip.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+
+interface MetadataItem {
+  label: string;
+  value: ReactNode;
+}
+
+interface MetadataStripProps {
+  items: MetadataItem[];
+}
+
+/**
+ * Compact "label · value" strip for page-header metadata. Used at the top of
+ * industry packs (Version · Last reviewed · Cadence), voice patterns, and
+ * other content-system pages where versioning is load-bearing.
+ *
+ * Stays tight — one line on desktop, wraps gracefully on mobile.
+ */
+export function MetadataStrip({ items }: MetadataStripProps) {
+  return (
+    <div
+      className="my-4 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border border-fd-border px-3 py-2 text-sm"
+      style={{ background: 'var(--surface-subtle, #fafafa)' }}
+    >
+      {items.map((item, i) => (
+        <span key={i} className="inline-flex items-baseline gap-1.5">
+          <span className="text-xs font-medium uppercase tracking-wide text-fd-muted-foreground">
+            {item.label}
+          </span>
+          <span className="font-mono text-sm text-fd-foreground">{item.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/docs-site/content/docs/components/button-group.mdx
+++ b/docs-site/content/docs/components/button-group.mdx
@@ -1,0 +1,95 @@
+---
+title: Button group
+description: Groups related buttons into a single visual unit. Use for action sets where buttons share context.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A ButtonGroup wraps two or more `<Button>` (or `<IconButton>`) elements into a connected cluster. Use it when the buttons are siblings in the same decision — the surrounding container makes the grouping explicit.
+
+## Use it for
+
+- Save / Cancel pairs in dialogs and form footers
+- Confirm / Discard pairs in destructive flows
+- Sign up / Log in stacks on auth screens
+- Toolbar action clusters where buttons act together
+
+## Import
+
+```tsx
+import { ButtonGroup, Button } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Horizontal (default)
+
+<ComponentPreview code={`<BDS.ButtonGroup>
+  <BDS.Button variant="primary">Save</BDS.Button>
+  <BDS.Button variant="outline">Cancel</BDS.Button>
+</BDS.ButtonGroup>`}>
+  <BDS.ButtonGroup>
+    <BDS.Button variant="primary">Save</BDS.Button>
+    <BDS.Button variant="outline">Cancel</BDS.Button>
+  </BDS.ButtonGroup>
+</ComponentPreview>
+
+### Vertical
+
+Stack buttons in a column. Pair with `fullWidth` on each button for stacked auth screens.
+
+<ComponentPreview code={`<BDS.ButtonGroup orientation="vertical">
+  <BDS.Button variant="primary" fullWidth>Sign up</BDS.Button>
+  <BDS.Button variant="outline" fullWidth>Log in</BDS.Button>
+</BDS.ButtonGroup>`}>
+  <BDS.ButtonGroup orientation="vertical">
+    <BDS.Button variant="primary" fullWidth>Sign up</BDS.Button>
+    <BDS.Button variant="outline" fullWidth>Log in</BDS.Button>
+  </BDS.ButtonGroup>
+</ComponentPreview>
+
+### Full width
+
+`fullWidth` on the group stretches each child equally. Use in narrow contexts (sheets, sidebars).
+
+<ComponentPreview code={`<BDS.ButtonGroup fullWidth>
+  <BDS.Button variant="primary">Save</BDS.Button>
+  <BDS.Button variant="outline">Cancel</BDS.Button>
+</BDS.ButtonGroup>`}>
+  <BDS.ButtonGroup fullWidth>
+    <BDS.Button variant="primary">Save</BDS.Button>
+    <BDS.Button variant="outline">Cancel</BDS.Button>
+  </BDS.ButtonGroup>
+</ComponentPreview>
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use ButtonGroup for unrelated actions.** It's a semantic group — readers infer that the buttons share context. Two unrelated CTAs in the same row look the same visually but break expectations.
+</Callout>
+
+- **Don't put more than 3 buttons in a group.** A "toolbar" of 5 unrelated actions is a different pattern — use spacing, not grouping.
+- **Don't mix sizes inside a group.** All buttons should share the same `size`. Mixed sizes break the rhythm.
+
+## Accessibility
+
+- Renders a plain `<div>` container. Each child Button keeps its own keyboard semantics.
+- Tab order follows DOM order — for vertical groups, primary actions should appear first in source.
+- No `role="group"` is added by default; if the group represents a single ARIA group (e.g. radiogroup-like behavior), wrap in your own labeled `<fieldset>` or `<div role="group" aria-labelledby="...">`.
+
+## API
+
+### ButtonGroup
+
+| Prop | Type | Default |
+|---|---|---|
+| `children` | `ReactNode` *(required)* | — |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` |
+| `fullWidth` | `boolean` | `false` |
+
+Plus all standard `<div>` HTML attributes.
+
+## Related
+
+- [Button](/docs/components/button) — the primary child component
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-action-button-group--overview)** — live variants and patterns

--- a/docs-site/content/docs/components/button.mdx
+++ b/docs-site/content/docs/components/button.mdx
@@ -5,11 +5,33 @@ description: Trigger an event or action. The button family includes three compon
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-The button family is three components for three semantic needs:
+The button family is three components for three semantic needs. Pick the right one before you reach for variants — the wrong shell semantically can't be fixed with styling.
 
-- **`Button`** — renders a `<button>`. Use for actions that stay on the page (submit, open dialog, confirm).
-- **`LinkButton`** — renders an `<a>`. Use when the action navigates to a URL.
-- **`IconButton`** — renders a `<button>` with an icon and required `aria-label`. Use when there's no visible text label.
+<ComparisonGrid
+  items={[
+    {
+      title: 'Button',
+      preview: <BDS.Button variant="primary">Save</BDS.Button>,
+      whenToUse: 'The action stays on this page (submit, open dialog, confirm).',
+      whenNotToUse: 'Use it for navigation — right-click and keyboard nav break.',
+      code: `<Button>Save</Button>`,
+    },
+    {
+      title: 'LinkButton',
+      preview: <BDS.LinkButton href="#" variant="outline">Read docs</BDS.LinkButton>,
+      whenToUse: 'The action navigates to a URL. Renders an `<a>` element.',
+      whenNotToUse: "Wrap a Button in a link — that breaks accessibility.",
+      code: `<LinkButton href="/docs">…</LinkButton>`,
+    },
+    {
+      title: 'IconButton',
+      preview: <BDS.IconButton icon={<span>×</span>} label="Close" variant="ghost" />,
+      whenToUse: "There's no visible text label. Single-icon trigger.",
+      whenNotToUse: "Downgrade emphasis when converting from Button — keep the variant.",
+      code: `<IconButton icon={…} label="Close" />`,
+    },
+  ]}
+/>
 
 ## Use it for
 
@@ -17,8 +39,6 @@ The button family is three components for three semantic needs:
 - Confirming or cancelling a destructive operation
 - Opening a sheet, dialog, or popover
 - Triggering an immediate, synchronous action
-
-If the action navigates somewhere, use **LinkButton** instead. If the trigger is a single icon (no label), use **IconButton**.
 
 ## Import
 
@@ -28,56 +48,81 @@ import { Button, LinkButton, IconButton } from '@brikdesigns/bds';
 
 ## Anatomy
 
-A Button is a labelled hit target with optional icons before or after the text.
-
-```text
-┌─────────────────────────────────┐
-│  [iconBefore]  Label  [iconAfter]
-└─────────────────────────────────┘
-        ↑          ↑          ↑
-     leading    text node   trailing
-```
+<ComponentAnatomy
+  parts={[
+    { number: 1, name: 'Container', description: 'The hit target. Sets size, padding, focus ring, and base variant styles.' },
+    { number: 2, name: 'Leading icon', description: 'Optional icon before the label. Use 1em sizing to scale with text.' },
+    { number: 3, name: 'Label', description: 'The accessible name of the button. Required for Button and LinkButton.', required: true },
+    { number: 4, name: 'Trailing icon', description: 'Optional icon after the label. Common for "Continue →" or external-link affordances.' },
+  ]}
+>
+  <BDS.Button variant="primary" size="lg">
+    <span style={{ opacity: 0.5 }}>◉</span>
+    &nbsp;Save changes&nbsp;
+    <span style={{ opacity: 0.5 }}>→</span>
+  </BDS.Button>
+</ComponentAnatomy>
 
 ## Variants
 
 Twelve variants. Pick by **action emphasis** and **destructive intent**, not by aesthetics.
 
-### Standard variants
+### Standard ladder
 
-<ComponentPreview code={`<BDS.Button variant="primary">Save</BDS.Button>
-<BDS.Button variant="outline">Cancel</BDS.Button>
-<BDS.Button variant="secondary">Secondary</BDS.Button>
-<BDS.Button variant="ghost">Tertiary</BDS.Button>`}>
-  <BDS.Button variant="primary">Save</BDS.Button>
-  <BDS.Button variant="outline">Cancel</BDS.Button>
-  <BDS.Button variant="secondary">Secondary</BDS.Button>
-  <BDS.Button variant="ghost">Tertiary</BDS.Button>
-</ComponentPreview>
+<EmphasisLadder
+  caption="highest emphasis → lowest"
+  rungs={[
+    {
+      label: 'primary',
+      example: <BDS.Button variant="primary">Save</BDS.Button>,
+      use: 'Main call-to-action. One per section.',
+    },
+    {
+      label: 'outline',
+      example: <BDS.Button variant="outline">Cancel</BDS.Button>,
+      use: 'Secondary emphasis. The "alongside primary" choice.',
+    },
+    {
+      label: 'secondary',
+      example: <BDS.Button variant="secondary">Learn more</BDS.Button>,
+      use: 'Tertiary, subtle. Supporting actions that don\'t compete.',
+    },
+    {
+      label: 'ghost',
+      example: <BDS.Button variant="ghost">Skip</BDS.Button>,
+      use: 'Minimal emphasis. Repeated actions, navigation, dismiss.',
+    },
+  ]}
+/>
 
-- **`primary`** — Main call-to-action. One per section.
-- **`outline`** — Secondary emphasis. Alternative to primary.
-- **`secondary`** — Tertiary/subtle. Supporting actions.
-- **`ghost`** — Minimal emphasis. Navigation, repeated actions.
+### Destructive ladder
 
-### Destructive variants
+Three flavors of destructive map onto the same ladder.
 
-Three flavors of destructive map onto the same emphasis ladder as primary actions.
-
-<ComponentPreview code={`<BDS.Button variant="danger">Delete</BDS.Button>
-<BDS.Button variant="danger-outline">Delete</BDS.Button>
-<BDS.Button variant="danger-ghost">Delete</BDS.Button>`}>
-  <BDS.Button variant="danger">Delete</BDS.Button>
-  <BDS.Button variant="danger-outline">Delete</BDS.Button>
-  <BDS.Button variant="danger-ghost">Delete</BDS.Button>
-</ComponentPreview>
-
-- **`danger`** — Destructive primary action (delete, remove).
-- **`danger-outline`** — Destructive with less emphasis.
-- **`danger-ghost`** — Destructive, minimal emphasis (inline delete).
+<EmphasisLadder
+  caption="highest emphasis → lowest"
+  rungs={[
+    {
+      label: 'danger',
+      example: <BDS.Button variant="danger">Delete project</BDS.Button>,
+      use: 'Primary destructive action — confirm dialogs, delete-and-go flows.',
+    },
+    {
+      label: 'danger-outline',
+      example: <BDS.Button variant="danger-outline">Delete</BDS.Button>,
+      use: 'Destructive with less emphasis. Pairs with a non-destructive primary.',
+    },
+    {
+      label: 'danger-ghost',
+      example: <BDS.Button variant="danger-ghost">Remove</BDS.Button>,
+      use: 'Inline delete in lists, table rows, repeated remove affordances.',
+    },
+  ]}
+/>
 
 ### State variants
 
-`positive` confirms a completed action. `selected` indicates a button is currently the active option in a group. `inverse` and `on-color` are for placement on dark or branded surfaces.
+`positive` confirms a completed action. `selected` indicates the active option in a group. `inverse` and `on-color` are for placement on dark or branded surfaces.
 
 <ComponentPreview code={`<BDS.Button variant="positive">Saved</BDS.Button>
 <BDS.Button variant="selected">Selected</BDS.Button>`}>
@@ -158,16 +203,6 @@ import { IconButton } from '@brikdesigns/bds';
 <Callout type="warn">
   **Don't downgrade emphasis when converting Button → IconButton.** A primary action stays a primary action. The 2026-04 IconButton-ghost regression came from agents converting `<Button variant="primary">` into `<IconButton variant="ghost">`. Match the emphasis level, always.
 </Callout>
-
-## When to use
-
-| Situation | Component |
-|---|---|
-| Action that stays on the page (Save, Submit, Open dialog) | **Button** |
-| Action that navigates to a new URL | **LinkButton** |
-| Single-icon trigger with no visible label | **IconButton** |
-| Toggle on/off | [Switch](/docs/components) |
-| One-of-many selection | [SegmentedControl](/docs/components) |
 
 ## When *not* to use
 

--- a/docs-site/content/docs/components/button.mdx
+++ b/docs-site/content/docs/components/button.mdx
@@ -1,9 +1,15 @@
 ---
 title: Button
-description: Trigger an action. The most common interactive element in the system.
+description: Trigger an event or action. The button family includes three components for different semantic needs.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+
+The button family is three components for three semantic needs:
+
+- **`Button`** — renders a `<button>`. Use for actions that stay on the page (submit, open dialog, confirm).
+- **`LinkButton`** — renders an `<a>`. Use when the action navigates to a URL.
+- **`IconButton`** — renders a `<button>` with an icon and required `aria-label`. Use when there's no visible text label.
 
 ## Use it for
 
@@ -17,26 +23,26 @@ If the action navigates somewhere, use **LinkButton** instead. If the trigger is
 ## Import
 
 ```tsx
-import { Button } from '@brikdesigns/bds';
+import { Button, LinkButton, IconButton } from '@brikdesigns/bds';
 ```
 
 ## Anatomy
 
-A Button is a labelled hit target with an optional leading or trailing icon. The label drives the implicit accessible name.
+A Button is a labelled hit target with optional icons before or after the text.
 
-```
-┌──────────────────────────────────┐
-│  [icon]   Label   [icon]         │
-└──────────────────────────────────┘
-   ↑         ↑          ↑
-   leading   text node  trailing
+```text
+┌─────────────────────────────────┐
+│  [iconBefore]  Label  [iconAfter]
+└─────────────────────────────────┘
+        ↑          ↑          ↑
+     leading    text node   trailing
 ```
 
 ## Variants
 
 Twelve variants. Pick by **action emphasis** and **destructive intent**, not by aesthetics.
 
-### Primary actions
+### Standard variants
 
 <ComponentPreview code={`<BDS.Button variant="primary">Save</BDS.Button>
 <BDS.Button variant="outline">Cancel</BDS.Button>
@@ -48,7 +54,12 @@ Twelve variants. Pick by **action emphasis** and **destructive intent**, not by 
   <BDS.Button variant="ghost">Tertiary</BDS.Button>
 </ComponentPreview>
 
-### Destructive actions
+- **`primary`** — Main call-to-action. One per section.
+- **`outline`** — Secondary emphasis. Alternative to primary.
+- **`secondary`** — Tertiary/subtle. Supporting actions.
+- **`ghost`** — Minimal emphasis. Navigation, repeated actions.
+
+### Destructive variants
 
 Three flavors of destructive map onto the same emphasis ladder as primary actions.
 
@@ -59,6 +70,10 @@ Three flavors of destructive map onto the same emphasis ladder as primary action
   <BDS.Button variant="danger-outline">Delete</BDS.Button>
   <BDS.Button variant="danger-ghost">Delete</BDS.Button>
 </ComponentPreview>
+
+- **`danger`** — Destructive primary action (delete, remove).
+- **`danger-outline`** — Destructive with less emphasis.
+- **`danger-ghost`** — Destructive, minimal emphasis (inline delete).
 
 ### State variants
 
@@ -86,52 +101,156 @@ Five sizes. `md` is the default. Use `sm` only inside dense surfaces (table rows
   <BDS.Button size="xl">XL</BDS.Button>
 </ComponentPreview>
 
+## Icons
+
+Use `iconBefore` and `iconAfter` props. Icons should use `1em` sizing to scale with the button's font size.
+
+```tsx
+<Button iconBefore={<PlusIcon />}>Add item</Button>
+<Button iconAfter={<ArrowRightIcon />}>Continue</Button>
+<Button iconBefore={<DownloadIcon />} variant="outline">
+  Export CSV
+</Button>
+```
+
+## Loading
+
+The `loading` prop replaces button content with a spinner while preserving button width. The button is automatically disabled during loading.
+
+```tsx
+<Button loading variant="primary">
+  Saving...
+</Button>
+```
+
+## LinkButton
+
+An `<a>` element styled as a button. Use when the action navigates to a URL. The `href` prop is required.
+
+```tsx
+import { LinkButton } from '@brikdesigns/bds';
+
+<LinkButton href="/docs" variant="outline">
+  Read docs
+</LinkButton>
+
+<LinkButton
+  href="https://github.com/brikdesigns/brik-bds"
+  target="_blank"
+  rel="noopener"
+  iconAfter={<ExternalLinkIcon />}
+>
+  GitHub
+</LinkButton>
+```
+
+## IconButton
+
+An icon-only button with a **required** `label` prop for accessibility. The label becomes the button's `aria-label`.
+
+```tsx
+import { IconButton } from '@brikdesigns/bds';
+
+<IconButton icon={<CloseIcon />} label="Close dialog" variant="ghost" />
+<IconButton icon={<TrashIcon />} label="Delete item" variant="danger-ghost" />
+```
+
+<Callout type="warn">
+  **Don't downgrade emphasis when converting Button → IconButton.** A primary action stays a primary action. The 2026-04 IconButton-ghost regression came from agents converting `<Button variant="primary">` into `<IconButton variant="ghost">`. Match the emphasis level, always.
+</Callout>
+
 ## When to use
 
 | Situation | Component |
 |---|---|
 | Action that stays on the page (Save, Submit, Open dialog) | **Button** |
-| Action that navigates to a new URL | [LinkButton](/docs/components/link-button) |
-| Single-icon trigger with no visible label | [IconButton](/docs/components/icon-button) |
-| Toggle on/off | [Switch](/docs/components/switch) |
-| One-of-many selection | [SegmentedControl](/docs/components/segmented-control) |
+| Action that navigates to a new URL | **LinkButton** |
+| Single-icon trigger with no visible label | **IconButton** |
+| Toggle on/off | [Switch](/docs/components) |
+| One-of-many selection | [SegmentedControl](/docs/components) |
 
 ## When *not* to use
 
-<Callout type="warn">
-**Don't downgrade emphasis when converting Button → IconButton.** A primary action stays a primary action. The 2026-04 IconButton-ghost regression came from agents converting `<Button variant="primary">` into `<IconButton variant="ghost">`. Match the emphasis level, always.
-</Callout>
-
 - **Don't use `ghost` for the only action on a page.** Ghost is the lowest emphasis tier — it should appear alongside a higher-emphasis sibling.
 - **Don't stack two `primary` buttons next to each other.** Only one primary action per surface.
+- **Don't use Button for navigation.** If clicking takes the user to a new URL, use LinkButton so right-click + keyboard navigation work correctly.
 
 ## Accessibility
 
-- Renders a real `<button>` element. Keyboard navigation, focus ring, and `Enter`/`Space` activation come from the platform.
-- Accessible name comes from the label. If you must hide the visual label (rare — use IconButton instead), pass `aria-label`.
+- Renders a real `<button>` element. Keyboard navigation, focus ring, and `Enter` / `Space` activation come from the platform.
+- Accessible name comes from the visible label. For IconButton, `label` becomes `aria-label`.
 - Disabled state uses the `disabled` attribute, which removes it from the tab order. For "blocked but explainable" actions, prefer keeping it focusable and showing a tooltip.
+- Loading state announces via `aria-busy` and disables interaction without removing focus.
 
 ## API
 
-The full prop reference (with auto-extracted TypeScript types and live controls) lives in [Storybook → Components/Action/Button](https://storybook.brikdesigns.com/?path=/docs/components-action-button--docs).
+The full prop reference (with auto-extracted TypeScript types and live controls) lives in [Storybook → Components/Action/Button](https://storybook.brikdesigns.com/?path=/docs/components-action-button--overview). Summary below.
+
+### Button
 
 | Prop | Type | Default |
 |---|---|---|
 | `variant` | `ButtonVariant` | `'primary'` |
 | `size` | `ButtonSize` | `'md'` |
-| `leadingIcon` | `ReactNode` | — |
-| `trailingIcon` | `ReactNode` | — |
+| `iconBefore` | `ReactNode` | — |
+| `iconAfter` | `ReactNode` | — |
 | `loading` | `boolean` | `false` |
 | `fullWidth` | `boolean` | `false` |
 | `disabled` | `boolean` | `false` |
 
-`ButtonVariant` = `primary | outline | secondary | ghost | inverse | on-color | danger | danger-outline | danger-ghost | destructive | positive | selected`
+### LinkButton
 
-`ButtonSize` = `tiny | sm | md | lg | xl`
+| Prop | Type | Default |
+|---|---|---|
+| `href` | `string` *(required)* | — |
+| `variant` | `ButtonVariant` | `'primary'` |
+| `size` | `ButtonSize` | `'md'` |
+| `iconBefore` | `ReactNode` | — |
+| `iconAfter` | `ReactNode` | — |
+| `fullWidth` | `boolean` | `false` |
+
+### IconButton
+
+| Prop | Type | Default |
+|---|---|---|
+| `icon` | `ReactNode` *(required)* | — |
+| `label` | `string` *(required)* | — |
+| `variant` | `ButtonVariant` | `'ghost'` |
+| `size` | `ButtonSize` | `'md'` |
+| `loading` | `boolean` | `false` |
+
+### Type unions
+
+```ts
+type ButtonVariant =
+  | 'primary' | 'outline' | 'secondary' | 'ghost'
+  | 'inverse' | 'on-color'
+  | 'danger' | 'danger-outline' | 'danger-ghost' | 'destructive'
+  | 'positive' | 'selected';
+
+type ButtonSize = 'tiny' | 'sm' | 'md' | 'lg' | 'xl';
+```
+
+## CSS Override API
+
+Component-scoped CSS variables exposed on `.bds-button`. Set these on a wrapping element or directly on the button to override without touching BDS internals.
+
+| Variable | Default | Controls |
+|---|---|---|
+| `--button-active-translate-y` | `1px` | Downward shift on `:active` press |
+| `--button-focus-outline-width` | `2px` | Focus ring stroke width |
+| `--button-focus-outline-offset` | `2px` | Gap between button edge and focus ring |
+
+```css
+/* Example: flatten press effect in a toolbar context */
+.my-toolbar {
+  --button-active-translate-y: 0;
+  --button-focus-outline-width: 3px;
+}
+```
 
 ## Related
 
-- [LinkButton](/docs/components/link-button) — same shape, renders an `<a>`
-- [IconButton](/docs/components/icon-button) — single-icon trigger
-- [ButtonGroup](/docs/components/button-group) — connected button cluster
-- [Forms pattern](/docs/patterns#forms) — Save/Cancel placement, submit-state handling
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-action-button--overview)** — every variant × size × state, live controls
+- [Forms pattern](/docs/patterns) — Save/Cancel placement, submit-state handling
+- [Components index](/docs/components) — full component catalog

--- a/docs-site/content/docs/components/button.mdx
+++ b/docs-site/content/docs/components/button.mdx
@@ -1,0 +1,137 @@
+---
+title: Button
+description: Trigger an action. The most common interactive element in the system.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## Use it for
+
+- Submitting a form
+- Confirming or cancelling a destructive operation
+- Opening a sheet, dialog, or popover
+- Triggering an immediate, synchronous action
+
+If the action navigates somewhere, use **LinkButton** instead. If the trigger is a single icon (no label), use **IconButton**.
+
+## Import
+
+```tsx
+import { Button } from '@brikdesigns/bds';
+```
+
+## Anatomy
+
+A Button is a labelled hit target with an optional leading or trailing icon. The label drives the implicit accessible name.
+
+```
+┌──────────────────────────────────┐
+│  [icon]   Label   [icon]         │
+└──────────────────────────────────┘
+   ↑         ↑          ↑
+   leading   text node  trailing
+```
+
+## Variants
+
+Twelve variants. Pick by **action emphasis** and **destructive intent**, not by aesthetics.
+
+### Primary actions
+
+<ComponentPreview code={`<BDS.Button variant="primary">Save</BDS.Button>
+<BDS.Button variant="outline">Cancel</BDS.Button>
+<BDS.Button variant="secondary">Secondary</BDS.Button>
+<BDS.Button variant="ghost">Tertiary</BDS.Button>`}>
+  <BDS.Button variant="primary">Save</BDS.Button>
+  <BDS.Button variant="outline">Cancel</BDS.Button>
+  <BDS.Button variant="secondary">Secondary</BDS.Button>
+  <BDS.Button variant="ghost">Tertiary</BDS.Button>
+</ComponentPreview>
+
+### Destructive actions
+
+Three flavors of destructive map onto the same emphasis ladder as primary actions.
+
+<ComponentPreview code={`<BDS.Button variant="danger">Delete</BDS.Button>
+<BDS.Button variant="danger-outline">Delete</BDS.Button>
+<BDS.Button variant="danger-ghost">Delete</BDS.Button>`}>
+  <BDS.Button variant="danger">Delete</BDS.Button>
+  <BDS.Button variant="danger-outline">Delete</BDS.Button>
+  <BDS.Button variant="danger-ghost">Delete</BDS.Button>
+</ComponentPreview>
+
+### State variants
+
+`positive` confirms a completed action. `selected` indicates a button is currently the active option in a group. `inverse` and `on-color` are for placement on dark or branded surfaces.
+
+<ComponentPreview code={`<BDS.Button variant="positive">Saved</BDS.Button>
+<BDS.Button variant="selected">Selected</BDS.Button>`}>
+  <BDS.Button variant="positive">Saved</BDS.Button>
+  <BDS.Button variant="selected">Selected</BDS.Button>
+</ComponentPreview>
+
+## Sizes
+
+Five sizes. `md` is the default. Use `sm` only inside dense surfaces (table rows, popovers); use `lg`/`xl` for primary CTAs on landing pages.
+
+<ComponentPreview code={`<BDS.Button size="tiny">Tiny</BDS.Button>
+<BDS.Button size="sm">Small</BDS.Button>
+<BDS.Button size="md">Medium</BDS.Button>
+<BDS.Button size="lg">Large</BDS.Button>
+<BDS.Button size="xl">XL</BDS.Button>`}>
+  <BDS.Button size="tiny">Tiny</BDS.Button>
+  <BDS.Button size="sm">Small</BDS.Button>
+  <BDS.Button size="md">Medium</BDS.Button>
+  <BDS.Button size="lg">Large</BDS.Button>
+  <BDS.Button size="xl">XL</BDS.Button>
+</ComponentPreview>
+
+## When to use
+
+| Situation | Component |
+|---|---|
+| Action that stays on the page (Save, Submit, Open dialog) | **Button** |
+| Action that navigates to a new URL | [LinkButton](/docs/components/link-button) |
+| Single-icon trigger with no visible label | [IconButton](/docs/components/icon-button) |
+| Toggle on/off | [Switch](/docs/components/switch) |
+| One-of-many selection | [SegmentedControl](/docs/components/segmented-control) |
+
+## When *not* to use
+
+<Callout type="warn">
+**Don't downgrade emphasis when converting Button → IconButton.** A primary action stays a primary action. The 2026-04 IconButton-ghost regression came from agents converting `<Button variant="primary">` into `<IconButton variant="ghost">`. Match the emphasis level, always.
+</Callout>
+
+- **Don't use `ghost` for the only action on a page.** Ghost is the lowest emphasis tier — it should appear alongside a higher-emphasis sibling.
+- **Don't stack two `primary` buttons next to each other.** Only one primary action per surface.
+
+## Accessibility
+
+- Renders a real `<button>` element. Keyboard navigation, focus ring, and `Enter`/`Space` activation come from the platform.
+- Accessible name comes from the label. If you must hide the visual label (rare — use IconButton instead), pass `aria-label`.
+- Disabled state uses the `disabled` attribute, which removes it from the tab order. For "blocked but explainable" actions, prefer keeping it focusable and showing a tooltip.
+
+## API
+
+The full prop reference (with auto-extracted TypeScript types and live controls) lives in [Storybook → Components/Action/Button](https://storybook.brikdesigns.com/?path=/docs/components-action-button--docs).
+
+| Prop | Type | Default |
+|---|---|---|
+| `variant` | `ButtonVariant` | `'primary'` |
+| `size` | `ButtonSize` | `'md'` |
+| `leadingIcon` | `ReactNode` | — |
+| `trailingIcon` | `ReactNode` | — |
+| `loading` | `boolean` | `false` |
+| `fullWidth` | `boolean` | `false` |
+| `disabled` | `boolean` | `false` |
+
+`ButtonVariant` = `primary | outline | secondary | ghost | inverse | on-color | danger | danger-outline | danger-ghost | destructive | positive | selected`
+
+`ButtonSize` = `tiny | sm | md | lg | xl`
+
+## Related
+
+- [LinkButton](/docs/components/link-button) — same shape, renders an `<a>`
+- [IconButton](/docs/components/icon-button) — single-icon trigger
+- [ButtonGroup](/docs/components/button-group) — connected button cluster
+- [Forms pattern](/docs/patterns#forms) — Save/Cancel placement, submit-state handling

--- a/docs-site/content/docs/components/filter-bar.mdx
+++ b/docs-site/content/docs/components/filter-bar.mdx
@@ -1,0 +1,137 @@
+---
+title: Filter bar
+description: Heading + count + filter-controls row for list and table views.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+FilterBar is the standard heading-and-controls strip above lists and tables. It renders a `heading-sm` title and a Counter on the left, filter children on the right, and an optional ghost "Clear filters" button that appears when any filter is active.
+
+Pairs naturally with [FilterButton](/docs/components/filter-button) (dropdown filters) and [FilterToggle](/docs/components/filter-toggle) (boolean toggle filters) for the control children.
+
+## Use it for
+
+- The header of a list, table, or grid view
+- Anywhere the user filters down a known total (`total` and `filtered` counts both surface)
+- Persistent filters that stay visible while the data changes underneath
+
+## Import
+
+```tsx
+import { FilterBar, FilterButton, FilterToggle } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+No filter applied — counter stays neutral and the Clear button is hidden.
+
+```tsx
+<FilterBar
+  title="Engagements"
+  total={42}
+  filtered={42}
+  label="engagements"
+>
+  <FilterButton label="Status" options={[...]} value={status} onChange={setStatus} />
+</FilterBar>
+```
+
+### Filtered
+
+When `filtered < total`, the counter switches to its `brand` style (configurable via `activeStatus`) and, if `onClear` is provided, a ghost Clear button appears after the controls.
+
+```tsx
+<FilterBar
+  title="Engagements"
+  total={42}
+  filtered={8}
+  label="engagements"
+  onClear={() => clearAllFilters()}
+>
+  <FilterButton ... />
+</FilterBar>
+```
+
+### No title
+
+The title is optional. When omitted the counter leads the row.
+
+### No clear callback
+
+Omit `onClear` to suppress the Clear button entirely — useful for table views that don't support bulk-clearing all filters at once.
+
+## Pattern: interactive filter bar
+
+Real-world wiring: local state holds filter values, `filtered.length` feeds the counter, and `onClear` resets all filters.
+
+```tsx
+import { FilterBar, FilterButton } from '@brikdesigns/bds';
+import { useState, useMemo } from 'react';
+
+function EngagementsTable({ rows }) {
+  const [status, setStatus] = useState<string | undefined>();
+
+  const filtered = useMemo(
+    () => (status ? rows.filter((r) => r.status === status) : rows),
+    [rows, status],
+  );
+
+  return (
+    <FilterBar
+      title="Engagements"
+      total={rows.length}
+      filtered={filtered.length}
+      label="engagements"
+      onClear={() => setStatus(undefined)}
+    >
+      <FilterButton
+        label="Status"
+        value={status}
+        onChange={setStatus}
+        options={[
+          { id: 'active', label: 'Active' },
+          { id: 'pending', label: 'Pending' },
+        ]}
+      />
+    </FilterBar>
+  );
+}
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't show a FilterBar with no filters.** If the view has no filterable axes, the header should be a regular `<h2>` + counter, not a FilterBar. The empty controls slot reads as a styling mistake.
+</Callout>
+
+## Accessibility
+
+- The title renders as an `<h2>` — ensure the surrounding page uses a sensible heading hierarchy (typically `<h1>` on the page and `<h2>` per table).
+- The container carries an `aria-label` (falls back to `"{title} filter bar"` or `"{label} filter bar"`).
+- The counter announces `"Count: {n}"` via `aria-label`.
+
+## API
+
+### FilterBar
+
+| Prop | Type | Default |
+|---|---|---|
+| `total` | `number` *(required)* | — |
+| `filtered` | `number` *(required)* | — |
+| `label` | `string` *(required)* | — |
+| `children` | `ReactNode` *(required)* | — |
+| `title` | `ReactNode` | — |
+| `activeStatus` | `CounterStatus` | `'brand'` |
+| `onClear` | `() => void` | — |
+| `clearLabel` | `string` | `'Clear filters'` |
+
+Plus all standard `<div>` HTML attributes (excluding `title`).
+
+## Related
+
+- [FilterButton](/docs/components/filter-button) — dropdown control children
+- [FilterToggle](/docs/components/filter-toggle) — boolean control children
+- [Counter](https://storybook.brikdesigns.com/?path=/docs/components-indicator-counter--overview) — the counter primitive used by the bar
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-action-filter-bar--overview)**

--- a/docs-site/content/docs/components/filter-button.mdx
+++ b/docs-site/content/docs/components/filter-button.mdx
@@ -1,0 +1,107 @@
+---
+title: Filter button
+description: Dropdown filter trigger for filter bars. Single-select with click-to-clear.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+FilterButton is a pill-shaped dropdown trigger that opens a single-select list. Switches to an active (brand) style when a value is selected. Click a selected item again to clear.
+
+## Use it for
+
+- Single-axis dropdown filters inside a [FilterBar](/docs/components/filter-bar)
+- Categorical filters with 3–15 options (longer lists belong in a Select with search)
+- Filters that should show a clear "active vs not" state visually
+
+For boolean on/off filters, use [FilterToggle](/docs/components/filter-toggle) instead.
+
+## Import
+
+```tsx
+import { FilterButton } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+const [category, setCategory] = useState<string | undefined>();
+
+<FilterButton
+  label="Category"
+  value={category}
+  onChange={setCategory}
+  options={[
+    { id: 'design', label: 'Brand design' },
+    { id: 'marketing', label: 'Marketing' },
+  ]}
+/>
+```
+
+### With icons
+
+Each option can include an `icon` for visual reinforcement.
+
+```tsx
+<FilterButton
+  label="Category"
+  value={category}
+  onChange={setCategory}
+  options={[
+    { id: 'design', label: 'Brand design', icon: <CrownIcon /> },
+    { id: 'marketing', label: 'Marketing', icon: <BullhornIcon /> },
+  ]}
+/>
+```
+
+### Sizes
+
+Three sizes — `sm`, `md` (default), `lg`. Match the size of surrounding controls.
+
+## Active state
+
+When `value` is set, the button switches to the brand-active style. Click the active option in the dropdown again to clear (the `onChange` callback receives `undefined`).
+
+<Callout type="info">
+  **The active state is driven by `value`, not internal state.** Always pair with controlled state in the parent — FilterButton is purely presentational.
+</Callout>
+
+## When *not* to use
+
+- **Don't use for boolean filters.** Use [FilterToggle](/docs/components/filter-toggle) — it has the right semantics and shape.
+- **Don't use for multi-select.** This component is single-select only. For multi-select, use a checkbox menu inside a Popover or a [MultiSelect](https://storybook.brikdesigns.com/?path=/docs/components-form-multi-select--overview).
+
+## Accessibility
+
+- The trigger is a real `<button>`. Keyboard `Enter`/`Space` opens the dropdown.
+- Active state is announced via `aria-pressed`.
+- Selected option in the dropdown carries `aria-selected="true"`.
+
+## API
+
+### FilterButton
+
+| Prop | Type | Default |
+|---|---|---|
+| `label` | `string` *(required)* | — |
+| `options` | `FilterButtonOption[]` *(required)* | — |
+| `value` | `string` | — |
+| `onChange` | `(value: string \| undefined) => void` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+
+### FilterButtonOption
+
+```ts
+interface FilterButtonOption {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+}
+```
+
+## Related
+
+- [FilterBar](/docs/components/filter-bar) — the parent container
+- [FilterToggle](/docs/components/filter-toggle) — boolean alternative
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-action-filter-button--overview)**

--- a/docs-site/content/docs/components/filter-toggle.mdx
+++ b/docs-site/content/docs/components/filter-toggle.mdx
@@ -1,0 +1,79 @@
+---
+title: Filter toggle
+description: Boolean filter trigger — on/off, no dropdown.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+FilterToggle is a pill-shaped button that flips a single boolean filter on or off. Switches to the active (brand) style when on. Use it for filters that don't need a dropdown — "Show archived," "Only mine," "Has membership plan."
+
+## Use it for
+
+- Boolean filters inside a [FilterBar](/docs/components/filter-bar)
+- Filters that don't need a value picker (just "applied vs not applied")
+- Quick toggles where the filter name itself describes the criterion
+
+For filters with 3+ options, use [FilterButton](/docs/components/filter-button).
+
+## Import
+
+```tsx
+import { FilterToggle } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+const [showArchived, setShowArchived] = useState(false);
+
+<FilterToggle
+  label="Show archived"
+  active={showArchived}
+  onToggle={() => setShowArchived((v) => !v)}
+/>
+```
+
+### Sizes
+
+Three sizes — `sm`, `md` (default), `lg`. Match the size of surrounding controls.
+
+## Active state
+
+The `active` prop drives the brand-active style. The component is fully controlled — clicking calls `onToggle`, and the parent decides what to do (typically flip a state boolean).
+
+<Callout type="info">
+  **`onToggle` receives no argument** — it's a "flip" callback, not a "set value" callback. The parent owns the truth of `active`.
+</Callout>
+
+## When *not* to use
+
+- **Don't use for filters with 3+ options.** Use [FilterButton](/docs/components/filter-button).
+- **Don't use as a primary action.** It's a *filter* control — the visual treatment is intentionally lighter than a real button. For "apply" or "save," use [Button](/docs/components/button).
+
+## Accessibility
+
+- Renders a `<button>` with `aria-pressed` reflecting the `active` state.
+- Keyboard `Enter`/`Space` toggles, just like a regular button.
+- The label is the accessible name.
+
+## API
+
+### FilterToggle
+
+| Prop | Type | Default |
+|---|---|---|
+| `label` | `string` *(required)* | — |
+| `active` | `boolean` *(required)* | — |
+| `onToggle` | `() => void` *(required)* | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+
+Plus all standard `<button>` HTML attributes (excluding `onChange`).
+
+## Related
+
+- [FilterBar](/docs/components/filter-bar) — the parent container
+- [FilterButton](/docs/components/filter-button) — multi-option alternative
+- [Switch](https://storybook.brikdesigns.com/?path=/docs/components-control-switch--overview) — for non-filter boolean toggles (settings, preferences)
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-action-filter-toggle--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -3,11 +3,13 @@ title: Components
 description: Building blocks. One job each, composable, themeable.
 ---
 
+import { Cards, Card } from 'fumadocs-ui/components/card';
+
 BDS components are organized by **job**, not by visual type. The same taxonomy backs Storybook's sidebar.
 
 | Group | Examples |
 |---|---|
-| **Action** | Button, IconButton, LinkButton, ButtonGroup, FilterBar |
+| **Action** | Button, IconButton, LinkButton, ButtonGroup, FilterBar, FilterButton, FilterToggle, TextLink |
 | **Form** | Field, TextInput, Select, MultiSelect, DatePicker, Form, FieldGrid |
 | **Indicator** | Badge, Chip, Tag, Counter, Spinner, Skeleton |
 | **Feedback** | AlertBanner, Toast, Tooltip, EmptyState, ProgressBar |
@@ -15,17 +17,25 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
 | **Addable** | AddableTagList, AddableEntryList, AddableFieldRowList |
 | **Structure** | Card, Divider, Accordion |
 
+## Documented here
+
+### Action
+
+<Cards>
+  <Card title="Button" href="/docs/components/button" description="Trigger an action. Twelve variants, five sizes; LinkButton + IconButton sub-components." />
+  <Card title="Button group" href="/docs/components/button-group" description="Group related buttons into a connected cluster. Horizontal or vertical stacking." />
+  <Card title="Filter bar" href="/docs/components/filter-bar" description="Heading + counter + filter controls row for list and table views." />
+  <Card title="Filter button" href="/docs/components/filter-button" description="Pill-shaped dropdown filter trigger. Single-select with click-to-clear." />
+  <Card title="Filter toggle" href="/docs/components/filter-toggle" description="Boolean filter trigger — on/off, no dropdown." />
+  <Card title="Text link" href="/docs/components/text-link" description="Styled anchor for inline navigation and footer links." />
+</Cards>
+
+## Still in Storybook
+
+The remaining ~50 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for every other group: Form, Indicator, Feedback, Control, Addable, Structure, Navigation.
+
 ## Page template
 
-Every component page on this site follows the same structure so agents and humans can find what they need:
+Every component page on this site follows the same structure. See [Contribution → Page templates](/docs/contribution/page-templates) for the full reference. Short version: *Use it for / Import / Anatomy / Variants / When (not) to use / Accessibility / API / Related*.
 
-1. **Use it for** — concrete situations
-2. **Install / Import** — copy-paste import
-3. **Anatomy** — labelled diagram of the parts
-4. **Variants** — live previews of each
-5. **When to use** / **When not to use** — adjacent components and the rule for picking
-6. **Accessibility** — keyboard, screen reader, ARIA
-7. **API** — props table (links to Storybook for the live `<ArgTypes>`)
-8. **Related** — cross-links to patterns and similar components
-
-> See [Button](/docs/components/button) for a worked example.
+[Button](/docs/components/button) is the canonical example — new pages should match its structure section-by-section.

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -1,0 +1,31 @@
+---
+title: Components
+description: Building blocks. One job each, composable, themeable.
+---
+
+BDS components are organized by **job**, not by visual type. The same taxonomy backs Storybook's sidebar.
+
+| Group | Examples |
+|---|---|
+| **Action** | Button, IconButton, LinkButton, ButtonGroup, FilterBar |
+| **Form** | Field, TextInput, Select, MultiSelect, DatePicker, Form, FieldGrid |
+| **Indicator** | Badge, Chip, Tag, Counter, Spinner, Skeleton |
+| **Feedback** | AlertBanner, Toast, Tooltip, EmptyState, ProgressBar |
+| **Control** | Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader |
+| **Addable** | AddableTagList, AddableEntryList, AddableFieldRowList |
+| **Structure** | Card, Divider, Accordion |
+
+## Page template
+
+Every component page on this site follows the same structure so agents and humans can find what they need:
+
+1. **Use it for** — concrete situations
+2. **Install / Import** — copy-paste import
+3. **Anatomy** — labelled diagram of the parts
+4. **Variants** — live previews of each
+5. **When to use** / **When not to use** — adjacent components and the rule for picking
+6. **Accessibility** — keyboard, screen reader, ARIA
+7. **API** — props table (links to Storybook for the live `<ArgTypes>`)
+8. **Related** — cross-links to patterns and similar components
+
+> See [Button](/docs/components/button) for a worked example.

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -1,4 +1,13 @@
 {
   "title": "Components",
-  "pages": ["index", "button"]
+  "pages": [
+    "index",
+    "---Action---",
+    "button",
+    "button-group",
+    "filter-bar",
+    "filter-button",
+    "filter-toggle",
+    "text-link"
+  ]
 }

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Components",
+  "pages": ["index", "button"]
+}

--- a/docs-site/content/docs/components/text-link.mdx
+++ b/docs-site/content/docs/components/text-link.mdx
@@ -1,0 +1,97 @@
+---
+title: Text link
+description: Styled anchor element for navigation and inline text links.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+TextLink is a styled `<a>` element with size variants and hover effects. Use it inside paragraphs, navigation menus, and any context where a Button would be too heavy.
+
+## Use it for
+
+- Links inside body copy
+- Horizontal navigation menus
+- Footer links and breadcrumb segments
+- "Read more" / "Learn more" links that don't deserve a button
+
+For an action that looks like a button but navigates to a URL, use [LinkButton](/docs/components/button#linkbutton).
+
+## Import
+
+```tsx
+import { TextLink } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+<ComponentPreview code={`<BDS.TextLink href="#">Learn more</BDS.TextLink>`}>
+  <BDS.TextLink href="#">Learn more</BDS.TextLink>
+</ComponentPreview>
+
+### Small
+
+For compact contexts — table rows, footer columns, breadcrumbs.
+
+<ComponentPreview code={`<BDS.TextLink href="#" size="small">View details</BDS.TextLink>`}>
+  <BDS.TextLink href="#" size="small">View details</BDS.TextLink>
+</ComponentPreview>
+
+### External link
+
+Open in a new tab with proper security attributes. Always use `rel="noopener noreferrer"` with `target="_blank"`.
+
+```tsx
+<TextLink
+  href="https://example.com"
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  Visit external site
+</TextLink>
+```
+
+### With icons
+
+`iconBefore` and `iconAfter` work the same as Button. A trailing arrow is the canonical "external" affordance.
+
+```tsx
+<TextLink href="https://example.com" iconAfter={<ExternalLinkIcon />}>
+  Read on GitHub
+</TextLink>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't style a Button as a TextLink.** If the action navigates, use TextLink (or LinkButton if it needs button emphasis). If the action stays on the page, use Button. Mixing the semantics breaks right-click and keyboard navigation.
+</Callout>
+
+- **Don't use TextLink for primary actions.** It's the lowest-emphasis link surface. Primary actions belong on a Button or LinkButton.
+- **Don't underline non-link text** to mimic TextLink. Underlines on non-anchor text confuse screen readers.
+
+## Accessibility
+
+- Renders a real `<a>`. Keyboard, focus ring, and right-click context menu come from the platform.
+- The accessible name is the visible text. Avoid generic labels like "click here" or "more" — use the destination as the label ("Read the cascade rules", not "Read more").
+- For external links opening in new tabs, include `rel="noopener noreferrer"` to prevent the destination from accessing the source page's `window`.
+
+## API
+
+### TextLink
+
+| Prop | Type | Default |
+|---|---|---|
+| `children` | `ReactNode` *(required)* | — |
+| `href` | `string` | — |
+| `size` | `'default' \| 'small'` | `'default'` |
+| `iconBefore` | `ReactNode` | — |
+| `iconAfter` | `ReactNode` | — |
+
+Plus all standard `<a>` HTML attributes.
+
+## Related
+
+- [Button → LinkButton](/docs/components/button#linkbutton) — anchor styled as a button
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-action-text-link--overview)**

--- a/docs-site/content/docs/content-system/atmospheres/index.mdx
+++ b/docs-site/content/docs/content-system/atmospheres/index.mdx
@@ -1,0 +1,6 @@
+---
+title: Atmospheres
+description: Mood overlays — grain, glow, vignettes, color casts. Applied as a class on top of the client theme.
+---
+
+> Stub page — port from `stories/foundation/theming/Atmospheres.mdx`. Should cover the full set: editorial-luxury, cinematic-dramatic, minimal-clinical, warm-soft, clean-bright, organic-textured, none. Each gets a live preview, the CSS file path (`@brikdesigns/bds/atmospheres/{slug}.css`), and pairing notes (which industries default to which, which voices clash).

--- a/docs-site/content/docs/content-system/atmospheres/meta.json
+++ b/docs-site/content/docs/content-system/atmospheres/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Atmospheres",
+  "pages": ["index"]
+}

--- a/docs-site/content/docs/content-system/index.mdx
+++ b/docs-site/content/docs/content-system/index.mdx
@@ -1,0 +1,55 @@
+---
+title: Content System
+description: The vocabulary peer to BDS — industries, voices, atmospheres, and locked enums.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+The Brik Content System (BCS) is the **content-vocabulary peer** to the visual token system. Same cascade pattern as tokens, but for copy instead of colors. Lives in `content-system/` in the BDS repo and ships from the same npm package via a second entry point.
+
+```ts
+import {
+  industryPacks,
+  voicePatterns,
+  PERSONALITY_VALUES,
+  VOICE_VALUES,
+  VISUAL_STYLE_VALUES,
+  DEFAULT_INDUSTRY_SLUG,
+  type IndustryPack,
+  type VoicePattern,
+} from '@brikdesigns/bds/content-system';
+```
+
+## What's in here
+
+| Section | Answers |
+|---|---|
+| [Industries](/docs/content-system/industries) | "What does this vertical care about? What's seasonal, regulated, or competitive?" |
+| [Voices](/docs/content-system/voices) | "How does this client sound? Direct, warm, witty, refined?" |
+| [Atmospheres](/docs/content-system/atmospheres) | "What mood does this brand sit in? Editorial-luxury, warm-soft, minimal-clinical?" |
+
+## How the cascade works
+
+Same shape as tokens: **industry defaults → client overrides win**.
+
+When a strategy doc, mockup, or page generates for a client, the BCS resolver:
+
+1. Loads the industry pack for `company_profile.industry_slug` (defaults to `small-business`)
+2. Layers on the client's voice picks, atmosphere selection, and copy overrides
+3. Returns a single resolved view that automations + content workers consume
+
+Client overrides on `cta_language`, `anti_messages`, and `naming_conventions` always win over industry seeds. Empty client fields fall through to the industry default.
+
+<Callout type="warn">
+  **Locked enums are the source of truth.** `PERSONALITY_VALUES`, `VOICE_VALUES`, `VISUAL_STYLE_VALUES`, and `INDUSTRY_SLUGS` are exported from BCS and imported by the portal. Never hardcode these values in consumer code; never drift them between repos.
+</Callout>
+
+## Pack lifecycle
+
+Every pack carries a `version`, `reviewCadence`, and `lastReviewed` field. Bump version on content change. Update `lastReviewed` when you confirm accuracy on a review pass — even with no changes. The catch-all `small-business` pack graduates a new vertical out when:
+
+- Brik has 3+ clients in it, OR
+- Seasonality / regulation / terminology diverges meaningfully from `small-business`, OR
+- Strategy docs repeat 60%+
+
+See [Industries → Dental](/docs/content-system/industries/dental) for a fully-fleshed reference pack.

--- a/docs-site/content/docs/content-system/industries/dental.mdx
+++ b/docs-site/content/docs/content-system/industries/dental.mdx
@@ -6,7 +6,13 @@ description: High-trust, local-first healthcare. The reference industry pack —
 import { Callout } from 'fumadocs-ui/components/callout';
 import { dental } from '@brikdesigns/bds/content-system';
 
-**Version:** {dental.version}  ·  **Last reviewed:** {dental.lastReviewed}  ·  **Review cadence:** {dental.reviewCadence}
+<MetadataStrip
+  items={[
+    { label: 'Version', value: dental.version },
+    { label: 'Last reviewed', value: dental.lastReviewed },
+    { label: 'Cadence', value: dental.reviewCadence },
+  ]}
+/>
 
 Static reference. Automations consume this when generating strategy documents. Never injected into client briefs as client-specific fact — always layer through the resolver so client overrides win.
 

--- a/docs-site/content/docs/content-system/industries/dental.mdx
+++ b/docs-site/content/docs/content-system/industries/dental.mdx
@@ -1,0 +1,206 @@
+---
+title: Dental
+description: High-trust, local-first healthcare. The reference industry pack — most fleshed-out structure of any vertical.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { dental } from '@brikdesigns/bds/content-system';
+
+**Version:** {dental.version}  ·  **Last reviewed:** {dental.lastReviewed}  ·  **Review cadence:** {dental.reviewCadence}
+
+Static reference. Automations consume this when generating strategy documents. Never injected into client briefs as client-specific fact — always layer through the resolver so client overrides win.
+
+Structured data lives in [`content-system/industries/dental.ts`](https://github.com/brikdesigns/brik-bds/blob/main/content-system/industries/dental.ts). This page is the narrative companion. Keep them in sync.
+
+---
+
+## 1. Industry Overview
+
+Dental is a high-trust, local-first professional healthcare category. Patients choose providers based on proximity, insurance acceptance, and reputation signals more than price. The market is bifurcating between independent and small-group practices competing on patient experience, and DSO-backed practices competing on scale, convenience, and marketing spend.
+
+Patient acquisition is expensive and slow. Lifetime value is high — a single retained family can generate **$15K–$40K+** over a decade. This asymmetry is why retention nearly always outperforms acquisition spend for established practices.
+
+## 2. Default Affinities
+
+When a client hasn't yet picked traits in the portal, these are the pack's starting affinities. Clients always override.
+
+| Axis | Affinities (first = strongest) |
+|---|---|
+| **Personality** | {dental.affinities.personality.join(' · ')} |
+| **Voice** | {dental.affinities.voice.join(' · ')} |
+| **Visual Style** | {dental.affinities.visualStyle.join(' · ')} |
+
+Independent practices skew warmer and more conversational; cosmetic boutiques skew more Refined + Modern; pediatric practices skew Playful + Approachable. The pack defaults aim at the median general-practice independent.
+
+## 3. Common Patient Pain Points
+
+- **Cost anxiety** — surprise bills, unclear coverage, sticker shock on crowns/implants/ortho
+- **Dental anxiety** — ~36% of adults report moderate-to-severe dental fear; top reason for avoidance
+- **Insurance confusion** — PPO vs HMO vs FFS, in-network vs out, annual maximums
+- **Trust deficit** — suspicion of over-treatment ("do I really need this crown?")
+- **Scheduling friction** — long new-patient waits, inflexible hours for working parents
+- **Continuity of care** — patients stay for years; hygienist/dentist turnover triggers churn
+- **Cosmetic hesitation** — 3–12 month shopping cycles for veneers, Invisalign, implants
+
+## 4. Seasonality
+
+| Quarter | Intent | Focus |
+|---|---|---|
+| **Q1 (Jan–Mar)** | high | Insurance reset surge. Highest-intent window. New-patient calls peak. |
+| **Q2 (Apr–Jun)** | medium | Tax refunds drive cosmetic/elective inquiries. Long shopping cycles start. |
+| **Q3 (Jul–Aug)** | high | Pediatric + ortho surge during summer break. Adult cosmetic dips. |
+| **Q4 (Nov–Dec)** | high | Use-it-or-lose-it benefits push. Best campaign ROI of year for insurance practices. |
+
+## 5. Competitive Landscape
+
+- **Independent solo/small-group** — relationship, community ties, owner-dentist continuity
+- **DSO-backed** (Heartland, Pacific Dental, Aspen, Smile Brands, MB2) — ad spend, extended hours, standardized experience
+- **Specialty** (ortho, endo, perio, oral surgery, pediatric, prosthodontics) — referral-driven, board-certified authority
+- **Cosmetic / boutique** — design-forward, concierge, premium pricing, Instagram-native
+- **Budget / insurance-heavy** — high-volume, Medicaid/HMO, compete on access
+- **DTC aligner disruptors** — Invisalign, ClearCorrect (SmileDirectClub's collapse slowed but didn't stop this)
+
+## 6. Listings Requirements
+
+**Required:** Google Business Profile (primary category "Dentist" or specialty variant), Bing Places, Apple Business Connect, Facebook, Yelp, Healthgrades, Zocdoc.
+
+**Conditional** (insurance-accepting practices only): Delta Dental, MetLife, Cigna, Aetna, Humana provider finders — verify annually.
+
+<Callout type="warn">
+  **NPI must match across all listings.** Mismatch hurts trust and insurance routing.
+</Callout>
+
+## 7. Regulatory Summary
+
+- **HIPAA** — patient photos, reviews, testimonials require written authorization; responses to reviews cannot confirm patient status
+- **State dental boards** — vary by state; common restrictions on "best," "#1," "specialist" (unless board-certified), "painless"
+- **Before/after photos** — require signed release; most states require "individual results vary" disclaimer
+- **ADA specialty recognition** — only 12 specialties are ADA-recognized; "cosmetic dentist" and "implant dentist" are NOT specialties
+- **ADA/WCAG 2.1 AA** — healthcare sites are frequent ADA-lawsuit targets; compliance is non-negotiable
+
+## 8. Vocabulary — Avoid
+
+<table>
+  <thead>
+    <tr><th>Term</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    {dental.vocabulary.avoid.map((v, i) => (
+      <tr key={i}>
+        <td><strong>{v.term}</strong></td>
+        <td>{v.reason}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+
+## 9. Navigation IA
+
+Default site-header shape for dental. Drives the BDS `<SiteHeader>` component in `@brikdesigns/bds/blueprints-astro` when consumer sites build. Clients can override any field per-engagement in the portal Intel tab, but the pack default represents Brik's curated recommendation for the vertical.
+
+Design intent: keep the top bar quiet (4 primary links, not 6) and route service discovery through a grouped mega-menu so cosmetic + restorative + comfort live in separate columns rather than a flat list. The frosted-glass-past-80 scroll behavior lets hero photography breathe at first load without sacrificing return-navigation reach.
+
+```ts
+// dental.navigationIA shape, from content-system/industries/dental.ts
+{
+  "primaryLinks": [/* 4 links */],
+  "megaMenu": { /* services grouped by column */ },
+  "scrollBehavior": "frosted-past-80",
+  "ctaSlot": { /* primary CTA placement */ }
+}
+```
+
+> The `<NavigationIASpec>` visualization that renders this in Storybook will be ported to Fumadocs as a custom MDX component. Until then, the structured shape lives in `dental.navigationIA`.
+
+## 10. Brik Strategic POV
+
+Three considerations that differentiate Brik's dental strategy. These are not generic industry facts — they reflect Brik's POV and should surface in briefs where applicable.
+
+### Retention Economics
+
+New-patient CAC ($200–$500+) vastly exceeds reactivation/case-close cost (under $10). A 1% hygiene reappt improvement on a ~2,000 active-patient practice produces $40–60K+/yr. A 5% case-acceptance gain can match 75–150 new patients in revenue.
+
+<Callout type="info">
+  **Stabilize retention before recommending acquisition.**
+</Callout>
+
+Brik audits: Total Active Patients, Unscheduled Active, New Patients (Last Month), Total Lost (Last Month), Hygiene Reappt %, Case Acceptance %, Production/Visit, No-Show Rate, Hyg/Dr Visit ratio, Email/Cell capture, ASAP List.
+
+### Independent vs DSO
+
+Independents should not out-spend DSOs. Structural moats: continuity of care, clinical autonomy, slower more personal experience, community embeddedness, owner-dentist visibility, decision speed, referral velocity.
+
+**Messaging posture:** continuity, ownership, community, clinical integrity. Avoid corporate gloss. *"Your dentist. Not a corporation."* — the emotional posture, not the literal words.
+
+### FFS Transition
+
+PPO write-offs commonly consume 20–40% of potential production. Transitioning toward FFS is typically the single highest-leverage long-term business decision for an established independent.
+
+**Prerequisites:** ~1,500+ active patients, hygiene reappt >90%, case acceptance >50%, healthy review presence, membership plan ready ($350–$500/yr covering 2 cleanings + exams + X-rays + 15–20% off treatment), owner-dentist with 3+ years of runway.
+
+Three transition patterns:
+
+1. **Selective drop** — lowest-paying PPOs first
+2. **Full FFS** — all-at-once
+3. **Hybrid / grandfather** — honor existing; FFS for new patients only
+
+---
+
+## 11. Site Audit Extractors
+
+When the portal audits a dental client's existing website, four pack-specific extractors run in addition to the universal ones (services, key messages, proof points, social links). Each turns live-site content into structured facts the content + preflight workers can reason about programmatically, rather than re-paraphrasing free text every run.
+
+### Page patterns
+
+The pack declares URL / path / title patterns that route scraped pages to the right extractor:
+
+| Pattern | Matches | Feeds extractor |
+|---|---|---|
+| `membership_plan` | `/membership`, `/membership-plan*`, `/dental-savings-plan`, `/care-plan` · titles containing "membership plan", "dental savings", "care plan" | `membership_plans` |
+| `insurance` | `/insurance`, `/insurance-accepted`, `/financing`, `/payment-options` · titles containing "insurance", "financing", "accepted insurance" | `insurance_accepted` |
+| `new_patients` | `/new-patients`, `/first-visit`, `/welcome`, `/specials`, `/offers` · titles containing "new patient", "first visit", "special offer" | `new_patient_offers` |
+| `contact_or_homepage` | `/`, `/contact*`, `/book`, `/schedule`, `/appointments` · titles containing "book", "schedule", "appointment" | `appointment_systems` |
+
+Matches are case-insensitive. Multiple patterns can match a single page; each matched page routes to every applicable extractor.
+
+### Structured extractors
+
+| Extractor | Writes to `company_profiles` | Shape |
+|---|---|---|
+| **`membership_plans`** | `membership_plans[]`, `has_membership_plan` | `{ tier, monthly_price_cents, annual_price_cents, included_services[], enrollment_cta, source_url }` |
+| **`insurance_accepted`** | `insurance_providers[]`, `insurance_plans[]` | Verbatim carrier names (Delta Dental, Aetna, Cigna) + plan/program names distinct from carriers (Medicaid, PPO, Out-of-Network) |
+| **`new_patient_offers`** | `new_patient_offers[]` | `{ offer, first_visit_duration_minutes, source_url }` |
+| **`appointment_systems`** | `appointment_systems[]` | Integration names (Zocdoc, LocalMed, Weave, NexHealth, "custom web form") |
+
+### Why these four
+
+- **Membership plans** — the most-missed dental fact. Content generators writing `/membership` copy must name tiers + prices verbatim; the paraphrase "plans starting at $X" reads as made-up. Birdwell's `/membership-plan-1` was the validation case that drove this work.
+- **Insurance accepted** — dental clients publish carrier lists specifically because patients filter on them. *"We accept most major insurance"* is marketing hedging; the actual carrier list is conversion-critical.
+- **New patient offers** — live promos on the existing site are load-bearing on the hero. A redesign that drops them silently breaks conversion copy clients are actively tracking.
+- **Appointment systems** — if the client has LocalMed or Weave wired up, the CTA must route there, not to a generic contact form. Misrouted CTAs are a common regression on template-based rebuilds.
+
+### Portal integration
+
+The portal's `website-audits` worker resolves this pack via `company_profiles.industry_slug === 'dental'`, invokes each matched extractor, validates output against the `fieldSchemas` shapes above, and enriches the profile with `source: 'website_audit'`. Generate-content for dental clients then renders the structured facts verbatim (no LLM paraphrasing on these fields).
+
+Structured fields are also stamped to the `design_decisions` log with `source: 'website_audit'` so re-runs can see what was extracted last time and diff against the current run.
+
+### Adding extractors to a new industry
+
+1. Implement `siteAudit: IndustryPackSiteAudit` on the pack's `.ts` file
+2. Declare `pagePatterns` — URL / path / title rules that route scraped pages to extractors
+3. List the extractors + the `company_profiles` columns they write to. Populate `fieldSchemas` with shape descriptions for each column
+4. Add portal-side migration for any new columns; extend `enrichProfile` allowlist for `website_audit` to cover them
+5. Implement the actual extraction logic in `src/lib/website-audits/industry-packs/<slug>.ts` on the portal side
+6. Document the extractors here in the pack's `.mdx` under "Site Audit Extractors"
+
+Consumers without `siteAudit` defined (the `small-business` fallback) run universal extractors only.
+
+---
+
+## Related
+
+- [Content System overview](/docs/content-system)
+- [Industries index](/docs/content-system/industries)
+- [Atmospheres](/docs/content-system/atmospheres) — the mood layer dental defaults to
+- [Voices](/docs/content-system/voices) — voice patterns the dental affinities point to

--- a/docs-site/content/docs/content-system/industries/index.mdx
+++ b/docs-site/content/docs/content-system/industries/index.mdx
@@ -1,0 +1,33 @@
+---
+title: Industries
+description: Per-vertical packs of pain points, seasonality, regulation, voice affinities, and audit extractors.
+---
+
+Industry packs answer the question "what does this vertical actually care about?" so strategy docs, mockups, and content generation start from the right baseline instead of generic small-business filler.
+
+Each pack ships:
+
+- **Default affinities** — personality, voice, and visual-style starting picks for clients in this vertical
+- **Pain points + seasonality + regulation** — the operational facts a writer or strategist needs
+- **Listings requirements** — directories that matter, plus conditional ones (e.g. insurance carriers)
+- **Site audit extractors** — pack-specific scrapers that turn a client's existing site into structured facts
+- **Brik strategic POV** — the vertical-specific opinions that differentiate Brik's recommendations
+
+## Available packs
+
+| Slug | Status | Notes |
+|---|---|---|
+| [`dental`](/docs/content-system/industries/dental) | Production | The reference pack — most fleshed out |
+| `real-estate-rv-mhc` | Production | RV / manufactured home community sales |
+| `real-estate-commercial` | Production | Commercial real estate brokerage |
+| `small-business` | Catch-all default | `DEFAULT_INDUSTRY_SLUG` — graduates verticals out |
+
+## Adding a new pack
+
+See [Contribution](/docs/contribution) for the full flow. The short version:
+
+1. Add the slug to `INDUSTRY_SLUGS` in `vocabularies/industry.ts`
+2. Create `industries/{slug}.ts` (typed `IndustryPack` data) and `{slug}.mdx` (narrative)
+3. Register the pack in `industries/index.ts`
+4. Run `npm run build:content-system` to validate types
+5. If the pack defines `siteAudit` extractors, wire matching portal-side code in `src/lib/website-audits/industry-packs/<slug>.ts`

--- a/docs-site/content/docs/content-system/industries/meta.json
+++ b/docs-site/content/docs/content-system/industries/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Industries",
+  "pages": ["index", "dental"]
+}

--- a/docs-site/content/docs/content-system/meta.json
+++ b/docs-site/content/docs/content-system/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Content System",
+  "pages": ["index", "industries", "voices", "atmospheres"]
+}

--- a/docs-site/content/docs/content-system/voices/index.mdx
+++ b/docs-site/content/docs/content-system/voices/index.mdx
@@ -1,0 +1,6 @@
+---
+title: Voices
+description: The eight voice patterns — how a brand sounds in copy, with rules and pairings.
+---
+
+> Stub page — port from `content-system/voices/Overview.mdx` and the per-voice `.ts` files. Each of the 8 voices needs its own page covering: rules, do/don't examples, pairing guidance, and which industries it pairs naturally with.

--- a/docs-site/content/docs/content-system/voices/meta.json
+++ b/docs-site/content/docs/content-system/voices/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Voices",
+  "pages": ["index"]
+}

--- a/docs-site/content/docs/contribution/index.mdx
+++ b/docs-site/content/docs/contribution/index.mdx
@@ -1,0 +1,8 @@
+---
+title: Contribution
+description: How to add or change BDS components, tokens, and patterns.
+---
+
+> Placeholder. Will cover: worktree workflow, scope-per-PR rule, the component-bloat guardrails (ADR-004), the release flow (feat PR → release PR → publish → consumer sync), and the deprecation policy.
+
+For now, see [`CLAUDE.md`](https://github.com/brikdesigns/brik-bds/blob/main/CLAUDE.md) in the BDS repo for the active rules.

--- a/docs-site/content/docs/contribution/index.mdx
+++ b/docs-site/content/docs/contribution/index.mdx
@@ -1,8 +1,18 @@
 ---
 title: Contribution
-description: How to add or change BDS components, tokens, and patterns.
+description: How to add or change BDS components, tokens, content packs, and docs pages.
 ---
 
-> Placeholder. Will cover: worktree workflow, scope-per-PR rule, the component-bloat guardrails (ADR-004), the release flow (feat PR → release PR → publish → consumer sync), and the deprecation policy.
+import { Cards, Card } from 'fumadocs-ui/components/card';
 
-For now, see [`CLAUDE.md`](https://github.com/brikdesigns/brik-bds/blob/main/CLAUDE.md) in the BDS repo for the active rules.
+This is where the rules for working on BDS live: branching and worktree flow, scope-per-PR, the component-bloat guardrails, the release flow, the deprecation policy, and — most importantly for agents writing on this site — the page template every new docs page must follow.
+
+<Cards>
+  <Card title="Page templates" href="/docs/contribution/page-templates" description="The standard shape for component, primitive, and content-system pages. Read this before authoring." />
+</Cards>
+
+## Workflow rules (placeholder)
+
+The detailed contribution workflow (worktrees, scope-per-PR, ADR cadence, release flow, deprecation policy) hasn't migrated yet. For now, see [`CLAUDE.md`](https://github.com/brikdesigns/brik-bds/blob/main/CLAUDE.md) in the BDS repo — it's the operational source of truth.
+
+Once those rules migrate here, this index page will turn into a navigation hub like the other top-level sections.

--- a/docs-site/content/docs/contribution/meta.json
+++ b/docs-site/content/docs/contribution/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Contribution",
-  "pages": ["index"]
+  "pages": ["index", "page-templates"]
 }

--- a/docs-site/content/docs/contribution/meta.json
+++ b/docs-site/content/docs/contribution/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Contribution",
+  "pages": ["index"]
+}

--- a/docs-site/content/docs/contribution/page-templates.mdx
+++ b/docs-site/content/docs/contribution/page-templates.mdx
@@ -1,0 +1,249 @@
+---
+title: Page templates
+description: The standard shape for every docs page. Read before authoring or migrating content.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Every page in this site follows one of three templates depending on what it documents. Templates are not arbitrary — they exist so agents and humans can find what they need at the same place on every page, and so cross-page navigation feels coherent.
+
+<Callout type="warn">
+  **Don't invent new page shapes.** If your page doesn't fit a template here, propose a template change in `docs-site/content/docs/contribution/page-templates.mdx` and update *every* page using that template in the same PR. The cost of two ad-hoc structures is a lot more than the cost of one rigid one.
+</Callout>
+
+## Frontmatter (required on every page)
+
+```yaml
+---
+title: Button
+description: Trigger an event or action. The button family includes three components for different semantic needs.
+---
+```
+
+Both `title` and `description` are required. The description renders below the page title in `<DocsDescription>`. Keep it under 140 characters and write it as a complete sentence — it doubles as the meta description.
+
+## Templates
+
+### Component page
+
+For pages under `/docs/components/`. The shape:
+
+```text
+1. One-line summary (no heading — opens the page)
+2. <ComparisonGrid> — only if there are sibling components to disambiguate (e.g. Button vs LinkButton vs IconButton)
+3. ## Use it for          — concrete situations, bullet list
+4. ## Import              — copy-paste import line
+5. ## Anatomy             — <ComponentAnatomy> with numbered parts
+6. ## Variants            — <EmphasisLadder> for ordered ladders, <ComponentPreview> for state/style families
+7. ## Sizes               — <ComponentPreview> grid of every size
+8. ## Other variant axes   — Icons, Loading, Full width, etc. — one ## per axis
+9. ## Sub-components       — LinkButton, IconButton, etc. each get their own ##
+10. ## When *not* to use   — bulleted "Don't" rules
+11. ## Accessibility       — keyboard, focus, aria, screen-reader behavior
+12. ## API                 — props tables (one ### per component); Storybook deep-link for full ArgTypes
+13. ## CSS Override API    — only if the component exposes scoped vars
+14. ## Related             — cross-links to playground, patterns, sibling components
+```
+
+[Button](/docs/components/button) is the reference implementation. New component pages should match its structure section-by-section.
+
+### Primitive page
+
+For pages under `/docs/primitives/`. The shape:
+
+```text
+1. One-line summary (no heading — opens the page)
+2. <Callout> — the most-broken rule for this primitive (e.g. "never use --text-* on a background")
+3. ## {Group}             — viz block per token group; e.g. Page and surface, Background, Text, Border
+4. ## Status / States     — interaction or status-state tokens if applicable
+5. ## Primitives          — <PaletteGrid>, <SpacingScale>, <BorderRadiusPreview>, etc. — raw scale below the semantic groups
+6. ## Modes               — only if the primitive has Figma "modes" (e.g. spacing has Base/Spacious)
+7. ## Related             — sibling primitive pages
+```
+
+[Color](/docs/primitives/color) and [Spacing](/docs/primitives/spacing) are reference implementations.
+
+### Content-system page
+
+For pages under `/docs/content-system/industries/`, `/voices/`, `/atmospheres/`. The shape:
+
+```text
+1. <MetadataStrip> — Version · Last reviewed · Cadence (required for industry packs and voice patterns)
+2. One-line summary
+3. ## 1. Overview
+4. ## 2. Default affinities (industries) or Tone profile (voices)
+5. ## 3. Pain points or Use cases
+6. ## 4. Seasonality (industries only)
+7. ## 5. Competitive landscape (industries only)
+8. ## 6. Listings requirements (industries only)
+9. ## 7. Regulatory summary (industries only)
+10. ## 8. Vocabulary — Avoid (HTML <table> — needs JSX .map() over pack data)
+11. ## 9. Navigation IA (industries only)
+12. ## 10. Brik Strategic POV (industries only)
+13. ## 11. Site Audit Extractors (industries only — only if the pack defines siteAudit)
+14. ## Related
+```
+
+[Industries → Dental](/docs/content-system/industries/dental) is the reference. Numbering the sections is intentional — it lets section-2 tables of contents read as a checklist.
+
+## Building blocks
+
+Components registered in `lib/mdx-components.tsx` are available in any `.mdx` without an explicit import.
+
+### Universal blocks
+
+- **`<ComponentPreview code={...}>`** — live render + Code tab + copy. Pass JSX as children, the source string as `code`.
+- **`<EmphasisLadder caption rungs={[...]}>`** — ordered variant ladder, top = strongest. Each rung is `{ label, example, use }`.
+- **`<ComparisonGrid items={[...]}>`** — three-column "X vs Y vs Z" decision grid. Each item is `{ title, preview, whenToUse, whenNotToUse?, code? }`.
+- **`<ComponentAnatomy parts={[...]}>`** — preview left, numbered parts right. Each part is `{ number, name, description, required? }`. Children render as the live preview.
+- **`<MetadataStrip items={[...]}>`** — page-header label/value strip. Each item is `{ label, value }`.
+
+### Foundation viz blocks
+
+Used on primitive pages.
+
+- **`<ColorGrid colors={[...]} columns={N}>`** — live click-to-copy swatches.
+- **`<PaletteGrid title palette prefix columns>`** — static hex swatches for primitive scales.
+- **`<SpacingScale title scale prefix>`** / **`<SemanticSpacing title tokens varPrefix>`**
+- **`<TypographyScale title scale prefix>`** / **`<FontFamilyShowcase families={[...]}>`** / **`<SemanticTypographyTable title tokens={[...]}>`** / **`<FontWeightShowcase weights={...}>`**
+- **`<BorderRadiusPreview title scale prefix>`** / **`<BorderWidthPreview title scale prefix>`** / **`<ShadowScale title scale prefix label>`**
+
+### Live BDS components
+
+Imported globally as a namespace.
+
+```mdx
+<ComponentPreview code={`<BDS.Button variant="primary">Save</BDS.Button>`}>
+  <BDS.Button variant="primary">Save</BDS.Button>
+</ComponentPreview>
+```
+
+Always namespaced as `BDS.*` to avoid collisions with HTML primitives like `<Card>`, `<Tabs>`, `<Switch>`.
+
+### Fumadocs primitives
+
+Imported per page as needed.
+
+```tsx
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+import { Cards, Card } from 'fumadocs-ui/components/card';
+```
+
+## Conventions
+
+### Code blocks
+
+Always tag the language. Use the canonical tag for the content type — `tsx` for TypeScript JSX, `ts` for plain TypeScript, `css` for CSS, `bash` for shell, `text` for plain text or ASCII art, `json` for JSON, `yaml` for YAML.
+
+````md
+```tsx
+<Button variant="primary">Save</Button>
+```
+````
+
+Never use unlabelled fences (\`\`\` alone) — they break syntax highlighting and can break the rehype pipeline.
+
+### Callouts
+
+Three types only.
+
+```mdx
+<Callout type="info">For principles, framing, context.</Callout>
+<Callout type="warn">For "don'ts" — cascade violations, scope creep, broken patterns.</Callout>
+<Callout type="error">For "this will break production" — security, data loss, accessibility lawsuits.</Callout>
+```
+
+Don't introduce other types. Don't nest callouts. Don't put more than 2-3 sentences inside one — if the callout grows, it should be a paragraph or its own section.
+
+### Tables
+
+Use markdown tables for static reference data:
+
+```md
+| Token | CSS Variable | Default |
+|---|---|---|
+| Small | `--shadow-sm` | `0px 2px 4px rgba(0,0,0,0.06)` |
+```
+
+Use HTML `<table>` only when you need JSX `.map()` over runtime data:
+
+```mdx
+<table>
+  <thead><tr><th>Term</th><th>Why</th></tr></thead>
+  <tbody>
+    {dental.vocabulary.avoid.map((v, i) => (
+      <tr key={i}><td><strong>{v.term}</strong></td><td>{v.reason}</td></tr>
+    ))}
+  </tbody>
+</table>
+```
+
+JSX expressions inside markdown table syntax don't get re-parsed at runtime — `{x.map(() => '\| col \|').join('\\n')}` renders as literal text, not a table.
+
+### Headings
+
+H1 is the page title (driven by frontmatter — never write `# ` in the body). H2 for sections, H3 for sub-sections. Don't go below H4.
+
+### Internal links
+
+Always absolute paths starting with `/docs/`. Never relative paths.
+
+```md
+✓  [Cascade rules](/docs/getting-started/cascade)
+✗  [Cascade rules](../getting-started/cascade)
+```
+
+### External links to Storybook
+
+Always full URLs, never short paths. They survive Fumadocs path renames.
+
+```md
+✓  [Storybook → Button](https://storybook.brikdesigns.com/?path=/docs/components-action-button--overview)
+✗  Some shortened or relative path
+```
+
+### Tabs (for multi-step or platform-specific content)
+
+Always blank lines around code blocks inside `<Tab>` — MDX needs the whitespace to parse correctly. (When showing nested code fences in your own page, wrap the outer fence in **four** backticks; otherwise the inner three-backtick fence closes the outer prematurely.)
+
+````mdx
+<Tabs items={['npm', 'pnpm', 'bun']}>
+
+<Tab value="npm">
+
+```bash
+npm install @brikdesigns/bds
+```
+
+</Tab>
+
+<Tab value="pnpm">
+
+```bash
+pnpm add @brikdesigns/bds
+```
+
+</Tab>
+
+</Tabs>
+````
+
+## How this site relates to Storybook
+
+| Surface | Job |
+|---|---|
+| **This site** | When-to-use, anatomy, do/don't, accessibility, design rationale |
+| **Storybook** | Live prop exploration, every visual variant, copy-paste code |
+
+If a page would be 80% prop tables with one prose paragraph at the top, it belongs in Storybook only — link out, don't migrate. If a page would be 80% prose with one code snippet, it belongs here.
+
+## Adding a new page
+
+1. Pick the template (component, primitive, content-system).
+2. Drop a new `.mdx` file in the right folder under `content/docs/`.
+3. Add the slug to the parent folder's `meta.json` `pages` array.
+4. Run `npm run build` from `docs-site/` to verify it compiles.
+5. Reload the dev server (Turbopack picks up new files automatically).
+
+The page renders at `/docs/{folder}/{slug}` once the meta.json knows about it.

--- a/docs-site/content/docs/getting-started/cascade.mdx
+++ b/docs-site/content/docs/getting-started/cascade.mdx
@@ -1,0 +1,41 @@
+---
+title: The Cascade
+description: How BDS tokens layer from Figma foundations to client themes.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+BDS uses a three-layer cascade. Each layer is a single CSS file imported in order.
+
+## The three layers
+
+1. **Foundations** (`figma-tokens.css`) — auto-generated from Figma variables. Never hand-edit.
+2. **Gap-fills** (`gap-fills.css`) — interaction-state tokens (hover, pressed) that haven't graduated to Figma yet.
+3. **Client theme** (`theme-{client}.css`) — per-project overrides for brand color, typography, atmosphere.
+
+<Callout type="warn">
+  **Never write raw `var()` strings inline.** Always go through `@/lib/tokens` and `@/lib/styles`. The cascade is a contract — bypassing it leaks brand drift into components.
+</Callout>
+
+## Why this order
+
+Foundations define the full token vocabulary. Gap-fills add what Figma can't yet express. Client themes override semantic tokens (e.g. `--text-brand`) without touching the underlying scales (`--color-orange-500`). A component that reads `--text-brand` automatically picks up whichever client is active.
+
+## What each layer can change
+
+| Layer | Can override |
+|---|---|
+| Foundations | Nothing — it's the source |
+| Gap-fills | Interaction states only |
+| Client theme | Semantic tokens (text, background, border, brand) |
+| Atmospheres | Mood layer (warm-soft, editorial-luxury, etc.) — applied as a class |
+
+## Where this is enforced
+
+The `lint-tokens` script (`npm run lint-tokens`) catches:
+
+- Hex values in component CSS
+- `var()` references to tokens that don't exist
+- Tokens used outside their semantic category (e.g. `--text-*` on a `background-color`)
+
+Run it locally before pushing; CI runs it on every PR.

--- a/docs-site/content/docs/getting-started/framework-guides.mdx
+++ b/docs-site/content/docs/getting-started/framework-guides.mdx
@@ -1,0 +1,28 @@
+---
+title: Framework Guides
+description: Adopting BDS in Next.js, Astro, and Webflow consumers.
+---
+
+Per-framework setup notes. Pick yours.
+
+## Next.js (App Router)
+
+The recommended consumer pattern. See `brik-client-portal` and `renew-pms` for reference implementations.
+
+- Token cascade goes in `app/globals.css`.
+- Fonts load via `next/font` — BDS doesn't ship fonts.
+- Components are imported from `@brikdesigns/bds` directly; no client wrapper required.
+
+## Astro
+
+The marketing-site pattern. See `brikdesigns.com` and exported `web/_newclient` template.
+
+- Token cascade in the global stylesheet.
+- BDS ships **Astro blueprints** at `@brikdesigns/bds/blueprints-astro` for hero, footer, contact form, and other page sections that are slow to recompose by hand.
+- Use `@brikdesigns/bds/atmospheres/{name}.css` to apply a mood layer to a page.
+
+## Webflow (legacy clients)
+
+For clients still on Webflow. Token names match the design system — `--text-primary`, `--background-brand-primary`, etc. — so guidance from this site applies.
+
+The Webflow CSS layer is partially synced from BDS via the Designer Bridge but is not the source of truth. Token-rename migrations are tracked in the BDS rename log.

--- a/docs-site/content/docs/getting-started/index.mdx
+++ b/docs-site/content/docs/getting-started/index.mdx
@@ -1,0 +1,23 @@
+---
+title: Introduction
+description: How BDS is organized and what to expect from this site.
+---
+
+BDS ships three things on a single npm package: **tokens** (design language), **components** (React building blocks), and **content vocabulary** (industries, voices, atmospheres — the BCS layer).
+
+Consumers import from `@brikdesigns/bds`. There is no submodule, no copy-paste — components and tokens stay in lockstep across products.
+
+## How this site is organized
+
+- **Foundations** — the rules everything else inherits from. Tokens, typography, spacing, motion.
+- **Building** — patterns for composing pages, components for the building blocks, hooks for behavior, utilities for one-offs.
+- **Working with BDS** — contribution rules, release flow, deprecation policy.
+
+## How this site relates to Storybook
+
+| Surface | Job |
+|---|---|
+| **This site** | When-to-use, anatomy, do/don't, accessibility, design rationale |
+| **Storybook** | Live prop exploration, every visual variant, copy-paste code |
+
+If you can answer your question with "what does this look like with `size=lg`," go to Storybook. If you're asking "should I use Button or LinkButton here," stay here.

--- a/docs-site/content/docs/getting-started/installation.mdx
+++ b/docs-site/content/docs/getting-started/installation.mdx
@@ -1,0 +1,64 @@
+---
+title: Installation
+description: Add BDS to a Next.js, Astro, or Webflow consumer.
+---
+
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+
+## Install the package
+
+<Tabs items={['npm', 'pnpm', 'bun']}>
+
+<Tab value="npm">
+
+```bash
+npm install @brikdesigns/bds
+```
+
+</Tab>
+
+<Tab value="pnpm">
+
+```bash
+pnpm add @brikdesigns/bds
+```
+
+</Tab>
+
+<Tab value="bun">
+
+```bash
+bun add @brikdesigns/bds
+```
+
+</Tab>
+
+</Tabs>
+
+## Wire the token cascade
+
+In your global stylesheet (`globals.css`, `app.css`, etc.) import in this order:
+
+```css
+@import '@brikdesigns/bds/tokens.css';
+@import './styles/theme-{client}.css'; /* your client's theme overrides */
+@import '@brikdesigns/bds/styles.css';
+```
+
+Order matters. Foundation tokens load first, the client theme overrides semantic tokens, component CSS reads whatever is current.
+
+## Import a component
+
+```tsx
+import { Button } from '@brikdesigns/bds';
+
+export function Example() {
+  return <Button variant="primary">Save</Button>;
+}
+```
+
+That's it. No provider required for components — they read tokens from the cascade above.
+
+## Next: read the cascade rules
+
+The [cascade rules page](/docs/getting-started/cascade) explains the three-layer architecture (foundations → gap-fills → client theme) and why it exists.

--- a/docs-site/content/docs/getting-started/meta.json
+++ b/docs-site/content/docs/getting-started/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Getting Started",
+  "pages": ["index", "installation", "cascade", "framework-guides"]
+}

--- a/docs-site/content/docs/hooks/index.mdx
+++ b/docs-site/content/docs/hooks/index.mdx
@@ -1,0 +1,6 @@
+---
+title: Hooks
+description: React hooks shipped with BDS for behavior reuse.
+---
+
+> Placeholder. BDS currently exposes a small set of behavior hooks (focus management, popover positioning via Radix, theme detection). Pages here will document each.

--- a/docs-site/content/docs/hooks/meta.json
+++ b/docs-site/content/docs/hooks/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Hooks",
+  "pages": ["index"]
+}

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -1,15 +1,121 @@
 ---
-title: Overview
-description: A guidance layer for the Brik Design System — foundations, components, and patterns.
+title: Brik Design System
+description: Four tenets in one repository, published as a single versioned package.
 ---
 
-The Brik Design System is the source of truth for everything visual and structural across Brik products and client sites: tokens, components, patterns, motion, and content vocabulary.
+import { Cards, Card } from 'fumadocs-ui/components/card';
+import { Callout } from 'fumadocs-ui/components/callout';
 
-This site is the **guidance layer**. It explains *when* and *why* to use what BDS gives you. For live prop exploration and visual variants, use [Storybook](https://storybook.brikdesigns.com).
+BDS is four tenets in one repository, shipped as a single versioned package. Each tenet is an independent vocabulary the portal, mockup generators, and client sites consume to ship work that looks and reads like Brik without anyone having to re-decide the basics every project.
+
+This site is the **guidance layer**. For live prop exploration and visual variants, [Storybook](https://storybook.brikdesigns.com) stays the playground.
+
+## The four tenets
+
+| Tenet | Answers | Ships |
+|---|---|---|
+| [**Foundation**](/docs/primitives) | *"What color, size, type?"* | Design tokens, scales, primitives |
+| [**Theming**](/docs/getting-started/cascade) | *"What brand, mood, shape?"* | Tokens + atmospheres + navigation archetypes + blueprints |
+| [**Motion**](/docs/primitives/motion) | *"How does it feel to move?"* | Three-tier animation system — CSS reveals → GSAP scroll → premium effects |
+| [**Content**](/docs/content-system) | *"What does it say, for whom?"* | Industry packs, voice patterns, locked vocabularies |
+
+Each tenet evolves on its own cadence but cross-links at the edges. An industry pack declares a default atmosphere and navigation archetype, so the Content tenet drives defaults for the Theming tenet that the client brand then optionally overrides.
 
 ## Where to start
 
-- **New to BDS?** Read [Getting Started](/docs/getting-started) for installation and the cascade.
-- **Designing a page?** Browse [Patterns](/docs/patterns) for forms, empty states, and page templates.
-- **Building a component?** Check [Components](/docs/components) for usage rules, anatomy, and accessibility.
-- **Defining a theme?** See [Primitives](/docs/primitives) for tokens and the Figma sync pipeline.
+<Cards>
+  <Card title="Getting Started" href="/docs/getting-started" description="Install BDS, wire the cascade, and read the rules." />
+  <Card title="Primitives" href="/docs/primitives" description="Tokens — color, type, spacing, motion, the design language." />
+  <Card title="Components" href="/docs/components" description="React building blocks. One job each, composable, themeable." />
+  <Card title="Patterns" href="/docs/patterns" description="Cross-component recipes for forms, empty states, page templates." />
+  <Card title="Content System" href="/docs/content-system" description="Industries, voices, atmospheres — the vocabulary peer to tokens." />
+  <Card title="Contribution" href="/docs/contribution" description="How to add or change BDS components, tokens, and packs." />
+</Cards>
+
+## Foundation — the visual atoms
+
+Design tokens are the atomic visual decisions that power BDS. Every component references tokens — never raw values.
+
+| Category | Page |
+|---|---|
+| Color | [Primitives → Color](/docs/primitives/color) |
+| Typography | [Primitives → Typography](/docs/primitives/typography) |
+| Spacing | [Primitives → Spacing](/docs/primitives/spacing) |
+| Motion | [Primitives → Motion](/docs/primitives/motion) |
+
+Border radius, border width, shadow, and size scales are documented in Storybook today and migrate here next.
+
+## Theming — the multi-tenant instrument
+
+Theming composes four orthogonal layers. Each is a decision a client can override independently of the rest.
+
+| Layer | Decides | Where it lives |
+|---|---|---|
+| Tokens | Color, type, spacing values per brand | `theme-{client}.css` in the consumer repo |
+| Atmospheres | Ambient mood — grain, glow, vignettes | [`@brikdesigns/bds/atmospheres/{slug}.css`](/docs/content-system/atmospheres) |
+| Navigation Archetypes | Site-header shape + scroll/drawer behavior | Industry pack → BDS `<SiteHeader>` |
+| Blueprints | Section composition + mood tagging | Authored in BDS, tagged per industry + mood |
+
+## Motion — the three-tier system
+
+| Tier | Use for |
+|---|---|
+| **Lightweight** | Reveals, hovers, transitions — pure CSS, no JS |
+| **GSAP** | Scroll-driven sequences, complex orchestration |
+| **Premium** | Cinematic moments — typography flourishes, video overlays |
+
+See [Primitives → Motion](/docs/primitives/motion) for the decision tree and per-tier specs.
+
+## Content — the vocabulary peer
+
+The content-vocabulary peer to the visual tokens. Paired with BDS to drive end-to-end mockup generation and structured strategy documents.
+
+| Category | Page |
+|---|---|
+| Overview | [Content System](/docs/content-system) |
+| Industries | [Content System → Industries](/docs/content-system/industries) |
+| Voices | [Content System → Voices](/docs/content-system/voices) |
+| Atmospheres | [Content System → Atmospheres](/docs/content-system/atmospheres) |
+
+## Components
+
+| Group | Components |
+|---|---|
+| **Action** | Button, IconButton, LinkButton, ButtonGroup, FilterBar |
+| **Form** | Field, TextInput, Select, MultiSelect, DatePicker, Form, FieldGrid |
+| **Indicator** | Badge, Chip, Tag, Counter, Spinner, Skeleton |
+| **Feedback** | AlertBanner, Toast, Tooltip, EmptyState, ProgressBar |
+| **Control** | Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader |
+| **Addable** | AddableTagList, AddableEntryList, AddableFieldRowList |
+| **Structure** | Card, Divider, Accordion |
+
+See [Components](/docs/components) for the full index.
+
+## Token system — the naming contract
+
+Components use CSS custom properties from the Style Dictionary token pipeline:
+
+```text
+--[category]-[type]-[variant]
+```
+
+**Primitives** — raw scale values, never used directly in components:
+
+```css
+--space-400;             /* 16px */
+--font-size-700;         /* 32px */
+--color-grayscale-darkest; /* #333 */
+```
+
+**Semantic** — purpose-bound aliases, always use these in components:
+
+```css
+--background-brand-primary; /* brand background color */
+--font-family-heading;      /* heading font family */
+--padding-lg;               /* large spacing value */
+--border-radius-md;         /* button/card corner radius */
+```
+
+<Callout type="warn">
+  **Never write raw `var()` strings inline in app code.** Import from `@/lib/tokens` and `@/lib/styles` in consumer projects. The cascade is a contract — bypassing it leaks brand drift into components.
+</Callout>

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Overview
+description: A guidance layer for the Brik Design System — foundations, components, and patterns.
+---
+
+The Brik Design System is the source of truth for everything visual and structural across Brik products and client sites: tokens, components, patterns, motion, and content vocabulary.
+
+This site is the **guidance layer**. It explains *when* and *why* to use what BDS gives you. For live prop exploration and visual variants, use [Storybook](https://storybook.brikdesigns.com).
+
+## Where to start
+
+- **New to BDS?** Read [Getting Started](/docs/getting-started) for installation and the cascade.
+- **Designing a page?** Browse [Patterns](/docs/patterns) for forms, empty states, and page templates.
+- **Building a component?** Check [Components](/docs/components) for usage rules, anatomy, and accessibility.
+- **Defining a theme?** See [Primitives](/docs/primitives) for tokens and the Figma sync pipeline.

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -1,0 +1,16 @@
+{
+  "title": "Brik Design System",
+  "pages": [
+    "index",
+    "---Foundations---",
+    "getting-started",
+    "primitives",
+    "---Building---",
+    "patterns",
+    "components",
+    "hooks",
+    "utilities",
+    "---Working with BDS---",
+    "contribution"
+  ]
+}

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -10,6 +10,8 @@
     "components",
     "hooks",
     "utilities",
+    "---Content System---",
+    "content-system",
     "---Working with BDS---",
     "contribution"
   ]

--- a/docs-site/content/docs/patterns/index.mdx
+++ b/docs-site/content/docs/patterns/index.mdx
@@ -1,0 +1,16 @@
+---
+title: Patterns
+description: Cross-component recipes — how multiple BDS pieces compose into common product moments.
+---
+
+Patterns answer the question "I'm building X, what does BDS recommend?" Each pattern is a reusable composition with a recommended structure, the components it uses, and notes on accessibility and edge cases.
+
+## Planned patterns
+
+- **Forms** — single-column, multi-step wizard, inline edit, sheet-driven edit
+- **Empty states** — no data, error, permission denied, search no-results
+- **Page templates** — dashboard shell, settings page, list-detail, two-pane editor
+- **Navigation** — primary nav, sidebar, breadcrumbs, pagination
+- **Notifications** — toast, banner, inline alert, modal confirmation
+
+> Patterns are the next major content fill-in. Most are documented partially in `stories/foundation/theming/Blueprints.mdx` and the Recipes section of Storybook — both should consolidate here.

--- a/docs-site/content/docs/patterns/meta.json
+++ b/docs-site/content/docs/patterns/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Patterns",
+  "pages": ["index"]
+}

--- a/docs-site/content/docs/primitives/border-radius.mdx
+++ b/docs-site/content/docs/primitives/border-radius.mdx
@@ -1,0 +1,38 @@
+---
+title: Border radius
+description: Corner-rounding tokens — from sharp (0px) to pill (999px) to fully circular.
+---
+
+import { borderRadiusScale } from '@bds-tokens';
+
+Border radius tokens control corner rounding across components. The system supports modes from sharp (0px) to pill (999px), with `circle` reserved for fully circular elements (avatars, dots).
+
+## Radius scale (primitives)
+
+<BorderRadiusPreview scale={borderRadiusScale} prefix="--border-radius" />
+
+## Semantic radius tokens
+
+| Token | CSS Variable | Description |
+|---|---|---|
+| None | `--border-radius-none` | No rounding (0px) |
+| Small | `--border-radius-sm` | Subtle rounding |
+| Medium | `--border-radius-md` | Default component radius |
+| Large | `--border-radius-lg` | Prominent rounding |
+| Pill | `--border-radius-pill` | Maximum rounding (999px) |
+
+## Radius modes
+
+Figma uses border-radius modes to drive the overall shape feel of a theme.
+
+| Mode | Effect | Use case |
+|---|---|---|
+| Sharp | All radii near 0 | Corporate, minimal |
+| Soft | Moderate radii | Default, balanced |
+| Round | Generous radii | Friendly, modern |
+| Pill | Maximum radii (999px) | Buttons, tags |
+
+## Related
+
+- [Border width](/docs/primitives/border-width) — pairs with radius for component framing
+- [Shadow](/docs/primitives/shadow) — elevation that complements radius choices

--- a/docs-site/content/docs/primitives/border-width.mdx
+++ b/docs-site/content/docs/primitives/border-width.mdx
@@ -1,0 +1,36 @@
+---
+title: Border width
+description: Line thickness for borders, dividers, and outlines.
+---
+
+import { borderWidthScale } from '@bds-tokens';
+
+Border width tokens control line thickness for borders, dividers, and outlines.
+
+## Width scale (primitives)
+
+<BorderWidthPreview scale={borderWidthScale} prefix="--border-width" />
+
+## Semantic width tokens
+
+| Token | CSS Variable | Description |
+|---|---|---|
+| None | `--border-width-none` | No border (0px) |
+| Small | `--border-width-sm` | Subtle hairline |
+| Medium | `--border-width-md` | Default visible border |
+| Large | `--border-width-lg` | Prominent border (1px) |
+
+## Width modes
+
+Figma uses border-width modes for overall border density at a theme level.
+
+| Mode | Effect |
+|---|---|
+| Thin | Minimal borders |
+| Default | Standard borders |
+| Thick | Prominent borders |
+
+## Related
+
+- [Border radius](/docs/primitives/border-radius) — pairs with width for component framing
+- [Color → Border tokens](/docs/primitives/color#border) — semantic border-color tokens

--- a/docs-site/content/docs/primitives/color.mdx
+++ b/docs-site/content/docs/primitives/color.mdx
@@ -1,0 +1,12 @@
+---
+title: Color
+description: Semantic and brand color tokens.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+> Stub page — content to migrate from `stories/foundation/Color.mdx` in the BDS repo. The custom `<PaletteGrid>` and `<ColorGrid>` Storybook components should be ported as MDX components for this page.
+
+<Callout>
+  Until this page is filled, view live tokens at [Storybook → Foundations → Color](https://storybook.brikdesigns.com/?path=/docs/foundation-color--docs).
+</Callout>

--- a/docs-site/content/docs/primitives/color.mdx
+++ b/docs-site/content/docs/primitives/color.mdx
@@ -1,12 +1,164 @@
 ---
 title: Color
-description: Semantic and brand color tokens.
+description: Semantic color tokens, interaction states, status colors, and the primitive palettes they reference.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { grayscale, poppy, tan, orange, yellow, green, blue, purple, pink } from '@bds-tokens';
 
-> Stub page — content to migrate from `stories/foundation/Color.mdx` in the BDS repo. The custom `<PaletteGrid>` and `<ColorGrid>` Storybook components should be ported as MDX components for this page.
+Color tokens define the visual identity across all BDS themes. The system separates **primitive color scales** (raw hex values) from **semantic color roles** (purpose-bound aliases). Components reference the semantic roles only.
 
-<Callout>
-  Until this page is filled, view live tokens at [Storybook → Foundations → Color](https://storybook.brikdesigns.com/?path=/docs/foundation-color--docs).
+<Callout type="warn">
+  **Never use a token outside its semantic category.** `--text-*` is for text. `--background-*` is for backgrounds. `--border-*` is for borders. No `--text-primary` on a `background-color`. The cascade is a contract — bypassing it leaks brand drift everywhere it isn't caught.
 </Callout>
+
+Click any swatch to copy `var(--token-name)` to your clipboard.
+
+## Page and surface
+
+<ColorGrid
+  colors={[
+    { name: 'page-primary', cssVar: '--page-primary' },
+    { name: 'page-secondary', cssVar: '--page-secondary' },
+    { name: 'page-brand-primary', cssVar: '--page-brand-primary' },
+    { name: 'surface-primary', cssVar: '--surface-primary' },
+    { name: 'surface-secondary', cssVar: '--surface-secondary' },
+    { name: 'surface-muted', cssVar: '--surface-muted' },
+    { name: 'surface-brand-primary', cssVar: '--surface-brand-primary' },
+  ]}
+  columns={4}
+/>
+
+## Background
+
+<ColorGrid
+  colors={[
+    { name: 'background-brand-primary', cssVar: '--background-brand-primary' },
+    { name: 'background-brand-secondary', cssVar: '--background-brand-secondary' },
+    { name: 'background-primary', cssVar: '--background-primary' },
+    { name: 'background-secondary', cssVar: '--background-secondary' },
+    { name: 'background-inverse', cssVar: '--background-inverse' },
+    { name: 'background-input', cssVar: '--background-input' },
+    { name: 'background-muted', cssVar: '--background-muted' },
+  ]}
+  columns={4}
+/>
+
+## Text
+
+<ColorGrid
+  colors={[
+    { name: 'text-primary', cssVar: '--text-primary', isText: true },
+    { name: 'text-secondary', cssVar: '--text-secondary', isText: true },
+    { name: 'text-muted', cssVar: '--text-muted', isText: true },
+    { name: 'text-brand-primary', cssVar: '--text-brand-primary', isText: true },
+    { name: 'text-inverse', cssVar: '--text-inverse', isText: true },
+    { name: 'text-on-color-dark', cssVar: '--text-on-color-dark', isText: true },
+    { name: 'text-on-color-light', cssVar: '--text-on-color-light', isText: true },
+  ]}
+  columns={4}
+/>
+
+## Border
+
+<ColorGrid
+  colors={[
+    { name: 'border-primary', cssVar: '--border-primary' },
+    { name: 'border-secondary', cssVar: '--border-secondary' },
+    { name: 'border-muted', cssVar: '--border-muted' },
+    { name: 'border-brand-primary', cssVar: '--border-brand-primary' },
+    { name: 'border-input', cssVar: '--border-input' },
+    { name: 'border-inverse', cssVar: '--border-inverse' },
+  ]}
+  columns={3}
+/>
+
+## Interaction states
+
+Hover, press, and disabled. These replace `filter: brightness()` and `opacity` hacks — the proper tokens compose with the rest of the cascade.
+
+<ColorGrid
+  colors={[
+    { name: 'background-brand-primary-hover', cssVar: '--background-brand-primary-hover' },
+    { name: 'background-brand-primary-pressed', cssVar: '--background-brand-primary-pressed' },
+    { name: 'background-primary-hover', cssVar: '--background-primary-hover' },
+    { name: 'background-primary-pressed', cssVar: '--background-primary-pressed' },
+    { name: 'background-secondary-hover', cssVar: '--background-secondary-hover' },
+    { name: 'background-secondary-pressed', cssVar: '--background-secondary-pressed' },
+    { name: 'background-disabled', cssVar: '--background-disabled' },
+    { name: 'text-disabled', cssVar: '--text-disabled', isText: true },
+    { name: 'border-disabled', cssVar: '--border-disabled' },
+  ]}
+  columns={3}
+/>
+
+## Status
+
+Canonical Figma tokens for positive, negative, and warning states. Background variants are saturated; surface variants are subtle tints.
+
+<ColorGrid
+  colors={[
+    { name: 'background-positive', cssVar: '--background-positive' },
+    { name: 'background-negative', cssVar: '--background-negative' },
+    { name: 'background-warning', cssVar: '--background-warning' },
+    { name: 'surface-positive', cssVar: '--surface-positive' },
+    { name: 'surface-negative', cssVar: '--surface-negative' },
+    { name: 'surface-warning', cssVar: '--surface-warning' },
+    { name: 'text-positive', cssVar: '--text-positive', isText: true },
+    { name: 'text-negative', cssVar: '--text-negative', isText: true },
+    { name: 'text-warning', cssVar: '--text-warning', isText: true },
+    { name: 'border-positive', cssVar: '--border-positive' },
+    { name: 'border-negative', cssVar: '--border-negative' },
+    { name: 'border-warning', cssVar: '--border-warning' },
+  ]}
+  columns={3}
+/>
+
+**Extended status (gap-fills)** — additional status tokens not yet in Figma.
+
+<ColorGrid
+  colors={[
+    { name: 'background-status-info', cssVar: '--background-status-info' },
+    { name: 'background-status-info-subtle', cssVar: '--background-status-info-subtle' },
+    { name: 'background-status-neutral', cssVar: '--background-status-neutral' },
+    { name: 'background-status-purple', cssVar: '--background-status-purple' },
+    { name: 'background-status-orange', cssVar: '--background-status-orange' },
+    { name: 'text-status-info', cssVar: '--text-status-info', isText: true },
+    { name: 'surface-status-info', cssVar: '--surface-status-info' },
+  ]}
+  columns={4}
+/>
+
+## Presence
+
+Online/offline indicator tokens used by Avatar and Dot components.
+
+<ColorGrid
+  colors={[
+    { name: 'presence-online', cssVar: '--background-presence-online' },
+    { name: 'presence-away', cssVar: '--background-presence-away' },
+    { name: 'presence-busy', cssVar: '--background-presence-busy' },
+    { name: 'presence-offline', cssVar: '--background-presence-offline' },
+  ]}
+  columns={4}
+/>
+
+## Primitives
+
+Raw color scales from the Figma Brand Kit. **Components reference these via semantic tokens — never directly.** The primitives change rarely; the semantic mappings change per theme.
+
+<PaletteGrid title="Grayscale" palette={grayscale} prefix="--color-grayscale" columns={8} />
+<PaletteGrid title="Poppy (brand primary)" palette={poppy} prefix="--color-poppy" columns={6} />
+<PaletteGrid title="Tan" palette={tan} prefix="--color-tan" columns={6} />
+<PaletteGrid title="Orange" palette={orange} prefix="--color-orange" columns={6} />
+<PaletteGrid title="Yellow" palette={yellow} prefix="--color-yellow" columns={6} />
+<PaletteGrid title="Green" palette={green} prefix="--color-green" columns={6} />
+<PaletteGrid title="Blue" palette={blue} prefix="--color-blue" columns={6} />
+<PaletteGrid title="Purple" palette={purple} prefix="--color-purple" columns={6} />
+<PaletteGrid title="Pink" palette={pink} prefix="--color-pink" columns={6} />
+
+## Related
+
+- [Cascade rules](/docs/getting-started/cascade) — the three-layer architecture every consumer follows
+- [Atmospheres](/docs/content-system/atmospheres) — the mood overlay layer that sits on top of theme tokens
+- [Storybook → Color contrast compliance](https://storybook.brikdesigns.com/?path=/docs/overview-health-contrast-compliance--docs)

--- a/docs-site/content/docs/primitives/index.mdx
+++ b/docs-site/content/docs/primitives/index.mdx
@@ -14,12 +14,16 @@ Each page below explains one primitive group: what tokens exist, what they mean 
   **Token source of truth lives in Figma.** This site documents what's available and how to use it. To add a new token, edit Figma first — don't add it to CSS directly.
 </Callout>
 
-## Documented here
+## Foundations
 
 <Cards>
   <Card title="Color" href="/docs/primitives/color" description="Semantic color roles + interaction states + status + the primitive palettes." />
   <Card title="Typography" href="/docs/primitives/typography" description="Font families, the type scale, weights, line heights, and the semantic role rule." />
   <Card title="Spacing" href="/docs/primitives/spacing" description="The 4-point grid, semantic padding and gap tokens, the primitive space scale." />
+  <Card title="Size" href="/docs/primitives/size" description="Container sizes, breakpoints, hero constraints, and the element-size scale." />
+  <Card title="Border radius" href="/docs/primitives/border-radius" description="Corner rounding from sharp (0) to pill (999) to fully circular." />
+  <Card title="Border width" href="/docs/primitives/border-width" description="Line thickness for borders, dividers, and outlines." />
+  <Card title="Shadow" href="/docs/primitives/shadow" description="Elevation tokens — composed semantic shadows + primitive blur/spread scales." />
   <Card title="Motion" href="/docs/primitives/motion" description="Duration, easing, keyframes, and the three-tier motion system." />
 </Cards>
 
@@ -27,13 +31,11 @@ Each page below explains one primitive group: what tokens exist, what they mean 
 
 These foundation pages haven't been migrated yet. Until they land here, view them in Storybook and treat the contents as canonical.
 
-| Token group | Where |
+| Page | Where |
 |---|---|
-| Border radius | [Storybook → Border Radius](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-border-radius--docs) |
-| Border width | [Storybook → Border Width](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-border-width--docs) |
-| Shadow | [Storybook → Shadow](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-shadow--docs) |
-| Size | [Storybook → Size](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-size--docs) |
-| Naming conventions | [Storybook → Naming Conventions](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-naming-conventions--docs) |
+| Motion (full) | [Storybook → Motion](https://storybook.brikdesigns.com/?path=/docs/motion-overview--docs) — overview, tiers, effects, vocabulary |
+| Naming Conventions | [Storybook → Naming Conventions](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-naming-conventions--docs) |
+| Design Tokens overview | [Storybook → Design Tokens](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-overview--docs) |
 
 ## How tokens flow into your app
 

--- a/docs-site/content/docs/primitives/index.mdx
+++ b/docs-site/content/docs/primitives/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Primitives
+description: Tokens — the design language every BDS component reads from.
+---
+
+BDS primitives are a flat token vocabulary covering color, typography, spacing, motion, radius, shadow, and border. They're authored in Figma, exported via Tokens Studio, transformed by Style Dictionary, and shipped as `@brikdesigns/bds/tokens.css`.
+
+Pages in this section explain each primitive group: what tokens exist, what they mean semantically, and the rules for using them outside their category (don't).
+
+> **Token source of truth lives in Figma.** This site documents what's available and how to use it. To add a new token, edit Figma first.

--- a/docs-site/content/docs/primitives/index.mdx
+++ b/docs-site/content/docs/primitives/index.mdx
@@ -3,8 +3,55 @@ title: Primitives
 description: Tokens — the design language every BDS component reads from.
 ---
 
+import { Cards, Card } from 'fumadocs-ui/components/card';
+import { Callout } from 'fumadocs-ui/components/callout';
+
 BDS primitives are a flat token vocabulary covering color, typography, spacing, motion, radius, shadow, and border. They're authored in Figma, exported via Tokens Studio, transformed by Style Dictionary, and shipped as `@brikdesigns/bds/tokens.css`.
 
-Pages in this section explain each primitive group: what tokens exist, what they mean semantically, and the rules for using them outside their category (don't).
+Each page below explains one primitive group: what tokens exist, what they mean semantically, and the rules for using them outside their category (don't).
 
-> **Token source of truth lives in Figma.** This site documents what's available and how to use it. To add a new token, edit Figma first.
+<Callout type="warn">
+  **Token source of truth lives in Figma.** This site documents what's available and how to use it. To add a new token, edit Figma first — don't add it to CSS directly.
+</Callout>
+
+## Documented here
+
+<Cards>
+  <Card title="Color" href="/docs/primitives/color" description="Semantic color roles + interaction states + status + the primitive palettes." />
+  <Card title="Typography" href="/docs/primitives/typography" description="Font families, the type scale, weights, line heights, and the semantic role rule." />
+  <Card title="Spacing" href="/docs/primitives/spacing" description="The 4-point grid, semantic padding and gap tokens, the primitive space scale." />
+  <Card title="Motion" href="/docs/primitives/motion" description="Duration, easing, keyframes, and the three-tier motion system." />
+</Cards>
+
+## Still in Storybook
+
+These foundation pages haven't been migrated yet. Until they land here, view them in Storybook and treat the contents as canonical.
+
+| Token group | Where |
+|---|---|
+| Border radius | [Storybook → Border Radius](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-border-radius--docs) |
+| Border width | [Storybook → Border Width](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-border-width--docs) |
+| Shadow | [Storybook → Shadow](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-shadow--docs) |
+| Size | [Storybook → Size](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-size--docs) |
+| Naming conventions | [Storybook → Naming Conventions](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-naming-conventions--docs) |
+
+## How tokens flow into your app
+
+```text
+Figma Variables
+      ↓
+design-tokens/tokens-studio.json    (build input)
+      ↓
+Style Dictionary
+      ↓
+tokens/figma-tokens.css             (auto-generated)
+tokens/figma-tokens-dark.css        (auto-generated, dark mode)
+tokens/gap-fills.css                (manual, interaction states)
+      ↓
+Consumer projects:
+  @import '@brikdesigns/bds/tokens.css';
+  @import './styles/theme-{client}.css';
+  @import '@brikdesigns/bds/styles.css';
+```
+
+See [the cascade rules](/docs/getting-started/cascade) for how the three layers interact.

--- a/docs-site/content/docs/primitives/meta.json
+++ b/docs-site/content/docs/primitives/meta.json
@@ -1,4 +1,14 @@
 {
   "title": "Primitives",
-  "pages": ["index", "color", "typography", "spacing", "motion"]
+  "pages": [
+    "index",
+    "color",
+    "typography",
+    "spacing",
+    "size",
+    "border-radius",
+    "border-width",
+    "shadow",
+    "motion"
+  ]
 }

--- a/docs-site/content/docs/primitives/meta.json
+++ b/docs-site/content/docs/primitives/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Primitives",
+  "pages": ["index", "color", "typography", "spacing", "motion"]
+}

--- a/docs-site/content/docs/primitives/motion.mdx
+++ b/docs-site/content/docs/primitives/motion.mdx
@@ -1,0 +1,6 @@
+---
+title: Motion
+description: Duration, easing, keyframes, and the three-tier motion system.
+---
+
+> Stub page — port from `stories/foundation/Motion.mdx` and the `stories/foundation/motion/Tiers/*.mdx` files.

--- a/docs-site/content/docs/primitives/shadow.mdx
+++ b/docs-site/content/docs/primitives/shadow.mdx
@@ -1,0 +1,49 @@
+---
+title: Shadow
+description: Elevation through blur, spread, and composed semantic shadow tokens.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { shadowBlurScale, shadowSpreadScale } from '@bds-tokens';
+
+Shadow tokens define elevation through blur, spread, and offset values. The granular primitives compose into ready-to-use semantic shadows.
+
+<Callout type="warn">
+  **Use composed semantic shadows in component CSS** — `--shadow-sm`, `--shadow-md`, `--shadow-lg`, `--shadow-xl`. Never compose raw blur and spread values yourself; the semantic tokens are tuned together for consistent perceived elevation.
+</Callout>
+
+## Composed shadow tokens
+
+Ready-to-use `box-shadow` values defined in `tokens/gap-fills.css`. These are what components reference.
+
+| Token | CSS Variable | Value | Use case |
+|---|---|---|---|
+| Small | `--shadow-sm` | `0px 2px 4px 0px rgba(0,0,0,0.06)` | Subtle cards, inputs |
+| Medium | `--shadow-md` | `0px 4px 12px 0px rgba(0,0,0,0.12)` | Cards, panels |
+| Large | `--shadow-lg` | `0px 4px 16px 0px rgba(0,0,0,0.12)` | Dropdowns, popovers |
+| Extra large | `--shadow-xl` | `0px 8px 24px 4px rgba(0,0,0,0.20)` | Modals, dialogs |
+
+### Overlay
+
+| Token | CSS Variable | Value |
+|---|---|---|
+| Overlay | `--background-overlay` | `rgba(0, 0, 0, 0.4)` |
+
+Used for modal backdrops and drawer overlays.
+
+## Shadow blur scale (primitives)
+
+Controls the softness/diffusion of shadows.
+
+<ShadowScale scale={shadowBlurScale} prefix="--shadow-blur" label="blur" />
+
+## Shadow spread scale (primitives)
+
+Controls how far a shadow extends outward.
+
+<ShadowScale scale={shadowSpreadScale} prefix="--shadow-spread" label="spread" />
+
+## Related
+
+- [Border radius](/docs/primitives/border-radius) — radius and elevation read together at the component edge
+- [Color tokens](/docs/primitives/color) — surface tokens shadows sit on

--- a/docs-site/content/docs/primitives/size.mdx
+++ b/docs-site/content/docs/primitives/size.mdx
@@ -1,0 +1,65 @@
+---
+title: Size
+description: Dimensional constraints for containers, breakpoints, and elements.
+---
+
+import { sizeScale } from '@bds-tokens';
+
+Size tokens define dimensional constraints — how big things can be, where the layout breaks, what hero heights to clamp.
+
+## Size scale (primitives)
+
+<SpacingScale scale={sizeScale} prefix="--size" />
+
+## Semantic size tokens
+
+### Container sizes
+
+Width constraints for content containers. Pair with `max-width` to bound page-level content.
+
+| Token | CSS Variable | Value |
+|---|---|---|
+| Full width | `--container-size-full-width` | 100% |
+| Three-quarter | `--container-size-three-quarter-width` | 75% |
+| Two-third | `--container-size-two-third-width` | 66% |
+| Half | `--container-size-half-width` | 50% |
+| One-third | `--container-size-one-third-width` | 33% |
+| Quarter | `--container-size-quarter-width` | 25% |
+
+### Screen breakpoints
+
+Used in CSS media queries and responsive container sizing.
+
+| Token | CSS Variable | Value |
+|---|---|---|
+| Wider | `--screen-size-wider` | 1440px |
+| Wide | `--screen-size-wide` | 1280px |
+| Desktop | `--screen-size-desktop` | 1080px |
+| Tablet | `--screen-size-tablet` | 768px |
+| Mobile | `--screen-size-mobile` | 320px |
+
+### Hero constraints
+
+| Token | CSS Variable | Value |
+|---|---|---|
+| Max hero height | `--container-size-max-hero-height` | 100vh |
+| Max hero width | `--container-size-max-hero-width` | 100vw |
+
+### Element sizes
+
+Semantic size tokens follow the same tiny-to-huge scale as spacing — for icons, dots, indicators.
+
+| Token | Value |
+|---|---|
+| `--size-tiny` | 2px |
+| `--size-sm` | 4px |
+| `--size-md` | 8px |
+| `--size-lg` | 16px |
+| `--size-xl` | 24px |
+| `--size-xxl` | 32px |
+| `--size-huge` | 40px |
+
+## Related
+
+- [Spacing tokens](/docs/primitives/spacing) — same numeric primitives used for padding and gap
+- [Typography → Icon sizes](/docs/primitives/typography#icon-sizes) — semantic icon-size tokens

--- a/docs-site/content/docs/primitives/spacing.mdx
+++ b/docs-site/content/docs/primitives/spacing.mdx
@@ -1,12 +1,86 @@
 ---
 title: Spacing
-description: The 4-point grid, scale tokens, and semantic spacing roles.
+description: The 4-point grid, semantic padding and gap tokens, and the primitive scale.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { spaceScale, semanticSpace } from '@bds-tokens';
 
-> Stub page — port from `stories/foundation/Spacing.mdx`.
+Spacing tokens control padding, margins, and gaps. BDS uses two spacing modes — **Base** (compact, used in product apps) and **Spacious** (expanded, used in marketing sites).
 
 <Callout type="warn">
-  All spacing values must be multiples of 4px. The `lint-tokens:grid` script blocks PRs that violate this.
+  **All spacing values must be multiples of 4px.** The 4-point grid is enforced by `npm run lint-tokens:grid`, which blocks PRs that introduce off-grid values. This holds across every consuming project.
 </Callout>
+
+## Semantic padding tokens
+
+Purpose-bound spacing used in components. These values change between Base and Spacious modes.
+
+<SemanticSpacing
+  title="Padding"
+  tokens={{
+    'padding-none': semanticSpace['none'],
+    'padding-tiny': semanticSpace['tiny'],
+    'padding-xs': semanticSpace['xs'],
+    'padding-sm': semanticSpace['sm'],
+    'padding-md': semanticSpace['md'],
+    'padding-lg': semanticSpace['lg'],
+    'padding-xl': semanticSpace['xl'],
+    'padding-huge': semanticSpace['huge'],
+  }}
+  varPrefix="--padding"
+/>
+
+## Semantic gap tokens
+
+Gap tokens for `flex` and `grid` layouts. Typically smaller than the equivalent padding tokens.
+
+<SemanticSpacing
+  title="Gap"
+  tokens={{
+    'gap-none': semanticSpace['gap--none'],
+    'gap-tiny': semanticSpace['gap--tiny'],
+    'gap-xs': semanticSpace['gap--xs'],
+    'gap-sm': semanticSpace['gap--sm'],
+    'gap-md': semanticSpace['gap--md'],
+    'gap-lg': semanticSpace['gap--lg'],
+    'gap-xl': semanticSpace['gap--xl'],
+    'gap-huge': semanticSpace['gap--huge'],
+  }}
+  varPrefix="--gap"
+/>
+
+## Component spacing
+
+Dedicated spacing tokens for specific component types.
+
+| Token | CSS Variable | Maps to |
+|---|---|---|
+| Button | `--padding-button` | `var(--space-200)` |
+| Input | `--padding-input` | `var(--space-200)` |
+
+## Spacing modes
+
+| Token | Base mode | Spacious mode |
+|---|---|---|
+| `--padding-tiny` | 8px | 24px |
+| `--padding-xs` | 10px | 24px |
+| `--padding-sm` | 12px | 24px |
+| `--padding-md` | 16px | 32px |
+| `--padding-lg` | 24px | 52px |
+| `--padding-xl` | 32px | 52px |
+| `--padding-huge` | 48px | 88px |
+
+Product apps default to Base mode. Marketing sites apply Spacious via `.body` class.
+
+## Space scale (primitives)
+
+The raw spacing scale from 0 to 176px. Semantic tokens reference these steps.
+
+<SpacingScale scale={spaceScale} prefix="--space" />
+
+## Related
+
+- [Cascade rules](/docs/getting-started/cascade) — how layers interact
+- [Color tokens](/docs/primitives/color) — semantic surface tokens that pair with these spacings
+- [Typography tokens](/docs/primitives/typography) — type scale for content within these spaces

--- a/docs-site/content/docs/primitives/spacing.mdx
+++ b/docs-site/content/docs/primitives/spacing.mdx
@@ -1,0 +1,12 @@
+---
+title: Spacing
+description: The 4-point grid, scale tokens, and semantic spacing roles.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+> Stub page — port from `stories/foundation/Spacing.mdx`.
+
+<Callout type="warn">
+  All spacing values must be multiples of 4px. The `lint-tokens:grid` script blocks PRs that violate this.
+</Callout>

--- a/docs-site/content/docs/primitives/typography.mdx
+++ b/docs-site/content/docs/primitives/typography.mdx
@@ -1,0 +1,12 @@
+---
+title: Typography
+description: Type scale, font families, and semantic role rules.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+> Stub page — port from `stories/foundation/Typography.mdx`.
+
+<Callout>
+  Until this page is filled, see [Storybook → Foundations → Typography](https://storybook.brikdesigns.com/?path=/docs/foundation-typography--docs).
+</Callout>

--- a/docs-site/content/docs/primitives/typography.mdx
+++ b/docs-site/content/docs/primitives/typography.mdx
@@ -1,12 +1,128 @@
 ---
 title: Typography
-description: Type scale, font families, and semantic role rules.
+description: Font families, the type scale, weights, and the semantic role rule.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { fontSizeScale, fontWeights } from '@bds-tokens';
 
-> Stub page — port from `stories/foundation/Typography.mdx`.
+Typography tokens control font families, sizes, weights, and line heights. Each theme can override font families — switching themes refreshes the live previews on this page.
 
-<Callout>
-  Until this page is filled, see [Storybook → Foundations → Typography](https://storybook.brikdesigns.com/?path=/docs/foundation-typography--docs).
+<Callout type="warn">
+  **Font family must match the element's semantic role.** Heading/title elements → `--font-family-heading`. Label/badge/tag/button/caption → `--font-family-label`. Body copy → `--font-family-body`. BDS defaults all three to the same family during development, so misuse only surfaces when a client theme assigns distinct typefaces — by which point the violation has shipped.
 </Callout>
+
+## Font families
+
+<FontFamilyShowcase
+  families={[
+    { name: 'Display', cssVar: '--font-family-display' },
+    { name: 'Heading', cssVar: '--font-family-heading' },
+    { name: 'Body', cssVar: '--font-family-body' },
+    { name: 'Label', cssVar: '--font-family-label' },
+  ]}
+/>
+
+## Semantic typography
+
+These are the tokens components actually use. Each row renders the sample at its actual size — comparing a heading-md to a body-md is a hover-and-look operation, not a math operation.
+
+### Heading sizes
+
+The heading scale starts at 18px (`--heading-tiny`). 16px territory is body and label.
+
+<SemanticTypographyTable
+  title="Headings"
+  tokens={[
+    'heading-tiny',
+    'heading-sm',
+    'heading-md',
+    'heading-lg',
+    'heading-xl',
+    'heading-xxl',
+    'heading-huge',
+  ]}
+/>
+
+### Body sizes
+
+<SemanticTypographyTable
+  title="Body"
+  tokens={[
+    'body-tiny',
+    'body-xs',
+    'body-sm',
+    'body-md',
+    'body-lg',
+    'body-xl',
+    'body-huge',
+  ]}
+/>
+
+### Label sizes
+
+<SemanticTypographyTable
+  title="Labels"
+  tokens={[
+    'label-tiny',
+    'label-xs',
+    'label-sm',
+    'label-md',
+    'label-lg',
+    'label-xl',
+  ]}
+/>
+
+### Display sizes
+
+<SemanticTypographyTable
+  title="Display"
+  tokens={[
+    'display-sm',
+    'display-md',
+    'display-lg',
+    'display-xl',
+  ]}
+/>
+
+### Icon sizes
+
+Icon sizing tokens used by IconButton and inline icons.
+
+<SemanticTypographyTable
+  title="Icons"
+  tokens={[
+    'icon-tiny',
+    'icon-xs',
+    'icon-sm',
+    'icon-md',
+    'icon-lg',
+    'icon-xl',
+    'icon-huge',
+  ]}
+/>
+
+## Font size scale (primitives)
+
+Primitive scale from 10px to 515px. Components reference these only through the semantic tokens above.
+
+<TypographyScale scale={fontSizeScale} prefix="--font-size" />
+
+## Font weights
+
+<FontWeightShowcase weights={fontWeights} />
+
+## Line heights
+
+| Token | Value |
+|---|---|
+| `--font-line-height-tight` | 100% |
+| `--font-line-height-snug` | 125% |
+| `--font-line-height-normal` | 150% |
+| `--font-line-height-175` | 175% |
+| `--font-line-height-200` | 200% |
+
+## Related
+
+- [Color tokens](/docs/primitives/color) — pair text-* tokens with semantic backgrounds
+- [Spacing tokens](/docs/primitives/spacing) — the rhythm typography sits on

--- a/docs-site/content/docs/utilities/index.mdx
+++ b/docs-site/content/docs/utilities/index.mdx
@@ -1,0 +1,6 @@
+---
+title: Utilities
+description: Token-aware helpers for use in app code.
+---
+
+> Placeholder. The `@/lib/tokens` and `@/lib/styles` helpers (required in every consumer) are documented here, plus the Style Dictionary build pipeline and the `bds-find` CLI.

--- a/docs-site/content/docs/utilities/meta.json
+++ b/docs-site/content/docs/utilities/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Utilities",
+  "pages": ["index"]
+}

--- a/docs-site/lib/layout.shared.tsx
+++ b/docs-site/lib/layout.shared.tsx
@@ -1,0 +1,17 @@
+import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+
+export const baseOptions: BaseLayoutProps = {
+  nav: {
+    title: (
+      <span style={{ fontWeight: 600, letterSpacing: '-0.01em' }}>
+        Brik Design System
+      </span>
+    ),
+    url: '/',
+  },
+  links: [
+    { text: 'Docs', url: '/docs' },
+    { text: 'Storybook', url: 'https://storybook.brikdesigns.com', external: true },
+    { text: 'GitHub', url: 'https://github.com/brikdesigns/brik-bds', external: true },
+  ],
+};

--- a/docs-site/lib/mdx-components.tsx
+++ b/docs-site/lib/mdx-components.tsx
@@ -1,0 +1,24 @@
+import defaultMdxComponents from 'fumadocs-ui/mdx';
+import type { MDXComponents } from 'mdx/types';
+import { ComponentPreview } from '@/components/component-preview';
+import * as BDS from '@brikdesigns/bds';
+
+/**
+ * MDX component registry. Anything exposed here is callable from any .mdx file
+ * without an explicit import — the lazy escape hatch for live demos.
+ *
+ * Pattern: BDS components are spread under `BDS.*` so authors write
+ * `<BDS.Button>...` in MDX. This keeps the component namespace explicit and
+ * avoids name collisions with HTML primitives (e.g. <Card>, <Tabs>).
+ */
+export function getMDXComponents(extra?: MDXComponents): MDXComponents {
+  return {
+    ...defaultMdxComponents,
+    ComponentPreview,
+    // The BDS namespace export includes hooks (useTheme) alongside components.
+    // MDX's component-map type rejects that mix; cast since MDX only ever calls
+    // the JSX entries (`<BDS.Button>`), never the hooks.
+    BDS: BDS as unknown as MDXComponents[string],
+    ...extra,
+  };
+}

--- a/docs-site/lib/mdx-components.tsx
+++ b/docs-site/lib/mdx-components.tsx
@@ -5,6 +5,17 @@ import { EmphasisLadder } from '@/components/mdx/emphasis-ladder';
 import { ComparisonGrid } from '@/components/mdx/comparison-grid';
 import { ComponentAnatomy } from '@/components/mdx/component-anatomy';
 import { MetadataStrip } from '@/components/mdx/metadata-strip';
+import { ColorGrid, PaletteGrid } from '@/components/mdx/foundation/color-grid';
+import {
+  SpacingScale,
+  SemanticSpacing,
+} from '@/components/mdx/foundation/spacing-scale';
+import {
+  TypographyScale,
+  FontFamilyShowcase,
+  SemanticTypographyTable,
+  FontWeightShowcase,
+} from '@/components/mdx/foundation/typography-scale';
 import * as BDS from '@brikdesigns/bds';
 
 /**
@@ -17,6 +28,9 @@ import * as BDS from '@brikdesigns/bds';
  *
  * Visual building blocks live under `@/components/mdx/` and are registered
  * unprefixed so they read naturally in MDX prose.
+ *
+ * Foundation viz components (ColorGrid, SpacingScale, etc.) are ported from
+ * the Storybook foundation/_components and used on Primitives pages.
  */
 export function getMDXComponents(extra?: MDXComponents): MDXComponents {
   return {
@@ -26,6 +40,14 @@ export function getMDXComponents(extra?: MDXComponents): MDXComponents {
     ComparisonGrid,
     ComponentAnatomy,
     MetadataStrip,
+    ColorGrid,
+    PaletteGrid,
+    SpacingScale,
+    SemanticSpacing,
+    TypographyScale,
+    FontFamilyShowcase,
+    SemanticTypographyTable,
+    FontWeightShowcase,
     // The BDS namespace export includes hooks (useTheme) alongside components.
     // MDX's component-map type rejects that mix; cast since MDX only ever calls
     // the JSX entries (`<BDS.Button>`), never the hooks.

--- a/docs-site/lib/mdx-components.tsx
+++ b/docs-site/lib/mdx-components.tsx
@@ -1,6 +1,10 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
 import { ComponentPreview } from '@/components/component-preview';
+import { EmphasisLadder } from '@/components/mdx/emphasis-ladder';
+import { ComparisonGrid } from '@/components/mdx/comparison-grid';
+import { ComponentAnatomy } from '@/components/mdx/component-anatomy';
+import { MetadataStrip } from '@/components/mdx/metadata-strip';
 import * as BDS from '@brikdesigns/bds';
 
 /**
@@ -10,11 +14,18 @@ import * as BDS from '@brikdesigns/bds';
  * Pattern: BDS components are spread under `BDS.*` so authors write
  * `<BDS.Button>...` in MDX. This keeps the component namespace explicit and
  * avoids name collisions with HTML primitives (e.g. <Card>, <Tabs>).
+ *
+ * Visual building blocks live under `@/components/mdx/` and are registered
+ * unprefixed so they read naturally in MDX prose.
  */
 export function getMDXComponents(extra?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
     ComponentPreview,
+    EmphasisLadder,
+    ComparisonGrid,
+    ComponentAnatomy,
+    MetadataStrip,
     // The BDS namespace export includes hooks (useTheme) alongside components.
     // MDX's component-map type rejects that mix; cast since MDX only ever calls
     // the JSX entries (`<BDS.Button>`), never the hooks.

--- a/docs-site/lib/mdx-components.tsx
+++ b/docs-site/lib/mdx-components.tsx
@@ -16,6 +16,11 @@ import {
   SemanticTypographyTable,
   FontWeightShowcase,
 } from '@/components/mdx/foundation/typography-scale';
+import {
+  BorderRadiusPreview,
+  BorderWidthPreview,
+  ShadowScale,
+} from '@/components/mdx/foundation/radius-shadow';
 import * as BDS from '@brikdesigns/bds';
 
 /**
@@ -48,6 +53,9 @@ export function getMDXComponents(extra?: MDXComponents): MDXComponents {
     FontFamilyShowcase,
     SemanticTypographyTable,
     FontWeightShowcase,
+    BorderRadiusPreview,
+    BorderWidthPreview,
+    ShadowScale,
     // The BDS namespace export includes hooks (useTheme) alongside components.
     // MDX's component-map type rejects that mix; cast since MDX only ever calls
     // the JSX entries (`<BDS.Button>`), never the hooks.

--- a/docs-site/lib/source.ts
+++ b/docs-site/lib/source.ts
@@ -1,0 +1,7 @@
+import { docs } from '@/.source/server';
+import { loader } from 'fumadocs-core/source';
+
+export const source = loader({
+  baseUrl: '/docs',
+  source: docs.toFumadocsSource(),
+});

--- a/docs-site/next.config.mjs
+++ b/docs-site/next.config.mjs
@@ -1,0 +1,11 @@
+import { createMDX } from 'fumadocs-mdx/next';
+
+const withMDX = createMDX();
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['@brikdesigns/bds'],
+};
+
+export default withMDX(nextConfig);

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1,0 +1,6039 @@
+{
+  "name": "@brikdesigns/bds-docs",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@brikdesigns/bds-docs",
+      "version": "0.1.0",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@brikdesigns/bds": "file:..",
+        "fumadocs-core": "^16.7.14",
+        "fumadocs-mdx": "^14.2.13",
+        "fumadocs-ui": "^16.7.14",
+        "next": "^16.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.0.0",
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "..": {
+      "name": "@brikdesigns/bds",
+      "version": "0.42.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@iconify-json/ph": "^1.2.2",
+        "@iconify/react": ">=5.0.0",
+        "@radix-ui/react-popover": "^1.1.15"
+      },
+      "bin": {
+        "bds-find": "scripts/bds-find.mjs"
+      },
+      "devDependencies": {
+        "@axe-core/playwright": "^4.10.0",
+        "@notionhq/client": "^3.1.3",
+        "@storybook/addon-a11y": "10.2.19",
+        "@storybook/addon-docs": "10.2.19",
+        "@storybook/addon-mcp": "^0.4.1",
+        "@storybook/addon-vitest": "^10.2.19",
+        "@storybook/react-vite": "10.2.19",
+        "@tokens-studio/sd-transforms": "^2.0.3",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.7.0",
+        "@vitest/browser": "^4.1.2",
+        "@vitest/browser-playwright": "^4.1.4",
+        "axe-core": "^4.10.0",
+        "chromatic": "^15.3.0",
+        "dotenv": "^16.6.1",
+        "husky": "^9.1.7",
+        "lottie-react": "^2.4.1",
+        "playwright": "^1.59.1",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+        "storybook": "10.2.19",
+        "style-dictionary": "^5.3.1",
+        "typescript": "^5.5.0",
+        "vite": "^6.0.0",
+        "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@iconify/react": ">=5.0.0",
+        "lottie-react": ">=2.4.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@brikdesigns/bds": {
+      "resolved": "..",
+      "link": true
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@fumadocs/tailwind": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@fumadocs/tailwind/-/tailwind-0.0.5.tgz",
+      "integrity": "sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tailwindcss/oxide": "^4.0.0",
+        "tailwindcss": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@tailwindcss/oxide": {
+          "optional": true
+        },
+        "tailwindcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@orama/orama": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-3.1.18.tgz",
+      "integrity": "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
+      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+      "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.22",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
+      "integrity": "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-value-to-estree": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.5.0.tgz",
+      "integrity": "sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fumadocs-core": {
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.8.4.tgz",
+      "integrity": "sha512-o8N7YocCSdoehR7cTSYv9usvE3F5q0rrnoro3hGRnSI1SdolmeuxTbdfQgebaP61E7wAI4hIWgo7CzImGRT2Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@orama/orama": "^3.1.18",
+        "estree-util-value-to-estree": "^3.5.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-to-estree": "^3.1.3",
+        "hast-util-to-jsx-runtime": "^2.3.6",
+        "js-yaml": "^4.1.1",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-to-markdown": "^2.1.2",
+        "remark": "^15.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-rehype": "^11.1.2",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "shiki": "^4.0.2",
+        "tinyglobby": "^0.2.16",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@mdx-js/mdx": "*",
+        "@mixedbread/sdk": "0.x.x",
+        "@orama/core": "1.x.x",
+        "@oramacloud/client": "2.x.x",
+        "@tanstack/react-router": "1.x.x",
+        "@types/estree-jsx": "*",
+        "@types/hast": "*",
+        "@types/mdast": "*",
+        "@types/react": "*",
+        "algoliasearch": "5.x.x",
+        "flexsearch": "*",
+        "lucide-react": "*",
+        "next": "16.x.x",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-router": "7.x.x",
+        "waku": "^0.26.0 || ^0.27.0 || ^1.0.0",
+        "zod": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@mdx-js/mdx": {
+          "optional": true
+        },
+        "@mixedbread/sdk": {
+          "optional": true
+        },
+        "@orama/core": {
+          "optional": true
+        },
+        "@oramacloud/client": {
+          "optional": true
+        },
+        "@tanstack/react-router": {
+          "optional": true
+        },
+        "@types/estree-jsx": {
+          "optional": true
+        },
+        "@types/hast": {
+          "optional": true
+        },
+        "@types/mdast": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "algoliasearch": {
+          "optional": true
+        },
+        "flexsearch": {
+          "optional": true
+        },
+        "lucide-react": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-router": {
+          "optional": true
+        },
+        "waku": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fumadocs-mdx": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/fumadocs-mdx/-/fumadocs-mdx-14.3.1.tgz",
+      "integrity": "sha512-0u2eXvYrZtrJB14y6fDhP0hhxLgmH8JOmRv6IVHALt5MqR9JIJxV5LJYlho8g8CJXRE8w12rVNFZN0rtUVAqGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.1.1",
+        "@standard-schema/spec": "^1.1.0",
+        "chokidar": "^5.0.0",
+        "esbuild": "^0.28.0",
+        "estree-util-value-to-estree": "^3.5.0",
+        "js-yaml": "^4.1.1",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-to-markdown": "^2.1.2",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.4",
+        "tinyexec": "^1.1.1",
+        "tinyglobby": "^0.2.16",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "fumadocs-mdx": "dist/bin.js"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*",
+        "@types/mdx": "*",
+        "@types/react": "*",
+        "fumadocs-core": "^15.0.0 || ^16.0.0",
+        "mdast-util-directive": "*",
+        "next": "^15.3.0 || ^16.0.0",
+        "react": "^19.2.0",
+        "vite": "6.x.x || 7.x.x || 8.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        },
+        "@types/mdx": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "mdast-util-directive": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fumadocs-ui": {
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-16.8.4.tgz",
+      "integrity": "sha512-KnNtGUT54772Rhafq9qK/5oo+77MoVwR9HEEvGfXz14hsBs4XWikkOqMbgm6Jjx45rUUbVIWU9qVMernPSXG0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fumadocs/tailwind": "0.0.5",
+        "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-collapsible": "^1.1.12",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-direction": "^1.1.1",
+        "@radix-ui/react-navigation-menu": "^1.2.14",
+        "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-presence": "^1.1.5",
+        "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
+        "class-variance-authority": "^0.7.1",
+        "lucide-react": "^1.11.0",
+        "motion": "^12.38.0",
+        "next-themes": "^0.4.6",
+        "react-remove-scroll": "^2.7.2",
+        "rehype-raw": "^7.0.0",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "shiki": "^4.0.2",
+        "tailwind-merge": "^3.5.0",
+        "unist-util-visit": "^5.1.0"
+      },
+      "peerDependencies": {
+        "@takumi-rs/image-response": "*",
+        "@types/mdx": "*",
+        "@types/react": "*",
+        "fumadocs-core": "16.8.4",
+        "next": "16.x.x",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@takumi-rs/image-response": {
+          "optional": true
+        },
+        "@types/mdx": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
+      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.4",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
+      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@brikdesigns/bds-docs",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Fumadocs-powered guidance site for the Brik Design System.",
+  "scripts": {
+    "dev": "next dev -p 3001",
+    "build": "next build",
+    "start": "next start -p 3001",
+    "postinstall": "fumadocs-mdx"
+  },
+  "dependencies": {
+    "@brikdesigns/bds": "file:..",
+    "fumadocs-core": "^16.7.14",
+    "fumadocs-mdx": "^14.2.13",
+    "fumadocs-ui": "^16.7.14",
+    "next": "^16.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/docs-site/postcss.config.mjs
+++ b/docs-site/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/docs-site/source.config.ts
+++ b/docs-site/source.config.ts
@@ -1,0 +1,7 @@
+import { defineDocs, defineConfig } from 'fumadocs-mdx/config';
+
+export const docs = defineDocs({
+  dir: 'content/docs',
+});
+
+export default defineConfig();

--- a/docs-site/tsconfig.json
+++ b/docs-site/tsconfig.json
@@ -29,6 +29,9 @@
       "@bds-src/*": [
         "../components/*"
       ],
+      "@bds-tokens": [
+        "../tokens/index"
+      ],
       "@bds-tokens/*": [
         "../tokens/*"
       ]

--- a/docs-site/tsconfig.json
+++ b/docs-site/tsconfig.json
@@ -1,0 +1,48 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2022"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ],
+      "@bds-src/*": [
+        "../components/*"
+      ],
+      "@bds-tokens/*": [
+        "../tokens/*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".source",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary

Stands up a new Fumadocs-powered guidance site at `/docs-site/` — the documentation half of the design system, paired with Storybook (which becomes the playground only). Mirrors the Primer split.

- **35 prerendered routes** — landing, Welcome, Getting Started, Primitives (×8 incl. Motion stub), Patterns, Components index, Action group (×6), Hooks/Utilities/Contribution, Content System (Industries/Dental + stubs)
- **Live BDS components in MDX** via `@brikdesigns/bds` (`file:..`) — components render real, not screenshots
- **Foundations: 7 of 8 migrated** — Color, Typography, Spacing, Size, BorderRadius, BorderWidth, Shadow (Motion still in Storybook; its 20K-line viz infrastructure is its own session)
- **Action group: complete** — Button (with LinkButton + IconButton sub-sections), ButtonGroup, FilterBar, FilterButton, FilterToggle, TextLink
- **Reusable MDX primitives** — `<ComponentPreview>`, `<EmphasisLadder>`, `<ComparisonGrid>`, `<ComponentAnatomy>`, `<MetadataStrip>`
- **Foundation viz components ported from Storybook** — `<ColorGrid>`, `<PaletteGrid>`, `<SpacingScale>`, `<SemanticSpacing>`, `<TypographyScale>` family, `<BorderRadiusPreview>`, `<BorderWidthPreview>`, `<ShadowScale>`
- **Page templates standardized** at `/docs/contribution/page-templates` — three canonical shapes (component, primitive, content-system)

Stack: Next.js 16 + React 19 + Fumadocs 16 + Tailwind v4. Token cascade wired (\`figma-tokens.css\` → dark → gap-fills → animations). Deploy target \`design.brikdesigns.com\` is out of scope for this PR — Netlify wiring + DNS is a follow-up.

## Test plan

- [ ] \`cd docs-site && npm install --ignore-scripts && npm run build\` succeeds (the BDS root must be built first; \`npm install --ignore-scripts && npm run build:lib\` from the worktree root)
- [ ] \`npm run dev\` boots clean on \`:3001\`
- [ ] Landing \`/\` renders with the four-tenet card grid
- [ ] \`/docs/components/button\` — \`<ComparisonGrid>\`, \`<ComponentAnatomy>\`, both \`<EmphasisLadder>\` blocks, all \`<ComponentPreview>\` previews render with live \`<BDS.Button>\`
- [ ] \`/docs/primitives/color\` — every \`<ColorGrid>\` swatch resolves to a real color; click-to-copy puts \`var(--token-name)\` on clipboard
- [ ] \`/docs/primitives/typography\` — sample text renders at the actual semantic-token sizes (not fallback values)
- [ ] \`/docs/primitives/spacing\` — preview bars match the value labels visually
- [ ] \`/docs/content-system/industries/dental\` — \`<MetadataStrip>\` shows real \`dental.version\` / \`lastReviewed\` / \`reviewCadence\` from the BCS pack; vocabulary table renders all \`dental.vocabulary.avoid\` rows
- [ ] Light/dark mode toggle in the Fumadocs theme switcher updates BDS tokens correctly (color swatches, type, surface backgrounds)
- [ ] Mobile responsive — \`<ComparisonGrid>\` doesn't overflow at narrow widths
- [ ] Internal links (e.g. Welcome → Components) all resolve, no 404s
- [ ] External Storybook deep-links open the right stories

## Out of scope (follow-ups)

- Netlify deploy + \`design.brikdesigns.com\` DNS
- Motion foundation port (its own session — 20K-line viz infrastructure)
- Other component groups: Form, Indicator, Feedback, Control, Addable, Structure, Navigation, Displays
- Remaining Industry packs (RealEstate RV/MHC, RealEstate Commercial, SmallBusiness)
- 8 Voice patterns + 7 Atmospheres
- \`<NavigationIASpec>\` viz port (Dental page has placeholder)
- Migrating contribution workflow rules (worktree flow, ADR cadence, release flow, deprecation policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)