### PR TITLE
feat(docs-site): migrate Form Inputs sub-batch (10 components)

### DIFF
--- a/docs-site/content/docs/components/address-input.mdx
+++ b/docs-site/content/docs/components/address-input.mdx
@@ -1,0 +1,99 @@
+---
+title: Address input
+description: Location text input with a leading map-pin icon and an autocomplete suggestion dropdown.
+---
+
+AddressInput is a TextInput specialized for location entry. It carries a built-in location icon and supports an autocomplete suggestion dropdown driven by the parent's data fetch.
+
+## Use it for
+
+- Office, business, or property address fields on a profile or company record
+- Location-based search where suggestions come from a geocoding API (Mapbox, Google Places)
+- Any free-form location entry that benefits from address autocomplete
+
+For arbitrary text without geocoding, use [TextInput](/docs/components/text-input).
+
+## Import
+
+```tsx
+import { AddressInput, type AddressSuggestion } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Sizes
+
+Two sizes — `md` (default) and `sm`. Use `sm` in dense rows or sidebars.
+
+```tsx
+<AddressInput label="Address" placeholder="Enter location" />
+<AddressInput label="Address" size="sm" placeholder="Enter location" />
+```
+
+## Pattern: with autocomplete
+
+The parent owns the suggestion fetch. Pass results as `suggestions` and handle selection via `onSuggestionSelect`.
+
+```tsx
+import { AddressInput, type AddressSuggestion } from '@brikdesigns/bds';
+import { useState } from 'react';
+
+const [value, setValue] = useState('');
+const [suggestions, setSuggestions] = useState<AddressSuggestion[]>([]);
+
+<AddressInput
+  label="Address"
+  value={value}
+  onChange={(e) => {
+    setValue(e.target.value);
+    fetchSuggestions(e.target.value).then(setSuggestions);
+  }}
+  suggestions={suggestions}
+  onSuggestionSelect={(s) => {
+    setValue(s.label);
+    setSuggestions([]);
+  }}
+  placeholder="Enter location"
+  fullWidth
+/>
+```
+
+Debounce the `fetchSuggestions` call upstream — typing fires `onChange` on every keystroke, which would hammer the geocoding API.
+
+## When *not* to use
+
+- **Don't use AddressInput for parsed-address fields.** If the form needs separate Street / City / State / Zip fields, use multiple [TextInput](/docs/components/text-input)s + a [Select](/docs/components/select) for State.
+- **Don't fake suggestions.** The dropdown implies a real autocomplete; without one, prefer plain TextInput so the icon doesn't make a promise the form can't keep.
+
+## Accessibility
+
+- Renders an `<input>` with the location icon as a decorative leading affordance (`aria-hidden`).
+- The suggestion list uses `role="listbox"`; selected suggestions are announced via `aria-activedescendant`.
+- Keyboard: `↓`/`↑` navigates suggestions, `Enter` selects, `Esc` dismisses.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `size` | `'sm' \| 'md'` | `'md'` |
+| `label` | `string` | — |
+| `fullWidth` | `boolean` | `false` |
+| `suggestions` | `AddressSuggestion[]` | — |
+| `onSuggestionSelect` | `(s: AddressSuggestion) => void` | — |
+
+Plus all standard `<input>` HTML attributes (excluding `size` and `type`).
+
+### AddressSuggestion shape
+
+```ts
+interface AddressSuggestion {
+  id: string;
+  label: string;
+  // Plus whatever your geocoder returns (lat/lng, place_id, etc.)
+}
+```
+
+## Related
+
+- [TextInput](/docs/components/text-input) — base text-input behavior
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-address-input--overview)**

--- a/docs-site/content/docs/components/catalog-picker.mdx
+++ b/docs-site/content/docs/components/catalog-picker.mdx
@@ -1,0 +1,157 @@
+---
+title: Catalog picker
+description: Industry-aware multi-pick with source attribution. Catalog picks + free-text additions, all stably slugged.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+CatalogPicker is the right primitive when an industry pack seeds defaults that the client can extend. It renders a reference catalog (e.g. the BCS dental industry pack's `servicesCatalog`) as suggestions, accepts free-text additions, and stamps every entry with a stable slug + `source: 'catalog' | 'custom'` attribution.
+
+## Use it for
+
+- Any client-intel field where the [industry pack](/docs/content-system/industries) seeds defaults the client can extend (services offered, pain points, competitor archetypes, keyword banks)
+- Fields where **provenance matters** — the difference between "this came from our industry default" and "this is client-specific" changes downstream behavior (copy generation, mockup content, competitive analysis framing)
+- Multi-pick controls where each entry needs a description alongside the name
+
+For locked vocabularies (no custom escape), use [MultiSelect](/docs/components/multi-select). For flat string picks without descriptions, use AddableComboList. For structured entries with fields other than description (URL + notes, name + role), use AddableEntryList directly.
+
+## Import
+
+```tsx
+import { CatalogPicker } from '@brikdesigns/bds';
+import { getIndustryServicesCatalog } from '@brikdesigns/bds/content-system';
+```
+
+## Variants
+
+### Default
+
+```tsx
+const catalog = getIndustryServicesCatalog(company.industry_slug);
+
+<CatalogPicker
+  label="Services Offered"
+  catalog={catalog}
+  value={services}
+  onChange={setServices}
+  searchPlaceholder="Search or add a service…"
+  descriptionPlaceholder="What makes this service unique here?"
+  addLabel="Add Service"
+  emptyDescriptionLabel="No description set"
+/>
+```
+
+### Strict (catalog-only)
+
+`strict` rejects free-text names that don't match a catalog `displayName` or alias. Use for locked vocabularies that still benefit from the catalog's metadata + description-per-entry shape.
+
+```tsx
+<CatalogPicker
+  label="Insurance accepted"
+  catalog={insuranceCatalog}
+  value={insurances}
+  onChange={setInsurances}
+  strict
+/>
+```
+
+### Different industry, same component
+
+The picker is vocabulary-agnostic — pass any catalog matching the `CatalogEntry` shape. Real estate, dental, commercial — same picker, different `catalog` prop.
+
+```tsx
+<CatalogPicker
+  label="Property types"
+  catalog={getIndustryPropertyTypesCatalog('real-estate-rv-mhc')}
+  value={propertyTypes}
+  onChange={setPropertyTypes}
+/>
+```
+
+### Sizes
+
+`sm`, `md` (default), `lg` — matching the AddableEntryList scale.
+
+### Disabled
+
+```tsx
+<CatalogPicker disabled value={services} onChange={() => {}} catalog={catalog} />
+```
+
+## Source attribution
+
+Every picked entry carries `source: 'catalog' | 'custom'`:
+
+- **`catalog`** — matched the catalog by exact `displayName` or alias (case-insensitive). The picker assigns the catalog entry's canonical `slug`.
+- **`custom`** — no catalog match. The picker derives a kebab-case slug from the typed `displayName`. If that slug collides with an existing one, `-2`, `-3`, … append until unique.
+
+Consumers persist the full array as a single JSONB column (e.g. `company_profiles.services_offered`). Downstream content generation reads the structure without re-deriving provenance every time.
+
+```ts
+// What the picker emits via onChange
+[
+  { source: 'catalog', slug: 'cosmetic-veneers', displayName: 'Veneers', description: 'Composite + porcelain' },
+  { source: 'custom', slug: 'in-house-membership', displayName: 'In-house membership plan', description: 'No PPO routing' },
+]
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use CatalogPicker for locked vocabularies with no custom escape.** That's [MultiSelect](/docs/components/multi-select)'s job — pass the catalog as `options`. CatalogPicker's value is the *escape hatch* for free-text additions; if you don't want one, use the simpler component.
+</Callout>
+
+- **Don't use for flat string picks** with no description. The description textarea adds vertical weight that's wasted on tag-only inputs — use AddableComboList.
+- **Don't use for structured entries** with fields other than description (URL + notes, name + role). Use AddableEntryList directly; you don't need catalog wiring.
+
+## Accessibility
+
+- The search input is a real `<input>` — keyboard, autocomplete, screen reader behaviors all platform.
+- Each picked entry has a labeled remove button (`removeLabel` prop, defaults to `Remove {name}`).
+- Description textareas autosize and announce row counts.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `catalog` | `readonly CatalogEntry[]` *(required)* | — |
+| `value` | `readonly PickedCatalogEntry[]` *(required)* | — |
+| `onChange` | `(next: PickedCatalogEntry[]) => void` *(required)* | — |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `searchPlaceholder` | `string` | — |
+| `descriptionPlaceholder` | `string` | — |
+| `addLabel` | `string` | `'Add'` |
+| `removeLabel` | `string` | auto |
+| `emptyLabel` | `string` | — |
+| `emptyDescriptionLabel` | `string` | `'No description'` |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `disabled` | `boolean` | `false` |
+| `strict` | `boolean` | `false` |
+| `maxItems` | `number` | — |
+| `descriptionRows` | `number` | `2` |
+| `className` | `string` | — |
+
+### CatalogEntry / PickedCatalogEntry shapes
+
+```ts
+interface CatalogEntry {
+  slug: string;
+  displayName: string;
+  aliases?: string[];
+  description?: string;
+}
+
+interface PickedCatalogEntry {
+  source: 'catalog' | 'custom';
+  slug: string;
+  displayName: string;
+  description?: string;
+}
+```
+
+## Related
+
+- [MultiSelect](/docs/components/multi-select) — locked-vocabulary alternative
+- [Industries](/docs/content-system/industries) — where the catalogs come from
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-catalog-picker--overview)**

--- a/docs-site/content/docs/components/checkbox.mdx
+++ b/docs-site/content/docs/components/checkbox.mdx
@@ -1,0 +1,110 @@
+---
+title: Checkbox
+description: Boolean selection with a label. Controlled or uncontrolled.
+---
+
+Checkbox is a themed boolean toggle with required label text. Use for true/false choices — terms acceptance, opt-in flags, individual feature toggles in a settings list. For multiple-of-many selection from a fixed list, group multiple Checkboxes; for single-of-many, use [Radio](/docs/components/radio).
+
+## Use it for
+
+- Terms-of-service / privacy-policy acceptance
+- Individual feature flags ("Email notifications," "SMS notifications")
+- Multiple-from-a-list selections (with several Checkboxes grouped together)
+- "Don't show this again" persistent dismissals
+
+For status toggling (on/off settings), use [Switch](https://storybook.brikdesigns.com/?path=/docs/components-control-switch--overview) — it carries the right semantic for "this preference is now active" vs "I am picking this option."
+
+## Import
+
+```tsx
+import { Checkbox } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Uncontrolled
+
+```tsx
+<Checkbox label="Accept terms" defaultChecked />
+```
+
+### Controlled
+
+```tsx
+import { useState } from 'react';
+
+const [enabled, setEnabled] = useState(false);
+
+<Checkbox
+  label="Enable notifications"
+  checked={enabled}
+  onChange={(e) => setEnabled(e.target.checked)}
+/>
+```
+
+### Disabled
+
+```tsx
+<Checkbox label="Required" disabled defaultChecked />
+```
+
+## Pattern: Checkbox group
+
+For "pick multiple from a known list," render a group of Checkboxes — each independently controlled.
+
+```tsx
+const [prefs, setPrefs] = useState({
+  email: true,
+  sms: false,
+  push: true,
+});
+
+<>
+  <Checkbox
+    label="Email"
+    checked={prefs.email}
+    onChange={(e) => setPrefs({ ...prefs, email: e.target.checked })}
+  />
+  <Checkbox
+    label="SMS"
+    checked={prefs.sms}
+    onChange={(e) => setPrefs({ ...prefs, sms: e.target.checked })}
+  />
+  <Checkbox
+    label="Push"
+    checked={prefs.push}
+    onChange={(e) => setPrefs({ ...prefs, push: e.target.checked })}
+  />
+</>
+```
+
+## When *not* to use
+
+- **Don't use Checkbox for on/off preferences.** Use [Switch](https://storybook.brikdesigns.com/?path=/docs/components-control-switch--overview) — the affordance is correct for "now active" semantics.
+- **Don't use Checkbox for single-of-many.** Use [Radio](/docs/components/radio).
+- **Don't use Checkbox for ≥10 options.** Use [MultiSelect](/docs/components/multi-select) — a vertical list of 10+ Checkboxes is unscannable.
+
+## Accessibility
+
+- Renders a real `<input type="checkbox">` — keyboard `Space` toggles, focus ring is platform native.
+- The `label` prop auto-wires the `<label>` element so clicking the label toggles the input.
+- For Checkbox groups, wrap in a `<fieldset>` with a `<legend>` to surface the group's name.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `label` | `ReactNode` *(required)* | — |
+| `checked` | `boolean` | — |
+| `defaultChecked` | `boolean` | — |
+| `disabled` | `boolean` | `false` |
+| `onChange` | `(e: ChangeEvent<HTMLInputElement>) => void` | — |
+
+Plus all standard `<input>` HTML attributes (excluding `type`).
+
+## Related
+
+- [Radio](/docs/components/radio) — single-of-many sibling
+- [MultiSelect](/docs/components/multi-select) — better for ≥10 options
+- [Switch](https://storybook.brikdesigns.com/?path=/docs/components-control-switch--overview) — for on/off preferences
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-checkbox--overview)**

--- a/docs-site/content/docs/components/date-picker.mdx
+++ b/docs-site/content/docs/components/date-picker.mdx
@@ -1,0 +1,107 @@
+---
+title: Date picker
+description: Date selection with a calendar popover. Min/max date constraints, controlled value as a Date object.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+DatePicker is a Radix-Popover-backed date selector. The trigger is a TextInput-shaped field; the popover renders a calendar grid for selection. Returns a real `Date` object, not a string.
+
+## Use it for
+
+- Single-date selection on forms (start date, due date, scheduled-for)
+- Filtering by date in dashboards (with `minDate` / `maxDate` constraints)
+- Any field where the user picks one specific calendar day
+
+For a time-of-day picker, use [TimePicker](/docs/components/time-picker). Date *and* time pickers should be paired side by side rather than combined into one component.
+
+## Import
+
+```tsx
+import { DatePicker } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { useState } from 'react';
+
+const [date, setDate] = useState<Date | null>(null);
+
+<DatePicker
+  label="Start date"
+  value={date}
+  onChange={setDate}
+  placeholder="Pick a date"
+/>
+```
+
+### With constraints
+
+`minDate` / `maxDate` clamp the selectable range. Out-of-range days render disabled in the popover.
+
+```tsx
+<DatePicker
+  label="Available date"
+  value={date}
+  onChange={setDate}
+  minDate={new Date()}
+  maxDate={addMonths(new Date(), 6)}
+/>
+```
+
+### Sizes
+
+`sm`, `md` (default), `lg` — match TextInput sizes.
+
+### Error state
+
+```tsx
+<DatePicker
+  label="Due date"
+  error="Pick a date in the future"
+  value={date}
+  onChange={setDate}
+/>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use DatePicker for date *ranges*.** Pair two DatePickers (`from` + `to`) and validate that `from <= to` in the parent. A combined range picker isn't part of BDS yet — adding one would be a separate component proposal.
+</Callout>
+
+- **Don't use DatePicker for time-only selection.** Use [TimePicker](/docs/components/time-picker).
+- **Don't use DatePicker for known months/days only** (e.g. picking a birthday year). A pair of [Select](/docs/components/select)s is faster for fields where the calendar UI is overkill.
+
+## Accessibility
+
+- The trigger is a real `<input>` — keyboard access, focus ring, screen-reader labels match TextInput.
+- The calendar popover uses Radix Popover under the hood — focus trap, `Esc` to dismiss, click-outside to close.
+- Selected date announces via `aria-live` on the trigger.
+- `label` auto-wires `htmlFor`/`id`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `value` | `Date \| null` | — |
+| `onChange` | `(date: Date \| null) => void` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `error` | `string` | — |
+| `placeholder` | `string` | — |
+| `fullWidth` | `boolean` | `false` |
+| `disabled` | `boolean` | `false` |
+| `minDate` | `Date` | — |
+| `maxDate` | `Date` | — |
+| `id` | `string` | auto |
+
+## Related
+
+- [TimePicker](/docs/components/time-picker) — pair with DatePicker for date-and-time entry
+- [TextInput](/docs/components/text-input) — base trigger shape
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-date-picker--overview)**

--- a/docs-site/content/docs/components/field-grid.mdx
+++ b/docs-site/content/docs/components/field-grid.mdx
@@ -1,0 +1,94 @@
+---
+title: Field grid
+description: Equal-column grid for laying out Field components side by side. Replaces ad-hoc inline grid templates.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+FieldGrid is a layout primitive for placing equal-weight cells side by side. Replaces the inline `display: grid; gridTemplateColumns: '1fr 1fr'` pattern that grew across portal sheets.
+
+The primary case is wrapping multiple [Field](/docs/components/field) components, but it accepts any equal-weight children — Cards, Tags, stat tiles.
+
+## Use it for
+
+- 2-column entity detail rows (Owner / Location, Industry / Subindustry)
+- 3- or 4-tile stat rows (Source / Scraped / Failed / Total)
+- Any side-by-side layout where the cells should be equal width
+
+For variable-width or 5+ column layouts, FieldGrid is the wrong primitive — use a Table.
+
+## Import
+
+```tsx
+import { FieldGrid, Field } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Columns
+
+Three locked column counts — `2` (default), `3`, `4`. No custom column templates: if you need something else, you're composing the wrong primitive.
+
+```tsx
+<FieldGrid columns={2}>
+  <Field label="Owner">Nick Stanerson</Field>
+  <Field label="Status">Active</Field>
+</FieldGrid>
+
+<FieldGrid columns={3}>
+  <Field label="Source">birdwelldentist.com</Field>
+  <Field label="Scraped">8</Field>
+  <Field label="Failed">12</Field>
+</FieldGrid>
+```
+
+### Gap sizes
+
+Three gaps — `md`, `lg`, `xl` (default). `xl` matches existing portal field grids.
+
+```tsx
+<FieldGrid columns={2} gap="md">
+  ...
+</FieldGrid>
+```
+
+### Stat tiles
+
+Wrapping each grid cell in `<Card variant="outlined">` gives you the canonical stat-tile pattern (e.g. Content Scrape's SOURCE / SCRAPED / FAILED tiles).
+
+```tsx
+<FieldGrid columns={3} gap="md">
+  <Card variant="outlined"><Field label="Source">birdwelldentist.com</Field></Card>
+  <Card variant="outlined"><Field label="Scraped">8</Field></Card>
+  <Card variant="outlined"><Field label="Failed">12</Field></Card>
+</FieldGrid>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **No custom columns.** If you need 5 cells or variable widths, you're reaching for the wrong primitive — use a Table.
+</Callout>
+
+- **All children must be equal-weight.** Don't mix a tall Card with a single-line Field in the same grid — that breaks the visual rhythm.
+- **Don't nest FieldGrids.** If you need a 4-column outer grid with 2-column inner cells, you're describing a Table.
+
+## Accessibility
+
+- Renders a `<div>` with `display: grid`. Children retain their own semantics — wrapping Fields in FieldGrid doesn't change their accessibility tree.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `columns` | `2 \| 3 \| 4` | `2` |
+| `gap` | `'md' \| 'lg' \| 'xl'` | `'xl'` |
+| `children` | `ReactNode` | — |
+
+Plus all standard `<div>` HTML attributes.
+
+## Related
+
+- [Field](/docs/components/field) — the canonical child
+- [Card](https://storybook.brikdesigns.com/?path=/docs/displays-cards-card--overview) — wrap each cell to get stat-tile styling
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-field-grid--overview)**

--- a/docs-site/content/docs/components/field.mdx
+++ b/docs-site/content/docs/components/field.mdx
@@ -1,0 +1,126 @@
+---
+title: Field
+description: Label + value pair for read-mode display inside Sheets. One API covers text, tags, links, lists, and empty states.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Field is the most important primitive in the sheet body set. One component replaces four legacy patterns (`FieldPair`, `TextValue`, `SmartTextValue`, raw label/value markup) that were drifting across portal sheets. Use it anywhere a labeled value renders in a read-mode view.
+
+## Use it for
+
+- Sheet body rows showing a labeled value (Status, Owner, Industry, etc.)
+- Stat lines on cards (Scraped · 8, Failed · 12)
+- Any "label + value" pair where the value is read-only (not editable in this view)
+- Empty-state placeholders when a value isn't set ("Not set" muted text by default)
+
+For editable variants, fields belong inside [Form](/docs/components/form) with the appropriate input — Field is read-mode only.
+
+## Import
+
+```tsx
+import { Field } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Stacked (default)
+
+Label above value. Default for sheet body rows where the value needs full width.
+
+```tsx
+<Field label="Status">Active</Field>
+<Field label="Industry">Dental — General Practice</Field>
+```
+
+### Inline
+
+Label left, value right-aligned. Compact stat row pattern — `Status · Active`, `Scraped · 8`.
+
+```tsx
+<Field layout="inline" label="Scraped">8</Field>
+<Field layout="inline" label="Status">Active</Field>
+```
+
+### Empty states
+
+When `children` is `null`, `undefined`, or empty string, Field renders an inline muted "Not set" by default.
+
+```tsx
+// Default: shows "Not set"
+<Field label="Owner" />
+
+// Custom empty message
+<Field label="Parent organization" empty="Independent" />
+```
+
+For a section-level empty state (the whole section has no data, not just one field), pass an `<EmptyState />` into `empty`. Use sparingly — one full bordered treatment per section at most.
+
+```tsx
+<Field
+  label="Recent activity"
+  empty={<EmptyState title="No activity yet" />}
+/>
+```
+
+### Value types
+
+`children` accepts any ReactNode — text, [TagGroup](/docs/components/tag-group)/[Tag](/docs/components/tag), `<a>` / [TextLink](/docs/components/text-link), `<BulletList>`, or compound content.
+
+```tsx
+// With tags
+<Field label="Services">
+  <TagGroup>
+    <Tag size="sm">Cosmetic</Tag>
+    <Tag size="sm">Implants</Tag>
+  </TagGroup>
+</Field>
+
+// With a link
+<Field label="Website">
+  <a href="https://example.com">example.com</a>
+</Field>
+
+// With a bullet list
+<Field label="Anti-messages">
+  <BulletList items={['No price-first', 'No corporate-clinic']} />
+</Field>
+
+// Inside a FieldGrid for side-by-side layout
+<FieldGrid columns={2}>
+  <Field label="Owner">Nick Stanerson</Field>
+  <Field label="Location">Thompson Station, TN</Field>
+</FieldGrid>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't style the value inline.** If a value needs tag treatment, use [Tag](/docs/components/tag). If it needs a link, use [TextLink](/docs/components/text-link). If it needs a list, use `<BulletList>`. Never reach for raw `color` or `text-transform` on a Field child — that drifts the visual language.
+</Callout>
+
+- **Don't nest Fields.** A value is a value. If you need sub-structure, it belongs in a new SheetSection.
+- **Don't use Field for editable forms.** Field is read-mode. For input, use [TextInput](/docs/components/text-input) (etc.) inside a [Form](/docs/components/form).
+
+## Accessibility
+
+- Renders a `<div>` with the label as a `<dt>`-equivalent label and the value as the `<dd>`-equivalent.
+- For a true `<dl>` semantic, wrap a list of Fields in a `<dl>` element manually — Field doesn't enforce parent shape.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `label` | `string` *(required)* | — |
+| `children` | `ReactNode` | — |
+| `layout` | `'stacked' \| 'inline'` | `'stacked'` |
+| `empty` | `ReactNode` | `'Not set'` |
+
+Plus all standard `<div>` HTML attributes (excluding `children`).
+
+## Related
+
+- [FieldGrid](/docs/components/field-grid) — equal-column wrapper for laying Fields out side by side
+- [Form](/docs/components/form) — editable counterpart with title/description/footer
+- [TagGroup](/docs/components/tag-group) — common Field child for tagged values
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-field--overview)**

--- a/docs-site/content/docs/components/form.mdx
+++ b/docs-site/content/docs/components/form.mdx
@@ -1,0 +1,122 @@
+---
+title: Form
+description: Structured form container with title, description, error/success states, and footer actions.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Form is the editable counterpart to [Field](/docs/components/field). It renders a real `<form>` with consistent spacing, optional title/description/footer slots, and form-level error or success messaging. Use it whenever you have more than one input that should submit together.
+
+## Use it for
+
+- Multi-input editable views (contact forms, settings panels, intake flows)
+- Any view where Save / Cancel are explicit actions, not auto-save
+- Forms that need a title / description / submit-state pattern out of the box
+
+For a single-input quick edit, you don't need Form — just render the input directly. For read-mode display, use [Field](/docs/components/field).
+
+## Import
+
+```tsx
+import { Form } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { Form, TextInput, TextArea, Button } from '@brikdesigns/bds';
+
+<Form
+  title="Contact us"
+  description="We'll get back to you within 24 hours."
+  onSubmit={handleSubmit}
+  footer={<Button type="submit">Send message</Button>}
+>
+  <TextInput label="Name" placeholder="Your name" fullWidth />
+  <TextInput label="Email" type="email" placeholder="you@example.com" fullWidth />
+  <TextArea label="Message" placeholder="How can we help?" fullWidth />
+</Form>
+```
+
+### Layout
+
+`vertical` (default) stacks fields. `horizontal` lays them side by side for compact forms.
+
+```tsx
+<Form layout="horizontal" {...props}>
+  <TextInput label="First" />
+  <TextInput label="Last" />
+</Form>
+```
+
+### Gap sizes
+
+| Size | Gap value |
+|---|---|
+| `sm` | `--gap-md` (8px) |
+| `md` (default) | `--gap-lg` (16px) |
+| `lg` | `--gap-xl` (24px) |
+
+```tsx
+<Form gap="lg" {...props}>...</Form>
+```
+
+### Form-level error
+
+```tsx
+<Form
+  error="Couldn't save. Try again in a moment."
+  onSubmit={handleSubmit}
+  footer={<Button type="submit">Save</Button>}
+>
+  ...
+</Form>
+```
+
+### Form-level success
+
+```tsx
+<Form
+  success="Saved. Settings updated."
+  onSubmit={handleSubmit}
+  footer={<Button type="submit">Save</Button>}
+>
+  ...
+</Form>
+```
+
+## When *not* to use
+
+- **Don't use Form for read-mode display.** Use [Field](/docs/components/field) + [FieldGrid](/docs/components/field-grid).
+- **Don't use Form for inline edit-in-place.** Single-field inline editing doesn't need a `<form>` wrapper. Use the input directly with controlled state.
+- **Don't put navigation actions in `footer`.** Footer is for submit/cancel of *this form's data*. "Back to dashboard" goes in the parent layout.
+
+## Accessibility
+
+- Renders a real `<form>` element. Browser handles `Enter` to submit, autofocus, autofill correctly.
+- `title` becomes a heading inside the form. Use a sensible heading hierarchy in the surrounding page (typically `<h1>` outside, this becomes `<h2>` inside).
+- `error` and `success` messages are announced via `aria-live="polite"` so screen readers pick up async submit feedback.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `children` | `ReactNode` *(required)* | — |
+| `layout` | `'vertical' \| 'horizontal'` | `'vertical'` |
+| `gap` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `title` | `string` | — |
+| `description` | `string` | — |
+| `error` | `string` | — |
+| `success` | `string` | — |
+| `footer` | `ReactNode` | — |
+
+Plus all standard `<form>` HTML attributes (including `onSubmit`, `action`, `method`, etc.).
+
+## Related
+
+- [Field](/docs/components/field) — read-mode counterpart
+- [FieldGrid](/docs/components/field-grid) — equal-column layout for read-mode
+- All Form Inputs ([TextInput](/docs/components/text-input), [Select](/docs/components/select), [Checkbox](/docs/components/checkbox), etc.) — typical Form children
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-form--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -49,7 +49,7 @@ The indicator family — read-only state communication. For interactive pills, u
 
 ### Form / Inputs
 
-The 10 input controls of the Form group. Field/FieldGrid/Form (the structure layer) still in Storybook for now.
+The 10 input controls of the Form group.
 
 <Cards>
   <Card title="Text input" href="/docs/components/text-input" description="Single-line input. Labels, helpers, errors, icons, sizes, any input type." />
@@ -64,9 +64,20 @@ The 10 input controls of the Form group. Field/FieldGrid/Form (the structure lay
   <Card title="Radio" href="/docs/components/radio" description="Single-select from a mutually exclusive group. Group by shared name." />
 </Cards>
 
+### Form / Structure
+
+The container, layout, and curated-multi-pick layer of the Form group. Closes out Form.
+
+<Cards>
+  <Card title="Field" href="/docs/components/field" description="Label + value pair for read-mode display. One API covers text, tags, links, lists, and empty states." />
+  <Card title="Field grid" href="/docs/components/field-grid" description="Equal-column grid (2/3/4) for laying Fields side by side. Replaces ad-hoc inline grids." />
+  <Card title="Form" href="/docs/components/form" description="Editable container with title/description/error/success/footer. Vertical or horizontal layout." />
+  <Card title="Catalog picker" href="/docs/components/catalog-picker" description="Industry-aware multi-pick with source attribution (catalog vs custom)." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining ~30 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Form structure (Field/FieldGrid/Form/CatalogPicker), Feedback, Control, Addable, Structure, Navigation, and Displays.
+The remaining ~26 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Feedback, Control, Addable, Structure, Navigation, and Displays.
 
 ## Page template
 

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -10,7 +10,7 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
 | Group | Examples |
 |---|---|
 | **Action** | Button, IconButton, LinkButton, ButtonGroup, FilterBar, FilterButton, FilterToggle, TextLink |
-| **Form** | Field, TextInput, Select, MultiSelect, DatePicker, Form, FieldGrid |
+| **Form** | TextInput, TextArea, PasswordInput, AddressInput, Select, MultiSelect, DatePicker, TimePicker, Checkbox, Radio, Field, FieldGrid, Form |
 | **Indicator** | Badge, Chip, Tag, Counter, Dot, Spinner, Skeleton, BadgeGroup, TagGroup, ServiceBadge |
 | **Feedback** | AlertBanner, Toast, Tooltip, EmptyState, ProgressBar |
 | **Control** | Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader |
@@ -47,9 +47,26 @@ The indicator family — read-only state communication. For interactive pills, u
   <Card title="Tag group" href="/docs/components/tag-group" description="Horizontal cluster of Tag elements with locked spacing." />
 </Cards>
 
+### Form / Inputs
+
+The 10 input controls of the Form group. Field/FieldGrid/Form (the structure layer) still in Storybook for now.
+
+<Cards>
+  <Card title="Text input" href="/docs/components/text-input" description="Single-line input. Labels, helpers, errors, icons, sizes, any input type." />
+  <Card title="Text area" href="/docs/components/text-area" description="Multi-line input with configurable rows and resize behavior." />
+  <Card title="Password input" href="/docs/components/password-input" description="Text input with show/hide visibility toggle." />
+  <Card title="Address input" href="/docs/components/address-input" description="Location input with leading icon and autocomplete suggestions." />
+  <Card title="Select" href="/docs/components/select" description="Single-select dropdown. Flat or grouped options, optional leading icon." />
+  <Card title="Multi-select" href="/docs/components/multi-select" description="Multi-pick dropdown — selected items render as removable Tag chips." />
+  <Card title="Date picker" href="/docs/components/date-picker" description="Calendar popover for date selection. Returns a real Date object." />
+  <Card title="Time picker" href="/docs/components/time-picker" description="Hour/minute popover. AM/PM or 24-hour display, value always HH:mm." />
+  <Card title="Checkbox" href="/docs/components/checkbox" description="Boolean selection with a label. Controlled or uncontrolled." />
+  <Card title="Radio" href="/docs/components/radio" description="Single-select from a mutually exclusive group. Group by shared name." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining ~40 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Form, Feedback, Control, Addable, Structure, Navigation, and Displays.
+The remaining ~30 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Form structure (Field/FieldGrid/Form/CatalogPicker), Feedback, Control, Addable, Structure, Navigation, and Displays.
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -19,6 +19,17 @@
     "skeleton",
     "spinner",
     "tag",
-    "tag-group"
+    "tag-group",
+    "---Form / Inputs---",
+    "text-input",
+    "text-area",
+    "password-input",
+    "address-input",
+    "select",
+    "multi-select",
+    "date-picker",
+    "time-picker",
+    "checkbox",
+    "radio"
   ]
 }

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -30,6 +30,11 @@
     "date-picker",
     "time-picker",
     "checkbox",
-    "radio"
+    "radio",
+    "---Form / Structure---",
+    "field",
+    "field-grid",
+    "form",
+    "catalog-picker"
   ]
 }

--- a/docs-site/content/docs/components/multi-select.mdx
+++ b/docs-site/content/docs/components/multi-select.mdx
@@ -1,0 +1,104 @@
+---
+title: Multi-select
+description: Select dropdown that supports multiple selections, with picked items rendered as removable Tag chips.
+---
+
+MultiSelect composes [Select](/docs/components/select) + [Tag](/docs/components/tag): pick from a dropdown, selected items render below as removable Tag chips. Use whenever a user can pick more than one option from a known set.
+
+## Use it for
+
+- Service category selection (Brand Design + Marketing + Content)
+- Tag/label assignment on a record
+- Multi-region or multi-tenant scoping
+- Any "pick N from M" choice with a visible-set affordance
+
+For single-pick, use [Select](/docs/components/select). For free-form tag entry where users type new values, use [AddableTagList](https://storybook.brikdesigns.com/?path=/docs/components-addable-addable-tag-list--overview).
+
+## Import
+
+```tsx
+import { MultiSelect } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { useState } from 'react';
+
+const [selected, setSelected] = useState<string[]>([]);
+
+<MultiSelect
+  label="Services"
+  placeholder="Select services..."
+  options={[
+    { label: 'Brand Design', value: 'brand' },
+    { label: 'Marketing', value: 'marketing' },
+    { label: 'Product Design', value: 'product' },
+  ]}
+  value={selected}
+  onChange={setSelected}
+/>
+```
+
+### Sizes
+
+```tsx
+<MultiSelect size="sm" {...props} />
+<MultiSelect size="md" {...props} />
+<MultiSelect size="lg" {...props} />
+```
+
+### Error state
+
+```tsx
+<MultiSelect
+  label="Required services"
+  error="Please select at least one"
+  options={options}
+  value={selected}
+  onChange={setSelected}
+/>
+```
+
+### Tag size override
+
+By default selected-item tags match the dropdown size. Override with `tagSize` for a tighter pill cluster.
+
+```tsx
+<MultiSelect size="md" tagSize="sm" {...props} />
+```
+
+## When *not* to use
+
+- **Don't use MultiSelect for ≤3 options.** Use [Checkbox](/docs/components/checkbox) groups — the choices are visible at all times.
+- **Don't use MultiSelect when users need to enter new tags.** Free-form tag entry belongs in [AddableTagList](https://storybook.brikdesigns.com/?path=/docs/components-addable-addable-tag-list--overview).
+
+## Accessibility
+
+- Renders a `<select multiple>` (visually hidden) plus the rendered Tag list. Keyboard navigation matches the native multi-select.
+- Each selected Tag carries a `Remove {label}` accessible name on its dismiss button.
+- `aria-invalid` on the underlying select when `error` is present.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `options` | `MultiSelectOption[]` *(required)* | — |
+| `value` / `defaultValue` | `string[]` | — |
+| `onChange` | `(values: string[]) => void` | — |
+| `placeholder` | `string` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `tagSize` | `'sm' \| 'md' \| 'lg'` | matches `size` |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `error` | `string` | — |
+| `disabled` | `boolean` | `false` |
+| `fullWidth` | `boolean` | `true` |
+
+## Related
+
+- [Select](/docs/components/select) — single-pick sibling
+- [Tag](/docs/components/tag) — the chip rendered for each selection
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-multi-select--overview)**

--- a/docs-site/content/docs/components/password-input.mdx
+++ b/docs-site/content/docs/components/password-input.mdx
@@ -1,0 +1,84 @@
+---
+title: Password input
+description: Text input with a show/hide toggle. Inherits TextInput's API minus type and iconAfter.
+---
+
+PasswordInput extends [TextInput](/docs/components/text-input) with a show/hide button on the trailing edge. Use it for any field that masks sensitive text — passwords, API keys, recovery phrases, tokens.
+
+## Use it for
+
+- Login and signup password fields
+- Change-password and reset-password forms
+- API key and secret entry
+- Any field where the user benefits from being able to verify what they typed without re-typing
+
+For non-sensitive text, use [TextInput](/docs/components/text-input).
+
+## Import
+
+```tsx
+import { PasswordInput } from '@brikdesigns/bds';
+```
+
+## Variants
+
+PasswordInput inherits TextInput's full API except `type` (locked to `password` / `text` based on the toggle) and `iconAfter` (occupied by the visibility button).
+
+### Default
+
+```tsx
+<PasswordInput label="Password" />
+```
+
+### With validation error
+
+```tsx
+<PasswordInput
+  label="Password"
+  error="Password must be at least 8 characters"
+/>
+```
+
+### With helper text
+
+```tsx
+<PasswordInput
+  label="New password"
+  helperText="At least 8 characters with a mix of letters and numbers"
+/>
+```
+
+### Sizes
+
+`sm`, `md`, `lg` — same as TextInput.
+
+```tsx
+<PasswordInput label="Password" size="lg" />
+```
+
+## When *not* to use
+
+- **Don't use TextInput with `type="password"`** when you mean PasswordInput. The toggle is real, load-bearing UX — users typo passwords and need to verify.
+- **Don't use PasswordInput for one-time codes.** Codes (2FA, magic-link) shouldn't be masked — use [TextInput](/docs/components/text-input) with `inputMode="numeric"` and `autoComplete="one-time-code"`.
+
+## Accessibility
+
+- The toggle button has `aria-label="Show password"` / `"Hide password"` reflecting current state.
+- `aria-pressed` on the toggle reflects the current visibility state.
+- The input's autocomplete attribute should be set per context — `current-password` for login, `new-password` for signup/change.
+
+```tsx
+<PasswordInput label="Password" autoComplete="current-password" />
+<PasswordInput label="New password" autoComplete="new-password" />
+```
+
+## API
+
+PasswordInput's prop type is `Omit<TextInputProps, 'type' | 'iconAfter'>` — it accepts everything TextInput accepts except those two.
+
+See [TextInput → API](/docs/components/text-input#api) for the full prop list.
+
+## Related
+
+- [TextInput](/docs/components/text-input) — base component
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-password-input--overview)**

--- a/docs-site/content/docs/components/radio.mdx
+++ b/docs-site/content/docs/components/radio.mdx
@@ -1,0 +1,97 @@
+---
+title: Radio
+description: Single selection from mutually exclusive options. Group by shared name.
+---
+
+Radio is a themed radio button with required label text. Group radios by their shared `name` prop — only one radio per group can be selected. Use for "pick exactly one" decisions among a small fixed set.
+
+## Use it for
+
+- Plan / tier selection on signup
+- Theme picker (Light / Dark / System)
+- Mutually exclusive settings (Layout: Compact / Comfortable / Spacious)
+- Fixed-set choices with ≤5 options
+
+For ≥6 options, use [Select](/docs/components/select). For boolean (single yes/no), use [Checkbox](/docs/components/checkbox) or [Switch](https://storybook.brikdesigns.com/?path=/docs/components-control-switch--overview).
+
+## Import
+
+```tsx
+import { Radio } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Basic group
+
+Same `name` ties radios into a group. Only one can be checked at a time.
+
+```tsx
+<Radio name="plan" value="basic" label="Basic Plan" />
+<Radio name="plan" value="pro" label="Pro Plan" defaultChecked />
+<Radio name="plan" value="enterprise" label="Enterprise Plan" />
+```
+
+### Controlled group
+
+Track selection in parent state; switch the `checked` derivation per radio.
+
+```tsx
+import { useState } from 'react';
+
+const [selected, setSelected] = useState('pro');
+
+<Radio
+  name="plan"
+  value="basic"
+  label="Basic Plan"
+  checked={selected === 'basic'}
+  onChange={(e) => setSelected(e.target.value)}
+/>
+<Radio
+  name="plan"
+  value="pro"
+  label="Pro Plan"
+  checked={selected === 'pro'}
+  onChange={(e) => setSelected(e.target.value)}
+/>
+```
+
+### Disabled
+
+```tsx
+<Radio name="plan" value="enterprise" label="Enterprise (contact sales)" disabled />
+```
+
+## When *not* to use
+
+- **Don't use Radio for ≥6 options.** A vertical list of radios is unscannable. Use [Select](/docs/components/select).
+- **Don't use Radio for boolean.** "Yes / No" with two radios is awkward; use a [Checkbox](/docs/components/checkbox) for opt-in or [Switch](https://storybook.brikdesigns.com/?path=/docs/components-control-switch--overview) for a setting.
+- **Don't forget `name`.** Radios without a shared `name` aren't grouped — multiple can be selected, defeating the entire control.
+
+## Accessibility
+
+- Renders a real `<input type="radio">` — keyboard arrow keys move focus and selection within a group, `Tab` moves between groups.
+- The `label` prop auto-wires the `<label>` so clicking the label selects the radio.
+- Wrap a Radio group in a `<fieldset>` with a `<legend>` to surface the group's purpose ("Choose a plan").
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `label` | `ReactNode` *(required)* | — |
+| `name` | `string` *(required)* | — |
+| `value` | `string` *(required)* | — |
+| `checked` | `boolean` | — |
+| `defaultChecked` | `boolean` | — |
+| `disabled` | `boolean` | `false` |
+| `onChange` | `(e: ChangeEvent<HTMLInputElement>) => void` | — |
+
+Plus all standard `<input>` HTML attributes (excluding `type`).
+
+## Related
+
+- [Checkbox](/docs/components/checkbox) — multiple-of-many sibling
+- [Select](/docs/components/select) — better for ≥6 options
+- [SegmentedControl](https://storybook.brikdesigns.com/?path=/docs/components-control-segmented-control--overview) — horizontal alternative for ≤4 short-label options
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-radio--overview)**

--- a/docs-site/content/docs/components/select.mdx
+++ b/docs-site/content/docs/components/select.mdx
@@ -1,0 +1,153 @@
+---
+title: Select
+description: Single-select dropdown with options, placeholder, optional leading icon, and grouped options.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Select is a native `<select>` styled to match BDS. Use for single-select choice from a known list. For multi-select, use [MultiSelect](/docs/components/multi-select). For filtering inside a FilterBar, use [FilterButton](/docs/components/filter-button).
+
+## Use it for
+
+- Country, state, currency, language pickers
+- Plan / tier / category selection
+- Sort-by controls
+- Any single-pick from a fixed enumeration
+
+## Import
+
+```tsx
+import { Select } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+<Select
+  placeholder="Select one..."
+  options={[
+    { label: 'First', value: 'first' },
+    { label: 'Second', value: 'second' },
+  ]}
+/>
+```
+
+### With label, icon, and helper
+
+```tsx
+<Select
+  label="Company"
+  placeholder="Select company..."
+  helperText="Pick the parent organization"
+  icon={<BuildingsIcon />}
+  options={options}
+  fullWidth
+/>
+```
+
+### Grouped options
+
+Pass an array mixing `SelectOption` (a single option) and `SelectOptionGroup` (a group with a `label` and nested `options`). Groups render as `<optgroup>`.
+
+```tsx
+<Select
+  label="Location"
+  placeholder="Select city..."
+  options={[
+    {
+      label: 'US',
+      options: [
+        { label: 'New York', value: 'nyc' },
+        { label: 'San Francisco', value: 'sfo' },
+      ],
+    },
+    {
+      label: 'Europe',
+      options: [
+        { label: 'London', value: 'lon' },
+        { label: 'Berlin', value: 'ber' },
+      ],
+    },
+  ]}
+/>
+```
+
+### Sizes
+
+`sm`, `md` (default), `lg` — match TextInput sizes.
+
+### Error state
+
+```tsx
+<Select label="Plan" error="Please select a plan" options={planOptions} />
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use Select for filter-bar dropdowns.** Use [FilterButton](/docs/components/filter-button) — it carries the right semantics and visual treatment for filter context.
+</Callout>
+
+- **Don't use Select for multi-select.** Use [MultiSelect](/docs/components/multi-select).
+- **Don't use Select for >50 options.** The native dropdown becomes unusable. Use a search-driven combobox pattern instead.
+- **Don't use Select for ≤3 options.** Use [Radio](/docs/components/radio) (vertical) or [SegmentedControl](https://storybook.brikdesigns.com/?path=/docs/components-control-segmented-control--overview) (horizontal) — both surface choices visibly.
+
+## Accessibility
+
+- Renders a real `<select>` — keyboard navigation (arrows, type-to-find), platform native-listbox UI.
+- `label` auto-wires `htmlFor`/`id`.
+- `error` sets `aria-invalid` and replaces `helperText` with the error message.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `options` | `(SelectOption \| SelectOptionGroup)[]` *(required)* | — |
+| `placeholder` | `string` | — |
+| `value` / `defaultValue` | `string` | — |
+| `onChange` | `(e: ChangeEvent<HTMLSelectElement>) => void` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `error` | `string` | — |
+| `fullWidth` | `boolean` | `true` |
+| `icon` | `ReactNode` | — |
+| `disabled` | `boolean` | `false` |
+
+### Option shapes
+
+```ts
+interface SelectOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+interface SelectOptionGroup {
+  label: string;
+  options: SelectOption[];
+}
+```
+
+## CSS Override API
+
+| Variable | Default | Controls |
+|---|---|---|
+| `--select-chevron-color` | `var(--text-muted)` | Chevron icon color |
+| `--select-icon-color` | `var(--text-muted)` | Leading icon color |
+
+```css
+.branded-form {
+  --select-chevron-color: var(--text-brand-primary);
+  --select-icon-color: var(--text-brand-primary);
+}
+```
+
+## Related
+
+- [MultiSelect](/docs/components/multi-select) — multi-pick sibling
+- [FilterButton](/docs/components/filter-button) — dropdown for filter bars
+- [Radio](/docs/components/radio) — alternative for ≤5 options
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-select--overview)**

--- a/docs-site/content/docs/components/text-area.mdx
+++ b/docs-site/content/docs/components/text-area.mdx
@@ -1,0 +1,111 @@
+---
+title: Text area
+description: Multi-line text input with configurable rows, resize behavior, and size variants.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+TextArea is the multi-line sibling of [TextInput](/docs/components/text-input). Use for longer-form text entry — comments, descriptions, messages, notes, anything that needs more than one line.
+
+## Use it for
+
+- Comments and reviews
+- Description fields on records (project descriptions, bio, notes)
+- Message composition
+- Free-form text where users may type more than ~60 characters
+
+## Import
+
+```tsx
+import { TextArea } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Sizes
+
+```tsx
+<TextArea size="sm" placeholder="Small" rows={3} />
+<TextArea size="md" placeholder="Medium (default)" rows={4} />
+<TextArea size="lg" placeholder="Large" rows={5} />
+```
+
+- **`sm`** — 14px text. Inline editing, dense forms.
+- **`md`** — 16px text. Default.
+- **`lg`** — 18px text. Prominent input contexts.
+
+### With label and helper
+
+```tsx
+<TextArea
+  label="Notes"
+  placeholder="Anything we should know?"
+  helperText="Maximum 500 characters"
+  rows={4}
+  fullWidth
+/>
+```
+
+### Error state
+
+```tsx
+<TextArea
+  label="Description"
+  error="This field is required"
+  rows={3}
+  fullWidth
+/>
+```
+
+### Resize modes
+
+Default is `vertical` — users can drag the bottom-right handle to make it taller. Use `none` for fixed-size cells.
+
+```tsx
+<TextArea placeholder="Fixed size" rows={4} resize="none" />
+<TextArea placeholder="Resize horizontally" resize="horizontal" />
+<TextArea placeholder="Resize both" resize="both" />
+```
+
+| Mode | Effect |
+|---|---|
+| `vertical` (default) | Height only |
+| `none` | Fixed dimensions |
+| `both` | Width and height |
+| `horizontal` | Width only |
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use TextArea for short text.** If the field will rarely exceed one line, use [TextInput](/docs/components/text-input) — the visual weight of a multi-line area implies the user *should* type more, which is a UX nudge.
+</Callout>
+
+- **Don't use TextArea for known-set choices.** Multi-select belongs in [MultiSelect](/docs/components/multi-select).
+- **Don't disable resize without good reason.** Users with verbose content benefit from being able to expand the area; the default `vertical` is almost always right.
+
+## Accessibility
+
+- Renders a real `<textarea>` — keyboard, scroll, native resize handle all platform.
+- `label` auto-wires `htmlFor`/`id`. If you don't pass `label`, supply `aria-label`.
+- `error` sets `aria-invalid` and links the message.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `rows` | `number` | `4` |
+| `resize` | `'none' \| 'both' \| 'horizontal' \| 'vertical'` | `'vertical'` |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `error` | `string` | — |
+| `fullWidth` | `boolean` | `false` |
+| `value` / `defaultValue` / `onChange` | controlled / uncontrolled standard | — |
+
+Plus all standard `<textarea>` HTML attributes.
+
+## Related
+
+- [TextInput](/docs/components/text-input) — single-line sibling
+- [Field](https://storybook.brikdesigns.com/?path=/docs/components-form-field--overview) — wrapper for label/helper/error layout
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-text-area--overview)**

--- a/docs-site/content/docs/components/text-input.mdx
+++ b/docs-site/content/docs/components/text-input.mdx
@@ -1,0 +1,142 @@
+---
+title: Text input
+description: Single-line text input. Labels, helper text, error states, icons, sizes, and any input type.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+TextInput is the workhorse single-line input. It renders a real `<input>` and supports any HTML input type (`text`, `email`, `search`, `url`, `tel`, `number`, etc.). For multi-line, use [TextArea](/docs/components/text-area). For passwords specifically, use [PasswordInput](/docs/components/password-input) — it adds the show/hide toggle.
+
+## Use it for
+
+- Any single-line text entry (name, email, search, URL, phone, number)
+- Inline form fields with labels, helpers, and error states
+- Search bars (use `type="search"` + `iconBefore` — no separate SearchInput component)
+- Email fields (use `type="email"` + `autoComplete="email"` + envelope icon)
+
+## Import
+
+```tsx
+import { TextInput } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Sizes
+
+<ComponentPreview code={`<BDS.TextInput size="sm" placeholder="Small" />
+<BDS.TextInput size="md" placeholder="Medium (default)" />
+<BDS.TextInput size="lg" placeholder="Large" />`}>
+  <BDS.TextInput size="sm" placeholder="Small" />
+  <BDS.TextInput size="md" placeholder="Medium (default)" />
+  <BDS.TextInput size="lg" placeholder="Large" />
+</ComponentPreview>
+
+- **`sm`** — 14px text. Compact forms, dense table-row editing.
+- **`md`** — 16px text. Default for most product UI.
+- **`lg`** — 18px text. Prominent inputs, marketing forms, hero search.
+
+### With label and helper
+
+```tsx
+<TextInput
+  label="Email"
+  type="email"
+  placeholder="you@example.com"
+  helperText="We'll never share your email"
+  fullWidth
+/>
+```
+
+### Error state
+
+```tsx
+<TextInput
+  label="Email"
+  type="email"
+  error="Please enter a valid email address"
+  fullWidth
+/>
+```
+
+### With icons
+
+`iconBefore` for leading icons (search, email, location), `iconAfter` for trailing affordances.
+
+```tsx
+<TextInput
+  label="Search"
+  type="search"
+  placeholder="Search..."
+  iconBefore={<MagnifyingGlassIcon />}
+/>
+```
+
+## Email, search, URL — no wrapper components
+
+The previous `EmailInput` and `SearchInput` wrappers were removed per [ADR-004](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md). They were 5–10 line shims that only set `type=` and a leading icon. Use TextInput directly:
+
+```tsx
+// Email — replaces <EmailInput />
+<TextInput
+  label="Email"
+  type="email"
+  autoComplete="email"
+  iconBefore={<Icon icon="ph:envelope" />}
+  placeholder="you@example.com"
+/>
+
+// Search — replaces <SearchInput />
+// type="search" automatically renders the native clear button (BDS-styled).
+<TextInput
+  type="search"
+  iconBefore={<Icon icon="ph:magnifying-glass" />}
+  placeholder="Search..."
+/>
+```
+
+## When *not* to use
+
+- **Don't use TextInput for passwords.** Use [PasswordInput](/docs/components/password-input) — the show/hide toggle is real, load-bearing UX.
+- **Don't use TextInput for multi-line.** Use [TextArea](/docs/components/text-area).
+- **Don't use TextInput for known-set choices.** If users pick from a known list, use [Select](/docs/components/select) (single) or [MultiSelect](/docs/components/multi-select) (multi).
+
+## Accessibility
+
+- Renders a real `<input>` — keyboard, focus ring, autofill, password manager hooks all platform-native.
+- `label` auto-wires `htmlFor`/`id`. If you don't pass `label`, supply `aria-label` or wrap in your own `<label>`.
+- `error` sets `aria-invalid` and links the message via `aria-describedby`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `error` | `string` | — |
+| `fullWidth` | `boolean` | `false` |
+| `iconBefore` | `ReactNode` | — |
+| `iconAfter` | `ReactNode` | — |
+
+Plus all standard `<input>` HTML attributes (excluding the `size` HTML attribute, which TextInput overrides for the size variant).
+
+## CSS Override API
+
+| Variable | Default | Controls |
+|---|---|---|
+| `--text-input-focus-ring-width` | `1px` | Width of the focus ring shadow spread |
+
+```css
+.high-contrast-form {
+  --text-input-focus-ring-width: 2px;
+}
+```
+
+## Related
+
+- [TextArea](/docs/components/text-area) — multi-line sibling
+- [PasswordInput](/docs/components/password-input) — adds show/hide toggle
+- [AddressInput](/docs/components/address-input) — adds autocomplete suggestions
+- [Field](https://storybook.brikdesigns.com/?path=/docs/components-form-field--overview) — wrapper for label/helper/error layout
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-text-input--overview)**

--- a/docs-site/content/docs/components/time-picker.mdx
+++ b/docs-site/content/docs/components/time-picker.mdx
@@ -1,0 +1,119 @@
+---
+title: Time picker
+description: Time-of-day selection with hour/minute controls. AM/PM or 24-hour display.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+TimePicker is a TextInput-shaped trigger with a popover for hour/minute selection. Value is always exchanged as a `HH:mm` string in 24-hour format — display switches with `use24Hour`, but the underlying value stays normalized.
+
+## Use it for
+
+- Time-of-day selection on forms (appointment slot, opening hours, alarm)
+- Pair with [DatePicker](/docs/components/date-picker) for date-and-time entry
+- Recurring schedules where the hour/minute matters
+
+## Import
+
+```tsx
+import { TimePicker } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default (12-hour AM/PM display)
+
+```tsx
+import { useState } from 'react';
+
+const [time, setTime] = useState('09:00');
+
+<TimePicker
+  label="Start time"
+  value={time}
+  onChange={setTime}
+  placeholder="Pick a time"
+/>
+```
+
+The displayed value is "9:00 AM" but `time` state holds `"09:00"`.
+
+### 24-hour display
+
+```tsx
+<TimePicker
+  label="Start time"
+  value={time}
+  onChange={setTime}
+  use24Hour
+/>
+```
+
+Now displays "09:00" / "21:30". The `value` exchange format is unchanged — it's always 24-hour `HH:mm`.
+
+### Minute step
+
+`minuteStep` constrains selectable minutes. Use 5, 15, or 30 for slot-based scheduling.
+
+```tsx
+<TimePicker
+  label="Appointment slot"
+  value={time}
+  onChange={setTime}
+  minuteStep={15}
+/>
+```
+
+### Sizes
+
+`sm`, `md` (default), `lg`.
+
+### Error state
+
+```tsx
+<TimePicker
+  label="Open at"
+  error="Open time must be before close time"
+  value={time}
+  onChange={setTime}
+/>
+```
+
+## When *not* to use
+
+- **Don't use TimePicker for date selection.** Use [DatePicker](/docs/components/date-picker).
+- **Don't use TimePicker for duration entry.** Duration ("30 minutes") is different semantically from time-of-day ("at 9:30 AM"). For durations, use a [Select](/docs/components/select) of preset values or two number inputs.
+- **Don't combine date + time into a custom component.** Pair DatePicker + TimePicker side by side — that's the BDS pattern.
+
+<Callout type="info">
+  **Value format is always 24-hour `HH:mm`.** Even with `use24Hour={false}`, the string passed to `onChange` is normalized — you don't need to parse AM/PM. The `use24Hour` flag is purely a display-layer concern.
+</Callout>
+
+## Accessibility
+
+- The trigger is a real `<input>` — keyboard, focus, screen-reader behaviors match TextInput.
+- Hour/minute selection in the popover uses arrow keys + type-to-find.
+- Selected time announces via `aria-live` on the trigger.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `value` | `string` (HH:mm 24h) | — |
+| `onChange` | `(value: string) => void` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `error` | `string` | — |
+| `placeholder` | `string` | — |
+| `fullWidth` | `boolean` | `false` |
+| `disabled` | `boolean` | `false` |
+| `minuteStep` | `number` | `1` |
+| `use24Hour` | `boolean` | `false` |
+| `id` | `string` | auto |
+
+## Related
+
+- [DatePicker](/docs/components/date-picker) — pair for date-and-time
+- [TextInput](/docs/components/text-input) — base trigger shape
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-time-picker--overview)**


### PR DESCRIPTION
## Summary

Migrates the 10 input controls of the Form group. Field / FieldGrid / Form (the structure layer) stay in Storybook for now — separate sub-batch.

| Page | Notes |
|---|---|
| \`text-input\` | Sizes, label/helper/error, icons. Documents \`type=email/search\` as the replacement for the removed EmailInput/SearchInput wrappers per ADR-004. CSS Override API. |
| \`text-area\` | Multi-line sibling. Resize modes (\`vertical\` / \`none\` / \`both\` / \`horizontal\`). |
| \`password-input\` | Show/hide toggle. Prop type is \`Omit<TextInputProps, 'type' \| 'iconAfter'>\` — inherits the rest. |
| \`address-input\` | Leading map-pin icon + autocomplete suggestion dropdown pattern with debounce note. |
| \`select\` | Single-select dropdown. Flat or grouped options. CSS Override API for chevron/icon color. |
| \`multi-select\` | Select + Tag composition. \`tagSize\` override for the rendered selection chips. |
| \`date-picker\` | Radix Popover + calendar. \`minDate\` / \`maxDate\` constraints. Returns a real \`Date\` object. **No source MDX in Storybook** — written from .tsx props. |
| \`time-picker\` | Hour/minute popover. AM/PM or 24h display. Value always normalized to \`HH:mm\` 24h string. **No source MDX in Storybook** — written from .tsx props. |
| \`checkbox\` | Boolean toggle. Required label. Group pattern for "pick multiple from a known list." |
| \`radio\` | Single-select via shared \`name\`. Group pattern with controlled state. |

Components index card grid grows to 26 (10 Action + 10 Indicator + 10 Form Inputs minus 4 already-covered overlaps from earlier groups). \`meta.json\` adds \`---Form / Inputs---\` after Indicator.

## MDX trap caught

Same pattern as the Counter \`{n}\` bug from PR #275: \`multi-select.mdx\` had \`"Remove {label}"\` in prose which MDX evaluated as a JSX expression and crashed prerender with \`ReferenceError: label is not defined\`. The page-templates doc already covers this gotcha — wrapping in backticks fixes it. Worth reading the [page-templates "Curly braces in prose" section](https://github.com/brikdesigns/brik-bds/blob/main/docs-site/content/docs/contribution/page-templates.mdx) before authoring future pages.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds (BDS dist must be built first)
- [ ] \`/docs/components\` renders Action (6) + Indicator (10) + Form/Inputs (10) card grids
- [ ] \`/docs/components/text-input\` — \`<ComponentPreview>\` renders three live BDS.TextInput instances at sm/md/lg sizes
- [ ] \`/docs/components/select\` — grouped-options code example renders cleanly
- [ ] \`/docs/components/multi-select\` — \`Remove {label}\` in accessibility section renders as inline code, not a broken JSX expression
- [ ] \`/docs/components/date-picker\` — content reflects intent (no source MDX existed; this is fresh content)
- [ ] \`/docs/components/time-picker\` — value-format note (always HH:mm 24h regardless of \`use24Hour\` display) reads correctly
- [ ] \`/docs/components/checkbox\` and \`/radio\` — group patterns are useful examples
- [ ] All Storybook deep-links at the bottom of each page resolve
- [ ] Internal cross-links between siblings (TextInput ↔ TextArea ↔ PasswordInput, Select ↔ MultiSelect, DatePicker ↔ TimePicker, Checkbox ↔ Radio) all work

## DatePicker and TimePicker — review carefully

Both had no source MDX in Storybook (only stories + tsx). I wrote the pages from the .tsx prop interfaces and component behavior. The narrative parts ("when to use," "when not to use") are inferred — review whether the framing matches your intent, especially:

- DatePicker → "don't use for date *ranges*" (recommends pairing two DatePickers)
- TimePicker → "value format is always 24-hour HH:mm regardless of use24Hour"
- Both → recommend pairing side-by-side rather than combined date+time

If any of those don't match how the team thinks about these components, flag and I'll revise.

## Out of scope (follow-ups)

- Form structure sub-batch: Field, FieldGrid, Form, CatalogPicker (4 pages)
- Feedback group (AlertBanner, Toast, Tooltip, EmptyState, ProgressBar)
- Control group (Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader)
- Addable group (AddableTagList, AddableEntryList, AddableFieldRowList)
- Structure group (Card, Divider, Accordion)
- Navigation, Displays, Motion foundation, remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)