### PR TITLE
feat(docs-site): migrate Addable group (4 components) + fix broken cross-links

### DIFF
--- a/docs-site/content/docs/components/addable-combo-list.mdx
+++ b/docs-site/content/docs/components/addable-combo-list.mdx
@@ -1,0 +1,154 @@
+---
+title: Addable combo list
+description: Suggestion-driven combobox for tag-style multi-select with free-form fallback.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+AddableComboList is the vocabulary-backed sibling of [AddableTextList](/docs/components/addable-text-list). Typing filters a known suggestion list (case-insensitive contains match); users can pick from suggestions via keyboard/click, or type a free-form value and press **Enter** (unless `strict`).
+
+Use for intake fields where a vocabulary exists but editors may need custom entries — services offered, payment types, insurance providers wired from BCS getters like `getIndustryServices`.
+
+<ComparisonGrid
+  items={[
+    {
+      title: 'AddableComboList',
+      whenToUse: 'Vocabulary-backed picks with optional free-form fallback. BCS getters, locked enums.',
+      whenNotToUse: 'No vocabulary — use AddableTextList.',
+      code: `<AddableComboList suggestions={...} />`,
+    },
+    {
+      title: 'AddableTextList',
+      whenToUse: 'Free-form one-string-per-row entry, no vocabulary.',
+      whenNotToUse: 'Vocabulary exists — use ComboList for autocomplete.',
+      code: `<AddableTextList values={...} />`,
+    },
+    {
+      title: 'MultiSelect',
+      whenToUse: 'Locked vocabulary, no free-form. Renders as Tag chips.',
+      whenNotToUse: 'Need free-form fallback — use ComboList with strict=false.',
+      code: `<MultiSelect options={...} />`,
+    },
+  ]}
+/>
+
+## Use it for
+
+- Services from a BCS catalog with the option to add custom ones
+- Payment types / insurance providers where the industry pack seeds defaults but clients may add specifics
+- Tag entry against a recent-tags suggestion list
+
+## Import
+
+```tsx
+import { AddableComboList } from '@brikdesigns/bds';
+import { getIndustryServices } from '@brikdesigns/bds/content-system';
+```
+
+## Variants
+
+### Default — vocabulary-backed
+
+```tsx
+import { useState } from 'react';
+const [values, setValues] = useState<string[]>([]);
+const services = getIndustryServices(company.industry_slug);
+
+<AddableComboList
+  label="Services offered"
+  values={values}
+  onChange={setValues}
+  suggestions={services}
+  placeholder="Type or pick a service…"
+/>
+```
+
+### Strict mode — vocabulary-only
+
+When `strict` is true, only suggestions can be added. Free-form `Enter` is blocked and a hint shows while the typed value doesn't match any suggestion.
+
+```tsx
+<AddableComboList
+  label="Insurance accepted"
+  values={values}
+  onChange={setValues}
+  suggestions={INSURANCE_PROVIDERS}
+  strict
+/>
+```
+
+### Sizes
+
+`sm`, `md` (default), `lg`.
+
+### Disabled
+
+Renders tags without input or remove controls.
+
+```tsx
+<AddableComboList values={values} onChange={() => {}} suggestions={[]} disabled />
+```
+
+### Max entries
+
+When `maxEntries` is reached, the add button is hidden.
+
+```tsx
+<AddableComboList
+  values={values}
+  onChange={setValues}
+  suggestions={services}
+  maxEntries={5}
+/>
+```
+
+## Behavior
+
+- **Typing** filters `suggestions` (case-insensitive contains) and opens the dropdown.
+- **Arrow keys** cycle through dropdown options.
+- **Enter** with a highlighted suggestion commits it; Enter with no highlight commits the raw typed string (unless `strict`).
+- **Esc** closes the dropdown (first press) or cancels the input (second press).
+- **Backspace** on empty input removes the last tag.
+- **Already-selected suggestions** are hidden from the dropdown.
+- Duplicates trigger a brief flash outline and are not added.
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use AddableComboList when there's no vocabulary.** Free-form-only is [AddableTextList](/docs/components/addable-text-list)'s job — the combobox dropdown adds visual weight that goes nowhere without suggestions.
+</Callout>
+
+- **Don't use for locked vocabularies with no free-form escape.** Use [MultiSelect](/docs/components/multi-select) — same Tag-chip output, simpler for users (just pick).
+- **Don't use for description-bearing entries.** Each row is one short string. Title + description belongs in [AddableEntryList](/docs/components/addable-entry-list).
+
+## Accessibility
+
+- Input: `role="combobox"`, `aria-expanded`, `aria-haspopup="listbox"`, `aria-activedescendant`
+- Dropdown: `role="listbox"` with `role="option"` items and `aria-selected`
+- Tags: `role="list"` / `role="listitem"` with accessible labels
+- Screen reader announce on add/remove via `aria-live` on the tag container
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `values` | `string[]` *(required)* | — |
+| `onChange` | `(next: string[]) => void` *(required)* | — |
+| `suggestions` | `string[]` *(required)* | — |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `placeholder` | `string` | — |
+| `addLabel` | `string` | `'Add'` |
+| `removeLabel` | `string` | `'Remove'` |
+| `emptyLabel` | `string` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `disabled` | `boolean` | `false` |
+| `maxEntries` | `number` | unlimited |
+| `strict` | `boolean` | `false` |
+
+## Related
+
+- [AddableTextList](/docs/components/addable-text-list) — free-form sibling
+- [AddableEntryList](/docs/components/addable-entry-list) — title+description sibling
+- [MultiSelect](/docs/components/multi-select) — locked-vocabulary alternative
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-addable-combo-list--overview)**

--- a/docs-site/content/docs/components/addable-entry-list.mdx
+++ b/docs-site/content/docs/components/addable-entry-list.mdx
@@ -1,0 +1,179 @@
+---
+title: Addable entry list
+description: Title + description sibling. Each row carries a primary value and a secondary note.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+AddableEntryList is the text + textarea sibling of [AddableTextList](/docs/components/addable-text-list). Use for lists where each row needs a headline value plus context — competitor URL + notes, reference site + why, line item + description, team member + role.
+
+The entry shape is intentionally generic (`{ primary, secondary }`) so a single component serves all of these. Map your domain shape at the boundary.
+
+## Use it for
+
+- Competitor list (URL + notes)
+- Reference sites (URL + why we like it)
+- Service catalog entries (name + description)
+- Line items (label + amount/description)
+- Team member rosters (name + role)
+
+For free-form one-string-per-row, use [AddableTextList](/docs/components/addable-text-list). For ≥3 structured fields, use [AddableFieldRowList](/docs/components/addable-field-row-list).
+
+## Import
+
+```tsx
+import { AddableEntryList } from '@brikdesigns/bds';
+```
+
+## Modes
+
+AddableEntryList has three rendering modes driven by props:
+
+### Plain mode
+
+No `primarySuggestions`. Each entry is **inline-editable**: a primary input + secondary textarea + Remove button per row. The Add button appends a new empty row. Default and the right choice for free-form lists (competitors, reference sites, line items).
+
+```tsx
+import { useState } from 'react';
+
+const [entries, setEntries] = useState<{ primary: string; secondary: string }[]>([]);
+
+<AddableEntryList
+  label="Competitors"
+  primaryLabel="URL"
+  secondaryLabel="Notes"
+  primaryInputType="url"
+  primaryPlaceholder="https://"
+  secondaryPlaceholder="What stands out?"
+  entries={entries}
+  onChange={setEntries}
+/>
+```
+
+### Suggestion mode
+
+With `primarySuggestions`. Preserves the reveal-form flow — existing entries render as **read-only cards** with an x-icon remove. Add reveals a staging combobox. Use for vocabulary-locked lists (services from a catalog).
+
+```tsx
+const services = getIndustryServices(company.industry_slug);
+
+<AddableEntryList
+  label="Services offered"
+  primaryLabel="Service"
+  secondaryLabel="What makes this unique here?"
+  primarySuggestions={services}
+  entries={entries}
+  onChange={setEntries}
+/>
+```
+
+With `primaryStrict`, free-form entries outside the suggestion list are rejected. For full BCS-aware multi-pick with `source: 'catalog' | 'custom'` attribution, use [CatalogPicker](/docs/components/catalog-picker) — it wraps AddableEntryList with extra metadata.
+
+### Read mode
+
+`disabled={true}` collapses both modes to **token-backed typography**: primary uses `--label-md`, secondary uses `--body-md`. When `primaryInputType="url"`, the primary renders as a clickable anchor.
+
+```tsx
+<AddableEntryList
+  entries={entries}
+  onChange={() => {}}
+  primaryInputType="url"
+  emptyDescriptionLabel="No description"
+  disabled
+/>
+```
+
+## Primary input type
+
+| Value | Behavior | Read-mode render |
+|---|---|---|
+| `'text'` (default) | Plain text input | Static text |
+| `'url'` | `type="url"` + URL autocomplete | Clickable anchor with brand color + underline |
+
+## Empty description fallback
+
+When `emptyDescriptionLabel` is set, read-mode rows with empty `secondary` show that fallback text instead of collapsing the slot. Useful when consistent row heights matter.
+
+```tsx
+<AddableEntryList
+  entries={entries}
+  onChange={() => {}}
+  emptyDescriptionLabel="No description set"
+  disabled
+/>
+```
+
+## Behavior
+
+### Plain mode
+
+- **Add** appends an empty `{ primary: '', secondary: '' }` row.
+- Typing into any field patches that row's primary or secondary via `onChange`.
+- **Remove** drops the row immediately.
+- When `maxItems` is reached, the Add button hides.
+
+### Suggestion mode
+
+- **Add** reveals a staging form with a combobox-backed primary (filtered by typed query).
+- **Arrow + Enter** commits a highlighted suggestion, moves focus to the secondary textarea.
+- **Save** commits the staged entry and keeps the form open for rapid entry.
+- **Esc** cancels the staging form.
+- Duplicates blocked case-insensitively unless `allowDuplicates`.
+- With `primaryStrict`, free-form entries outside `primarySuggestions` are rejected.
+
+## When *not* to use
+
+<Callout type="warn">
+  **For free-form one-string-per-row, use AddableTextList.** AddableEntryList's textarea is wasted vertical space when there's no description to enter. AddableTextList console-warns when values contain `—`, `–`, `:`, newline, or tab to catch mis-pickings at the source.
+</Callout>
+
+- **Don't use for ≥3 structured fields.** Use [AddableFieldRowList](/docs/components/addable-field-row-list).
+- **Don't use for locked vocabularies with provenance tracking.** Use [CatalogPicker](/docs/components/catalog-picker) — it wraps this component with `source: 'catalog' | 'custom'` and stable slug derivation.
+
+## Accessibility
+
+- Plain mode: each row is a labeled fieldset with two real inputs. Tab order moves through primary → secondary → remove.
+- Suggestion mode: combobox + textarea, both with proper ARIA. Read-only cards have `aria-label` on the remove button.
+- Read mode: primary anchors get `target` / `rel` defaults preserving security on external URLs.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `entries` | `AddableEntry[]` *(required)* | — |
+| `onChange` | `(next: AddableEntry[]) => void` *(required)* | — |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `primaryLabel` | `string` | — |
+| `secondaryLabel` | `string` | — |
+| `primaryPlaceholder` | `string` | — |
+| `secondaryPlaceholder` | `string` | — |
+| `primaryInputType` | `'text' \| 'url'` | `'text'` |
+| `primarySuggestions` | `string[]` | — |
+| `primaryStrict` | `boolean` | `false` |
+| `addLabel` | `string` | — |
+| `removeLabel` | `string` | — |
+| `emptyLabel` | `string` | — |
+| `emptyDescriptionLabel` | `string` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `disabled` | `boolean` | `false` |
+| `maxItems` | `number` | unlimited |
+| `secondaryRows` | `number` | `2` |
+| `allowDuplicates` | `boolean` | `false` |
+
+### AddableEntry shape
+
+```ts
+interface AddableEntry {
+  primary: string;
+  secondary: string;
+}
+```
+
+## Related
+
+- [AddableTextList](/docs/components/addable-text-list) — free-form one-string sibling
+- [AddableComboList](/docs/components/addable-combo-list) — vocabulary one-string sibling
+- [AddableFieldRowList](/docs/components/addable-field-row-list) — multi-field sibling
+- [CatalogPicker](/docs/components/catalog-picker) — wraps AddableEntryList with source attribution
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-addable-entry-list--overview)**

--- a/docs-site/content/docs/components/addable-field-row-list.mdx
+++ b/docs-site/content/docs/components/addable-field-row-list.mdx
@@ -1,0 +1,229 @@
+---
+title: Addable field row list
+description: Multi-field row collection. Each row carries 2+ structured fields with type-safe row data.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+AddableFieldRowList is the most flexible primitive in the addable family. Each row holds 2+ structured fields — `Name + Purpose + Category`, `open time + close time + closed-checkbox`. Field types vary freely (TextInput, Select, Checkbox, TextArea) and row data stays type-safe via a generic.
+
+Per [ADR-005](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-005-addable-field-row-list.md). Replaces three hand-rolled patterns identified in the [2026-Q2 portal addable survey](https://github.com/brikdesigns/brik-bds/blob/main/docs/audits/2026-Q2-portal-addable-survey.md).
+
+## Use it for
+
+- Phone systems / Other tools (Name + Purpose + Category)
+- Holiday hours (Date + Open time + Close time + Closed checkbox)
+- Competitive positioning (3 TextArea fields per row)
+- Office locations (Address + Hours + Phone)
+- Any list where each item has 2+ structured fields and field types vary
+
+## Import
+
+```tsx
+import { AddableFieldRowList, TextInput, Select } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Phone System (TextInput + TextInput + Select)
+
+The canonical 3-field row. The `columns` prop sets the grid template; the primitive auto-appends an `auto` track for the per-row remove button.
+
+```tsx
+import { useState } from 'react';
+
+interface Tool {
+  name: string;
+  purpose: string;
+  category: 'phone' | 'crm' | 'other';
+}
+
+const [tools, setTools] = useState<Tool[]>([]);
+
+<AddableFieldRowList<Tool>
+  label="Tools"
+  values={tools}
+  onChange={setTools}
+  newRow={() => ({ name: '', purpose: '', category: 'other' })}
+  columns="1fr 1fr 160px"
+  addLabel="Add tool"
+  removeLabel="Remove tool"
+>
+  {({ row, update }) => (
+    <>
+      <TextInput
+        value={row.name}
+        onChange={(e) => update({ name: e.target.value })}
+      />
+      <TextInput
+        value={row.purpose}
+        onChange={(e) => update({ purpose: e.target.value })}
+      />
+      <Select
+        options={CATEGORY_OPTIONS}
+        value={row.category}
+        onChange={(e) => update({ category: e.target.value as Tool['category'] })}
+      />
+    </>
+  )}
+</AddableFieldRowList>
+```
+
+### Holiday hours (cross-field disabling)
+
+The render-prop API supports cross-field interactions naturally — read `row.closed` and conditionally set `disabled` on the time inputs. No special primitive support needed.
+
+```tsx
+interface HolidayRow {
+  date: string;
+  open: string;
+  close: string;
+  closed: boolean;
+}
+
+<AddableFieldRowList<HolidayRow>
+  values={holidays}
+  onChange={setHolidays}
+  newRow={() => ({ date: '', open: '09:00', close: '17:00', closed: false })}
+  columns="1fr 120px 120px auto"
+>
+  {({ row, update }) => (
+    <>
+      <TextInput value={row.date} onChange={(e) => update({ date: e.target.value })} />
+      <TextInput
+        type="time"
+        value={row.open}
+        onChange={(e) => update({ open: e.target.value })}
+        disabled={row.closed}
+      />
+      <TextInput
+        type="time"
+        value={row.close}
+        onChange={(e) => update({ close: e.target.value })}
+        disabled={row.closed}
+      />
+      <Checkbox
+        label="Closed"
+        checked={row.closed}
+        onChange={(e) => update({ closed: e.target.checked })}
+      />
+    </>
+  )}
+</AddableFieldRowList>
+```
+
+### Three TextAreas (Competitive positioning)
+
+Same primitive, taller content. Three TextArea fields per row in a `1fr 1fr 1fr` grid.
+
+```tsx
+<AddableFieldRowList<CompetitiveFrame>
+  values={frames}
+  onChange={setFrames}
+  newRow={() => ({ competitor: '', gap: '', copyImplication: '' })}
+  columns="1fr 1fr 1fr"
+>
+  {({ row, update }) => (
+    <>
+      <TextArea value={row.competitor} onChange={(e) => update({ competitor: e.target.value })} rows={3} />
+      <TextArea value={row.gap} onChange={(e) => update({ gap: e.target.value })} rows={3} />
+      <TextArea value={row.copyImplication} onChange={(e) => update({ copyImplication: e.target.value })} rows={3} />
+    </>
+  )}
+</AddableFieldRowList>
+```
+
+### Empty + maxItems
+
+When `values.length === 0`, `emptyLabel` shows in place of the row list. When `values.length >= maxItems`, the Add button hides automatically.
+
+```tsx
+<AddableFieldRowList
+  values={tools}
+  onChange={setTools}
+  newRow={() => ({ ... })}
+  emptyLabel="No tools added yet."
+  maxItems={10}
+>
+  {({ row, update }) => /* fields */}
+</AddableFieldRowList>
+```
+
+## Render-prop context
+
+The `children` render-prop receives `{ row, index, update }`:
+
+- **`row: T`** — current row data, typed via the generic `<T>` parameter
+- **`index: number`** — zero-indexed row position
+- **`update: (patch: Partial<T>) => void`** — patches the row, merging into current values
+
+## `columns` prop
+
+CSS `grid-template-columns` value for the field columns. The primitive appends an `auto` track for the per-row remove button automatically.
+
+```tsx
+columns="1fr 1fr 160px"   // 2 flexible + 1 fixed-width
+columns="1fr 1fr 1fr"     // 3 equal columns
+columns="1fr"             // single full-width field
+```
+
+## Remove icon semantics
+
+Per-row remove uses `IconButton variant="ghost"` with `ph:dash-circle`. The icon choice carries a deliberate semantic distinction (per ADR-005):
+
+| Icon | Component | Meaning |
+|---|---|---|
+| `ph:dash-circle` | AddableFieldRowList (this) | **remove from list** (subtract) |
+| `ph:x` | [Tag](/docs/components/tag) `onRemove` | **dismiss selection** (close) |
+| `ph:trash-fill` | Page-level destructive actions | **delete record** (permanent) |
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use AddableFieldRowList for single-string-per-item.** Use [AddableTextList](/docs/components/addable-text-list) (free-form) or [AddableComboList](/docs/components/addable-combo-list) (vocabulary). The render-prop overhead is wasted on a single field.
+</Callout>
+
+- **Don't use for title + description.** Use [AddableEntryList](/docs/components/addable-entry-list).
+- **Don't use for picking from a fixed enum.** Use [MultiSelect](/docs/components/multi-select) — renders as Tag chips, simpler than a row grid.
+
+## Accessibility
+
+- Each row is a `<div role="group">` with the field label as an `aria-labelledby` reference.
+- Per-row remove button uses the `removeLabel` prop as its accessible name.
+- The Add button is a real `<button>` with the `addLabel` prop as its name.
+- Type-safe row data via the generic doesn't affect runtime — all ARIA wiring is unchanged.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `values` | `T[]` *(required)* | — |
+| `onChange` | `(next: T[]) => void` *(required)* | — |
+| `newRow` | `() => T` *(required)* | — |
+| `children` | `(ctx: AddableFieldRowContext<T>) => ReactNode` *(required)* | — |
+| `columns` | `string` (CSS grid template) | `'1fr'` |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `emptyLabel` | `string` | — |
+| `addLabel` | `string` | `'Add row'` |
+| `removeLabel` | `string` | `'Remove row'` |
+| `maxItems` | `number` | unlimited |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+
+### AddableFieldRowContext shape
+
+```ts
+interface AddableFieldRowContext<T> {
+  row: T;
+  index: number;
+  update: (patch: Partial<T>) => void;
+}
+```
+
+## Related
+
+- [AddableTextList](/docs/components/addable-text-list) — single string per row
+- [AddableComboList](/docs/components/addable-combo-list) — vocabulary single string
+- [AddableEntryList](/docs/components/addable-entry-list) — primary + secondary
+- [MultiSelect](/docs/components/multi-select) — locked enum, Tag chip output
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-addable-field-row-list--overview)**

--- a/docs-site/content/docs/components/addable-text-list.mdx
+++ b/docs-site/content/docs/components/addable-text-list.mdx
@@ -1,0 +1,141 @@
+---
+title: Addable text list
+description: Reveal-on-click input for capturing a list of single-line, unstructured text values.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+AddableTextList is the lightest primitive in the addable family. Each row is one short string — services offered, tags, back-office tools. The input is hidden until the user clicks **Add New**, then **Enter** commits and re-focuses for rapid entry, **Escape** cancels.
+
+<ComparisonGrid
+  items={[
+    {
+      title: 'AddableTextList',
+      whenToUse: 'One short, unstructured string per row. No vocabulary.',
+      whenNotToUse: 'Vocabulary or structure — use a sibling.',
+      code: `<AddableTextList values={...} onChange={...} />`,
+    },
+    {
+      title: 'AddableComboList',
+      whenToUse: 'One string per row, picked from a known vocabulary (with optional free-form fallback).',
+      whenNotToUse: 'No vocabulary — use AddableTextList.',
+      code: `<AddableComboList suggestions={...} />`,
+    },
+    {
+      title: 'AddableEntryList',
+      whenToUse: 'Each row needs a primary + secondary (URL + notes, name + description).',
+      whenNotToUse: 'Single value — use TextList/ComboList.',
+      code: `<AddableEntryList entries={...} />`,
+    },
+  ]}
+/>
+
+For 2+ structured fields per row, use [AddableFieldRowList](/docs/components/addable-field-row-list).
+
+## Use it for
+
+- Services offered (free-form, no catalog)
+- Tags / labels on a record
+- Back-office tools, integrations the user types from memory
+- Any short-string list where capture speed matters more than structure
+
+## Import
+
+```tsx
+import { AddableTextList } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { useState } from 'react';
+const [values, setValues] = useState<string[]>([]);
+
+<AddableTextList
+  label="Services offered"
+  values={values}
+  onChange={setValues}
+  placeholder="Add a service…"
+  addLabel="Add service"
+/>
+```
+
+### With helper text + max items
+
+```tsx
+<AddableTextList
+  label="Back-office tools"
+  helperText="Up to 5 tools — CRM, billing, scheduling, etc."
+  values={values}
+  onChange={setValues}
+  maxItems={5}
+/>
+```
+
+### Sizes
+
+`sm`, `md` (default), `lg` — match TextInput sizes for inline placement.
+
+### Disabled (read-only)
+
+Renders tags without input or remove controls.
+
+```tsx
+<AddableTextList values={values} onChange={() => {}} disabled />
+```
+
+### Allow duplicates
+
+By default duplicates are blocked case-insensitively. Set `allowDuplicates` if dupes are meaningful (e.g. quantity-by-repeat patterns).
+
+```tsx
+<AddableTextList values={values} onChange={setValues} allowDuplicates />
+```
+
+## Behavior
+
+- **Enter** commits the trimmed value and keeps the input open for the next entry.
+- **Escape** or **blur on empty** cancels and hides the input.
+- Duplicates are blocked case-insensitively unless `allowDuplicates` is set.
+- When `maxItems` is reached, the Add button is hidden.
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use AddableTextList for title + description pairs.** This component console-warns in dev when any value contains structural separators (`—`, `–`, `:`, newline, tab) — that's the signal you reached for the wrong primitive. Use [AddableEntryList](/docs/components/addable-entry-list).
+</Callout>
+
+- **Don't use AddableTextList when a vocabulary exists.** If the values come from a BCS getter or locked enum, use [AddableComboList](/docs/components/addable-combo-list) — users get autocomplete and you get consistent values.
+- **Don't use AddableTextList for ≥3 structured fields.** Use [AddableFieldRowList](/docs/components/addable-field-row-list).
+
+## Accessibility
+
+- Each tag is a `<li>` with a labeled remove button (`removeLabel`, defaults to "Remove").
+- Reveal input has `role="textbox"` with platform-native autocomplete.
+- The Add button is a real `<button>` — keyboard, focus, all platform.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `values` | `string[]` *(required)* | — |
+| `onChange` | `(next: string[]) => void` *(required)* | — |
+| `label` | `string` | — |
+| `helperText` | `string` | — |
+| `placeholder` | `string` | — |
+| `addLabel` | `string` | `'Add'` |
+| `emptyLabel` | `string` | — |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `disabled` | `boolean` | `false` |
+| `maxItems` | `number` | unlimited |
+| `allowDuplicates` | `boolean` | `false` |
+
+## Related
+
+- [AddableComboList](/docs/components/addable-combo-list) — vocabulary-backed sibling
+- [AddableEntryList](/docs/components/addable-entry-list) — primary + secondary sibling
+- [AddableFieldRowList](/docs/components/addable-field-row-list) — multi-field sibling
+- [Tag](/docs/components/tag) — the chip rendered for each value
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-form-addable-text-list--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -14,7 +14,7 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
 | **Indicator** | Badge, Chip, Tag, Counter, Dot, Spinner, Skeleton, BadgeGroup, TagGroup, ServiceBadge |
 | **Feedback** | Banner, Toast, Tooltip, EmptyState, ProgressBar (AlertBanner deprecated → Banner) |
 | **Control** | Switch, Slider, Stepper, ProgressStepper, Pagination, SegmentedControl, FileUploader |
-| **Addable** | AddableTagList, AddableEntryList, AddableFieldRowList |
+| **Addable** | AddableTextList, AddableComboList, AddableEntryList, AddableFieldRowList |
 | **Structure** | Card, Divider, Accordion |
 
 ## Documented here
@@ -102,9 +102,20 @@ Toggles, sliders, steppers, paginators, and the file uploader.
   <Card title="File uploader" href="/docs/components/file-uploader" description="Drag-and-drop file upload zone with click-to-browse fallback." />
 </Cards>
 
+### Addable
+
+Add / remove list primitives. Pick by row shape — single string, vocabulary-backed string, primary+secondary, or arbitrary multi-field rows.
+
+<Cards>
+  <Card title="Addable text list" href="/docs/components/addable-text-list" description="Single short string per row. Free-form, no vocabulary. Reveal-on-click input." />
+  <Card title="Addable combo list" href="/docs/components/addable-combo-list" description="Single string per row, picked from a known vocabulary with optional free-form fallback." />
+  <Card title="Addable entry list" href="/docs/components/addable-entry-list" description="Primary + secondary per row. Plain inline-edit, suggestion-mode, or read-mode." />
+  <Card title="Addable field row list" href="/docs/components/addable-field-row-list" description="Multi-field row with type-safe data via render-prop. 2+ structured fields per row." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining ~13 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Addable, Structure, Navigation, and Displays.
+The remaining ~9 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Structure, Navigation, and Displays.
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -50,6 +50,11 @@
     "progress-stepper",
     "pagination",
     "segmented-control",
-    "file-uploader"
+    "file-uploader",
+    "---Addable---",
+    "addable-text-list",
+    "addable-combo-list",
+    "addable-entry-list",
+    "addable-field-row-list"
   ]
 }


### PR DESCRIPTION
## Summary

Migrates the **Addable** group — four sibling primitives covering the full add/remove spectrum. Closes out Addable entirely.

| Page | Row shape | Use |
|---|---|---|
| [\`addable-text-list\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-addable/docs-site/content/docs/components/addable-text-list.mdx) | Single short string | Free-form, no vocabulary. Services typed from memory, tags. |
| [\`addable-combo-list\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-addable/docs-site/content/docs/components/addable-combo-list.mdx) | Single string + vocabulary | BCS-getter-backed picks with optional free-form fallback. \`strict\` mode for locked vocabs. |
| [\`addable-entry-list\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-addable/docs-site/content/docs/components/addable-entry-list.mdx) | Primary + secondary | Three modes: plain inline-edit, suggestion-mode (vocabulary cards), read-mode (token typography + URL anchors). |
| [\`addable-field-row-list\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-addable/docs-site/content/docs/components/addable-field-row-list.mdx) | N structured fields | Render-prop, type-safe via generic. Per [ADR-005](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-005-addable-field-row-list.md). Documents the dash-circle / x / trash-fill icon semantic distinction. |

\`<ComparisonGrid>\` at the top of TextList and ComboList disambiguates the four siblings — picking the right one is the hardest part of using these.

## Cross-link fix

\`multi-select.mdx\` had two broken links to \`AddableTagList\` (a non-existent component — ADR-003 names it as a future consolidation target but it isn't shipped yet). Updated both to point to \`AddableTextList\`, which is the actual primitive for free-form one-string-per-row entry.

If you grep for \`AddableTagList\` across docs-site there are no remaining references in this branch's tree.

## State of the migration after this lands

| Group | Status |
|---|---|
| Action | 6/6 ✅ |
| Indicator | 10/10 ✅ |
| Form / Inputs | 10/10 ✅ |
| Form / Structure | 4/4 ✅ |
| Feedback | 6/6 ✅ |
| Control | 7/7 ✅ |
| **Addable** | **4/4 ✅ (this PR)** |
| Structure | 0/3 |
| Navigation | 0/4 |
| Displays | 0/~14 |

Foundations: 7/8 (Motion still pending). Total docs-site routes: **76**. Total component pages: **47**.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds (BDS dist must be built first)
- [ ] \`/docs/components\` shows an Addable card grid below Control
- [ ] \`/docs/components/addable-text-list\` — \`<ComparisonGrid>\` at top disambiguates the four siblings
- [ ] \`/docs/components/addable-combo-list\` — \`<ComparisonGrid>\` (with MultiSelect inclusion) makes the strict-mode vs MultiSelect decision clear
- [ ] \`/docs/components/addable-entry-list\` — three-mode framing (plain/suggestion/read) is accurate to current intent
- [ ] \`/docs/components/addable-field-row-list\` — render-prop API + columns prop + remove-icon semantic table render correctly
- [ ] \`/docs/components/multi-select\` — both \`AddableTagList\` references now point to \`/docs/components/addable-text-list\` and resolve

## Heads-up: my read on AddableEntryList might be wrong

I framed AddableEntryList's three modes as **plain** / **suggestion** / **read**. The source MDX uses those terms but I picked them as *modes* — meaning they're driven by prop combinations, not a discrete prop. If the team thinks of them differently (e.g. "suggestion mode = CatalogPicker's job", "read mode = a separate component"), the framing on my page is wrong.

Quick read of the .tsx confirms it's all driven by \`primarySuggestions\` (presence → suggestion mode) and \`disabled\` (true → read mode), so the framing is accurate to the code — but if there's a higher-level mental model that doesn't surface in the props, push back.

## Out of scope (follow-ups)

- Structure group (Card, Divider, Accordion)
- Navigation group (TabBar, Breadcrumb, SidebarNavigation, Menu)
- Displays section (~14 components)
- Motion foundation port
- Remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)