### PR TITLE
feat(docs-site): close out Form group (Field, FieldGrid, Form, CatalogPicker)

### DIFF
--- a/docs-site/content/docs/components/catalog-picker.mdx
+++ b/docs-site/content/docs/components/catalog-picker.mdx
@@ -1,0 +1,157 @@
+---
+title: Catalog picker
+description: Industry-aware multi-pick with source attribution. Catalog picks + free-text additions, all stably slugged.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+CatalogPicker is the right primitive when an industry pack seeds defaults that the client can extend. It renders a reference catalog (e.g. the BCS dental industry pack's `servicesCatalog`) as suggestions, accepts free-text additions, and stamps every entry with a stable slug + `source: 'catalog' | 'custom'` attribution.
+
+## Use it for
+
+- Any client-intel field where the [industry pack](/docs/content-system/industries) seeds defaults the client can extend (services offered, pain points, competitor archetypes, keyword banks)
+- Fields where **provenance matters** — the difference between "this came from our industry default" and "this is client-specific" changes downstream behavior (copy generation, mockup content, competitive analysis framing)
+- Multi-pick controls where each entry needs a description alongside the name
+
+For locked vocabularies (no custom escape), use [MultiSelect](/docs/components/multi-select). For flat string picks without descriptions, use AddableComboList. For structured entries with fields other than description (URL + notes, name + role), use AddableEntryList directly.
+
+## Import
+
+```tsx
+import { CatalogPicker } from '@brikdesigns/bds';
+import { getIndustryServicesCatalog } from '@brikdesigns/bds/content-system';
+```
+
+## Variants
+
+### Default
+
+```tsx
+const catalog = getIndustryServicesCatalog(company.industry_slug);
+
+<CatalogPicker
+  label="Services Offered"
+  catalog={catalog}
+  value={services}
+  onChange={setServices}
+  searchPlaceholder="Search or add a service…"
+  descriptionPlaceholder="What makes this service unique here?"
+  addLabel="Add Service"
+  emptyDescriptionLabel="No description set"
+/>
+```
+
+### Strict (catalog-only)
+
+`strict` rejects free-text names that don't match a catalog `displayName` or alias. Use for locked vocabularies that still benefit from the catalog's metadata + description-per-entry shape.
+
+```tsx
+<CatalogPicker
+  label="Insurance accepted"
+  catalog={insuranceCatalog}
+  value={insurances}
+  onChange={setInsurances}
+  strict
+/>
+```
+
+### Different industry, same component
+
+The picker is vocabulary-agnostic — pass any catalog matching the `CatalogEntry` shape. Real estate, dental, commercial — same picker, different `catalog` prop.
+
+```tsx
+<CatalogPicker
+  label="Property types"
+  catalog={getIndustryPropertyTypesCatalog('real-estate-rv-mhc')}
+  value={propertyTypes}
+  onChange={setPropertyTypes}
+/>
+```
+
+### Sizes
+
+`sm`, `md` (default), `lg` — matching the AddableEntryList scale.
+
+### Disabled
+
+```tsx
+<CatalogPicker disabled value={services} onChange={() => {}} catalog={catalog} />
+```
+
+## Source attribution
+
+Every picked entry carries `source: 'catalog' | 'custom'`:
+
+- **`catalog`** — matched the catalog by exact `displayName` or alias (case-insensitive). The picker assigns the catalog entry's canonical `slug`.
+- **`custom`** — no catalog match. The picker derives a kebab-case slug from the typed `displayName`. If that slug collides with an existing one, `-2`, `-3`, … append until unique.
+
+Consumers persist the full array as a single JSONB column (e.g. `company_profiles.services_offered`). Downstream content generation reads the structure without re-deriving provenance every time.
+
+```ts
+// What the picker emits via onChange
+[
+  { source: 'catalog', slug: 'cosmetic-veneers', displayName: 'Veneers', description: 'Composite + porcelain' },
+  { source: 'custom', slug: 'in-house-membership', displayName: 'In-house membership plan', description: 'No PPO routing' },
+]
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use CatalogPicker for locked vocabularies with no custom escape.** That's [MultiSelect](/docs/components/multi-select)'s job — pass the catalog as `options`. CatalogPicker's value is the *escape hatch* for free-text additions; if you don't want one, use the simpler component.
+</Callout>
+
+- **Don't use for flat string picks** with no description. The description textarea adds vertical weight that's wasted on tag-only inputs — use AddableComboList.
+- **Don't use for structured entries** with fields other than description (URL + notes, name + role). Use AddableEntryList directly; you don't need catalog wiring.
+
+## Accessibility
+
+- The search input is a real `<input>` — keyboard, autocomplete, screen reader behaviors all platform.
+- Each picked entry has a labeled remove button (`removeLabel` prop, defaults to `Remove {name}`).
+- Description textareas autosize and announce row counts.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `catalog` | `readonly CatalogEntry[]` *(required)* | — |
+| `value` | `readonly PickedCatalogEntry[]` *(required)* | — |
+| `onChange` | `(next: PickedCatalogEntry[]) => void` *(required)* | — |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `searchPlaceholder` | `string` | — |
+| `descriptionPlaceholder` | `string` | — |
+| `addLabel` | `string` | `'Add'` |
+| `removeLabel` | `string` | auto |
+| `emptyLabel` | `string` | — |
+| `emptyDescriptionLabel` | `string` | `'No description'` |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `disabled` | `boolean` | `false` |
+| `strict` | `boolean` | `false` |
+| `maxItems` | `number` | — |
+| `descriptionRows` | `number` | `2` |
+| `className` | `string` | — |
+
+### CatalogEntry / PickedCatalogEntry shapes
+
+```ts
+interface CatalogEntry {
+  slug: string;
+  displayName: string;
+  aliases?: string[];
+  description?: string;
+}
+
+interface PickedCatalogEntry {
+  source: 'catalog' | 'custom';
+  slug: string;
+  displayName: string;
+  description?: string;
+}
+```
+
+## Related
+
+- [MultiSelect](/docs/components/multi-select) — locked-vocabulary alternative
+- [Industries](/docs/content-system/industries) — where the catalogs come from
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-catalog-picker--overview)**

--- a/docs-site/content/docs/components/field-grid.mdx
+++ b/docs-site/content/docs/components/field-grid.mdx
@@ -1,0 +1,94 @@
+---
+title: Field grid
+description: Equal-column grid for laying out Field components side by side. Replaces ad-hoc inline grid templates.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+FieldGrid is a layout primitive for placing equal-weight cells side by side. Replaces the inline `display: grid; gridTemplateColumns: '1fr 1fr'` pattern that grew across portal sheets.
+
+The primary case is wrapping multiple [Field](/docs/components/field) components, but it accepts any equal-weight children — Cards, Tags, stat tiles.
+
+## Use it for
+
+- 2-column entity detail rows (Owner / Location, Industry / Subindustry)
+- 3- or 4-tile stat rows (Source / Scraped / Failed / Total)
+- Any side-by-side layout where the cells should be equal width
+
+For variable-width or 5+ column layouts, FieldGrid is the wrong primitive — use a Table.
+
+## Import
+
+```tsx
+import { FieldGrid, Field } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Columns
+
+Three locked column counts — `2` (default), `3`, `4`. No custom column templates: if you need something else, you're composing the wrong primitive.
+
+```tsx
+<FieldGrid columns={2}>
+  <Field label="Owner">Nick Stanerson</Field>
+  <Field label="Status">Active</Field>
+</FieldGrid>
+
+<FieldGrid columns={3}>
+  <Field label="Source">birdwelldentist.com</Field>
+  <Field label="Scraped">8</Field>
+  <Field label="Failed">12</Field>
+</FieldGrid>
+```
+
+### Gap sizes
+
+Three gaps — `md`, `lg`, `xl` (default). `xl` matches existing portal field grids.
+
+```tsx
+<FieldGrid columns={2} gap="md">
+  ...
+</FieldGrid>
+```
+
+### Stat tiles
+
+Wrapping each grid cell in `<Card variant="outlined">` gives you the canonical stat-tile pattern (e.g. Content Scrape's SOURCE / SCRAPED / FAILED tiles).
+
+```tsx
+<FieldGrid columns={3} gap="md">
+  <Card variant="outlined"><Field label="Source">birdwelldentist.com</Field></Card>
+  <Card variant="outlined"><Field label="Scraped">8</Field></Card>
+  <Card variant="outlined"><Field label="Failed">12</Field></Card>
+</FieldGrid>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **No custom columns.** If you need 5 cells or variable widths, you're reaching for the wrong primitive — use a Table.
+</Callout>
+
+- **All children must be equal-weight.** Don't mix a tall Card with a single-line Field in the same grid — that breaks the visual rhythm.
+- **Don't nest FieldGrids.** If you need a 4-column outer grid with 2-column inner cells, you're describing a Table.
+
+## Accessibility
+
+- Renders a `<div>` with `display: grid`. Children retain their own semantics — wrapping Fields in FieldGrid doesn't change their accessibility tree.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `columns` | `2 \| 3 \| 4` | `2` |
+| `gap` | `'md' \| 'lg' \| 'xl'` | `'xl'` |
+| `children` | `ReactNode` | — |
+
+Plus all standard `<div>` HTML attributes.
+
+## Related
+
+- [Field](/docs/components/field) — the canonical child
+- [Card](https://storybook.brikdesigns.com/?path=/docs/displays-cards-card--overview) — wrap each cell to get stat-tile styling
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-field-grid--overview)**

--- a/docs-site/content/docs/components/field.mdx
+++ b/docs-site/content/docs/components/field.mdx
@@ -1,0 +1,126 @@
+---
+title: Field
+description: Label + value pair for read-mode display inside Sheets. One API covers text, tags, links, lists, and empty states.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Field is the most important primitive in the sheet body set. One component replaces four legacy patterns (`FieldPair`, `TextValue`, `SmartTextValue`, raw label/value markup) that were drifting across portal sheets. Use it anywhere a labeled value renders in a read-mode view.
+
+## Use it for
+
+- Sheet body rows showing a labeled value (Status, Owner, Industry, etc.)
+- Stat lines on cards (Scraped · 8, Failed · 12)
+- Any "label + value" pair where the value is read-only (not editable in this view)
+- Empty-state placeholders when a value isn't set ("Not set" muted text by default)
+
+For editable variants, fields belong inside [Form](/docs/components/form) with the appropriate input — Field is read-mode only.
+
+## Import
+
+```tsx
+import { Field } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Stacked (default)
+
+Label above value. Default for sheet body rows where the value needs full width.
+
+```tsx
+<Field label="Status">Active</Field>
+<Field label="Industry">Dental — General Practice</Field>
+```
+
+### Inline
+
+Label left, value right-aligned. Compact stat row pattern — `Status · Active`, `Scraped · 8`.
+
+```tsx
+<Field layout="inline" label="Scraped">8</Field>
+<Field layout="inline" label="Status">Active</Field>
+```
+
+### Empty states
+
+When `children` is `null`, `undefined`, or empty string, Field renders an inline muted "Not set" by default.
+
+```tsx
+// Default: shows "Not set"
+<Field label="Owner" />
+
+// Custom empty message
+<Field label="Parent organization" empty="Independent" />
+```
+
+For a section-level empty state (the whole section has no data, not just one field), pass an `<EmptyState />` into `empty`. Use sparingly — one full bordered treatment per section at most.
+
+```tsx
+<Field
+  label="Recent activity"
+  empty={<EmptyState title="No activity yet" />}
+/>
+```
+
+### Value types
+
+`children` accepts any ReactNode — text, [TagGroup](/docs/components/tag-group)/[Tag](/docs/components/tag), `<a>` / [TextLink](/docs/components/text-link), `<BulletList>`, or compound content.
+
+```tsx
+// With tags
+<Field label="Services">
+  <TagGroup>
+    <Tag size="sm">Cosmetic</Tag>
+    <Tag size="sm">Implants</Tag>
+  </TagGroup>
+</Field>
+
+// With a link
+<Field label="Website">
+  <a href="https://example.com">example.com</a>
+</Field>
+
+// With a bullet list
+<Field label="Anti-messages">
+  <BulletList items={['No price-first', 'No corporate-clinic']} />
+</Field>
+
+// Inside a FieldGrid for side-by-side layout
+<FieldGrid columns={2}>
+  <Field label="Owner">Nick Stanerson</Field>
+  <Field label="Location">Thompson Station, TN</Field>
+</FieldGrid>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't style the value inline.** If a value needs tag treatment, use [Tag](/docs/components/tag). If it needs a link, use [TextLink](/docs/components/text-link). If it needs a list, use `<BulletList>`. Never reach for raw `color` or `text-transform` on a Field child — that drifts the visual language.
+</Callout>
+
+- **Don't nest Fields.** A value is a value. If you need sub-structure, it belongs in a new SheetSection.
+- **Don't use Field for editable forms.** Field is read-mode. For input, use [TextInput](/docs/components/text-input) (etc.) inside a [Form](/docs/components/form).
+
+## Accessibility
+
+- Renders a `<div>` with the label as a `<dt>`-equivalent label and the value as the `<dd>`-equivalent.
+- For a true `<dl>` semantic, wrap a list of Fields in a `<dl>` element manually — Field doesn't enforce parent shape.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `label` | `string` *(required)* | — |
+| `children` | `ReactNode` | — |
+| `layout` | `'stacked' \| 'inline'` | `'stacked'` |
+| `empty` | `ReactNode` | `'Not set'` |
+
+Plus all standard `<div>` HTML attributes (excluding `children`).
+
+## Related
+
+- [FieldGrid](/docs/components/field-grid) — equal-column wrapper for laying Fields out side by side
+- [Form](/docs/components/form) — editable counterpart with title/description/footer
+- [TagGroup](/docs/components/tag-group) — common Field child for tagged values
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-field--overview)**

--- a/docs-site/content/docs/components/form.mdx
+++ b/docs-site/content/docs/components/form.mdx
@@ -1,0 +1,122 @@
+---
+title: Form
+description: Structured form container with title, description, error/success states, and footer actions.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Form is the editable counterpart to [Field](/docs/components/field). It renders a real `<form>` with consistent spacing, optional title/description/footer slots, and form-level error or success messaging. Use it whenever you have more than one input that should submit together.
+
+## Use it for
+
+- Multi-input editable views (contact forms, settings panels, intake flows)
+- Any view where Save / Cancel are explicit actions, not auto-save
+- Forms that need a title / description / submit-state pattern out of the box
+
+For a single-input quick edit, you don't need Form — just render the input directly. For read-mode display, use [Field](/docs/components/field).
+
+## Import
+
+```tsx
+import { Form } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { Form, TextInput, TextArea, Button } from '@brikdesigns/bds';
+
+<Form
+  title="Contact us"
+  description="We'll get back to you within 24 hours."
+  onSubmit={handleSubmit}
+  footer={<Button type="submit">Send message</Button>}
+>
+  <TextInput label="Name" placeholder="Your name" fullWidth />
+  <TextInput label="Email" type="email" placeholder="you@example.com" fullWidth />
+  <TextArea label="Message" placeholder="How can we help?" fullWidth />
+</Form>
+```
+
+### Layout
+
+`vertical` (default) stacks fields. `horizontal` lays them side by side for compact forms.
+
+```tsx
+<Form layout="horizontal" {...props}>
+  <TextInput label="First" />
+  <TextInput label="Last" />
+</Form>
+```
+
+### Gap sizes
+
+| Size | Gap value |
+|---|---|
+| `sm` | `--gap-md` (8px) |
+| `md` (default) | `--gap-lg` (16px) |
+| `lg` | `--gap-xl` (24px) |
+
+```tsx
+<Form gap="lg" {...props}>...</Form>
+```
+
+### Form-level error
+
+```tsx
+<Form
+  error="Couldn't save. Try again in a moment."
+  onSubmit={handleSubmit}
+  footer={<Button type="submit">Save</Button>}
+>
+  ...
+</Form>
+```
+
+### Form-level success
+
+```tsx
+<Form
+  success="Saved. Settings updated."
+  onSubmit={handleSubmit}
+  footer={<Button type="submit">Save</Button>}
+>
+  ...
+</Form>
+```
+
+## When *not* to use
+
+- **Don't use Form for read-mode display.** Use [Field](/docs/components/field) + [FieldGrid](/docs/components/field-grid).
+- **Don't use Form for inline edit-in-place.** Single-field inline editing doesn't need a `<form>` wrapper. Use the input directly with controlled state.
+- **Don't put navigation actions in `footer`.** Footer is for submit/cancel of *this form's data*. "Back to dashboard" goes in the parent layout.
+
+## Accessibility
+
+- Renders a real `<form>` element. Browser handles `Enter` to submit, autofocus, autofill correctly.
+- `title` becomes a heading inside the form. Use a sensible heading hierarchy in the surrounding page (typically `<h1>` outside, this becomes `<h2>` inside).
+- `error` and `success` messages are announced via `aria-live="polite"` so screen readers pick up async submit feedback.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `children` | `ReactNode` *(required)* | — |
+| `layout` | `'vertical' \| 'horizontal'` | `'vertical'` |
+| `gap` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `title` | `string` | — |
+| `description` | `string` | — |
+| `error` | `string` | — |
+| `success` | `string` | — |
+| `footer` | `ReactNode` | — |
+
+Plus all standard `<form>` HTML attributes (including `onSubmit`, `action`, `method`, etc.).
+
+## Related
+
+- [Field](/docs/components/field) — read-mode counterpart
+- [FieldGrid](/docs/components/field-grid) — equal-column layout for read-mode
+- All Form Inputs ([TextInput](/docs/components/text-input), [Select](/docs/components/select), [Checkbox](/docs/components/checkbox), etc.) — typical Form children
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-form--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -49,7 +49,7 @@ The indicator family — read-only state communication. For interactive pills, u
 
 ### Form / Inputs
 
-The 10 input controls of the Form group. Field/FieldGrid/Form (the structure layer) still in Storybook for now.
+The 10 input controls of the Form group.
 
 <Cards>
   <Card title="Text input" href="/docs/components/text-input" description="Single-line input. Labels, helpers, errors, icons, sizes, any input type." />
@@ -64,9 +64,20 @@ The 10 input controls of the Form group. Field/FieldGrid/Form (the structure lay
   <Card title="Radio" href="/docs/components/radio" description="Single-select from a mutually exclusive group. Group by shared name." />
 </Cards>
 
+### Form / Structure
+
+The container, layout, and curated-multi-pick layer of the Form group. Closes out Form.
+
+<Cards>
+  <Card title="Field" href="/docs/components/field" description="Label + value pair for read-mode display. One API covers text, tags, links, lists, and empty states." />
+  <Card title="Field grid" href="/docs/components/field-grid" description="Equal-column grid (2/3/4) for laying Fields side by side. Replaces ad-hoc inline grids." />
+  <Card title="Form" href="/docs/components/form" description="Editable container with title/description/error/success/footer. Vertical or horizontal layout." />
+  <Card title="Catalog picker" href="/docs/components/catalog-picker" description="Industry-aware multi-pick with source attribution (catalog vs custom)." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining ~30 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Form structure (Field/FieldGrid/Form/CatalogPicker), Feedback, Control, Addable, Structure, Navigation, and Displays.
+The remaining ~26 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Feedback, Control, Addable, Structure, Navigation, and Displays.
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -30,6 +30,11 @@
     "date-picker",
     "time-picker",
     "checkbox",
-    "radio"
+    "radio",
+    "---Form / Structure---",
+    "field",
+    "field-grid",
+    "form",
+    "catalog-picker"
   ]
 }


### PR DESCRIPTION
## Summary

Closes out the **Form** group. Stacked on top of [PR #276](https://github.com/brikdesigns/brik-bds/pull/276) (Form Inputs sub-batch) — base is \`task/docs-form-inputs\`. When #276 merges, this PR's diff auto-rebases against \`main\`.

| Page | Notes |
|---|---|
| \`field\` | Read-mode label + value primitive. Stacked / inline layouts. Default \`"Not set"\` empty + section-level \`<EmptyState />\` empty. Value types: text, [Tag](/docs/components/tag) groups, links, [BulletList]. The "don't style the value inline" rule that drove the FieldPair/TextValue/SmartTextValue consolidation. |
| \`field-grid\` | Equal-column grid wrapper (2/3/4 only). Stat tile pattern: wrap each cell in \`<Card variant="outlined">\`. |
| \`form\` | Editable container. \`title\`/\`description\`/\`footer\` slots, form-level error/success messaging, \`vertical\`/\`horizontal\` layout, sm/md/lg gap sizes. |
| \`catalog-picker\` | Industry-aware multi-pick with source attribution (\`source: 'catalog' \| 'custom'\`). \`strict\` mode for locked vocabularies. Documents when to reach for [MultiSelect](/docs/components/multi-select) vs CatalogPicker vs AddableComboList vs AddableEntryList. |

Components index card grid grows; \`meta.json\` adds \`---Form / Structure---\` divider after Form/Inputs.

After this lands the **Form** group is **14/14 ✅** (10 inputs from #276 + 4 structure here).

## MDX trap caught (third time)

\`catalog-picker.mdx\` had \`"Remove {name}"\` in prose, crashed prerender with \`ReferenceError: name is not defined\`. Same pattern as Counter \`{n}\` (PR #275) and MultiSelect \`{label}\` (PR #276). Fixed by wrapping in backticks. The page-templates doc covers this — clearly worth keeping the gotcha section there since it's recurring.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds (BDS dist must be built first)
- [ ] \`/docs/components\` shows a fourth card grid section "Form / Structure" below Form / Inputs
- [ ] \`/docs/components/field\` — empty-state and value-types code examples make the "don't inline-style values" rule clear
- [ ] \`/docs/components/field-grid\` — stat-tile code example references real Card component
- [ ] \`/docs/components/form\` — error/success states + footer pattern reads well
- [ ] \`/docs/components/catalog-picker\` — \`Remove {name}\` in accessibility section renders as inline code, not a broken JSX expression
- [ ] \`/docs/components/catalog-picker\` — the MultiSelect vs CatalogPicker vs AddableComboList vs AddableEntryList decision section is accurate to current intent
- [ ] All Storybook deep-links resolve
- [ ] Cross-links from Form Inputs pages to Field/FieldGrid/Form now point to real pages (not Storybook)

## Out of scope (follow-ups)

- Feedback group (AlertBanner, Toast, Tooltip, EmptyState, ProgressBar)
- Control group (Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader)
- Addable group (AddableTagList, AddableEntryList, AddableFieldRowList)
- Structure group (Card, Divider, Accordion)
- Navigation group (TabBar, Breadcrumb, Pagination, SidebarNavigation)
- Displays section (~14 components)
- Motion foundation port
- Remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)