### PR TITLE
feat(docs-site): migrate Feedback group (6 components)

### DIFF
--- a/docs-site/content/docs/components/alert-banner.mdx
+++ b/docs-site/content/docs/components/alert-banner.mdx
@@ -1,0 +1,50 @@
+---
+title: Alert banner
+description: DEPRECATED — use Banner with tone instead.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+<Callout type="error">
+  **AlertBanner is deprecated.** Migrate to [`Banner`](/docs/components/banner) with the appropriate `tone` prop. This component is slated for deletion in a future major version per [ADR-004](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md).
+</Callout>
+
+## Migration
+
+Same shape, same Badge, same surface — just renamed under Banner.
+
+```tsx
+// Before
+<AlertBanner variant="warning" title="Trial ends in 7 days" />
+
+// After
+<Banner tone="warning" title="Trial ends in 7 days" />
+```
+
+| AlertBanner variant | Banner tone |
+|---|---|
+| `information` | `information` |
+| `warning` | `warning` |
+| `error` | `error` |
+
+The `title`, `description`, and `action` props are unchanged. Banner additionally supports `onDismiss` (close button) and `tone="announcement"` (brand-primary surface, the default — for marketing notices distinct from status alerts).
+
+## Why the consolidation
+
+AlertBanner and the legacy "marketing announcement banner" pattern were two visually similar components doing the same job at different surfaces. Per ADR-004 component-bloat guardrails, two components ≥ 70% overlap collapse into one with a prop. The result: [Banner](/docs/components/banner) with `tone={announcement | warning | error | information}`.
+
+## Existing AlertBanner shape (frozen)
+
+For reference while migrating. New code should not use this component.
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `ReactNode` *(required)* | — |
+| `description` | `ReactNode` | — |
+| `variant` | `'warning' \| 'error' \| 'information'` | `'information'` |
+| `action` | `ReactNode` | — |
+
+## Related
+
+- [Banner](/docs/components/banner) — the canonical replacement
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-feedback-alert-banner--overview)** *(legacy)*

--- a/docs-site/content/docs/components/banner.mdx
+++ b/docs-site/content/docs/components/banner.mdx
@@ -1,0 +1,153 @@
+---
+title: Banner
+description: Full-width contextual banner. One component covers announcements (brand surface) and status alerts (tone surface).
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Banner is the canonical full-width banner component. The `tone` prop switches between two visual modes: **announcement** (brand-primary surface, marketing notices) and **status** (secondary surface + leading status Badge, replaces the deprecated AlertBanner).
+
+<ComparisonGrid
+  items={[
+    {
+      title: 'Banner',
+      preview: <BDS.Banner title="New feature" tone="announcement" />,
+      whenToUse: 'Persistent, dismissible, full-width — site-wide announcements, tone-coded alerts that need to stay visible.',
+      whenNotToUse: 'For ephemeral confirmation — that\'s Toast.',
+      code: `<Banner title="..." tone="warning" />`,
+    },
+    {
+      title: 'Toast',
+      preview: <BDS.Toast title="Saved" variant="success" />,
+      whenToUse: 'Ephemeral confirmation that auto-dismisses. Save success, error retry, copied-to-clipboard.',
+      whenNotToUse: 'Persistent state — user might miss it.',
+      code: `<Toast title="..." variant="success" />`,
+    },
+    {
+      title: 'Tooltip',
+      preview: <BDS.Tooltip content="On hover"><span>?</span></BDS.Tooltip>,
+      whenToUse: 'Hover-revealed contextual help. Icon button labels, keyboard shortcut hints.',
+      whenNotToUse: 'Critical info — keyboard users without hover may miss it.',
+      code: `<Tooltip content="..."><Trigger /></Tooltip>`,
+    },
+  ]}
+/>
+
+## Use it for
+
+- Site-wide marketing announcements (brand-primary surface, default tone)
+- Persistent status alerts that need to stay visible (`tone="warning|error|information"`)
+- Trial-expires / quota-exceeded / system-degraded warnings
+- Maintenance windows, deployment notices
+
+For ephemeral confirmations that auto-dismiss, use [Toast](/docs/components/toast). For hover-only help, use [Tooltip](/docs/components/tooltip).
+
+## Import
+
+```tsx
+import { Banner } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Announcement (default)
+
+Brand-primary surface with inverse text. The marketing-notice mode.
+
+```tsx
+<Banner
+  title="New feature available"
+  description="Check out our latest update — it's live now."
+  action={<Button variant="secondary" size="sm">Learn more</Button>}
+  onDismiss={() => setVisible(false)}
+/>
+```
+
+### Status tones
+
+`information`, `warning`, `error` render on a secondary surface with a leading status Badge and `role="alert"` for assistive tech. **Replaces the deprecated AlertBanner** — same shape, same Badge, same surface.
+
+```tsx
+<Banner
+  tone="warning"
+  title="Trial ends in 7 days"
+  description="Upgrade to keep access to all features."
+  action={<Button size="sm">Upgrade</Button>}
+/>
+
+<Banner
+  tone="error"
+  title="Deployment failed"
+  description="Build #4291 hit an unrecoverable error. Logs attached."
+/>
+
+<Banner
+  tone="information"
+  title="Maintenance window"
+  description="System will be unavailable Saturday 2-4am UTC."
+/>
+```
+
+### Dismissible
+
+Pass `onDismiss` to render a close button. Common with announcements.
+
+```tsx
+<Banner
+  title="Welcome back"
+  onDismiss={() => setVisible(false)}
+/>
+```
+
+### Title-only
+
+`description` is optional — title-only banners work for short messages.
+
+```tsx
+<Banner title="System updates tonight at 11pm UTC" tone="information" />
+```
+
+## When *not* to use
+
+- **Don't use Banner for short-lived confirmations** ("Saved", "Copied"). Those are [Toast](/docs/components/toast)s.
+- **Don't stack multiple Banners.** A second Banner stack reads as visual noise. Pick the highest-priority message and surface it; queue others.
+- **Don't put navigation actions in Banner.** Use it for "this state needs your attention," not "here's a link to somewhere else."
+
+## Accessibility
+
+- Tone-coded banners (`warning|error|information`) get `role="alert"` so assistive tech announces them on render.
+- Announcement banners (default) render as a generic landmark.
+- The leading Badge uses an `aria-hidden` icon plus the tone-implicit semantics — title text carries the meaning.
+- `onDismiss` adds a button with `aria-label="Dismiss"`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `ReactNode` *(required)* | — |
+| `description` | `ReactNode` | — |
+| `tone` | `'announcement' \| 'warning' \| 'error' \| 'information'` | `'announcement'` |
+| `action` | `ReactNode` | — |
+| `onDismiss` | `() => void` | — |
+
+Plus all standard `<div>` HTML attributes (excluding `title`).
+
+## Migration from AlertBanner
+
+[AlertBanner](/docs/components/alert-banner) is `@deprecated` and slated for deletion. Same shape, same Badge, same secondary surface — just renamed under Banner.
+
+```tsx
+// Before
+<AlertBanner variant="warning" title="..." description="..." />
+
+// After
+<Banner tone="warning" title="..." description="..." />
+```
+
+## Related
+
+- [Toast](/docs/components/toast) — ephemeral sibling
+- [Tooltip](/docs/components/tooltip) — hover-revealed sibling
+- [EmptyState](/docs/components/empty-state) — for when a section has no data
+- [AlertBanner](/docs/components/alert-banner) *(deprecated)* — migrate to `<Banner tone="...">`
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-feedback-banner--overview)**

--- a/docs-site/content/docs/components/empty-state.mdx
+++ b/docs-site/content/docs/components/empty-state.mdx
@@ -1,0 +1,101 @@
+---
+title: Empty state
+description: Placeholder for screens with no data. Title, description, optional action — guides users toward the next step.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+EmptyState fills a list, table, or section that has no content. Use it to explain *why* the area is empty and *what to do next* — never leave a blank panel.
+
+For per-row empties (a single missing value inside a [Field](/docs/components/field)), use Field's built-in `empty` prop instead — EmptyState's full bordered treatment is too heavy for a single row.
+
+## Use it for
+
+- "No projects yet" / "Inbox zero" first-time-user states
+- "No results" after a search returns nothing
+- Empty tables / lists / dashboards
+- Permission-denied or "you don't have access" placeholders
+
+## Import
+
+```tsx
+import { EmptyState } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### With action
+
+The most common form — a primary action button to seed the empty state.
+
+```tsx
+<EmptyState
+  title="No projects yet"
+  description="Create your first project to get started."
+  buttonProps={{ children: 'Create project', onClick: handleCreate }}
+/>
+```
+
+### Informational only
+
+When there's no action to recommend (e.g. waiting for someone else, or search-no-results).
+
+```tsx
+<EmptyState
+  title="No results found"
+  description="Try adjusting your search or filters."
+/>
+```
+
+### Custom content
+
+Replace the default button slot with `children` for non-Button actions (links, multiple buttons, illustrations).
+
+```tsx
+<EmptyState title="Connect an integration">
+  <ButtonGroup>
+    <Button variant="primary">Connect Stripe</Button>
+    <Button variant="outline">Connect Square</Button>
+  </ButtonGroup>
+</EmptyState>
+```
+
+### Title-only
+
+When even a description would be excess noise.
+
+```tsx
+<EmptyState title="Nothing here yet" />
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use EmptyState inside Field rows.** Use Field's `empty` prop ("Not set" or a custom string) — the full EmptyState card is for whole sections, not single values.
+</Callout>
+
+- **Don't use EmptyState during loading.** Loading is a different state — use [Skeleton](/docs/components/skeleton) for layout-preserving placeholders. EmptyState is for *resolved-with-no-data*.
+- **Don't show a blank panel.** If a section has no data, you owe the user an EmptyState. A literal blank screen reads as broken.
+
+## Accessibility
+
+- Renders a `<div>` with the title as a heading. Use sensible heading hierarchy in the surrounding page.
+- The optional action button gets full Button accessibility (keyboard, focus, aria).
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `string` *(required)* | — |
+| `description` | `string` | — |
+| `buttonProps` | `Pick<ButtonProps, 'children' \| 'onClick' \| 'iconBefore' \| 'iconAfter'>` | — |
+| `children` | `ReactNode` (replaces button) | — |
+
+Plus all standard `<div>` HTML attributes (excluding `title`).
+
+## Related
+
+- [Field](/docs/components/field) — has a built-in inline empty for single rows
+- [Skeleton](/docs/components/skeleton) — for *loading*, not *empty*
+- [Button](/docs/components/button) — the action affordance
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-feedback-empty-state--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -12,7 +12,7 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
 | **Action** | Button, IconButton, LinkButton, ButtonGroup, FilterBar, FilterButton, FilterToggle, TextLink |
 | **Form** | TextInput, TextArea, PasswordInput, AddressInput, Select, MultiSelect, DatePicker, TimePicker, Checkbox, Radio, Field, FieldGrid, Form |
 | **Indicator** | Badge, Chip, Tag, Counter, Dot, Spinner, Skeleton, BadgeGroup, TagGroup, ServiceBadge |
-| **Feedback** | AlertBanner, Toast, Tooltip, EmptyState, ProgressBar |
+| **Feedback** | Banner, Toast, Tooltip, EmptyState, ProgressBar (AlertBanner deprecated → Banner) |
 | **Control** | Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader |
 | **Addable** | AddableTagList, AddableEntryList, AddableFieldRowList |
 | **Structure** | Card, Divider, Accordion |
@@ -75,9 +75,22 @@ The container, layout, and curated-multi-pick layer of the Form group. Closes ou
   <Card title="Catalog picker" href="/docs/components/catalog-picker" description="Industry-aware multi-pick with source attribution (catalog vs custom)." />
 </Cards>
 
+### Feedback
+
+User feedback surfaces — banners, toasts, tooltips, empty states, progress bars.
+
+<Cards>
+  <Card title="Banner" href="/docs/components/banner" description="Full-width contextual banner. Announcement (brand surface) or status tones (replaces AlertBanner)." />
+  <Card title="Alert banner" href="/docs/components/alert-banner" description="DEPRECATED — migrate to Banner with tone." />
+  <Card title="Toast" href="/docs/components/toast" description="Ephemeral white-surface notification. Optional colored Badge for status." />
+  <Card title="Tooltip" href="/docs/components/tooltip" description="Hover/focus contextual help. Four placements with arrow indicator." />
+  <Card title="Empty state" href="/docs/components/empty-state" description="No-data placeholder with title, description, optional action." />
+  <Card title="Progress bar" href="/docs/components/progress-bar" description="Visual indicator of measurable completion. Use for uploads, multi-step forms, batch jobs." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining ~26 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Feedback, Control, Addable, Structure, Navigation, and Displays.
+The remaining ~20 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Control, Addable, Structure, Navigation, and Displays.
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -35,6 +35,13 @@
     "field",
     "field-grid",
     "form",
-    "catalog-picker"
+    "catalog-picker",
+    "---Feedback---",
+    "banner",
+    "alert-banner",
+    "toast",
+    "tooltip",
+    "empty-state",
+    "progress-bar"
   ]
 }

--- a/docs-site/content/docs/components/progress-bar.mdx
+++ b/docs-site/content/docs/components/progress-bar.mdx
@@ -1,0 +1,95 @@
+---
+title: Progress bar
+description: Visual indicator of completion. Use for measurable tasks — uploads, multi-step forms, batch operations.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+ProgressBar shows how far along a measurable task is. Use it whenever you can answer "what % done?" — file uploads, multi-step forms, batch syncs, scrape progress. For unmeasurable loading, use [Spinner](/docs/components/spinner).
+
+## Use it for
+
+- File upload progress
+- Multi-step form completion (Step 2 of 5)
+- Batch operation progress (12 of 50 records processed)
+- Scrape / sync / migration jobs with known totals
+
+## Import
+
+```tsx
+import { ProgressBar } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+`value` is a number 0–100.
+
+```tsx
+<ProgressBar value={35} label="Upload progress" />
+```
+
+### Empty / partial / full
+
+```tsx
+<ProgressBar value={0} label="Not started" />
+<ProgressBar value={50} label="Halfway" />
+<ProgressBar value={100} label="Complete" />
+```
+
+### Custom fill color
+
+`fillColor` overrides the brand-primary default. Use for status-coded progress (red for "deletion in progress", green for "import complete").
+
+```tsx
+<ProgressBar value={75} label="Migration progress" fillColor="var(--background-positive)" />
+```
+
+## Pattern: animated progress
+
+Drive `value` from state for live progress updates. Pair with a label that includes the actual count for accessibility.
+
+```tsx
+import { useState, useEffect } from 'react';
+
+const [progress, setProgress] = useState(0);
+
+useEffect(() => {
+  const id = setInterval(() => setProgress((p) => Math.min(p + 10, 100)), 500);
+  return () => clearInterval(id);
+}, []);
+
+<ProgressBar value={progress} label={`Upload progress: ${progress}%`} />
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use ProgressBar for unmeasurable loading.** If you can't compute a percentage ("waiting on server"), use [Spinner](/docs/components/spinner) instead. A fake "indeterminate" progress bar is worse than honest indeterminate-spinner UX.
+</Callout>
+
+- **Don't use ProgressBar for boolean done/not-done states.** That's a [Badge](/docs/components/badge) (Active / Failed) or [Counter](/docs/components/counter) ("3 of 5").
+- **Don't show a ProgressBar that doesn't move.** A frozen progress bar is broken UX — if the value won't update for >5s, switch to a Spinner with a message.
+
+## Accessibility
+
+- Renders a `<div>` with `role="progressbar"`, `aria-valuenow`, `aria-valuemin="0"`, `aria-valuemax="100"`.
+- **Always pass `label`** — it becomes the accessible name. Screen readers without it get "progress bar 35" with no context.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `value` | `number` (0–100) *(required)* | — |
+| `label` | `string` | — |
+| `fillColor` | `string` | `var(--background-brand-primary)` |
+
+Plus all standard `<div>` HTML attributes (excluding `role`, which ProgressBar locks to `progressbar`).
+
+## Related
+
+- [Spinner](/docs/components/spinner) — for indeterminate loading
+- [Skeleton](/docs/components/skeleton) — layout-preserving loading placeholder
+- [Counter](/docs/components/counter) — for discrete numeric progress ("3 of 5")
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-feedback-progress-bar--overview)**

--- a/docs-site/content/docs/components/toast.mdx
+++ b/docs-site/content/docs/components/toast.mdx
@@ -1,0 +1,102 @@
+---
+title: Toast
+description: White-surface notification with an optional colored Badge icon. The surface stays neutral; only the badge communicates status.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Toast is the ephemeral confirmation surface. Use for short-lived "this just happened" messages — saved, copied, queued, retrying. The surface stays neutral white; only the leading Badge changes color to communicate success / error / warning / info.
+
+For persistent state alerts, use [Banner](/docs/components/banner). For hover-only help, use [Tooltip](/docs/components/tooltip).
+
+## Use it for
+
+- Save / publish / delete confirmations after a user action
+- "Copied to clipboard" feedback
+- Queued / scheduled / retrying status pings
+- Any sub-second-to-few-seconds confirmation that the user can dismiss when ready
+
+## Import
+
+```tsx
+import { Toast } from '@brikdesigns/bds';
+```
+
+## Variants
+
+Five variants — `default` (no badge) plus four status badges.
+
+```tsx
+<Toast title="Just so you know" variant="default" />
+<Toast title="Saved" description="Settings updated." variant="success" />
+<Toast title="Couldn't save" description="Try again." variant="error" />
+<Toast title="Almost there" description="Trial ends tomorrow." variant="warning" />
+<Toast title="Heads up" description="Maintenance scheduled." variant="info" />
+```
+
+- **`default`** — No badge, no icon. Plain text confirmation.
+- **`success`** — Positive badge, `circle-check` icon.
+- **`error`** — Error badge, `circle-exclamation` icon.
+- **`warning`** — Warning badge, `triangle-exclamation` icon.
+- **`info`** — Info badge, `circle-info` icon.
+
+### Title-only
+
+`description` is optional. For one-line confirmations the title alone reads cleaner.
+
+```tsx
+<Toast title="Saved" variant="success" onDismiss={() => hide()} />
+```
+
+### Non-dismissible
+
+Omit `onDismiss` and the close button is hidden. Use for self-dismissing toast queues controlled by a parent provider.
+
+```tsx
+<Toast title="Saved" variant="success" />
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use Toast for persistent state.** Toasts are ephemeral by convention — users assume they'll go away. Trial-expires warnings, system-degraded notices, and "trial ends in 7 days" callouts belong in [Banner](/docs/components/banner) where they stay visible.
+</Callout>
+
+- **Don't use Toast for required user input.** Toasts dismiss; if the user must respond, use a [Banner](/docs/components/banner) or modal.
+- **Don't stack 5 Toasts.** A queue of 2-3 is fine; longer queues are noisy. Aggregate ("3 changes saved").
+
+## Accessibility
+
+- Renders a `<div role="status" aria-live="polite">` so screen readers announce the toast on render without interrupting current speech.
+- For destructive or critical messages, escalate to `role="alert"` (`aria-live="assertive"`) — but prefer Banner for those, since Toast's auto-dismiss conflicts with critical content.
+- Dismiss button carries `aria-label="Dismiss notification"`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `ReactNode` *(required)* | — |
+| `description` | `ReactNode` | — |
+| `variant` | `'default' \| 'success' \| 'error' \| 'warning' \| 'info'` | `'default'` |
+| `onDismiss` | `() => void` | — |
+
+Plus all standard `<div>` HTML attributes (excluding `title`).
+
+## CSS Override API
+
+| Variable | Default | Controls |
+|---|---|---|
+| `--toast-shadow` | `0px 4px 12px 4px rgba(0,0,0,0.24)` | Elevation shadow |
+
+```css
+.side-panel {
+  --toast-shadow: 0px 2px 8px rgba(0, 0, 0, 0.12);
+}
+```
+
+## Related
+
+- [Banner](/docs/components/banner) — persistent sibling
+- [Tooltip](/docs/components/tooltip) — hover-revealed sibling
+- [Badge](/docs/components/badge) — the status badge rendered inside Toast
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-feedback-toast--overview)**

--- a/docs-site/content/docs/components/tooltip.mdx
+++ b/docs-site/content/docs/components/tooltip.mdx
@@ -1,0 +1,106 @@
+---
+title: Tooltip
+description: Contextual help on hover or focus. Four placements with arrow indicator.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Tooltip wraps a trigger element and reveals a small contextual message on hover or keyboard focus. Use for icon-button labels, field-help hints, and keyboard shortcut indicators — anywhere the trigger doesn't carry enough context on its own.
+
+For persistent guidance, use [Field](/docs/components/field) helper text. For ephemeral confirmations, use [Toast](/docs/components/toast).
+
+## Use it for
+
+- Icon-only button labels ("Edit", "Archive", "Delete") — paired with the visible icon
+- Keyboard shortcut hints on toolbar buttons (`⌘K`, `⌘S`, etc.)
+- Truncated text full content on hover
+- Brief field-help that doesn't deserve a full helper-text line
+
+## Import
+
+```tsx
+import { Tooltip } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+<Tooltip content="This is helpful information">
+  <button>Hover me</button>
+</Tooltip>
+```
+
+### Placement
+
+Four positions — `top` (default), `bottom`, `left`, `right`. Pick based on the trigger's surroundings; `top` is safest for buttons in toolbars.
+
+```tsx
+<Tooltip content="Appears above" placement="top">
+  <button>...</button>
+</Tooltip>
+
+<Tooltip content="Appears below" placement="bottom">
+  <button>...</button>
+</Tooltip>
+```
+
+### With delay
+
+`delay` (ms) adds a hover-intent debounce so brushing-past triggers don't pop tooltips. Default 0 (instant).
+
+```tsx
+<Tooltip content="After 500ms hover" delay={500}>
+  <button>...</button>
+</Tooltip>
+```
+
+### Pattern: icon button toolbar
+
+The canonical pattern. Each IconButton's `label` becomes both the `aria-label` (always read) and the tooltip content (visible on hover).
+
+```tsx
+import { Tooltip, IconButton } from '@brikdesigns/bds';
+
+<Tooltip content="Edit item">
+  <IconButton icon={<EditIcon />} label="Edit item" />
+</Tooltip>
+
+<Tooltip content="Archive item">
+  <IconButton icon={<ArchiveIcon />} label="Archive item" />
+</Tooltip>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't put critical info only in a Tooltip.** Keyboard-only users can't hover, and screen-reader users may not get the tooltip at all. Tooltip is *supplementary* — the trigger should still convey the action, with the tooltip as a hint.
+</Callout>
+
+- **Don't put long text in a Tooltip.** Three lines max. For longer guidance, use a Popover or Banner.
+- **Don't use Tooltip for form-error messages.** Use the input's `error` prop — error state is too important to hide behind hover.
+- **Don't nest interactive content in a Tooltip.** No links, no buttons. Tooltips dismiss when the user moves the cursor away; they can't reach interactive content reliably.
+
+## Accessibility
+
+- Tooltip content is announced via `aria-describedby` linking the trigger to the tooltip element.
+- Triggers reveal the tooltip on `focus` (keyboard) as well as `hover` (pointer).
+- `Esc` dismisses an open tooltip.
+- The trigger's own accessible name (label, `aria-label`, etc.) is unchanged — Tooltip doesn't replace it.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `content` | `ReactNode` *(required)* | — |
+| `placement` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` |
+| `delay` | `number` (ms) | `0` |
+| `children` | `ReactNode` *(required, the trigger)* | — |
+
+## Related
+
+- [IconButton](/docs/components/button#iconbutton) — common Tooltip trigger
+- [Banner](/docs/components/banner) — persistent alternative
+- [Toast](/docs/components/toast) — ephemeral alternative
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-feedback-tooltip--overview)**


### PR DESCRIPTION
## Summary

Migrates the **Feedback** group (6 components). Stacked on top of [#276](https://github.com/brikdesigns/brik-bds/pull/276) (Form Inputs) — base is \`task/docs-form-inputs\`. PR #277 (Form Structure) already squash-merged into #276's branch, so this stack flattens to: #276 → this PR → main.

| Page | Notes |
|---|---|
| \`banner\` | Canonical full-width banner. \`tone="announcement"\` (default, brand surface) for marketing notices; \`tone="warning\|error\|information"\` for status alerts (replaces AlertBanner). Top-of-page \`<ComparisonGrid>\` disambiguates Banner vs Toast vs Tooltip. |
| \`alert-banner\` | Minimal **deprecation page**. Migration table to Banner + frozen-API reference. No new code examples. |
| \`toast\` | Ephemeral white-surface notification. Five variants — \`default\` (no badge) + four status badges. CSS Override API for shadow. |
| \`tooltip\` | Hover/focus contextual help. Four placements, \`delay\` prop, IconButton pairing pattern. Strong "critical info shouldn't be only in a Tooltip" warning for keyboard accessibility. |
| \`empty-state\` | No-data placeholder. \`buttonProps\` for primary action, \`children\` for custom layouts. Distinguished from [Field](/docs/components/field)'s inline \`empty\` prop. |
| \`progress-bar\` | Measurable completion indicator. Distinguished from [Spinner](/docs/components/spinner) (indeterminate) and [Counter](/docs/components/counter) (discrete). |

After this lands the **Feedback** group is **6/6 ✅**.

## State of the migration after this stack merges

| Group | Status |
|---|---|
| Action | 6/6 ✅ |
| Indicator | 10/10 ✅ |
| Form / Inputs | 10/10 ✅ |
| Form / Structure | 4/4 ✅ |
| **Feedback** | **6/6 ✅ (this PR)** |
| Control | 0/7 |
| Addable | 0/3 |
| Structure | 0/3 |
| Navigation | 0/4 |
| Displays | 0/~14 |

Foundations: 7/8 (Motion still pending). Total docs-site routes after this stack lands: 65.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds (BDS dist must be built first)
- [ ] \`/docs/components\` shows a Feedback card grid below Form / Structure
- [ ] \`/docs/components/banner\` — \`<ComparisonGrid>\` at top renders three live previews (Banner, Toast, Tooltip)
- [ ] \`/docs/components/banner\` — both announcement and tone code examples are accurate to current Banner API
- [ ] \`/docs/components/alert-banner\` — opens with a prominent deprecation \`<Callout type="error">\`; migration table is the page's main content
- [ ] \`/docs/components/toast\` — five-variant code list reads correctly
- [ ] \`/docs/components/tooltip\` — IconButton pairing pattern + accessibility warning are clear
- [ ] \`/docs/components/empty-state\` — \`buttonProps\` vs \`children\` distinction is clear
- [ ] \`/docs/components/progress-bar\` — Spinner / Counter / ProgressBar decision moment reads correctly
- [ ] All Storybook deep-links resolve

## Out of scope (follow-ups)

- Control group (Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader)
- Addable group (AddableTagList, AddableEntryList, AddableFieldRowList)
- Structure group (Card, Divider, Accordion)
- Navigation, Displays, Motion foundation
- Remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)