### PR TITLE
feat(docs-site): migrate Indicator group (10 components)

### DIFF
--- a/docs-site/content/docs/components/badge-group.mdx
+++ b/docs-site/content/docs/components/badge-group.mdx
@@ -1,0 +1,96 @@
+---
+title: Badge group
+description: Horizontal cluster of Badge elements with locked spacing.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+BadgeGroup is the indicator-family sibling of [TagGroup](/docs/components/tag-group). Same API shape, different child. Use it when multiple status indicators sit side by side — integration health rows, payment-state summaries, multi-status entity rows.
+
+## Use it for
+
+- Multiple statuses on one entity (Helicone Active, Stripe Pending, Supabase Active)
+- Integration health rows where each service has its own status
+- Compact status clusters inside a `Field` or table cell
+
+For categorical labels (industry, segment), use [TagGroup](/docs/components/tag-group).
+
+## Import
+
+```tsx
+import { BadgeGroup, Badge } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+<ComponentPreview code={`<BDS.BadgeGroup>
+  <BDS.Badge status="positive" size="sm">Helicone</BDS.Badge>
+  <BDS.Badge status="positive" size="sm">Supabase</BDS.Badge>
+  <BDS.Badge status="warning" size="sm">Stripe</BDS.Badge>
+</BDS.BadgeGroup>`}>
+  <BDS.BadgeGroup>
+    <BDS.Badge status="positive" size="sm">Helicone</BDS.Badge>
+    <BDS.Badge status="positive" size="sm">Supabase</BDS.Badge>
+    <BDS.Badge status="warning" size="sm">Stripe</BDS.Badge>
+  </BDS.BadgeGroup>
+</ComponentPreview>
+
+### Gap sizes
+
+Three locked gaps — `xs` (default, tight), `sm` (standard), `md` (roomy).
+
+<ComponentPreview code={`<BDS.BadgeGroup gap="md">
+  <BDS.Badge status="positive" size="sm">Active</BDS.Badge>
+  <BDS.Badge status="info" size="sm">Verified</BDS.Badge>
+</BDS.BadgeGroup>`}>
+  <BDS.BadgeGroup gap="md">
+    <BDS.Badge status="positive" size="sm">Active</BDS.Badge>
+    <BDS.Badge status="info" size="sm">Verified</BDS.Badge>
+  </BDS.BadgeGroup>
+</ComponentPreview>
+
+## Pattern: inside a Field
+
+The canonical use — a `Field` value expressed as a status cluster.
+
+```tsx
+import { BadgeGroup, Badge, Field } from '@brikdesigns/bds';
+
+<Field label="Integrations health">
+  <BadgeGroup>
+    <Badge status="positive" size="sm">Helicone</Badge>
+    <Badge status="positive" size="sm">Supabase</Badge>
+    <Badge status="warning" size="sm">Stripe</Badge>
+  </BadgeGroup>
+</Field>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't wrap a single Badge.** If there's only one, render `<Badge>` directly. The group container adds no value at count=1 and just adds DOM noise.
+</Callout>
+
+- **Don't use non-Badge children.** BadgeGroup locks spacing for Badge's specific footprint; arbitrary nodes (Buttons, Tags, raw text) misalign.
+- **Don't mix `solid` and `subtle` appearances inside one group.** BadgeGroup doesn't enforce this at the API, but it reads as inconsistent — pick one appearance per cluster.
+
+## Accessibility
+
+- Renders a plain `<div>` container. Each Badge keeps its own semantics.
+- No `role` or `aria-label` is added — if the group represents a labeled set (e.g. "Integrations"), surface that label via the parent `<Field>` or a heading.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `gap` | `'xs' \| 'sm' \| 'md'` | `'xs'` |
+| `wrap` | `boolean` | `true` |
+| `children` | `ReactNode` | — |
+
+## Related
+
+- [Badge](/docs/components/badge) — the child component
+- [TagGroup](/docs/components/tag-group) — categorical sibling
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-badge-group--overview)**

--- a/docs-site/content/docs/components/badge.mdx
+++ b/docs-site/content/docs/components/badge.mdx
@@ -1,0 +1,140 @@
+---
+title: Badge
+description: Status indicators and labels. Non-interactive — for displaying state, never for triggering actions.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Badge displays contextual status. It uses semantic system colors to communicate state at a glance, with `solid` (saturated) and `subtle` (pastel) appearances for different surface contexts.
+
+<ComparisonGrid
+  items={[
+    {
+      title: 'Badge',
+      preview: <BDS.Badge status="positive">Done</BDS.Badge>,
+      whenToUse: 'Read-only status with a value judgment (good/bad/waiting). Published, Active, Failed.',
+      whenNotToUse: 'Wire onClick — Badge is an indicator, not an action.',
+      code: `<Badge status="positive">Done</Badge>`,
+    },
+    {
+      title: 'Tag',
+      preview: <BDS.Tag>Cosmetic</BDS.Tag>,
+      whenToUse: 'Neutral categorization without a value judgment. Industry, segment, owner, size.',
+      whenNotToUse: 'Use for status — that\'s Badge.',
+      code: `<Tag>Cosmetic</Tag>`,
+    },
+    {
+      title: 'Chip',
+      preview: <BDS.Chip label="Status: Active" />,
+      whenToUse: 'Interactive pill — filter selections, removable tokens, multi-select.',
+      whenNotToUse: 'Render with no handler — that\'s Badge or Tag.',
+      code: `<Chip label="Active" onRemove={...} />`,
+    },
+  ]}
+/>
+
+## Use it for
+
+- A record's status (Published, Draft, In Review, Archived)
+- Pipeline state (Pending, Processing, Completed, Failed)
+- Categorical states with a value judgment (Healthy/Warning/Critical)
+
+For neutral categorization without a status meaning, use [Tag](/docs/components/tag). For interactive pills, use [Chip](/docs/components/chip).
+
+## Import
+
+```tsx
+import { Badge } from '@brikdesigns/bds';
+```
+
+## Variants
+
+Six status colors across four sizes, each available in `solid` and `subtle` appearances.
+
+### Status colors
+
+<ComponentPreview code={`<BDS.Badge status="positive">Done</BDS.Badge>
+<BDS.Badge status="warning">Pending</BDS.Badge>
+<BDS.Badge status="error">Failed</BDS.Badge>
+<BDS.Badge status="info">Note</BDS.Badge>
+<BDS.Badge status="progress">In progress</BDS.Badge>
+<BDS.Badge status="brand">Featured</BDS.Badge>`}>
+  <BDS.Badge status="positive">Done</BDS.Badge>
+  <BDS.Badge status="warning">Pending</BDS.Badge>
+  <BDS.Badge status="error">Failed</BDS.Badge>
+  <BDS.Badge status="info">Note</BDS.Badge>
+  <BDS.Badge status="progress">In progress</BDS.Badge>
+  <BDS.Badge status="brand">Featured</BDS.Badge>
+</ComponentPreview>
+
+### Subtle appearance
+
+Lower-emphasis pastel fill. Use inline with content, in table cells, on cards — anywhere `solid` would over-emphasize.
+
+<ComponentPreview code={`<BDS.Badge status="positive" appearance="subtle">Done</BDS.Badge>
+<BDS.Badge status="progress" appearance="subtle">In progress</BDS.Badge>`}>
+  <BDS.Badge status="positive" appearance="subtle">Done</BDS.Badge>
+  <BDS.Badge status="progress" appearance="subtle">In progress</BDS.Badge>
+</ComponentPreview>
+
+### Sizes
+
+Four sizes — `xs` is icon-only (no text), `sm` `md` `lg` carry text.
+
+<ComponentPreview code={`<BDS.Badge size="sm" status="positive">Done</BDS.Badge>
+<BDS.Badge size="md" status="positive">Done</BDS.Badge>
+<BDS.Badge size="lg" status="positive">Done</BDS.Badge>`}>
+  <BDS.Badge size="sm" status="positive">Done</BDS.Badge>
+  <BDS.Badge size="md" status="positive">Done</BDS.Badge>
+  <BDS.Badge size="lg" status="positive">Done</BDS.Badge>
+</ComponentPreview>
+
+### With icon
+
+Pass `icon` for a leading visual. Required when `size="xs"` (icon-only).
+
+```tsx
+<Badge status="positive" icon={<CheckIcon />}>Done</Badge>
+<Badge size="xs" status="error" icon={<XCircleIcon />} />
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Badge is read-only.** Never wire `onClick`, never wrap in a `<Link>`, never trigger behavior. Reading "Active" is different from clicking "Active to filter" — the latter is a [Chip](/docs/components/chip).
+</Callout>
+
+- **Don't pick `brand` for routine status.** It draws the eye like a CTA. Reserve for genuinely-featured states.
+- **Don't mix `solid` and `subtle` appearances in the same cluster.** Pick one per row for visual coherence.
+
+## Accessibility
+
+- Renders a `<span>` — non-interactive by default.
+- The text content is the accessible name. For icon-only (`xs`), pass `aria-label`.
+- Status is communicated via color *and* text — never color alone.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `status` | `'positive' \| 'warning' \| 'error' \| 'info' \| 'progress' \| 'brand'` | — |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` |
+| `appearance` | `'solid' \| 'subtle'` | `'solid'` |
+| `icon` | `ReactNode` | — |
+| `children` | `ReactNode` | — |
+
+## Tokens
+
+- `--color-system-green` / `--color-system-green-light` — Positive
+- `--color-system-red` / `--color-system-red-light` — Error
+- `--color-system-yellow` / `--color-system-yellow-light` — Warning
+- `--color-system-blue` / `--color-system-blue-light` — Progress
+- `--color-system-neutral` / `--color-system-neutral-light` — Info
+
+## Related
+
+- [Tag](/docs/components/tag) — neutral categorization sibling
+- [Chip](/docs/components/chip) — interactive sibling
+- [BadgeGroup](/docs/components/badge-group) — multi-badge cluster
+- [Dot](/docs/components/dot) — minimal status indicator
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-badge--overview)**

--- a/docs-site/content/docs/components/chip.mdx
+++ b/docs-site/content/docs/components/chip.mdx
@@ -1,0 +1,144 @@
+---
+title: Chip
+description: Compact interactive pill for filtering, selection, and removable tokens.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Chip is the **action** sibling of [Badge](/docs/components/badge) and [Tag](/docs/components/tag). Always interactive. Render a Chip only when `onChipClick`, `onRemove`, or `showDropdown` is wired up — a Chip with no handler is a bug.
+
+<ComparisonGrid
+  items={[
+    {
+      title: 'Chip',
+      preview: <BDS.Chip label="Status: Active" />,
+      whenToUse: 'Compact pill *after* a filter choice is made, multi-select tokens, secondary toggle pills.',
+      whenNotToUse: 'Render with no handler — use Badge or Tag.',
+      code: `<Chip label="Active" onRemove={...} />`,
+    },
+    {
+      title: 'FilterButton',
+      preview: <BDS.FilterButton label="Status" options={[]} />,
+      whenToUse: 'Dropdown trigger inside a FilterBar — encapsulates dropdown state.',
+      whenNotToUse: 'Show selections after picking — those are Chips.',
+      code: `<FilterButton label="Status" options={...} />`,
+    },
+    {
+      title: 'Button',
+      preview: <BDS.Button size="sm">Save</BDS.Button>,
+      whenToUse: 'Primary CTAs, form submits, primary workflows.',
+      whenNotToUse: 'Compact filter pills — use Chip.',
+      code: `<Button>Save</Button>`,
+    },
+  ]}
+/>
+
+## Use it for
+
+- Active filter pills with a dismiss X ("Status: Active" × — clear that filter)
+- Multi-select tokens — selected categories rendered as removable pills
+- Filter dropdown triggers ("All statuses" with a chevron)
+- Compact toggleable pills inside facet sidebars
+
+## Import
+
+```tsx
+import { Chip } from '@brikdesigns/bds';
+```
+
+## Variants
+
+Two variants × two appearances. Match the chip's role:
+
+- **`secondary` + `solid`** — Default filter chip. High contrast.
+- **`secondary` + `outline`** — Softer filter chip. Transparent + neutral border.
+- **`primary` + `solid`** — Active/selected filter. Brand emphasis.
+- **`primary` + `outline`** — Active filter with lower brand emphasis.
+
+```tsx
+<Chip label="Design" variant="secondary" appearance="solid" />
+<Chip label="Design" variant="primary" appearance="outline" />
+```
+
+## Common shapes
+
+### Removable filter chip
+
+```tsx
+<Chip label="Status: Active" onRemove={() => clearFilter('status')} />
+```
+
+### Filter dropdown trigger
+
+```tsx
+<Chip
+  label="All statuses"
+  icon={<FilterIcon />}
+  showDropdown
+  onChipClick={() => openMenu()}
+/>
+```
+
+### With avatar
+
+```tsx
+<Chip label="Sarah Chen" avatar={<Avatar src={...} />} />
+```
+
+### Disabled
+
+```tsx
+<Chip label="Archived" disabled />
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Chip is always interactive.** A read-only pill is a [Badge](/docs/components/badge) (status) or [Tag](/docs/components/tag) (category). Rendering a Chip with no handler implies clickability that doesn't exist.
+</Callout>
+
+- **Don't duplicate FilterButton.** If you're inside a `FilterBar` opening a dropdown, use FilterButton — it handles the state machine. Chip is for what comes *after* the choice.
+- **Don't use Chip for primary CTAs.** It's compact by design. Form submits and primary workflows belong on a [Button](/docs/components/button).
+
+## Accessibility
+
+- Renders a `<button>` when interactive. Keyboard `Enter`/`Space` activates.
+- `onRemove` adds a separate dismiss button with its own accessible name (`aria-label="Remove {label}"`).
+- `showDropdown` adds `aria-haspopup="listbox"` to the chip body.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `label` | `string` *(required)* | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `variant` | `'primary' \| 'secondary'` | `'secondary'` |
+| `appearance` | `'solid' \| 'outline'` | `'solid'` |
+| `icon` | `ReactNode` | — |
+| `avatar` | `ReactNode` | — |
+| `showDropdown` | `boolean` | `false` |
+| `onRemove` | `() => void` | — |
+| `onChipClick` | `() => void` | — |
+| `disabled` | `boolean` | `false` |
+
+## CSS Override API
+
+| Variable | Default | Controls |
+|---|---|---|
+| `--chip-hover-overlay` | `var(--state-hover-overlay)` | Inset overlay color on hover |
+| `--chip-pressed-overlay` | `var(--state-pressed-overlay)` | Inset overlay color on press |
+
+```css
+.filter-bar {
+  --chip-hover-overlay: rgba(0, 0, 0, 0.08);
+  --chip-pressed-overlay: rgba(0, 0, 0, 0.14);
+}
+```
+
+## Related
+
+- [Badge](/docs/components/badge) — read-only status sibling
+- [Tag](/docs/components/tag) — read-only categorization sibling
+- [FilterButton](/docs/components/filter-button) — dropdown trigger inside FilterBar
+- [Button](/docs/components/button) — primary action shape
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-chip--overview)**

--- a/docs-site/content/docs/components/counter.mdx
+++ b/docs-site/content/docs/components/counter.mdx
@@ -1,0 +1,97 @@
+---
+title: Counter
+description: Numeric count indicator with status colors. Pill-shaped badge for notifications and quantities.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Counter shows a number with a status color. Use for notification counts, item quantities, step indicators, and anywhere you'd want "8" or "3" or "99+" with a hint of urgency or progress baked into the color.
+
+## Use it for
+
+- Notification badges on icons and tabs
+- Item quantities in cart/inbox/queue indicators
+- Step counters in multi-step flows
+- Any `{n}`-of-something indicator that benefits from a status color
+
+For boolean status (no count, just "Active" / "Failed"), use [Badge](/docs/components/badge).
+
+## Import
+
+```tsx
+import { Counter } from '@brikdesigns/bds';
+```
+
+## Variants
+
+Six status colors across four sizes.
+
+### Status colors
+
+<ComponentPreview code={`<BDS.Counter count={5} status="success" />
+<BDS.Counter count={3} status="error" />
+<BDS.Counter count={2} status="warning" />
+<BDS.Counter count={7} status="progress" />
+<BDS.Counter count={4} status="brand" />
+<BDS.Counter count={9} status="neutral" />`}>
+  <BDS.Counter count={5} status="success" />
+  <BDS.Counter count={3} status="error" />
+  <BDS.Counter count={2} status="warning" />
+  <BDS.Counter count={7} status="progress" />
+  <BDS.Counter count={4} status="brand" />
+  <BDS.Counter count={9} status="neutral" />
+</ComponentPreview>
+
+- **`success`** — Completed items, positive counts
+- **`error`** — Error counts, alert counts
+- **`warning`** — Pending items, attention needed
+- **`progress`** — In-progress items
+- **`brand`** — General counts, notification badges
+- **`neutral`** — Inactive, disabled counts
+
+### Sizes
+
+<ComponentPreview code={`<BDS.Counter count={3} size="xs" status="error" />
+<BDS.Counter count={3} size="sm" status="error" />
+<BDS.Counter count={3} size="md" status="error" />
+<BDS.Counter count={3} size="lg" status="error" />`}>
+  <BDS.Counter count={3} size="xs" status="error" />
+  <BDS.Counter count={3} size="sm" status="error" />
+  <BDS.Counter count={3} size="md" status="error" />
+  <BDS.Counter count={3} size="lg" status="error" />
+</ComponentPreview>
+
+### Max overflow
+
+Use `max` to cap the displayed value. Anything over renders as `{max}+`.
+
+<ComponentPreview code={`<BDS.Counter count={150} max={99} status="brand" />
+<BDS.Counter count={9} max={99} status="brand" />`}>
+  <BDS.Counter count={150} max={99} status="brand" />
+  <BDS.Counter count={9} max={99} status="brand" />
+</ComponentPreview>
+
+## When *not* to use
+
+- **Don't use Counter for boolean status.** "Active" or "Failed" with no count is a [Badge](/docs/components/badge).
+- **Don't use Counter for non-integer values.** It renders the value as-is; decimals and formatted values (currency, percentages) belong in regular text.
+
+## Accessibility
+
+- Renders a `<span>` with the count as text content — read naturally by screen readers.
+- For Counters used as notification badges on icons, pair with an `aria-label` on the parent button: `<button aria-label="Inbox, 5 unread"><Inbox /><Counter count={5} /></button>`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `count` | `number` *(required)* | — |
+| `status` | `'success' \| 'error' \| 'warning' \| 'neutral' \| 'progress' \| 'brand'` | `'brand'` |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` |
+| `max` | `number` | — |
+
+## Related
+
+- [Badge](/docs/components/badge) — non-numeric status sibling
+- [Dot](/docs/components/dot) — minimal status indicator
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-counter--overview)**

--- a/docs-site/content/docs/components/dot.mdx
+++ b/docs-site/content/docs/components/dot.mdx
@@ -1,0 +1,95 @@
+---
+title: Dot
+description: Small status indicator circles. Color-coded state, no text.
+---
+
+Dot is the most minimal status indicator — a colored circle with no text. Use it inline next to a label, in a status list, or as a presence indicator. When you want status with text, use [Badge](/docs/components/badge).
+
+## Use it for
+
+- Online/offline presence indicators next to user names
+- Status lists where the row label provides the context ("Helicone •" + "Stripe •")
+- Compact status indicators in dense table cells
+- Activity feeds where the dot pulses to indicate live state
+
+## Import
+
+```tsx
+import { Dot } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Status colors
+
+<ComponentPreview code={`<BDS.Dot status="default" />
+<BDS.Dot status="positive" />
+<BDS.Dot status="warning" />
+<BDS.Dot status="error" />
+<BDS.Dot status="info" />
+<BDS.Dot status="neutral" />`}>
+  <BDS.Dot status="default" />
+  <BDS.Dot status="positive" />
+  <BDS.Dot status="warning" />
+  <BDS.Dot status="error" />
+  <BDS.Dot status="info" />
+  <BDS.Dot status="neutral" />
+</ComponentPreview>
+
+- **`default`** — Brand primary. General-purpose indicator.
+- **`positive`** — Online, success, operational.
+- **`warning`** — Away, attention needed.
+- **`error`** — Offline, failure, outage.
+- **`info`** — Informational, in-progress.
+- **`neutral`** — Inactive, disabled.
+
+### Sizes
+
+<ComponentPreview code={`<BDS.Dot size="sm" status="positive" />
+<BDS.Dot size="md" status="positive" />
+<BDS.Dot size="lg" status="positive" />`}>
+  <BDS.Dot size="sm" status="positive" />
+  <BDS.Dot size="md" status="positive" />
+  <BDS.Dot size="lg" status="positive" />
+</ComponentPreview>
+
+### Pulse
+
+Use `pulse` for active/running states — a continuously running process, a live feed, an in-progress sync.
+
+```tsx
+<Dot status="positive" pulse />
+```
+
+## Pattern: inline with label
+
+```tsx
+<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+  <Dot status="positive" />
+  <span>Online</span>
+</div>
+```
+
+## When *not* to use
+
+- **Don't rely on color alone to convey status.** Always pair with a text label (visible or `aria-label`). Color-only state is inaccessible.
+- **Don't use Dot when a value is meaningful.** "5 unread" is a [Counter](/docs/components/counter), not a Dot.
+
+## Accessibility
+
+- Renders a `<span>`. Pair with a visible text label or pass `aria-label` on the parent container.
+- Status is communicated via color *and* text — never color alone.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `status` | `'default' \| 'positive' \| 'warning' \| 'error' \| 'info' \| 'neutral'` | `'default'` |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `pulse` | `boolean` | `false` |
+
+## Related
+
+- [Badge](/docs/components/badge) — status with text
+- [Counter](/docs/components/counter) — numeric status
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-dot--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -11,7 +11,7 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
 |---|---|
 | **Action** | Button, IconButton, LinkButton, ButtonGroup, FilterBar, FilterButton, FilterToggle, TextLink |
 | **Form** | Field, TextInput, Select, MultiSelect, DatePicker, Form, FieldGrid |
-| **Indicator** | Badge, Chip, Tag, Counter, Spinner, Skeleton |
+| **Indicator** | Badge, Chip, Tag, Counter, Dot, Spinner, Skeleton, BadgeGroup, TagGroup, ServiceBadge |
 | **Feedback** | AlertBanner, Toast, Tooltip, EmptyState, ProgressBar |
 | **Control** | Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader |
 | **Addable** | AddableTagList, AddableEntryList, AddableFieldRowList |
@@ -30,9 +30,26 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
   <Card title="Text link" href="/docs/components/text-link" description="Styled anchor for inline navigation and footer links." />
 </Cards>
 
+### Indicator
+
+The indicator family — read-only state communication. For interactive pills, use [Chip](/docs/components/chip) (Action group sibling).
+
+<Cards>
+  <Card title="Badge" href="/docs/components/badge" description="Status indicators with semantic colors. Read-only, six statuses, four sizes." />
+  <Card title="Badge group" href="/docs/components/badge-group" description="Horizontal cluster of Badge elements with locked spacing." />
+  <Card title="Chip" href="/docs/components/chip" description="Interactive pill for filtering, selection, removable tokens. Always wired up." />
+  <Card title="Counter" href="/docs/components/counter" description="Numeric count with status colors. Notification badges, item quantities." />
+  <Card title="Dot" href="/docs/components/dot" description="Minimal status circles. Six statuses, three sizes, optional pulse." />
+  <Card title="Service badge" href="/docs/components/service-badge" description="Icon-only badge for Brik service categories." />
+  <Card title="Skeleton" href="/docs/components/skeleton" description="Loading-state placeholder shapes. Text, circular, rectangular." />
+  <Card title="Spinner" href="/docs/components/spinner" description="Circular loading indicator. Inline and container sizes." />
+  <Card title="Tag" href="/docs/components/tag" description="Neutral categorization labels. Read-only, four sizes, two appearances." />
+  <Card title="Tag group" href="/docs/components/tag-group" description="Horizontal cluster of Tag elements with locked spacing." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining ~50 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for every other group: Form, Indicator, Feedback, Control, Addable, Structure, Navigation.
+The remaining ~40 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Form, Feedback, Control, Addable, Structure, Navigation, and Displays.
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -8,6 +8,17 @@
     "filter-bar",
     "filter-button",
     "filter-toggle",
-    "text-link"
+    "text-link",
+    "---Indicator---",
+    "badge",
+    "badge-group",
+    "chip",
+    "counter",
+    "dot",
+    "service-badge",
+    "skeleton",
+    "spinner",
+    "tag",
+    "tag-group"
   ]
 }

--- a/docs-site/content/docs/components/service-badge.mdx
+++ b/docs-site/content/docs/components/service-badge.mdx
@@ -1,0 +1,70 @@
+---
+title: Service badge
+description: Icon-only badge for service categories. Resolves a category-specific icon SVG.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+ServiceBadge renders a category icon for a Brik service line — design, marketing, content, etc. Used in dashboard tiles, service-line indicators on entity rows, and anywhere a category needs a visual marker.
+
+<Callout type="warn">
+  **`mode` is deprecated** and ignored — ServiceBadge is icon-only going forward. For text-or-icon-text variants, use the in-progress `ServiceTag` component.
+</Callout>
+
+## Use it for
+
+- Visual marker for a service category (Brand Design, Marketing, Content)
+- Dashboard tiles that need a recognizable category icon
+- Sidebar entries grouped by service line
+
+## Import
+
+```tsx
+import { ServiceBadge } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Sizes
+
+Three sizes — `sm` for inline, `md` for default, `lg` for tile-style placement.
+
+```tsx
+<ServiceBadge category="design" size="sm" />
+<ServiceBadge category="design" size="md" />
+<ServiceBadge category="design" size="lg" />
+```
+
+### With service name
+
+Pass `serviceName` to resolve a specific service icon (within a category) when the generic category icon is too generic.
+
+```tsx
+<ServiceBadge category="design" serviceName="brand-identity" />
+<ServiceBadge category="content" serviceName="seo-strategy" />
+```
+
+## When *not* to use
+
+- **Don't use ServiceBadge for non-service categories.** It's tied to the Brik service taxonomy. For generic category labels, use [Tag](/docs/components/tag).
+- **Don't use it as a primary action.** It's an indicator — the icon doesn't carry click semantics.
+- **Don't pass `mode`.** The prop is deprecated and ignored. Use the in-progress `ServiceTag` if you need text or icon-text variants.
+
+## Accessibility
+
+- Renders a `<div>` with the icon SVG. Pass an `aria-label` or wrap in a labeled container — the icon alone isn't a sufficient accessible name.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `category` | `ServiceCategory` *(required)* | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `serviceName` | `string` | — |
+| ~~`mode`~~ | ~~`'badge' \| 'label'`~~ | *(deprecated, ignored)* |
+
+## Related
+
+- [Tag](/docs/components/tag) — generic categorization
+- [Badge](/docs/components/badge) — status indicator
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-service-badge--overview)**

--- a/docs-site/content/docs/components/skeleton.mdx
+++ b/docs-site/content/docs/components/skeleton.mdx
@@ -1,0 +1,88 @@
+---
+title: Skeleton
+description: Content placeholder with shimmer animation for loading states.
+---
+
+Skeleton renders a low-emphasis placeholder shape while content loads. It maintains layout (so the page doesn't jump when the real content arrives) and reduces perceived load time.
+
+## Use it for
+
+- Initial loading of a list, card, or section while data fetches
+- Image placeholders during upload or fetch
+- Text-line placeholders inside loading article previews
+- Skeleton screens that mirror the final content's shape
+
+For inline button or icon loading, use [Spinner](/docs/components/spinner).
+
+## Import
+
+```tsx
+import { Skeleton } from '@brikdesigns/bds';
+```
+
+## Variants
+
+Three shape variants matching the most common loading targets.
+
+### Text
+
+100% width, `1em` height. Use for text line placeholders.
+
+```tsx
+<Skeleton variant="text" width="200px" />
+<Skeleton variant="text" />
+```
+
+### Circular
+
+Circle. Use for avatar and circular icon placeholders.
+
+```tsx
+<Skeleton variant="circular" width={48} height={48} />
+```
+
+### Rectangular
+
+Rectangle. Use for image, card, and section placeholders.
+
+```tsx
+<Skeleton variant="rectangular" width="300px" height="200px" />
+```
+
+## Pattern: skeleton card
+
+Mirror the final content's shape — avatar, two text lines, image.
+
+```tsx
+<div style={{ display: 'flex', gap: 12 }}>
+  <Skeleton variant="circular" width={48} height={48} />
+  <div style={{ flex: 1 }}>
+    <Skeleton variant="text" width="60%" />
+    <Skeleton variant="text" width="40%" />
+  </div>
+</div>
+<Skeleton variant="rectangular" width="100%" height={200} />
+```
+
+## When *not* to use
+
+- **Don't use Skeleton for short-lived loading.** Sub-300ms loads finish before the user sees the skeleton — they read as a flash. Use [Spinner](/docs/components/spinner) inline or no indicator at all.
+- **Don't use Skeleton in places the final content might be empty.** "No results" is a different state than "loading"; use [EmptyState](https://storybook.brikdesigns.com/?path=/docs/components-feedback-empty-state--overview) once the load resolves.
+
+## Accessibility
+
+- Renders a `<div>` with `aria-busy="true"` and `role="status"` — screen readers announce loading.
+- The shimmer animation respects `prefers-reduced-motion`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `variant` | `'text' \| 'circular' \| 'rectangular'` | `'text'` |
+| `width` | `string \| number` | `'100%'` (text/rectangular) |
+| `height` | `string \| number` | `'1em'` (text), `40` (circular), `140` (rectangular) |
+
+## Related
+
+- [Spinner](/docs/components/spinner) — inline loading indicator
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-skeleton--overview)**

--- a/docs-site/content/docs/components/spinner.mdx
+++ b/docs-site/content/docs/components/spinner.mdx
@@ -1,0 +1,89 @@
+---
+title: Spinner
+description: Circular loading indicator with animated rotation. Inline and container variants.
+---
+
+Spinner is a small spinning circle for short-lived loading states — a button mid-submit, an inline data fetch, a centered container loader. For longer loads where layout matters, use [Skeleton](/docs/components/skeleton).
+
+## Use it for
+
+- Loading state inside a button while a form submits
+- Inline indicator next to a label ("Loading…")
+- Centered container loader for full-page or panel-level loading
+- Any sub-second to few-second wait where Skeleton would be overkill
+
+## Import
+
+```tsx
+import { Spinner } from '@brikdesigns/bds';
+```
+
+## Variants
+
+Two sizes — `sm` for inline, `lg` for container.
+
+<ComponentPreview code={`<BDS.Spinner size="sm" />
+<BDS.Spinner size="lg" />`}>
+  <BDS.Spinner size="sm" />
+  <BDS.Spinner size="lg" />
+</ComponentPreview>
+
+- **`sm`** — 16×16px. Inline use, button loading states.
+- **`lg`** — 48×48px. Container loading, full-page loading.
+
+## Pattern: button loading
+
+Most Buttons accept a `loading` prop directly — use that. Spinner is for cases where the loading indicator lives outside a Button.
+
+```tsx
+<div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+  <Spinner size="sm" />
+  <span>Loading data…</span>
+</div>
+```
+
+## Pattern: container loading
+
+```tsx
+<div style={{ display: 'flex', justifyContent: 'center', padding: 64 }}>
+  <Spinner size="lg" />
+</div>
+```
+
+## Custom colors
+
+Spinner inherits theme color by default. To override (e.g. on a dark-brand background where the default would be invisible):
+
+```tsx
+<Spinner
+  size="sm"
+  style={{
+    borderColor: 'rgba(255,255,255,0.3)',
+    borderTopColor: 'white',
+  }}
+/>
+```
+
+## When *not* to use
+
+- **Don't use Spinner for loads over ~3 seconds.** The user has no sense of progress. Use [Skeleton](/docs/components/skeleton) (preserves layout) or a `<ProgressBar>` if you can estimate completion.
+- **Don't put Spinner in a button without `loading`.** Use the Button's built-in loading prop — it handles disable, width preservation, and accessibility.
+
+## Accessibility
+
+- Renders a `<div>` with `role="status"` and `aria-label="Loading"`.
+- Respects `prefers-reduced-motion` — pauses the rotation animation.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `size` | `'sm' \| 'lg'` | `'sm'` |
+
+Plus all standard `<div>` HTML attributes.
+
+## Related
+
+- [Skeleton](/docs/components/skeleton) — layout-preserving loading
+- [Button](/docs/components/button) — built-in `loading` prop
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-spinner--overview)**

--- a/docs-site/content/docs/components/tag-group.mdx
+++ b/docs-site/content/docs/components/tag-group.mdx
@@ -1,0 +1,97 @@
+---
+title: Tag group
+description: Horizontal cluster of Tag elements with locked spacing.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+TagGroup is a thin wrapper that locks spacing for a cluster of [Tag](/docs/components/tag) elements. Replaces the ad-hoc `<div style={{ display: 'flex', gap, flexWrap }}>` that grew around tag arrays across the portal.
+
+Use it as a `Field` value, inside a table cell, or standalone inside a `SheetSection`. For status clusters, use [BadgeGroup](/docs/components/badge-group) — same shape, different child.
+
+## Use it for
+
+- Industry / vertical / segment lists on company rows
+- Brand personality / voice / style traits on profile sheets
+- Service category clusters
+- Any read-only multi-tag display
+
+## Import
+
+```tsx
+import { TagGroup, Tag } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+<ComponentPreview code={`<BDS.TagGroup>
+  <BDS.Tag size="sm">Cosmetic</BDS.Tag>
+  <BDS.Tag size="sm">General</BDS.Tag>
+  <BDS.Tag size="sm">Implants</BDS.Tag>
+</BDS.TagGroup>`}>
+  <BDS.TagGroup>
+    <BDS.Tag size="sm">Cosmetic</BDS.Tag>
+    <BDS.Tag size="sm">General</BDS.Tag>
+    <BDS.Tag size="sm">Implants</BDS.Tag>
+  </BDS.TagGroup>
+</ComponentPreview>
+
+### Gap sizes
+
+Three locked gaps — `xs` (default, tight), `sm` (standard), `md` (roomy).
+
+<ComponentPreview code={`<BDS.TagGroup gap="md">
+  <BDS.Tag size="sm">Dental</BDS.Tag>
+  <BDS.Tag size="sm">Healthcare</BDS.Tag>
+</BDS.TagGroup>`}>
+  <BDS.TagGroup gap="md">
+    <BDS.Tag size="sm">Dental</BDS.Tag>
+    <BDS.Tag size="sm">Healthcare</BDS.Tag>
+  </BDS.TagGroup>
+</ComponentPreview>
+
+## Pattern: inside a Field
+
+The canonical use — a `Field` value expressed as tagged categories.
+
+```tsx
+import { TagGroup, Tag, Field } from '@brikdesigns/bds';
+
+<Field label="Services offered">
+  <TagGroup>
+    <Tag size="sm">Cosmetic</Tag>
+    <Tag size="sm">General</Tag>
+    <Tag size="sm">Implants</Tag>
+  </TagGroup>
+</Field>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't wrap a single Tag.** If there's only one, render `<Tag>` directly. The group container adds nothing at count=1.
+</Callout>
+
+- **Don't use non-Tag children.** TagGroup locks spacing for Tag's specific footprint — arbitrary nodes (Buttons, Badges, raw text) misalign.
+- **Don't use TagGroup for status clusters.** Use [BadgeGroup](/docs/components/badge-group) — same API, different child.
+
+## Accessibility
+
+- Renders a plain `<div>` container. Each Tag keeps its own semantics.
+- No `role` or `aria-label` is added — surface the group's label via the parent `<Field>` or a heading.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `gap` | `'xs' \| 'sm' \| 'md'` | `'xs'` |
+| `wrap` | `boolean` | `true` |
+| `children` | `ReactNode` | — |
+
+## Related
+
+- [Tag](/docs/components/tag) — the child component
+- [BadgeGroup](/docs/components/badge-group) — status sibling
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-tag-group--overview)**

--- a/docs-site/content/docs/components/tag.mdx
+++ b/docs-site/content/docs/components/tag.mdx
@@ -1,0 +1,119 @@
+---
+title: Tag
+description: Categorization labels. Non-interactive — for what a record *is*, not what a user can *do*.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Tag is the indicator-family sibling of [Badge](/docs/components/badge) and [Chip](/docs/components/chip). Use it to label *what a record is* — its industry, segment, owner, size, or any other neutral category. Tag is read-only.
+
+<ComparisonGrid
+  items={[
+    {
+      title: 'Tag',
+      preview: <BDS.Tag>Cosmetic</BDS.Tag>,
+      whenToUse: 'Neutral categorization. Industry, owner, segment, size — facts that have no value judgment.',
+      whenNotToUse: 'Use it as a status indicator — that\'s Badge.',
+      code: `<Tag>Cosmetic</Tag>`,
+    },
+    {
+      title: 'Badge',
+      preview: <BDS.Badge status="positive">Active</BDS.Badge>,
+      whenToUse: 'Status with a value judgment (good/bad/waiting). Active, Failed, In review.',
+      whenNotToUse: 'Use for neutral categorization — that\'s Tag.',
+      code: `<Badge status="positive">Active</Badge>`,
+    },
+    {
+      title: 'Chip',
+      preview: <BDS.Chip label="Cosmetic" />,
+      whenToUse: 'Interactive pill — toggleable filter, dismissible selection, dropdown trigger.',
+      whenNotToUse: 'Render with no handler — that\'s Tag.',
+      code: `<Chip label="Cosmetic" onRemove={...} />`,
+    },
+  ]}
+/>
+
+## Use it for
+
+- Industry, segment, vertical labels (Dental, Real Estate, Cosmetic)
+- Owner attribution chips on rows
+- Categorical metadata that doesn't carry a status meaning
+- Non-interactive labels that need consistent visual treatment
+
+## Import
+
+```tsx
+import { Tag } from '@brikdesigns/bds';
+```
+
+## Variants
+
+Four sizes (`xs` is icon-only) and two appearances.
+
+### Sizes
+
+<ComponentPreview code={`<BDS.Tag size="sm">Small</BDS.Tag>
+<BDS.Tag size="md">Medium</BDS.Tag>
+<BDS.Tag size="lg">Large</BDS.Tag>`}>
+  <BDS.Tag size="sm">Small</BDS.Tag>
+  <BDS.Tag size="md">Medium</BDS.Tag>
+  <BDS.Tag size="lg">Large</BDS.Tag>
+</ComponentPreview>
+
+### Appearances
+
+`solid` (default) is neutral filled. `subtle` is transparent with a hairline border — lower visual weight when Tags sit on a colored surface.
+
+```tsx
+<Tag appearance="solid">Cosmetic</Tag>
+<Tag appearance="subtle">Cosmetic</Tag>
+```
+
+### With icons
+
+Pass `icon` (left) or `trailingIcon` (right). Icon is **required** when `size="xs"` (icon-only).
+
+```tsx
+<Tag icon={<CertificateIcon />}>Featured</Tag>
+<Tag trailingIcon={<XCircleIcon />}>Dismiss</Tag>
+<Tag size="xs" icon={<CrownIcon />} />
+```
+
+### Disabled
+
+```tsx
+<Tag disabled>Archived</Tag>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Tag is read-only.** Never wire `onClick`, never wrap in a `<Link>`, never trigger behavior. The `onRemove` prop exists for backward compat but is **deprecated** — migrate removable pills to [Chip](/docs/components/chip).
+</Callout>
+
+- **Don't use Tag for status with a value judgment.** "Active" / "Failed" / "Pending" are [Badge](/docs/components/badge).
+- **Don't use Tag for interactive pills.** Filter toggles, dismissible selections, dropdown triggers are [Chip](/docs/components/chip).
+
+## Accessibility
+
+- Renders a `<span>` — non-interactive by default.
+- Text content is the accessible name. For `xs` (icon-only), pass `aria-label`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` |
+| `appearance` | `'solid' \| 'subtle'` | `'solid'` |
+| `icon` | `ReactNode` | — |
+| `trailingIcon` | `ReactNode` | — |
+| `disabled` | `boolean` | `false` |
+| `children` | `ReactNode` | — |
+| ~~`onRemove`~~ | ~~`() => void`~~ | *(deprecated — use Chip)* |
+
+## Related
+
+- [Badge](/docs/components/badge) — status sibling
+- [Chip](/docs/components/chip) — interactive sibling
+- [TagGroup](/docs/components/tag-group) — multi-tag cluster
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-indicator-tag--overview)**

--- a/docs-site/content/docs/contribution/page-templates.mdx
+++ b/docs-site/content/docs/contribution/page-templates.mdx
@@ -181,6 +181,20 @@ Use HTML `<table>` only when you need JSX `.map()` over runtime data:
 
 JSX expressions inside markdown table syntax don't get re-parsed at runtime — `{x.map(() => '\| col \|').join('\\n')}` renders as literal text, not a table.
 
+### Curly braces in prose
+
+MDX evaluates `{anything}` as a JSX expression — even inside plain text. Writing `"{n}-of-something"` in a bullet means MDX tries to read a variable called `n` and crashes the build with `ReferenceError: n is not defined`.
+
+Two ways to escape:
+
+```md
+✓  Wrap in backticks: `{n}`-of-something
+✓  Use HTML entity: &#123;n&#125;-of-something
+✗  Bare braces: {n}-of-something — crashes prerender
+```
+
+This bites hardest in feature-prop-shape descriptions and template-literal-style copy. When in doubt, backticks.
+
 ### Headings
 
 H1 is the page title (driven by frontmatter — never write `# ` in the body). H2 for sections, H3 for sub-sections. Don't go below H4.

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -63,7 +63,7 @@
         "storybook": "10.2.19",
         "style-dictionary": "^5.3.1",
         "typescript": "^5.5.0",
-        "vite": "^6.0.0",
+        "vite": "^6.4.2",
         "vitest": "^4.1.2"
       },
       "engines": {


### PR DESCRIPTION
## Summary

Closes out the **Indicator** component category in the docs site. All 10 indicator components now live at \`design.brikdesigns.com\` (eventually) under \`/docs/components/\`, leaving Storybook as the playground only.

Component pages added:

| Page | What |
|---|---|
| \`badge\` | Six statuses, four sizes, solid/subtle. ComparisonGrid disambiguates Badge vs Tag vs Chip. |
| \`badge-group\` | Horizontal cluster wrapper for Badges. |
| \`chip\` | Interactive sibling — filter pills, dismissible tokens. Includes Chip vs FilterButton vs Button decision grid + CSS Override API. |
| \`counter\` | Numeric counts with status colors + \`max\` overflow ("99+"). |
| \`dot\` | Minimal status circles + optional \`pulse\` for active states. |
| \`service-badge\` | Icon-only badge for Brik service categories. \`mode\` prop documented as deprecated per .tsx JSDoc. |
| \`skeleton\` | text/circular/rectangular loading placeholders. |
| \`spinner\` | sm/lg sizes + custom-color escape hatch. |
| \`tag\` | Read-only categorization sibling. ComparisonGrid disambiguates Tag vs Badge vs Chip. |
| \`tag-group\` | Horizontal cluster wrapper for Tags. |

ServiceBadge had no source MDX in Storybook (only stories + tsx); this page is fresh from props + JSDoc deprecation notes.

Components index updated to a card grid for the 10-page Indicator section; \`meta.json\` adds an \`---Indicator---\` divider after Action.

## Page-templates doc updated

Added **"Curly braces in prose"** gotcha — caught when Counter's bullet \`"{n}-of-something"\` crashed prerender with \`ReferenceError: n is not defined\`. MDX evaluates \`{x}\` as a JSX expression even in plain text. Backticks or HTML entities escape; bare braces don't. Worth its own callout in the template doc since this is a real authoring trap.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds (BDS dist must be built first)
- [ ] \`/docs/components\` renders both Action (6) and Indicator (10) card grids
- [ ] \`/docs/components/badge\` — ComparisonGrid at top renders three live previews (Badge/Tag/Chip)
- [ ] \`/docs/components/chip\` — three-way ComparisonGrid + CSS Override table render
- [ ] \`/docs/components/counter\` — \`<BDS.Counter count={150} max={99}>\` shows "99+" in the overflow ComponentPreview
- [ ] \`/docs/components/dot\` — pulse animation respects \`prefers-reduced-motion\` (hard to assert in screenshot)
- [ ] \`/docs/components/skeleton\` — code blocks render correctly (no live preview by design)
- [ ] All Indicator pages have working "Storybook playground" deep-links at the bottom
- [ ] Internal cross-links resolve (Badge ↔ Tag ↔ Chip, BadgeGroup ↔ TagGroup)
- [ ] \`/docs/contribution/page-templates\` shows new "Curly braces in prose" section

## Out of scope (follow-ups)

- Form group (12 components — Field, TextInput, Select, MultiSelect, etc.)
- Feedback group (AlertBanner, Toast, Tooltip, EmptyState, ProgressBar)
- Control group (Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader)
- Addable group (AddableTagList, AddableEntryList, AddableFieldRowList)
- Structure group (Card, Divider, Accordion)
- Navigation group (TabBar, Breadcrumb, Pagination, SidebarNavigation)
- Displays section (~14 components — Cards/Overlays/Notifications/Sheets/Table/etc.)
- Motion foundation port
- Remaining Industry packs + Voices + Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)