### PR TITLE
feat(docs-site): migrate Navigation group (5 components)

### DIFF
--- a/docs-site/content/docs/components/breadcrumb.mdx
+++ b/docs-site/content/docs/components/breadcrumb.mdx
@@ -1,0 +1,102 @@
+---
+title: Breadcrumb
+description: Navigation trail showing current page location within a hierarchy.
+---
+
+Breadcrumb shows where the user is in a hierarchical structure — Home → Products → Design System → Button. Each crumb (except the last) is a link back up the tree; the last is plain text marked as the current page.
+
+For sibling navigation between sections, use [TabBar](/docs/components/tab-bar). For flat top-level nav, use [NavBar](/docs/components/nav-bar) or [SidebarNavigation](/docs/components/sidebar-navigation).
+
+## Use it for
+
+- Page headers in apps with hierarchical navigation
+- Settings page section position
+- Documentation site current-location markers
+- Any place users benefit from "where am I" + "how do I go up"
+
+## Import
+
+```tsx
+import { Breadcrumb } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Slash separator (default)
+
+```tsx
+<Breadcrumb
+  items={[
+    { label: 'Home', href: '/' },
+    { label: 'Products', href: '/products' },
+    { label: 'Design System' },
+  ]}
+/>
+```
+
+### Chevron separator
+
+```tsx
+<Breadcrumb
+  items={[
+    { label: 'Home', href: '/' },
+    { label: 'Settings', href: '/settings' },
+    { label: 'Profile' },
+  ]}
+  separator="chevron"
+/>
+```
+
+### Deep nesting
+
+For 5+ level hierarchies, consider truncating with an ellipsis or root-only fallback — Breadcrumb itself doesn't auto-truncate; the consumer trims `items` before passing.
+
+```tsx
+<Breadcrumb
+  items={[
+    { label: 'Home', href: '/' },
+    { label: '…', href: '/clients' },
+    { label: 'Acme Co', href: '/clients/acme' },
+    { label: 'Engagements', href: '/clients/acme/engagements' },
+    { label: 'Brand Refresh' },
+  ]}
+/>
+```
+
+## When *not* to use
+
+- **Don't use Breadcrumb when there's no hierarchy.** Single-level apps don't benefit — drop the trail entirely.
+- **Don't use Breadcrumb as primary navigation.** It's a contextual aid, not a nav bar. Use [NavBar](/docs/components/nav-bar) / [SidebarNavigation](/docs/components/sidebar-navigation) for primary nav.
+- **Don't make the last item a link.** It represents the current page; clicking it would reload to itself.
+
+## Accessibility
+
+- Renders a `<nav aria-label="Breadcrumb">` element.
+- The last item carries `aria-current="page"` and renders as plain text — not a link.
+- Earlier items render as `<a>` when `href` is set.
+- Separators are decorative (`aria-hidden`).
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `items` | `BreadcrumbItem[]` *(required)* | — |
+| `separator` | `'slash' \| 'chevron'` | `'slash'` |
+
+Plus standard `<nav>` HTML attributes.
+
+### BreadcrumbItem
+
+```ts
+interface BreadcrumbItem {
+  label: ReactNode;
+  href?: string;
+}
+```
+
+## Related
+
+- [TabBar](/docs/components/tab-bar) — sibling-section navigation
+- [NavBar](/docs/components/nav-bar) — top-level primary nav
+- [SidebarNavigation](/docs/components/sidebar-navigation) — vertical primary nav
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-secondary-breadcrumb--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -16,6 +16,7 @@ BDS components are organized by **job**, not by visual type. The same taxonomy b
 | **Control** | Switch, Slider, Stepper, ProgressStepper, Pagination, SegmentedControl, FileUploader |
 | **Addable** | AddableTextList, AddableComboList, AddableEntryList, AddableFieldRowList |
 | **Structure** | Card, Divider, Accordion (Card family CardControl, CardList, etc. still under Displays) |
+| **Navigation** | NavBar, SidebarNavigation, TabBar, Breadcrumb, Menu |
 
 ## Documented here
 
@@ -121,6 +122,18 @@ Content containers and separators. Card has two locked-down presets (control + s
   <Card title="Card" href="/docs/components/card" description="Flexible content container. Default + control preset + summary preset. Composable with CardTitle / CardDescription / CardFooter." />
   <Card title="Divider" href="/docs/components/divider" description="Visual separator. Horizontal or vertical, four spacing scales." />
   <Card title="Accordion" href="/docs/components/accordion" description="Collapsible content sections. Single-open default, optional multi-open mode." />
+</Cards>
+
+### Navigation
+
+Primary nav (NavBar / SidebarNavigation), secondary nav (TabBar / Breadcrumb), and floating Menu.
+
+<Cards>
+  <Card title="Nav bar" href="/docs/components/nav-bar" description="Top-level horizontal nav with logo, links, and actions. Optional sticky positioning." />
+  <Card title="Sidebar navigation" href="/docs/components/sidebar-navigation" description="Fixed-position vertical sidebar with logo, nav items, footer actions, user section." />
+  <Card title="Tab bar" href="/docs/components/tab-bar" description="Horizontal tab navigation. text/tab/box variants, on-color mode for dark backgrounds." />
+  <Card title="Breadcrumb" href="/docs/components/breadcrumb" description="Hierarchical position trail. Slash or chevron separators." />
+  <Card title="Menu" href="/docs/components/menu" description="Floating dropdown panel. Outside-click and Escape dismissal built in." />
 </Cards>
 
 ## Still in Storybook

--- a/docs-site/content/docs/components/menu.mdx
+++ b/docs-site/content/docs/components/menu.mdx
@@ -1,0 +1,149 @@
+---
+title: Menu
+description: Floating dropdown panel for navigation and action menus. Outside-click and Escape dismissal built in.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Menu is a floating dropdown panel anchored to a trigger element. Use for action menus on row context (Edit / Duplicate / Delete), filter menus, and small navigation popovers.
+
+## Use it for
+
+- Per-row action menus on tables and lists
+- Overflow / "more options" buttons
+- Filter selection menus inside a [FilterButton](/docs/components/filter-button) pattern
+- Small navigation popovers (5-10 destinations)
+
+For a drop-down option picker tied to form state, use [Select](/docs/components/select) or [FilterButton](/docs/components/filter-button) — those handle their own state. Menu is for cases where the consumer owns open state and the menu is purely presentational.
+
+## Import
+
+```tsx
+import { Menu } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Basic
+
+The consumer owns `isOpen` state and provides `onClose`. Menu auto-closes on outside click and Escape.
+
+```tsx
+import { useState } from 'react';
+
+const [open, setOpen] = useState(false);
+
+<div style={{ position: 'relative' }}>
+  <Button onClick={() => setOpen(!open)}>Options</Button>
+  <Menu
+    isOpen={open}
+    onClose={() => setOpen(false)}
+    items={[
+      { id: '1', label: 'Edit', onClick: handleEdit },
+      { id: '2', label: 'Duplicate', onClick: handleDuplicate },
+      { id: '3', label: 'Delete', onClick: handleDelete },
+    ]}
+    style={{ top: '100%', left: 0 }}
+  />
+</div>
+```
+
+### With icons
+
+```tsx
+<Menu
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  items={[
+    { id: '1', label: 'Edit', icon: <EditIcon />, onClick: handleEdit },
+    { id: '2', label: 'Delete', icon: <TrashIcon />, onClick: handleDelete },
+  ]}
+/>
+```
+
+### Active item highlight
+
+`activeId` highlights the currently selected item — useful when Menu doubles as a "current view" indicator.
+
+```tsx
+<Menu
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  activeId="grid"
+  items={[
+    { id: 'grid', label: 'Grid view' },
+    { id: 'list', label: 'List view' },
+    { id: 'board', label: 'Board view' },
+  ]}
+/>
+```
+
+### Disabled item
+
+```tsx
+<Menu
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  items={[
+    { id: 'edit', label: 'Edit' },
+    { id: 'archive', label: 'Archive (Pro plan)', disabled: true },
+  ]}
+/>
+```
+
+## Positioning
+
+Menu doesn't position itself — the consumer applies CSS to place it relative to the trigger. The standard pattern: parent has `position: relative`, Menu has `position: absolute` (default) with `top` / `left` (or `right`) set inline.
+
+```tsx
+<Menu isOpen={open} onClose={onClose} items={items} style={{ top: '100%', right: 0 }} />
+```
+
+For more sophisticated positioning (collision detection, viewport-aware flips), use a Popover-based solution like [DatePicker](/docs/components/date-picker)'s underlying pattern.
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use Menu where Select fits.** If the menu drives form state, use [Select](/docs/components/select) — it owns its open/close state and integrates with forms. Menu is for *presentational* dropdowns where the consumer manages everything.
+</Callout>
+
+- **Don't use Menu for 1-2 items.** Wrap a Button or a [Tooltip](/docs/components/tooltip)-revealed action instead.
+- **Don't use Menu without a trigger.** It's anchored to something — a button, an icon, a row's overflow control. A floating menu without an obvious source is confusing.
+
+## Accessibility
+
+- Menu carries `role="menu"`; each item is `role="menuitem"`.
+- The trigger should set `aria-haspopup="menu"` and `aria-expanded` to reflect Menu state.
+- Keyboard arrows move between items; `Enter` activates; `Escape` closes (auto-handled).
+- Outside click closes — auto-handled.
+- Focus trap: focus moves into the menu on open; closing returns focus to the trigger.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `items` | `MenuItemData[]` *(required)* | — |
+| `isOpen` | `boolean` *(required)* | — |
+| `onClose` | `() => void` *(required)* | — |
+| `activeId` | `string` | — |
+
+Plus standard `<div>` HTML attributes (excluding `children`).
+
+### MenuItemData
+
+```ts
+interface MenuItemData {
+  id: string;
+  label: ReactNode;
+  icon?: ReactNode;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+```
+
+## Related
+
+- [Select](/docs/components/select) — form-state dropdown
+- [FilterButton](/docs/components/filter-button) — filter dropdown with its own state machine
+- [Tooltip](/docs/components/tooltip) — hover-revealed contextual help
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-menu-menu--overview)**

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -59,6 +59,12 @@
     "---Structure---",
     "card",
     "divider",
-    "accordion"
+    "accordion",
+    "---Navigation---",
+    "nav-bar",
+    "sidebar-navigation",
+    "tab-bar",
+    "breadcrumb",
+    "menu"
   ]
 }

--- a/docs-site/content/docs/components/nav-bar.mdx
+++ b/docs-site/content/docs/components/nav-bar.mdx
@@ -1,0 +1,116 @@
+---
+title: Nav bar
+description: Top-level navigation bar with logo, links, and action buttons. Optional sticky positioning.
+---
+
+NavBar is the canonical top-bar navigation for marketing sites and product landing pages. Logo on the left, links in the middle, action buttons on the right. Optional `sticky` for scroll-persistent nav.
+
+For app shell navigation with many items, use [SidebarNavigation](/docs/components/sidebar-navigation). For section navigation within a page, use [TabBar](/docs/components/tab-bar).
+
+## Use it for
+
+- Marketing site top nav (Features / Pricing / About + Get Started CTA)
+- Product landing page navigation
+- Content sites (blogs, docs sites)
+- Any layout where horizontal top-bar nav fits the audience expectation
+
+## Import
+
+```tsx
+import { NavBar } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+<NavBar
+  logo={<img src="/logo.svg" alt="Acme" />}
+  links={[
+    { label: 'Features', href: '/features', active: true },
+    { label: 'Pricing', href: '/pricing' },
+    { label: 'About', href: '/about' },
+  ]}
+  actions={<Button size="sm">Get started</Button>}
+/>
+```
+
+### Sticky
+
+`sticky` keeps the nav at the top of the viewport as the user scrolls.
+
+```tsx
+<NavBar
+  logo={<Logo />}
+  links={links}
+  actions={<Button>Sign in</Button>}
+  sticky
+/>
+```
+
+### Links only
+
+Both `links` and `actions` are optional. Logo-only is valid for very minimal layouts.
+
+```tsx
+<NavBar logo={<Logo />} />
+```
+
+### Multiple actions
+
+`actions` is a ReactNode — pass a fragment for multiple CTAs.
+
+```tsx
+<NavBar
+  logo={<Logo />}
+  links={links}
+  actions={
+    <>
+      <Button variant="ghost" size="sm">Sign in</Button>
+      <Button size="sm">Get started</Button>
+    </>
+  }
+/>
+```
+
+## When *not* to use
+
+- **Don't use NavBar for app chrome.** App shells with many sections should use [SidebarNavigation](/docs/components/sidebar-navigation) — top-bar nav with 8+ items wraps awkwardly.
+- **Don't use NavBar for in-page section nav.** Use [TabBar](/docs/components/tab-bar).
+- **Don't pair NavBar + SidebarNavigation as primary nav.** Pick one. Combining them makes "primary" ambiguous.
+
+## Accessibility
+
+- Renders a `<nav aria-label="Primary">` element.
+- Each link is a real `<a>`. Active link carries `aria-current="page"`.
+- Mobile responsive: at narrow widths, links collapse to a hamburger menu (handled internally — no special prop needed).
+- Sticky positioning preserves keyboard navigation; focus rings remain visible above sticky chrome.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `logo` | `ReactNode` *(required)* | — |
+| `links` | `NavBarLink[]` | — |
+| `actions` | `ReactNode` | — |
+| `sticky` | `boolean` | `false` |
+
+Plus standard `<header>` / `<nav>` HTML attributes.
+
+### NavBarLink
+
+```ts
+interface NavBarLink {
+  label: ReactNode;
+  href: string;
+  active?: boolean;
+}
+```
+
+## Related
+
+- [SidebarNavigation](/docs/components/sidebar-navigation) — vertical app-shell alternative
+- [TabBar](/docs/components/tab-bar) — section nav within the main content area
+- [Breadcrumb](/docs/components/breadcrumb) — hierarchical position
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-primary-nav-bar--overview)**

--- a/docs-site/content/docs/components/sidebar-navigation.mdx
+++ b/docs-site/content/docs/components/sidebar-navigation.mdx
@@ -1,0 +1,135 @@
+---
+title: Sidebar navigation
+description: Fixed-position vertical sidebar with logo, navigation items, footer actions, and user section.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+SidebarNavigation is the canonical app shell sidebar. Fixed position, vertical layout, four labeled regions (logo, nav items, footer actions, user section). Use for apps with persistent navigation that benefits from being always-visible.
+
+For top-bar navigation in marketing sites, use [NavBar](/docs/components/nav-bar). For tab-style section navigation within a page, use [TabBar](/docs/components/tab-bar).
+
+## Use it for
+
+- Application chrome where navigation should always be visible
+- Settings shells with many sections
+- Dashboards with primary + secondary + utility sections
+- Any layout where ≥5 nav items would overflow a horizontal NavBar
+
+## Import
+
+```tsx
+import { SidebarNavigation } from '@brikdesigns/bds';
+```
+
+## Anatomy
+
+The sidebar has four labeled regions, top to bottom:
+
+1. **Logo** *(required)* — branding mark or wordmark
+2. **Nav items** *(required)* — primary navigation links with optional icons and active state
+3. **Footer actions** *(optional)* — secondary actions (settings, theme toggle, help)
+4. **User section** *(optional)* — account chip with avatar / email / sign-out
+
+## Variants
+
+### Default
+
+```tsx
+<SidebarNavigation
+  logo={<img src="/logo.svg" alt="Brand" />}
+  navItems={[
+    { label: 'Dashboard', href: '/dashboard', active: true },
+    { label: 'Projects', href: '/projects' },
+    { label: 'Settings', href: '/settings' },
+  ]}
+/>
+```
+
+### With icons
+
+Each nav item accepts an `icon` rendered before the label.
+
+```tsx
+<SidebarNavigation
+  logo={<Logo />}
+  navItems={[
+    { label: 'Dashboard', href: '/dashboard', icon: <DashboardIcon />, active: true },
+    { label: 'Projects', href: '/projects', icon: <FolderIcon /> },
+    { label: 'Settings', href: '/settings', icon: <CogIcon /> },
+  ]}
+/>
+```
+
+### With footer actions and user section
+
+```tsx
+<SidebarNavigation
+  logo={<Logo />}
+  navItems={navItems}
+  footerActions={
+    <Button variant="primary" size="sm" fullWidth>New project</Button>
+  }
+  userSection={
+    <div>
+      <Avatar src={user.avatarUrl} />
+      <span>{user.email}</span>
+      <Button variant="ghost" size="sm">Sign out</Button>
+    </div>
+  }
+/>
+```
+
+### Custom width
+
+Default is `260px`. Override for compact (icon-only) or wide layouts.
+
+```tsx
+<SidebarNavigation logo={<Logo />} navItems={items} width="320px" />
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use SidebarNavigation for marketing sites.** Use [NavBar](/docs/components/nav-bar) — top-bar nav matches what visitors expect on a website. Sidebars are for apps where users spend extended time.
+</Callout>
+
+- **Don't use SidebarNavigation for ≤3 nav items.** Use [NavBar](/docs/components/nav-bar) — a tall sidebar with 2 items reads as wasted space.
+- **Don't pair SidebarNavigation with NavBar in the same layout.** Pick one primary nav surface; secondary nav goes inside the main content area as TabBar / Breadcrumb.
+
+## Accessibility
+
+- Renders a `<nav aria-label="Primary">` region.
+- Each nav item is a real `<a>` (or `<button>` if `onClick` instead of `href`).
+- Active item carries `aria-current="page"`.
+- Keyboard navigation follows DOM order — Tab moves between regions.
+- The user section's avatar accepts an `alt` text via the underlying Avatar component.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `logo` | `ReactNode` *(required)* | — |
+| `navItems` | `SidebarNavItem[]` *(required)* | — |
+| `footerActions` | `ReactNode` | — |
+| `userSection` | `ReactNode` | — |
+| `width` | `string` (CSS length) | `'260px'` |
+
+### SidebarNavItem
+
+```ts
+interface SidebarNavItem {
+  label: ReactNode;
+  href?: string;
+  icon?: ReactNode;
+  active?: boolean;
+  onClick?: () => void;
+}
+```
+
+## Related
+
+- [NavBar](/docs/components/nav-bar) — top-bar alternative for marketing sites
+- [TabBar](/docs/components/tab-bar) — secondary section navigation inside the main content area
+- [Breadcrumb](/docs/components/breadcrumb) — hierarchical position within a section
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-primary-sidebar-navigation--overview)**

--- a/docs-site/content/docs/components/tab-bar.mdx
+++ b/docs-site/content/docs/components/tab-bar.mdx
@@ -1,0 +1,136 @@
+---
+title: Tab bar
+description: Horizontal tab navigation. Three style variants, on-color mode for dark backgrounds.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+TabBar is for **navigating between sections of a page** — Settings tabs, profile-page sections, content-filter tabs. For switching content in-place inside a single panel, use [SegmentedControl](/docs/components/segmented-control).
+
+<ComparisonGrid
+  items={[
+    {
+      title: 'TabBar',
+      whenToUse: 'Page-level navigation between sections (Settings → Account / Billing / Security).',
+      whenNotToUse: 'In-panel content switcher — that\'s SegmentedControl.',
+      code: `<TabBar items={...} variant="tab" />`,
+    },
+    {
+      title: 'SegmentedControl',
+      whenToUse: 'Switch content in-place inside a single panel (Grid / List, Monthly / Yearly).',
+      whenNotToUse: 'Page navigation with section URLs — use TabBar.',
+      code: `<SegmentedControl items={...} />`,
+    },
+    {
+      title: 'Breadcrumb',
+      whenToUse: 'Show position in a hierarchical structure.',
+      whenNotToUse: 'Sibling navigation — use TabBar.',
+      code: `<Breadcrumb items={...} />`,
+    },
+  ]}
+/>
+
+## Use it for
+
+- Settings page sub-section navigation
+- Profile page sections (Overview / Activity / Connections)
+- Content filter tabs (All / Active / Archived)
+- Any flat sibling-section navigation where each tab corresponds to a distinct view
+
+## Import
+
+```tsx
+import { TabBar } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### `tab` — underline (default for app navigation)
+
+```tsx
+<TabBar
+  variant="tab"
+  items={[
+    { label: 'Overview', active: true, onClick: () => setTab('overview') },
+    { label: 'Billing', onClick: () => setTab('billing') },
+    { label: 'Security', onClick: () => setTab('security') },
+  ]}
+/>
+```
+
+### `text` — minimal
+
+Plain labels with brand color for active tab. Use in tight headers where the underline would crowd.
+
+```tsx
+<TabBar variant="text" items={items} />
+```
+
+### `box` — filled
+
+Filled background for active, bordered for inactive. Use for content filters where the active state needs strong visual weight.
+
+```tsx
+<TabBar variant="box" items={items} />
+```
+
+### On-color (dark backgrounds)
+
+`onColor` switches text and border colors to on-color-dark tokens for legibility against brand or dark surfaces.
+
+```tsx
+<TabBar variant="text" onColor items={items} />
+```
+
+### Disabled tabs
+
+Set `disabled: true` on individual items.
+
+```tsx
+<TabBar items={[
+  { label: 'Overview', active: true },
+  { label: 'Billing' },
+  { label: 'Security', disabled: true },
+]} />
+```
+
+## When *not* to use
+
+- **Don't use TabBar for in-panel content switching.** Use [SegmentedControl](/docs/components/segmented-control) — different visual treatment, different navigation model.
+- **Don't use TabBar for hierarchical navigation.** Use [Breadcrumb](/docs/components/breadcrumb).
+- **Don't put more than ~6 tabs in a row.** Long tab strips wrap awkwardly. Switch to [SidebarNavigation](/docs/components/sidebar-navigation) for vertical nav with more items.
+
+## Accessibility
+
+- Renders a `<div role="tablist">` with each tab as `<button role="tab">`.
+- Active tab carries `aria-selected="true"`.
+- Keyboard arrow keys move focus between tabs (left/right or up/down per orientation).
+- Disabled tabs use `aria-disabled` and skip in keyboard nav.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `items` | `TabItem[]` *(required)* | — |
+| `variant` | `'text' \| 'tab' \| 'box'` | `'tab'` |
+| `onColor` | `boolean` | `false` |
+
+Plus standard `<div>` HTML attributes.
+
+### TabItem
+
+```ts
+interface TabItem {
+  label: ReactNode;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+```
+
+## Related
+
+- [SegmentedControl](/docs/components/segmented-control) — in-panel content switcher
+- [Breadcrumb](/docs/components/breadcrumb) — hierarchical position
+- [SidebarNavigation](/docs/components/sidebar-navigation) — vertical nav for many items
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-secondary-tab-bar--overview)**


### PR DESCRIPTION
## Summary

Migrates the **Navigation** category — primary nav, secondary nav, and the floating Menu primitive. NavBar wasn't on my original 4-component scope but I discovered it during the inventory pass and included it (natural pair to SidebarNavigation).

| Page | Notes |
|---|---|
| [\`nav-bar\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-navigation/docs-site/content/docs/components/nav-bar.mdx) | Top-level horizontal nav (marketing-site-first). Logo + links + actions, optional \`sticky\`. |
| [\`sidebar-navigation\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-navigation/docs-site/content/docs/components/sidebar-navigation.mdx) | Fixed-position vertical sidebar (app-shell-first). Four-region anatomy: logo / navItems / footerActions / userSection. |
| [\`tab-bar\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-navigation/docs-site/content/docs/components/tab-bar.mdx) | Horizontal tab nav with three variants (text/tab/box) and on-color mode. Top-of-page \`<ComparisonGrid>\` disambiguates TabBar vs SegmentedControl vs Breadcrumb. |
| [\`breadcrumb\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-navigation/docs-site/content/docs/components/breadcrumb.mdx) | Hierarchical position trail. Slash or chevron separator. |
| [\`menu\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-navigation/docs-site/content/docs/components/menu.mdx) | Floating dropdown panel — consumer owns \`isOpen\`, component handles outside-click + Escape dismissal. |

After this lands the **Navigation** group is **5/5 ✅**. Total docs-site routes: **84**. Total component pages: **55**.

## State of the migration

| Group | Status |
|---|---|
| Action | 6/6 ✅ |
| Indicator | 10/10 ✅ |
| Form / Inputs | 10/10 ✅ |
| Form / Structure | 4/4 ✅ |
| Feedback | 6/6 ✅ |
| Control | 7/7 ✅ |
| Addable | 4/4 ✅ |
| Structure | 3/3 ✅ |
| **Navigation** | **5/5 ✅ (this PR)** |
| Displays | 0/~14 |

Foundations: 7/8 (Motion still pending).

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds
- [ ] \`/docs/components\` shows a Navigation card grid below Structure with 5 cards
- [ ] \`/docs/components/tab-bar\` — \`<ComparisonGrid>\` at top renders TabBar vs SegmentedControl vs Breadcrumb decision moment
- [ ] \`/docs/components/sidebar-navigation\` — four-region anatomy reads cleanly
- [ ] \`/docs/components/menu\` — consumer-owns-state framing matches actual API (isOpen / onClose required)
- [ ] All Storybook deep-links resolve

## Out of scope (follow-ups)

- Displays section (~14 components — Cards, Overlays, Notifications, Sheets, Table, Timeline, Calendar, Board, Charts)
- Card family siblings (CardControl, CardList, CardTestimonial, CollapsibleCard, PricingCard) — likely with Displays
- Motion foundation port — the deferred big lift
- Remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)