### PR TITLE
feat(docs-site): migrate Structure group (Card, Divider, Accordion)

### DIFF
--- a/docs-site/content/docs/components/accordion.mdx
+++ b/docs-site/content/docs/components/accordion.mdx
@@ -1,0 +1,138 @@
+---
+title: Accordion
+description: Collapsible content sections. Single-open by default, optional multi-open mode.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Accordion renders a list of expandable sections. Each item has a title trigger and a content area. Use for FAQ pages, settings panels, and any place where content density would overwhelm if shown all at once.
+
+## Use it for
+
+- FAQ sections
+- Settings panels with collapsible groups
+- Long-form content split into navigable sections
+- Help docs where the user picks what to expand
+- Any list of related items where most users only need one or two at a time
+
+## Import
+
+```tsx
+import { Accordion } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default (single-open)
+
+Only one item open at a time. Opening a new item auto-closes the previous one.
+
+```tsx
+<Accordion
+  items={[
+    { id: '1', title: 'What services do you offer?', content: 'Brand design, marketing, product, web.' },
+    { id: '2', title: 'How long does a project take?', content: '2–12 weeks depending on scope.' },
+    { id: '3', title: 'Do you offer ongoing retainers?', content: 'Yes, monthly retainers available.' },
+  ]}
+/>
+```
+
+### Allow multiple open
+
+```tsx
+<Accordion items={items} allowMultiple />
+```
+
+### Pre-opened
+
+```tsx
+<Accordion items={items} defaultOpenItems={['1', '3']} />
+```
+
+### Controlled
+
+Hold open state in the parent for full control over which items are expanded.
+
+```tsx
+import { useState } from 'react';
+
+const [openIds, setOpenIds] = useState<string[]>(['1']);
+
+<Accordion
+  items={items}
+  openItems={openIds}
+  onOpenChange={setOpenIds}
+/>
+```
+
+When `openItems` is provided, internal state is ignored — `onOpenChange` is the only way state advances.
+
+### Rich content
+
+`content` accepts any ReactNode — paragraphs, lists, links, even nested components.
+
+```tsx
+<Accordion
+  items={[
+    {
+      id: '1',
+      title: 'How do I get started?',
+      content: (
+        <>
+          <p>Read the <a href="/docs/getting-started">Getting Started</a> guide first.</p>
+          <ul>
+            <li>Install the package</li>
+            <li>Wire the cascade</li>
+            <li>Import a component</li>
+          </ul>
+        </>
+      ),
+    },
+  ]}
+/>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use Accordion to hide critical content.** Anything below the fold of an Accordion has a real chance of being missed. If the content is required reading, surface it directly — use Accordion only for things users *can choose* to expand.
+</Callout>
+
+- **Don't use Accordion for ≤2 items.** Two collapsible rows reads as visual noise. Just show both.
+- **Don't use Accordion for navigation.** It's content disclosure, not nav. Use TabBar / SidebarNavigation for app navigation.
+- **Don't nest Accordions deeply.** One level of nesting is acceptable; two becomes hard to follow.
+
+## Accessibility
+
+- Each item's title is a real `<button>` with `aria-expanded` reflecting open/closed state.
+- The content panel uses `role="region"` linked via `aria-labelledby` to the title button.
+- Keyboard `Enter` / `Space` toggles, `Tab` moves between items.
+- Focus stays on the trigger after toggling — no focus jumping into expanded content unless the user navigates there.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `items` | `AccordionItemData[]` *(required)* | — |
+| `allowMultiple` | `boolean` | `false` |
+| `openItems` | `string[]` (controlled) | — |
+| `onOpenChange` | `(openItems: string[]) => void` | — |
+| `defaultOpenItems` | `string[]` | `[]` |
+
+Plus all standard `<div>` HTML attributes.
+
+### AccordionItemData
+
+```ts
+interface AccordionItemData {
+  id: string;
+  title: ReactNode;
+  content: ReactNode;
+}
+```
+
+## Related
+
+- [CollapsibleCard](https://storybook.brikdesigns.com/?path=/docs/displays-card-collapsible-card--overview) — Card + Accordion mash-up (Storybook)
+- [Tooltip](/docs/components/tooltip) — for short hover-revealed content
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-accordion-accordion--overview)**

--- a/docs-site/content/docs/components/card.mdx
+++ b/docs-site/content/docs/components/card.mdx
@@ -1,0 +1,167 @@
+---
+title: Card
+description: Flexible content container with composable subcomponents and two locked-down presets (control + summary).
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Card is the canonical content-grouping container. Three rendering modes:
+
+- **Default** — flexible container, compose with `CardTitle` / `CardDescription` / `CardFooter` subcomponents.
+- **`preset="control"`** — locked-down settings/control layout (badge + title + description + action). Replaces the legacy `CardControl` component per [ADR-004](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md).
+- **`preset="summary"`** — compact metric/stat layout (label + large value + optional link). Replaces the deprecated `CardSummary` component.
+
+## Use it for
+
+- Service grids, feature cards, and content blocks (default mode)
+- Settings panels with title + description + toggle/action (`preset="control"`)
+- Dashboard stat tiles ($48K Q1 revenue, 142 active users) (`preset="summary"`)
+- Any grouped-content surface where consistent border/padding/shadow matter
+
+For a horizontal stack of card-like rows, use [FieldGrid](/docs/components/field-grid) wrapping Cards. For loading-state placeholders, use [Skeleton](/docs/components/skeleton) `variant="rectangular"`.
+
+## Import
+
+```tsx
+import { Card, CardTitle, CardDescription, CardFooter } from '@brikdesigns/bds';
+```
+
+## Default mode
+
+Compose freely with the Title / Description / Footer subcomponents.
+
+```tsx
+<Card variant="outlined" padding="md">
+  <CardTitle>Title</CardTitle>
+  <CardDescription>Description text goes here.</CardDescription>
+  <CardFooter>
+    <Button variant="primary" size="sm">Action</Button>
+  </CardFooter>
+</Card>
+```
+
+### Variants
+
+- **`outlined`** (default) — Subtle secondary border.
+- **`brand`** — Primary-color border for emphasis.
+- **`elevated`** — Shadow for visual prominence.
+
+### Padding
+
+`none`, `sm`, `md` (default), `lg`. Match content density.
+
+### Interactive + link
+
+`interactive` adds hover affordance. `href` renders as an `<a>` so the whole card becomes a link.
+
+```tsx
+<Card variant="elevated" interactive>
+  Hover me
+</Card>
+
+<Card href="/articles/foo" interactive>
+  Whole card is a link
+</Card>
+```
+
+## Control preset
+
+`preset="control"` is the canonical settings-row card. Locked layout: leading badge + (title + description) on the left, action slot on the right.
+
+```tsx
+<Card
+  preset="control"
+  badge={<Badge status="positive">On</Badge>}
+  title="Email notifications"
+  description="Send a weekly digest to your inbox."
+  action={<Button variant="outline" size="sm">Configure</Button>}
+/>
+```
+
+`actionAlign` controls vertical alignment of the action slot — `center` (default) or `top` (anchors to the upper-right when descriptions are tall).
+
+<Callout type="info">
+  **Both `<Card preset="control">` and standalone `<CardControl>` ship as first-class APIs in v0.39.0+.** The 2026-Q2 audit recommended folding CardControl into Card; the user reversed that decision 2026-04-24 to preserve optionality at the call site. Pick whichever reads cleaner in context. See the [audit doc](https://github.com/brikdesigns/brik-bds/blob/main/docs/audits/2026-Q2-component-bloat-audit.md).
+</Callout>
+
+## Summary preset
+
+`preset="summary"` is the compact stat tile. Label on top, large numeric value below, optional text link.
+
+```tsx
+<Card
+  preset="summary"
+  label="Q1 revenue"
+  value={48250.75}
+  type="price"
+  textLink={{ label: 'Details', href: '/revenue' }}
+/>
+```
+
+### Number formatting
+
+- **`type="numeric"`** (default) — locale-formatted integer (`1,234`).
+- **`type="price"`** — USD currency (`$1,234.50`).
+- String values render verbatim regardless of `type`.
+
+<Callout type="warn">
+  **The standalone `CardSummary` component is `@deprecated`** and slated for deletion in a future major version. Migrate to `Card preset="summary"` — same prop names, same number formatting, same layout. See [ADR-004](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md).
+</Callout>
+
+## When *not* to use
+
+- **Don't use Card for inline content blocks.** Cards imply discrete grouping; for paragraphs and section dividers, use prose + [Divider](/docs/components/divider).
+- **Don't use Card for tables.** Use a table component when rows share columns. Cards are for self-contained groupings.
+- **Don't reach for the default mode when `preset="control"` or `preset="summary"` fits.** The presets carry locked-down semantics that propagate consistently across screens.
+
+## Accessibility
+
+- Default Card renders a `<div>`; with `href`, it renders an `<a>` with full anchor semantics (right-click, keyboard, screen-reader link role).
+- `interactive` without `href` adds `role="button"` only when `onClick` is also passed; otherwise it's a non-interactive hover affordance.
+- Title becomes an `<h3>` semantic by default in the Title subcomponent — adjust the surrounding heading hierarchy accordingly.
+
+## API
+
+### Default mode
+
+| Prop | Type | Default |
+|---|---|---|
+| `variant` | `'outlined' \| 'brand' \| 'elevated'` | `'outlined'` |
+| `padding` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'md'` |
+| `interactive` | `boolean` | `false` |
+| `href` | `string` | — |
+| `children` | `ReactNode` *(required)* | — |
+
+### Control preset
+
+| Prop | Type | Default |
+|---|---|---|
+| `preset` | `'control'` *(required)* | — |
+| `title` | `string` *(required)* | — |
+| `description` | `string` | — |
+| `badge` | `ReactNode` | — |
+| `action` | `ReactNode` | — |
+| `actionAlign` | `'center' \| 'top'` | `'center'` |
+
+### Summary preset
+
+| Prop | Type | Default |
+|---|---|---|
+| `preset` | `'summary'` *(required)* | — |
+| `label` | `string` *(required)* | — |
+| `value` | `string \| number` *(required)* | — |
+| `type` | `'numeric' \| 'price'` | `'numeric'` |
+| `textLink` | `{ label: string; href: string }` | — |
+
+All modes accept standard `<div>` HTML attributes (excluding `title`, which is repurposed in the control preset).
+
+## Related
+
+- [CardControl](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-control--overview) — sibling settings-card component (still in Storybook)
+- [CardList](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-list--overview) — list-of-cards composition (Storybook)
+- [CardTestimonial](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-testimonial--overview) — testimonial layout (Storybook)
+- [CollapsibleCard](https://storybook.brikdesigns.com/?path=/docs/displays-card-collapsible-card--overview) — Card + Accordion mash-up (Storybook)
+- [PricingCard](https://storybook.brikdesigns.com/?path=/docs/displays-card-pricing-card--overview) — pricing tier card (Storybook)
+- [Divider](/docs/components/divider) — for non-card section separators
+- [FieldGrid](/docs/components/field-grid) — equal-column wrapper for stat tiles
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-card-card--overview)**

--- a/docs-site/content/docs/components/divider.mdx
+++ b/docs-site/content/docs/components/divider.mdx
@@ -1,0 +1,77 @@
+---
+title: Divider
+description: Visual separator for content sections. Horizontal or vertical, four spacing scales.
+---
+
+Divider is a simple visual separator. Horizontal by default; switch to vertical for inline toolbars and breadcrumbs.
+
+For grouping content into discrete blocks, use [Card](/docs/components/card) — that's the explicit boundary. Use Divider for in-flow separation where a card would be too heavy.
+
+## Use it for
+
+- Section breaks within a long form
+- Toolbar separators between command groups
+- Inline separators between metadata pieces ("John Doe · jdoe@example.com")
+- Settings panel divisions
+
+## Import
+
+```tsx
+import { Divider } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Horizontal (default)
+
+```tsx
+<Divider />
+<Divider spacing="lg" />
+```
+
+### Vertical (inline)
+
+Pair with `display: flex` on the parent so the line shows up correctly.
+
+```tsx
+<div style={{ display: 'flex', alignItems: 'center' }}>
+  <span>Left</span>
+  <Divider orientation="vertical" spacing="md" />
+  <span>Right</span>
+</div>
+```
+
+### Spacing
+
+Four scales for the margin around the line.
+
+| Spacing | Value | Use case |
+|---|---|---|
+| `none` | 0px | Tight separators, table rows |
+| `sm` | 12px | Compact spacing |
+| `md` (default) | 16px | Default breathing room |
+| `lg` | 24px | Section-level separation |
+
+## When *not* to use
+
+- **Don't use Divider as a content boundary.** If two areas should *feel* separate (different responsibilities, different content types), use [Card](/docs/components/card) — explicit borders read better than thin lines.
+- **Don't use Divider with no surrounding content.** A line floating alone is visual noise.
+
+## Accessibility
+
+- Renders a real `<hr>` element (or visually-hidden role for vertical orientation).
+- Carries `role="separator"` and `aria-orientation` matching the orientation prop.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` |
+| `spacing` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'md'` |
+
+Plus all standard `<hr>` HTML attributes.
+
+## Related
+
+- [Card](/docs/components/card) — for explicit content boundaries
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-structure-divider--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -15,7 +15,7 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
 | **Feedback** | Banner, Toast, Tooltip, EmptyState, ProgressBar (AlertBanner deprecated → Banner) |
 | **Control** | Switch, Slider, Stepper, ProgressStepper, Pagination, SegmentedControl, FileUploader |
 | **Addable** | AddableTextList, AddableComboList, AddableEntryList, AddableFieldRowList |
-| **Structure** | Card, Divider, Accordion |
+| **Structure** | Card, Divider, Accordion (Card family CardControl, CardList, etc. still under Displays) |
 
 ## Documented here
 
@@ -113,9 +113,19 @@ Add / remove list primitives. Pick by row shape — single string, vocabulary-ba
   <Card title="Addable field row list" href="/docs/components/addable-field-row-list" description="Multi-field row with type-safe data via render-prop. 2+ structured fields per row." />
 </Cards>
 
+### Structure
+
+Content containers and separators. Card has two locked-down presets (control + summary) on top of the default flexible mode.
+
+<Cards>
+  <Card title="Card" href="/docs/components/card" description="Flexible content container. Default + control preset + summary preset. Composable with CardTitle / CardDescription / CardFooter." />
+  <Card title="Divider" href="/docs/components/divider" description="Visual separator. Horizontal or vertical, four spacing scales." />
+  <Card title="Accordion" href="/docs/components/accordion" description="Collapsible content sections. Single-open default, optional multi-open mode." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining ~9 components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for Structure, Navigation, and Displays.
+The remaining components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for **Card family** (CardControl, CardList, CardTestimonial, CollapsibleCard, PricingCard), **Navigation** (TabBar, Breadcrumb, SidebarNavigation, Menu), and **Displays** sub-categories (Cards, Overlays, Notifications, Sheets, Table, Timeline, Calendar, Board, Charts).
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -55,6 +55,10 @@
     "addable-text-list",
     "addable-combo-list",
     "addable-entry-list",
-    "addable-field-row-list"
+    "addable-field-row-list",
+    "---Structure---",
+    "card",
+    "divider",
+    "accordion"
   ]
 }


### PR DESCRIPTION
## Summary

Migrates the **Structure** category — three pages, the most central being Card with its three rendering modes (default + control preset + summary preset).

| Page | Notes |
|---|---|
| [\`card\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-structure/docs-site/content/docs/components/card.mdx) | Flexible container. Default mode (compose CardTitle / CardDescription / CardFooter), \`preset="control"\` (replaces CardControl per [ADR-004](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md), but CardControl remains a first-class API per the 2026-04-24 user reversal), \`preset="summary"\` (replaces deprecated CardSummary). Documents number formatting (\`numeric\` / \`price\`), \`interactive\` + \`href\` modes, and links to the rest of the Card family. |
| [\`divider\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-structure/docs-site/content/docs/components/divider.mdx) | Horizontal / vertical orientation, four spacing scales. Distinguishes Divider from Card boundaries. |
| [\`accordion\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-structure/docs-site/content/docs/components/accordion.mdx) | Single-open vs \`allowMultiple\`, default-open + controlled patterns, rich content support, "don't hide critical content" accessibility warning. |

After this lands the **Structure** group (per the project's component taxonomy) is **3/3 ✅**. Total docs-site routes: **79**.

## Worth flagging — taxonomy mismatch

Storybook source tags Card and Accordion as \`Displays/*\`; only Divider is \`Components/Structure/*\`. Per the project memory, [ADR-006](https://github.com/brikdesigns/brik-bds/issues?q=ADR-006) plans to **drop the \`Displays/\` category entirely** and fold its contents into \`Components/\`.

My docs-site organizes around the **future taxonomy**, not the currently shipped Storybook one — Card and Accordion sit in Components/Structure here. If the team wants to preserve the current Storybook mapping (Card/Accordion stay in their own Displays section in docs-site too), the index card grid + \`meta.json\` need rework. Flag and I'll restructure.

## Card family siblings still in Storybook

Card has 5 siblings that didn't migrate in this PR (out of scope — they belong with Displays):

- [CardControl](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-control--overview) — sibling settings-card (still first-class even though Card has \`preset="control"\`)
- [CardList](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-list--overview)
- [CardTestimonial](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-testimonial--overview)
- [CollapsibleCard](https://storybook.brikdesigns.com/?path=/docs/displays-card-collapsible-card--overview) — Card + Accordion mash-up
- [PricingCard](https://storybook.brikdesigns.com/?path=/docs/displays-card-pricing-card--overview)

The Card page links to all five via Storybook URLs in its Related section.

## State of the migration

| Group | Status |
|---|---|
| Action | 6/6 ✅ |
| Indicator | 10/10 ✅ |
| Form / Inputs | 10/10 ✅ |
| Form / Structure | 4/4 ✅ |
| Feedback | 6/6 ✅ |
| Control | 7/7 ✅ |
| Addable | 4/4 ✅ |
| **Structure** | **3/3 ✅ (this PR)** |
| Navigation | 0/4 |
| Displays | 0/~14 |

Foundations: 7/8 (Motion still pending). Total component pages migrated: **50**.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds
- [ ] \`/docs/components\` shows a Structure card grid below Addable
- [ ] \`/docs/components/card\` — three modes (default / control preset / summary preset) render code examples cleanly; the CardControl-still-first-class callout is prominent
- [ ] \`/docs/components/card\` — Card-family Related links resolve to Storybook
- [ ] \`/docs/components/divider\` — both horizontal and vertical orientations show in the table
- [ ] \`/docs/components/accordion\` — single-open vs allow-multiple distinction is clear; the controlled-vs-uncontrolled pattern reads correctly
- [ ] All Storybook deep-links resolve

## Out of scope (follow-ups)

- Card family siblings (CardControl, CardList, CardTestimonial, CollapsibleCard, PricingCard) — likely with Displays batch
- Navigation group (TabBar, Breadcrumb, SidebarNavigation, Menu)
- Displays section (~14 components — Cards, Overlays, Notifications, Sheets, Table, Timeline, Calendar, Board, Charts)
- Motion foundation port
- Remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)