### PR TITLE
feat(docs-site): migrate Control group (7 components)

### DIFF
--- a/docs-site/content/docs/components/file-uploader.mdx
+++ b/docs-site/content/docs/components/file-uploader.mdx
@@ -1,0 +1,127 @@
+---
+title: File uploader
+description: Drag-and-drop file upload zone with click-to-browse fallback. Type filtering, size limits, multi-file support.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+FileUploader is a drag-and-drop drop zone with click-to-browse fallback. Use anywhere users need to upload one or more files — avatar selection, document uploads, image galleries, CSV imports.
+
+## Use it for
+
+- Document upload (PDF, DOCX, CSV imports)
+- Image uploads (avatars, gallery, before/after photos)
+- Multi-file batch uploads
+- Any field where the user supplies a file from their device
+
+## Import
+
+```tsx
+import { FileUploader } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+<FileUploader
+  accept=".pdf,.jpg,.png"
+  helperText="PDF, JPG, or PNG up to 10MB"
+  onChange={(files) => handleFiles(files)}
+/>
+```
+
+### Multiple files with size limit
+
+```tsx
+<FileUploader
+  accept="image/*"
+  multiple
+  maxSize={5 * 1024 * 1024}
+  label="Upload images"
+  helperText="Select one or more images (5MB max)"
+  onChange={(files) => handleFiles(files)}
+/>
+```
+
+### Error state
+
+Surface validation errors (size exceeded, wrong type, server rejection) inline.
+
+```tsx
+<FileUploader
+  accept=".pdf"
+  error="File must be a PDF"
+  onChange={(files) => handleFiles(files)}
+/>
+```
+
+### Disabled
+
+```tsx
+<FileUploader disabled label="Upload" />
+```
+
+## Pattern: with file list display
+
+FileUploader handles selection. Rendering the picked-files list afterward is the parent's responsibility — typically a list with each file's name, size, and a remove button.
+
+```tsx
+import { useState } from 'react';
+const [files, setFiles] = useState<File[]>([]);
+
+<>
+  <FileUploader
+    accept="image/*"
+    multiple
+    onChange={(picked) => setFiles((prev) => [...prev, ...picked])}
+  />
+  <ul>
+    {files.map((f, i) => (
+      <li key={i}>
+        {f.name} — {Math.round(f.size / 1024)}KB
+        <button onClick={() => setFiles(files.filter((_, j) => j !== i))}>
+          Remove
+        </button>
+      </li>
+    ))}
+  </ul>
+</>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use FileUploader for camera/scan capture.** Native `<input type="file" capture="user">` is for photo capture from a device camera. FileUploader doesn't expose `capture` — for camera-first flows, use a plain input or extend the component.
+</Callout>
+
+- **Don't use FileUploader for paste-from-clipboard.** Clipboard image paste is a different interaction — wire it on the surrounding container.
+- **Don't use FileUploader without `accept`.** Letting users upload arbitrary file types invites server-side validation work that should happen client-side first.
+
+## Accessibility
+
+- The drop zone is a real `<button>` — keyboard `Enter`/`Space` opens the file picker.
+- Drag-over state is announced via `aria-busy` on the zone during drop.
+- `error` sets `aria-invalid` and links to the message via `aria-describedby`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `accept` | `string` (e.g. `'.pdf,.jpg'` or `'image/*'`) | — |
+| `multiple` | `boolean` | `false` |
+| `maxSize` | `number` (bytes) | — |
+| `disabled` | `boolean` | `false` |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `error` | `string` | — |
+| `onChange` | `(files: File[]) => void` | — |
+
+Plus standard `<div>` HTML attributes (excluding native `onChange`).
+
+## Related
+
+- [TextInput](/docs/components/text-input) — for non-file form fields
+- [ProgressBar](/docs/components/progress-bar) — pair with FileUploader for upload-progress feedback
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-control-file-uploader--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -13,7 +13,7 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
 | **Form** | TextInput, TextArea, PasswordInput, AddressInput, Select, MultiSelect, DatePicker, TimePicker, Checkbox, Radio, Field, FieldGrid, Form |
 | **Indicator** | Badge, Chip, Tag, Counter, Dot, Spinner, Skeleton, BadgeGroup, TagGroup, ServiceBadge |
 | **Feedback** | Banner, Toast, Tooltip, EmptyState, ProgressBar (AlertBanner deprecated → Banner) |
-| **Control** | Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader |
+| **Control** | Switch, Slider, Stepper, ProgressStepper, Pagination, SegmentedControl, FileUploader |
 | **Addable** | AddableTagList, AddableEntryList, AddableFieldRowList |
 | **Structure** | Card, Divider, Accordion |
 
@@ -88,9 +88,23 @@ User feedback surfaces — banners, toasts, tooltips, empty states, progress bar
   <Card title="Progress bar" href="/docs/components/progress-bar" description="Visual indicator of measurable completion. Use for uploads, multi-step forms, batch jobs." />
 </Cards>
 
+### Control
+
+Toggles, sliders, steppers, paginators, and the file uploader.
+
+<Cards>
+  <Card title="Switch" href="/docs/components/switch" description="Binary on/off toggle. Three sizes, controlled or uncontrolled." />
+  <Card title="Slider" href="/docs/components/slider" description="Continuous-range input. Drag-to-select numeric values." />
+  <Card title="Stepper" href="/docs/components/stepper" description="Numeric input with +/− buttons. Discrete steps, exact values." />
+  <Card title="Progress stepper" href="/docs/components/progress-stepper" description="Multi-step flow indicator. Steps (labeled) or dots (compact) variant." />
+  <Card title="Pagination" href="/docs/components/pagination" description="Page navigation with prev/next + numbers + ellipsis." />
+  <Card title="Segmented control" href="/docs/components/segmented-control" description="Pill-shaped switcher for 2-5 mutually exclusive views." />
+  <Card title="File uploader" href="/docs/components/file-uploader" description="Drag-and-drop file upload zone with click-to-browse fallback." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining ~20 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Control, Addable, Structure, Navigation, and Displays.
+The remaining ~13 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Addable, Structure, Navigation, and Displays.
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -42,6 +42,14 @@
     "toast",
     "tooltip",
     "empty-state",
-    "progress-bar"
+    "progress-bar",
+    "---Control---",
+    "switch",
+    "slider",
+    "stepper",
+    "progress-stepper",
+    "pagination",
+    "segmented-control",
+    "file-uploader"
   ]
 }

--- a/docs-site/content/docs/components/pagination.mdx
+++ b/docs-site/content/docs/components/pagination.mdx
@@ -1,0 +1,112 @@
+---
+title: Pagination
+description: Page navigation controls. Previous / next arrows, page numbers, ellipsis for large counts.
+---
+
+Pagination renders page-navigation controls under tables, lists, and search results. Supports left / center / right alignment and configurable sibling counts.
+
+For multi-step flow indicators, use [ProgressStepper](/docs/components/progress-stepper) — Pagination is for browsing a paginated dataset.
+
+## Use it for
+
+- Tables and lists with paged data
+- Search results with multiple pages
+- Long content split into chapters / sections
+- Anywhere the user can move backward and forward through known-count pages
+
+## Import
+
+```tsx
+import { Pagination } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { useState } from 'react';
+const [page, setPage] = useState(1);
+
+<Pagination
+  currentPage={page}
+  totalPages={80}
+  onChange={setPage}
+/>
+```
+
+### Alignment
+
+`position` controls horizontal alignment. Choose based on container layout — `center` for full-width tables, `right` for sidebars, `left` for left-aligned lists.
+
+```tsx
+<Pagination currentPage={page} totalPages={80} onChange={setPage} position="left" />
+<Pagination currentPage={page} totalPages={80} onChange={setPage} position="center" />
+<Pagination currentPage={page} totalPages={80} onChange={setPage} position="right" />
+```
+
+### Sibling count
+
+`siblingCount` controls how many page numbers show on each side of the current page (default 1). Increase for wider containers; decrease for compact ones.
+
+```tsx
+<Pagination
+  currentPage={page}
+  totalPages={80}
+  onChange={setPage}
+  siblingCount={2}
+/>
+```
+
+### Few pages
+
+When `totalPages` is small, all pages render — no ellipsis needed.
+
+```tsx
+<Pagination currentPage={2} totalPages={5} onChange={setPage} />
+```
+
+## Pattern: pagination + result count
+
+Standard table footer pattern — count on the left, controls on the right.
+
+```tsx
+<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+  <span>{`Showing ${start}–${end} of ${total}`}</span>
+  <Pagination
+    currentPage={page}
+    totalPages={Math.ceil(total / pageSize)}
+    onChange={setPage}
+  />
+</div>
+```
+
+## When *not* to use
+
+- **Don't use Pagination for infinite-scroll lists.** Pagination implies discrete pages with stable URLs. For continuous loading, use a "Load more" button or true infinite scroll.
+- **Don't use Pagination for ≤2 pages.** Single-page or two-page sets read as visual noise — drop the control entirely or show the result count alone.
+- **Don't use Pagination as a navigation primitive.** Page numbers don't carry context like links do. For navigation between sections of an app, use TabBar or links.
+
+## Accessibility
+
+- Renders a `<nav>` with `aria-label="Pagination"`.
+- Each page button is a real `<button>` with `aria-current="page"` on the active one.
+- Previous / Next buttons carry `aria-label`s and disable on the first/last page.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `currentPage` | `number` (1-indexed) *(required)* | — |
+| `totalPages` | `number` *(required)* | — |
+| `onChange` | `(page: number) => void` *(required)* | — |
+| `position` | `'left' \| 'center' \| 'right'` | `'center'` |
+| `siblingCount` | `number` | `1` |
+
+Plus standard `<nav>` HTML attributes (excluding native `onChange`).
+
+## Related
+
+- [ProgressStepper](/docs/components/progress-stepper) — flow progress, not page navigation
+- [Stepper](/docs/components/stepper) — numeric +/− input, different component
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-control-pagination--overview)**

--- a/docs-site/content/docs/components/progress-stepper.mdx
+++ b/docs-site/content/docs/components/progress-stepper.mdx
@@ -1,0 +1,127 @@
+---
+title: Progress stepper
+description: Step indicator for multi-step flows. Two variants — labeled vertical steps and compact horizontal dots.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+ProgressStepper shows where the user is in a multi-step flow. One component, two layouts: `steps` (labeled, vertical or horizontal with descriptions) and `dots` (compact horizontal indicator). Both share the same `activeStep`, `linear`, and `onStepClick` model.
+
+The `dots` variant **replaced the standalone ProgressDots component** per [ADR-004 §3](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md) — same shape, same logic, different layout = one component with a variant prop, not two.
+
+Note: this is **not** the same as [Stepper](/docs/components/stepper) — that's a numeric +/− input.
+
+## Use it for
+
+- Checkout / signup / setup wizard step indicators
+- Multi-page form progress
+- Onboarding flow markers
+- Any sequential flow where the user benefits from seeing position + total steps
+
+For boolean done/in-progress on a single task, use [ProgressBar](/docs/components/progress-bar). For numeric input, use [Stepper](/docs/components/stepper).
+
+## Import
+
+```tsx
+import { ProgressStepper } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Steps (default, labeled)
+
+```tsx
+<ProgressStepper
+  steps={[
+    { label: 'Account' },
+    { label: 'Profile' },
+    { label: 'Review' },
+  ]}
+  activeStep={1}
+/>
+```
+
+### Steps with descriptions
+
+```tsx
+<ProgressStepper
+  steps={[
+    { label: 'Details', description: 'Enter your information' },
+    { label: 'Payment', description: 'Add billing details' },
+    { label: 'Confirm', description: 'Review and submit' },
+  ]}
+  activeStep={0}
+  onStepClick={(step) => setStep(step)}
+/>
+```
+
+### Dots variant — compact horizontal
+
+The active dot stretches wider; completed dots are dimmed; upcoming dots are muted. No label text — pair with a page heading or step counter.
+
+```tsx
+<ProgressStepper
+  variant="dots"
+  count={5}
+  activeStep={2}
+  onStepClick={(step) => setStep(step)}
+/>
+```
+
+### Linear mode
+
+Restrict navigation to sequential steps — clicking a future step beyond `activeStep + 1` is blocked. Use for flows where steps depend on completion of prior ones.
+
+```tsx
+<ProgressStepper
+  steps={steps}
+  activeStep={1}
+  linear
+  onStepClick={(step) => setStep(step)}
+/>
+```
+
+### Sizes
+
+`sm` for constrained layouts, `md` (default) otherwise.
+
+```tsx
+<ProgressStepper steps={steps} activeStep={0} size="sm" />
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use ProgressStepper for measurable progress within a single task.** That's [ProgressBar](/docs/components/progress-bar). ProgressStepper is for *between* discrete steps; ProgressBar is for *within* a single step.
+</Callout>
+
+- **Don't use Steps with >5 entries.** A 7-step labeled flow is unscannable — switch to `dots` and lean on the page heading for context.
+- **Don't use Dots for unfamiliar flows.** Without labels, dots assume the user already knows what each step is about. Use Steps for first-time-user flows.
+
+## Accessibility
+
+- Renders an `<ol>` with `aria-label` describing the flow.
+- Active step carries `aria-current="step"`.
+- `onStepClick` makes each step a real `<button>` — keyboard navigation, focus ring all work.
+- `linear` mode disables future steps via `aria-disabled` so assistive tech announces the constraint.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `variant` | `'steps' \| 'dots'` | `'steps'` |
+| `activeStep` | `number` (0-indexed) | — |
+| `steps` | `Array<{ label: string; description?: string }>` (steps variant) | — |
+| `count` | `number` (dots variant) | — |
+| `linear` | `boolean` | `false` |
+| `onStepClick` | `(step: number) => void` | — |
+| `size` | `'sm' \| 'md'` | `'md'` |
+
+The `steps` and `count` props are mutually exclusive — `variant="steps"` requires `steps`, `variant="dots"` requires `count`.
+
+## Related
+
+- [ProgressBar](/docs/components/progress-bar) — within-step progress
+- [Stepper](/docs/components/stepper) — different component (numeric input)
+- [Pagination](/docs/components/pagination) — page navigation, not flow progress
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-control-progress-stepper--overview)**

--- a/docs-site/content/docs/components/segmented-control.mdx
+++ b/docs-site/content/docs/components/segmented-control.mdx
@@ -1,0 +1,150 @@
+---
+title: Segmented control
+description: Pill-shaped toggle for switching between mutually exclusive views or modes.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+SegmentedControl is a horizontal pill switcher for **mutually exclusive views in the same panel** — Grid / List, Monthly / Yearly, This Week / This Month. Unlike TabBar (which navigates between page sections), SegmentedControl swaps content in-place.
+
+<ComparisonGrid
+  items={[
+    {
+      title: 'SegmentedControl',
+      preview: <BDS.SegmentedControl items={[{label: 'Grid', value: 'grid'}, {label: 'List', value: 'list'}]} value="grid" />,
+      whenToUse: 'Toggle between 2-5 views in the same panel. Inline, compact, mutually exclusive.',
+      whenNotToUse: 'Page-level navigation — that\'s TabBar.',
+      code: `<SegmentedControl items={...} />`,
+    },
+    {
+      title: 'Switch',
+      preview: <BDS.Switch label="On" defaultChecked />,
+      whenToUse: 'Binary on/off setting. Settings panels, feature flags.',
+      whenNotToUse: '3+ options — use SegmentedControl.',
+      code: `<Switch label="..." />`,
+    },
+    {
+      title: 'Select',
+      preview: <BDS.Select options={[{label:'A', value:'a'},{label:'B',value:'b'}]} />,
+      whenToUse: 'One-of-many from a longer list (6+ options).',
+      whenNotToUse: '≤5 options that fit horizontally — use SegmentedControl.',
+      code: `<Select options={...} />`,
+    },
+  ]}
+/>
+
+## Use it for
+
+- View switchers (Grid / List / Calendar)
+- Pricing toggles (Monthly / Yearly)
+- Date range selectors (Today / This Week / This Month)
+- Mode pickers in tool panels (Edit / Preview)
+
+## Import
+
+```tsx
+import { SegmentedControl } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { useState } from 'react';
+const [view, setView] = useState('grid');
+
+<SegmentedControl
+  value={view}
+  onChange={setView}
+  items={[
+    { label: 'Grid', value: 'grid' },
+    { label: 'List', value: 'list' },
+  ]}
+/>
+```
+
+### Sizes
+
+- **`sm`** — compact toolbars, dense UI
+- **`md`** — default for forms and panels
+- **`lg`** — prominent page-level toggles
+
+### Full-width
+
+```tsx
+<SegmentedControl
+  value={period}
+  onChange={setPeriod}
+  size="lg"
+  fullWidth
+  items={[
+    { label: 'Monthly', value: 'monthly' },
+    { label: 'Yearly', value: 'yearly' },
+  ]}
+/>
+```
+
+### Many segments
+
+SegmentedControl tolerates up to ~5 segments before the labels feel cramped. Beyond that, switch to [Select](/docs/components/select).
+
+```tsx
+<SegmentedControl
+  value={range}
+  onChange={setRange}
+  items={[
+    { label: 'Today', value: 'today' },
+    { label: 'Week', value: 'week' },
+    { label: 'Month', value: 'month' },
+    { label: 'Quarter', value: 'quarter' },
+    { label: 'Year', value: 'year' },
+  ]}
+/>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use SegmentedControl for page-level navigation.** TabBar carries the right semantic for "navigate to a different section"; SegmentedControl is for "swap content in place." The visual treatments are similar; the navigation model is not.
+</Callout>
+
+- **Don't use SegmentedControl for >5 options.** Long pills wrap or truncate. Use [Select](/docs/components/select).
+- **Don't use SegmentedControl for binary on/off.** Use [Switch](/docs/components/switch) — the affordance is correct.
+- **Don't pair with conflicting selection state.** SegmentedControl is single-select; for multi-select toggles use a Checkbox group or [MultiSelect](/docs/components/multi-select).
+
+## Accessibility
+
+- Renders a `<div role="tablist">` with each segment as `<button role="tab">`.
+- The selected segment carries `aria-selected="true"`; unselected carry `false`.
+- Keyboard arrows move selection between segments.
+- Items can carry their own `aria-label` for icon-only segments.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `items` | `SegmentItem[]` *(required)* | — |
+| `value` | `string` | — |
+| `onChange` | `(value: string) => void` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `fullWidth` | `boolean` | `false` |
+| `disabled` | `boolean` | `false` |
+
+### SegmentItem
+
+```ts
+interface SegmentItem {
+  label: ReactNode;
+  value: string;
+  disabled?: boolean;
+}
+```
+
+## Related
+
+- [Switch](/docs/components/switch) — binary on/off
+- [Radio](/docs/components/radio) — vertical one-of-many
+- [Select](/docs/components/select) — for >5 options
+- TabBar — page-level navigation (in Storybook)
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-control-segmented-control--overview)**

--- a/docs-site/content/docs/components/slider.mdx
+++ b/docs-site/content/docs/components/slider.mdx
@@ -1,0 +1,115 @@
+---
+title: Slider
+description: Range input. Drag-to-select a numeric value across a continuous range.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Slider is a continuous-range input — drag the thumb to pick a value. Use for settings where approximate selection is fine and the user benefits from seeing where they are on a scale (volume, brightness, price filter).
+
+For exact discrete values, use [Stepper](/docs/components/stepper). For known-set picks, use [Select](/docs/components/select).
+
+## Use it for
+
+- Volume / brightness / opacity controls
+- Price-range filters in search UI
+- Audio scrubbers and timeline scrubbers
+- Any setting where the user thinks "make it about this much" rather than "exactly N"
+
+## Import
+
+```tsx
+import { Slider } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Sizes
+
+- **`sm`** — 4px track, 16px thumb. Compact settings.
+- **`md`** — 6px track, 20px thumb. Default.
+- **`lg`** — 8px track, 24px thumb. Prominent controls.
+
+### Default
+
+```tsx
+import { useState } from 'react';
+const [value, setValue] = useState(50);
+
+<Slider label="Volume" value={value} onChange={setValue} showValue />
+```
+
+### Custom range and step
+
+`min`, `max`, and `step` constrain the value space. Use for non-percentage scales.
+
+```tsx
+<Slider
+  label="Price"
+  value={value}
+  onChange={setValue}
+  min={0}
+  max={1000}
+  step={50}
+  size="lg"
+  showValue
+/>
+```
+
+### Show value
+
+`showValue` renders the current value next to the label.
+
+```tsx
+<Slider label="Brightness" value={75} onChange={setValue} showValue />
+```
+
+## When *not* to use
+
+- **Don't use Slider for exact integer counts.** Quantity selectors belong in [Stepper](/docs/components/stepper) — typing "5" is faster than dragging to "5".
+- **Don't use Slider for ≤4 discrete values.** Use [SegmentedControl](/docs/components/segmented-control) — visible options beat hidden positions.
+- **Don't use Slider without a visible value indicator.** Without `showValue` or an external readout, users can't confirm the exact pick.
+
+<Callout type="warn">
+  **Slider is approximate by design.** If exact-value entry matters (currency, units), pair Slider with a [TextInput](/docs/components/text-input) showing the exact value, or skip Slider entirely.
+</Callout>
+
+## Accessibility
+
+- Renders a real `<input type="range">` — keyboard arrows nudge the value, `Home`/`End` jump to min/max.
+- `label` auto-wires `htmlFor`/`id`. Pair with `aria-label` if you skip the visible label.
+- The current value is announced via `aria-valuenow` (set automatically from `value`).
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `value` / `defaultValue` | `number` | — |
+| `min` | `number` | `0` |
+| `max` | `number` | `100` |
+| `step` | `number` | `1` |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `label` | `string` | — |
+| `showValue` | `boolean` | `false` |
+| `disabled` | `boolean` | `false` |
+| `onChange` | `(value: number) => void` | — |
+
+Plus all standard `<input>` HTML attributes (excluding `type`, `size`, native `onChange`).
+
+## CSS Override API
+
+| Variable | Default | Controls |
+|---|---|---|
+| `--slider-thumb-shadow` | `0 2px 4px rgba(0,0,0,0.1)` | Drop shadow on the thumb |
+
+```css
+.settings-panel {
+  --slider-thumb-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+```
+
+## Related
+
+- [Stepper](/docs/components/stepper) — discrete-value sibling
+- [SegmentedControl](/docs/components/segmented-control) — for ≤4 values
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-control-slider--overview)**

--- a/docs-site/content/docs/components/stepper.mdx
+++ b/docs-site/content/docs/components/stepper.mdx
@@ -1,0 +1,91 @@
+---
+title: Stepper
+description: Numeric input with increment / decrement buttons. Discrete steps, exact values.
+---
+
+Stepper is a numeric input with `−` / `+` buttons. Use for quantity selectors, count adjusters, and any setting that increments in discrete units. For continuous-range "about this much" selection, use [Slider](/docs/components/slider).
+
+Note: this is **not** the same as [ProgressStepper](/docs/components/progress-stepper) — that's the multi-step wizard indicator.
+
+## Use it for
+
+- Quantity selectors (cart items, user-count picker)
+- Discrete-step adjusters (font size, padding overrides)
+- Pagination by-N controls (page size)
+- Any field where the user thinks "exactly N" and N changes by a known step
+
+## Import
+
+```tsx
+import { Stepper } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { useState } from 'react';
+const [count, setCount] = useState(1);
+
+<Stepper value={count} onChange={setCount} />
+```
+
+### Bounds and custom step
+
+`min`, `max`, and `step` constrain and quantize the value.
+
+```tsx
+<Stepper
+  value={count}
+  onChange={setCount}
+  min={0}
+  max={100}
+  step={5}
+  size="lg"
+/>
+```
+
+### Sizes
+
+`sm`, `md` (default), `lg` — match TextInput sizes for inline placement next to other form controls.
+
+### Disabled
+
+```tsx
+<Stepper value={5} onChange={() => {}} disabled />
+```
+
+## When *not* to use
+
+- **Don't use Stepper for continuous values.** Use [Slider](/docs/components/slider).
+- **Don't use Stepper for large ranges** (e.g. 1–10,000). The button-clicks-per-change ratio gets unusable. Use [TextInput](/docs/components/text-input) with `type="number"`.
+- **Don't use Stepper for non-numeric stepping.** "Tier: Bronze / Silver / Gold" is [SegmentedControl](/docs/components/segmented-control) territory.
+
+## Accessibility
+
+- Renders a `<div>` containing an `<input type="number">` plus two `<button>`s.
+- The buttons carry `aria-label="Decrement"` / `aria-label="Increment"`.
+- Keyboard arrows on the input itself increment/decrement (native number-input behavior).
+- `min` and `max` map to `aria-valuemin` / `aria-valuemax`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `value` | `number` *(required)* | — |
+| `onChange` | `(value: number) => void` *(required)* | — |
+| `min` | `number` | `0` |
+| `max` | `number` | — |
+| `step` | `number` | `1` |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `disabled` | `boolean` | `false` |
+
+Plus all standard `<div>` HTML attributes (excluding native `onChange`).
+
+## Related
+
+- [Slider](/docs/components/slider) — continuous-range sibling
+- [TextInput](/docs/components/text-input) `type="number"` — for large ranges
+- [ProgressStepper](/docs/components/progress-stepper) — multi-step wizard indicator (different component)
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-control-stepper--overview)**

--- a/docs-site/content/docs/components/switch.mdx
+++ b/docs-site/content/docs/components/switch.mdx
@@ -1,0 +1,100 @@
+---
+title: Switch
+description: Toggle control for binary on/off states. The right shape for "is this feature active?"
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Switch is the on/off control. Use it for settings and preferences where the user is **enabling or disabling something**, not picking from a list. For "I am picking this option" semantics, use [Checkbox](/docs/components/checkbox); for one-of-many exclusive choice, use [Radio](/docs/components/radio).
+
+## Use it for
+
+- Settings toggles ("Email notifications", "Dark mode", "Auto-save")
+- Feature flags exposed to users
+- Inline on/off controls inside table rows
+- Anywhere the affordance "this preference is now active" matters more than "I am selecting this option"
+
+## Import
+
+```tsx
+import { Switch } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Sizes
+
+```tsx
+<Switch label="Compact panel toggle" size="sm" />
+<Switch label="Standard form toggle" size="md" />
+<Switch label="Page-level setting" size="lg" />
+```
+
+- **`sm`** — 28×16. Compact settings panels, dense rows.
+- **`md`** — 32×18. Default for most form controls.
+- **`lg`** — 56×32. Primary settings, feature toggles, prominent placements.
+
+### Uncontrolled
+
+```tsx
+<Switch label="Enable feature" defaultChecked />
+```
+
+### Controlled
+
+```tsx
+import { useState } from 'react';
+
+const [darkMode, setDarkMode] = useState(false);
+
+<Switch
+  label="Dark mode"
+  checked={darkMode}
+  onChange={(e) => setDarkMode(e.target.checked)}
+/>
+```
+
+### Without label
+
+For label-on-the-side patterns where the surrounding row carries the name.
+
+```tsx
+<div style={{ display: 'flex', justifyContent: 'space-between' }}>
+  <span>Email notifications</span>
+  <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+</div>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use Switch for "I am picking this option" semantics.** Settings panels are Switch territory. Form options the user is *choosing* (terms acceptance, opt-in flags) are [Checkbox](/docs/components/checkbox). The visual shape carries semantic meaning — switching them confuses the read.
+</Callout>
+
+- **Don't use Switch for one-of-many.** Use [Radio](/docs/components/radio) (vertical) or [SegmentedControl](/docs/components/segmented-control) (horizontal).
+- **Don't use Switch in form submissions.** Switches usually trigger immediate state change (auto-save). Form submits batch state — use Checkbox if the change applies on submit.
+
+## Accessibility
+
+- Renders a real `<input type="checkbox">` with `role="switch"` and the platform-correct `aria-checked` semantics.
+- Keyboard `Space` toggles, just like a checkbox.
+- Pair with a visible label (preferred) or `aria-label` if the surrounding row provides the name.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `label` | `ReactNode` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `checked` / `defaultChecked` | `boolean` | — |
+| `disabled` | `boolean` | `false` |
+| `onChange` | `(e: ChangeEvent<HTMLInputElement>) => void` | — |
+
+Plus all standard `<input>` HTML attributes (excluding `type` and the HTML `size` attribute).
+
+## Related
+
+- [Checkbox](/docs/components/checkbox) — picking-an-option sibling
+- [Radio](/docs/components/radio) — single-of-many sibling
+- [SegmentedControl](/docs/components/segmented-control) — horizontal one-of-many
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-control-switch--overview)**


### PR DESCRIPTION
## Summary

Migrates the **Control** group (7 components). Stacked on top of [#278](https://github.com/brikdesigns/brik-bds/pull/278) — base is \`task/docs-feedback\`. Stack: #276 → #278 → this PR → main.

| Page | Notes |
|---|---|
| \`switch\` | Binary on/off toggle. Three sizes. Disambiguated from Checkbox / Radio in the "when not to use" section. |
| \`slider\` | Continuous-range input. \`min\`/\`max\`/\`step\` constraints, \`showValue\` for visible readout. CSS Override API for thumb shadow. |
| \`stepper\` | Discrete numeric +/−. Explicitly distinguished from ProgressStepper (different component, similar name). |
| \`progress-stepper\` | Multi-step flow indicator. Two variants — \`steps\` (labeled, supports descriptions) and \`dots\` (compact horizontal). Documents the ADR-004 §3 ProgressDots → dots-variant consolidation. |
| \`pagination\` | Page nav with prev/next + numbers + ellipsis. Standard "result count + pagination" footer pattern. |
| \`segmented-control\` | Pill switcher for 2-5 mutually exclusive views. Top-of-page \`<ComparisonGrid>\` disambiguates SegmentedControl vs Switch vs Select. Notes TabBar as the page-nav alternative. |
| \`file-uploader\` | Drag-drop zone with click-to-browse fallback. Type filter, size limit, multi-file. Documents the file-list-display pattern as parent's responsibility. |

## State of the migration after this stack merges

| Group | Status |
|---|---|
| Action | 6/6 ✅ |
| Indicator | 10/10 ✅ |
| Form / Inputs | 10/10 ✅ |
| Form / Structure | 4/4 ✅ |
| Feedback | 6/6 ✅ |
| **Control** | **7/7 ✅ (this PR)** |
| Addable | 0/3 |
| Structure | 0/3 |
| Navigation | 0/4 |
| Displays | 0/~14 |

Foundations: 7/8 (Motion still pending). Total docs-site routes after this stack lands: **72**. Total component pages: **43**.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds (BDS dist must be built first)
- [ ] \`/docs/components\` shows a Control card grid below Feedback
- [ ] \`/docs/components/segmented-control\` — \`<ComparisonGrid>\` at top renders three live previews
- [ ] \`/docs/components/progress-stepper\` — both \`steps\` and \`dots\` variants are documented; the ADR-004 ProgressDots consolidation note is clear
- [ ] \`/docs/components/stepper\` — disambiguation note vs ProgressStepper is prominent (different components, similar names)
- [ ] \`/docs/components/slider\` — CSS Override API table renders correctly
- [ ] \`/docs/components/pagination\` — "result count + pagination" footer pattern code reads correctly
- [ ] \`/docs/components/file-uploader\` — file-list-display pattern code shows the parent owning the picked-files state
- [ ] \`/docs/components/switch\` — Switch / Checkbox / Radio decision rule is clear
- [ ] All Storybook deep-links resolve

## Out of scope (follow-ups)

- Addable group (AddableTagList, AddableEntryList, AddableFieldRowList)
- Structure group (Card, Divider, Accordion)
- Navigation group (TabBar, Breadcrumb, SidebarNavigation, Menu)
- Displays section (~14 components)
- Motion foundation port
- Remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)