### PR TITLE
feat(docs-site): migrate Card family (5 components)

### DIFF
--- a/docs-site/content/docs/components/card-control.mdx
+++ b/docs-site/content/docs/components/card-control.mdx
@@ -1,0 +1,124 @@
+---
+title: Card control
+description: Settings control card — badge + title + description + action. Standalone alternative to Card preset="control".
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+CardControl is a locked-down settings-row card. Leading badge or icon, title + description in the middle, action (Switch / Button / link) on the right. Use for notification toggles, feature flags, and any settings panel where each row's affordance matters.
+
+<Callout type="info">
+  **Both `<CardControl>` and `<Card preset="control">` ship as first-class APIs in v0.39.0+.** The 2026-Q2 audit recommended folding CardControl into Card; the user reversed that decision 2026-04-24 to preserve optionality at the call site. Pick whichever reads cleaner — same shape, same Badge slot, same action alignment behavior. See [Card](/docs/components/card) for the preset version.
+</Callout>
+
+## Use it for
+
+- Settings rows ("Email notifications" + Switch on/off)
+- Feature flag toggles in admin panels
+- Status/state displays where a badge + name + value+action layout fits
+- Stacks of these in a [CardList](/docs/components/card-list) for full settings panels
+
+For a flexible-content card, use [Card](/docs/components/card) default mode. For stat tiles, use [Card preset="summary"](/docs/components/card#summary-preset).
+
+## Import
+
+```tsx
+import { CardControl } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+<CardControl
+  title="Notifications"
+  description="Receive email notifications for updates"
+  badge={<Badge size="xs" status="positive" icon={<CheckIcon />} />}
+  action={<Switch checked={enabled} onChange={handleChange} />}
+/>
+```
+
+### Action types
+
+`action` accepts any ReactNode — Switch, Button, link, or compound content.
+
+```tsx
+<CardControl
+  title="Two-factor authentication"
+  description="Required for admin accounts"
+  action={<Button variant="outline" size="sm">Set up</Button>}
+/>
+
+<CardControl
+  title="API access"
+  description="Generate tokens for integrations"
+  action={<TextLink href="/settings/api">Manage</TextLink>}
+/>
+```
+
+### Action alignment
+
+Use `actionAlign="top"` when the description wraps to multiple lines — anchors the action to the upper-right corner instead of the vertical center.
+
+```tsx
+<CardControl
+  title="Storage"
+  description="You're using 8.2 GB of your 10 GB plan. Upgrade for more or clean up old assets to make space."
+  action={<Button size="sm">Upgrade</Button>}
+  actionAlign="top"
+/>
+```
+
+## Pattern: settings panel
+
+Stack CardControls inside a [CardList](/docs/components/card-list) with `gap="sm"` for a clean settings-page layout.
+
+```tsx
+<CardList gap="sm">
+  <CardControl
+    title="Email notifications"
+    description="Daily digest"
+    action={<Switch checked={email} onChange={(e) => setEmail(e.target.checked)} />}
+  />
+  <CardControl
+    title="SMS notifications"
+    description="Urgent alerts only"
+    action={<Switch checked={sms} onChange={(e) => setSms(e.target.checked)} />}
+  />
+  <CardControl
+    title="Slack integration"
+    description="Connect a workspace"
+    action={<Button variant="outline" size="sm">Connect</Button>}
+  />
+</CardList>
+```
+
+## When *not* to use
+
+- **Don't use CardControl for free-form content.** Use [Card](/docs/components/card) default mode — CardControl's locked layout doesn't accept arbitrary children.
+- **Don't use CardControl when the action isn't always present.** A row without an action reads as broken in this layout.
+
+## Accessibility
+
+- Renders a `<div>`. The action element keeps its own semantics (Switch is a switch, Button is a button).
+- For full accessibility, the action element should pair with the title via `aria-labelledby` on the action — most often automatic for Switch when a label is provided.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `string` *(required)* | — |
+| `description` | `string` | — |
+| `badge` | `ReactNode` | — |
+| `action` | `ReactNode` | — |
+| `actionAlign` | `'center' \| 'top'` | `'center'` |
+
+Plus standard `<div>` HTML attributes.
+
+## Related
+
+- [Card](/docs/components/card) — flexible-content sibling. `Card preset="control"` is API-equivalent to CardControl.
+- [CardList](/docs/components/card-list) — wrapper for stacking multiple CardControls
+- [Switch](/docs/components/switch) — most common `action` content
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-control--overview)**

--- a/docs-site/content/docs/components/card-list.mdx
+++ b/docs-site/content/docs/components/card-list.mdx
@@ -1,0 +1,103 @@
+---
+title: Card list
+description: Layout wrapper for stacking cards vertically or horizontally. Locks gap and equal-column distribution.
+---
+
+CardList is a thin layout primitive that wraps any card-shaped child ([Card](/docs/components/card), [CardControl](/docs/components/card-control), [CardTestimonial](/docs/components/card-testimonial), [CollapsibleCard](/docs/components/collapsible-card), [PricingCard](/docs/components/pricing-card)) in a column or row. Handles gap, equal-column distribution, and wrapping so the card components themselves stay layout-agnostic.
+
+For mixed equal-weight content (Cards + Tags + Fields side-by-side), use [FieldGrid](/docs/components/field-grid) instead — it's the same layout primitive but with stricter equal-cell semantics.
+
+## Use it for
+
+- Settings panels stacking multiple [CardControl](/docs/components/card-control)s vertically
+- Feature/service grids using horizontal Card columns
+- Pricing-tier rows with [PricingCard](/docs/components/pricing-card)s side by side
+- Testimonial walls with [CardTestimonial](/docs/components/card-testimonial)s
+
+## Import
+
+```tsx
+import { CardList } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Vertical (default)
+
+Stacks cards top-to-bottom at full width. Default orientation for feeds and settings lists.
+
+```tsx
+<CardList gap="md">
+  <Card>...</Card>
+  <Card>...</Card>
+  <Card>...</Card>
+</CardList>
+```
+
+### Horizontal
+
+Lays cards out in a row with equal-width columns. Wraps to a new line on narrow viewports.
+
+```tsx
+<CardList orientation="horizontal" gap="lg">
+  <Card variant="outlined" padding="lg">
+    <CardTitle>Design</CardTitle>
+    <CardDescription>Brand and identity.</CardDescription>
+  </Card>
+  <Card variant="outlined" padding="lg">
+    <CardTitle>Development</CardTitle>
+    <CardDescription>Product engineering.</CardDescription>
+  </Card>
+</CardList>
+```
+
+### Horizontal — fit content
+
+When each card declares its own width (e.g. a scrollable carousel of products), set `fitContent` so items size to their children instead of stretching to fill equal columns.
+
+```tsx
+<CardList orientation="horizontal" gap="md" fitContent>
+  <Card style={{ width: 240 }}>...</Card>
+  <Card style={{ width: 240 }}>...</Card>
+</CardList>
+```
+
+### Gap scale
+
+Four sizes — `sm`, `md` (default), `lg`, `xl`. Match the visual density of the surrounding context.
+
+```tsx
+<CardList gap="sm">...</CardList>   /* tight settings rows */
+<CardList gap="md">...</CardList>   /* default */
+<CardList gap="lg">...</CardList>   /* breathing room */
+<CardList gap="xl">...</CardList>   /* hero/feature grids */
+```
+
+## When *not* to use
+
+- **Don't use CardList for non-card children.** It expects card-shaped layout — single column-fill or equal columns. Free-form children misalign.
+- **Don't use CardList for tabular data.** Use a Table when columns share semantics. CardList is for grouping, not structured data.
+- **Don't nest CardLists deeply.** One level is fine; two becomes hard to reason about. If you need a complex grid, build it directly with CSS Grid.
+
+## Accessibility
+
+- Renders a `<ul>` with each child wrapped in `<li>` automatically.
+- Screen readers announce the list and item count, which is appropriate semantics for grouped cards.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `orientation` | `'vertical' \| 'horizontal'` | `'vertical'` |
+| `gap` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` |
+| `fitContent` | `boolean` (horizontal only) | `false` |
+| `children` | `ReactNode` *(required)* | — |
+
+Plus standard `<ul>` HTML attributes.
+
+## Related
+
+- [Card](/docs/components/card) — most common child
+- [CardControl](/docs/components/card-control), [CardTestimonial](/docs/components/card-testimonial), [CollapsibleCard](/docs/components/collapsible-card), [PricingCard](/docs/components/pricing-card) — other card-family children
+- [FieldGrid](/docs/components/field-grid) — alternative for read-mode Field rows
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-list--overview)**

--- a/docs-site/content/docs/components/card-testimonial.mdx
+++ b/docs-site/content/docs/components/card-testimonial.mdx
@@ -1,0 +1,115 @@
+---
+title: Card testimonial
+description: Customer testimonial card — quote, attribution, optional star rating. Brand or outlined variant.
+---
+
+CardTestimonial renders a customer quote in a card layout. Brand variant for marketing surfaces (colored background), outlined variant for in-app contexts (neutral surface with border).
+
+## Use it for
+
+- Marketing testimonial walls
+- Trust indicators on landing pages and pricing pages
+- Customer story callouts
+- Case-study card grids inside [CardList](/docs/components/card-list)
+
+For free-form quotes inside body copy, use a `<blockquote>` directly — CardTestimonial is for displayed-as-card placement.
+
+## Import
+
+```tsx
+import { CardTestimonial } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Brand (default)
+
+Colored background with inverse text. The marketing-page default.
+
+```tsx
+<CardTestimonial
+  quote="Amazing service and results — turnaround was faster than promised."
+  authorName="Sarah Chen"
+  authorRole="Owner, Bloom Cafe"
+  rating={5}
+/>
+```
+
+### Outlined
+
+Neutral surface with a border. Use in app contexts where the brand variant would over-emphasize.
+
+```tsx
+<CardTestimonial
+  variant="outlined"
+  quote="The redesign tripled our conversion rate."
+  authorName="Marcus Lee"
+  authorRole="CMO, Northwind"
+  rating={5}
+/>
+```
+
+### Without rating
+
+Star rating is optional. Drop it for product-line testimonials where stars don't apply.
+
+```tsx
+<CardTestimonial
+  quote="They get our brand voice better than we do."
+  authorName="Priya Patel"
+  authorRole="VP Product, Lumen"
+/>
+```
+
+### Minimal attribution
+
+`authorRole` is optional. Use for community/user testimonials where context isn't load-bearing.
+
+```tsx
+<CardTestimonial
+  quote="Best dental cleaning I've ever had."
+  authorName="J. Morrison"
+/>
+```
+
+## Pattern: testimonial wall
+
+Mix variants in a [CardList](/docs/components/card-list) grid for a visually varied wall.
+
+```tsx
+<CardList orientation="horizontal" gap="lg">
+  <CardTestimonial variant="brand" quote="..." authorName="..." rating={5} />
+  <CardTestimonial variant="outlined" quote="..." authorName="..." rating={5} />
+  <CardTestimonial variant="brand" quote="..." authorName="..." />
+</CardList>
+```
+
+## When *not* to use
+
+- **Don't use CardTestimonial for non-testimonial content.** Press mentions, awards, or other social proof are different patterns — use [Card](/docs/components/card) default mode with appropriate composition.
+- **Don't fake testimonials.** Real attribution matters for trust; fake or composite quotes erode credibility when discovered.
+- **Don't truncate quotes silently.** If a quote is too long, edit it to fit (with the customer's permission) or use a [Card](/docs/components/card) with explicit quote-and-link-to-full pattern.
+
+## Accessibility
+
+- Renders the quote inside a `<blockquote>` with proper semantics.
+- Star rating uses filled/empty SVG icons with `aria-label="Rated {n} out of 5"`.
+- Author and role render as `<cite>` with the role as `<span>`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `quote` | `string` *(required)* | — |
+| `authorName` | `string` *(required)* | — |
+| `authorRole` | `string` | — |
+| `rating` | `1 \| 2 \| 3 \| 4 \| 5` | — |
+| `variant` | `'brand' \| 'outlined'` | `'brand'` |
+
+Plus standard `<article>` / `<div>` HTML attributes.
+
+## Related
+
+- [Card](/docs/components/card) — flexible content alternative
+- [CardList](/docs/components/card-list) — for grids of testimonials
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-card-card-testimonial--overview)**

--- a/docs-site/content/docs/components/collapsible-card.mdx
+++ b/docs-site/content/docs/components/collapsible-card.mdx
@@ -1,0 +1,123 @@
+---
+title: Collapsible card
+description: Expandable section in a card shell. Section label + title header, click to reveal content.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+CollapsibleCard combines [Accordion](/docs/components/accordion)'s expand/collapse behavior with [Card](/docs/components/card)'s container styling. Use for FAQs and proposal sections that benefit from both individual emphasis and progressive disclosure.
+
+For tight FAQ lists where individual cards would be visual overhead, use [Accordion](/docs/components/accordion) directly. For non-collapsible card content, use [Card](/docs/components/card).
+
+## Use it for
+
+- Long-form proposal sections (Section 01 / Section 02 / Section 03)
+- FAQ entries that need standalone visual weight
+- Settings groups inside dashboards
+- Stacked content blocks where each is meaningful enough to be its own surface
+
+## Import
+
+```tsx
+import { CollapsibleCard } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default — uncontrolled
+
+Click the header to toggle. Internal state.
+
+```tsx
+<CollapsibleCard
+  sectionLabel="Section 01"
+  title="Overview and Goals"
+>
+  <p>Content goes here…</p>
+</CollapsibleCard>
+```
+
+### Initially open
+
+```tsx
+<CollapsibleCard title="Settings" defaultOpen>
+  <p>Settings content…</p>
+</CollapsibleCard>
+```
+
+### Controlled
+
+When you need parent control over expansion (e.g. accordion-style "only one open" coordination across multiple cards).
+
+```tsx
+import { useState } from 'react';
+
+const [open, setOpen] = useState(false);
+
+<CollapsibleCard
+  title="Pricing"
+  isOpen={open}
+  onOpenChange={setOpen}
+>
+  <p>Pricing details…</p>
+</CollapsibleCard>
+```
+
+### Without section label
+
+`sectionLabel` is optional. Drop it for FAQ-style cards where numbered sections aren't meaningful.
+
+```tsx
+<CollapsibleCard title="Do you offer discounts for nonprofits?">
+  <p>Yes — 20% off all annual plans for verified 501(c)(3) organizations.</p>
+</CollapsibleCard>
+```
+
+### Header actions
+
+`headerActions` accepts ReactNode rendered next to the toggle — useful for per-card edit / share / dismiss buttons.
+
+```tsx
+<CollapsibleCard
+  title="Project brief"
+  headerActions={<IconButton icon={<EditIcon />} label="Edit brief" />}
+>
+  <p>...</p>
+</CollapsibleCard>
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use CollapsibleCard for tight FAQ stacks** — use [Accordion](/docs/components/accordion). The card surface adds visual weight that gets noisy when 6+ stacked items each have their own border.
+</Callout>
+
+- **Don't use CollapsibleCard when content shouldn't be hidden.** If users need to see the content to make a decision, render it directly in a [Card](/docs/components/card) without the collapse.
+- **Don't use CollapsibleCard for navigation.** It's content disclosure, not navigation. Use [TabBar](/docs/components/tab-bar) / [SidebarNavigation](/docs/components/sidebar-navigation) for navigation.
+
+## Accessibility
+
+- The header is a real `<button>` with `aria-expanded` reflecting open/closed state.
+- The content panel uses `role="region"` linked via `aria-labelledby` to the header.
+- Keyboard `Enter` / `Space` toggles. Focus stays on the header after toggling.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `string` *(required)* | — |
+| `children` | `ReactNode` *(required)* | — |
+| `sectionLabel` | `string` | — |
+| `isOpen` | `boolean` (controlled) | — |
+| `onOpenChange` | `(isOpen: boolean) => void` | — |
+| `defaultOpen` | `boolean` | `false` |
+| `headerActions` | `ReactNode` | — |
+
+Plus standard `<div>` HTML attributes.
+
+## Related
+
+- [Accordion](/docs/components/accordion) — for tight FAQ stacks
+- [Card](/docs/components/card) — non-collapsible card sibling
+- [CardList](/docs/components/card-list) — wrapper for stacking multiple CollapsibleCards
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-card-collapsible-card--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -136,6 +136,18 @@ Primary nav (NavBar / SidebarNavigation), secondary nav (TabBar / Breadcrumb), a
   <Card title="Menu" href="/docs/components/menu" description="Floating dropdown panel. Outside-click and Escape dismissal built in." />
 </Cards>
 
+### Card family
+
+Specialized card layouts that compose alongside the base [Card](/docs/components/card) component. Each is a locked-down layout for a recurring pattern.
+
+<Cards>
+  <Card title="Card control" href="/docs/components/card-control" description="Settings control card — badge + title + description + action. Standalone alternative to Card preset='control'." />
+  <Card title="Card list" href="/docs/components/card-list" description="Layout wrapper for stacking cards vertically or horizontally." />
+  <Card title="Card testimonial" href="/docs/components/card-testimonial" description="Customer testimonial card — quote, attribution, optional star rating." />
+  <Card title="Collapsible card" href="/docs/components/collapsible-card" description="Expandable section in a card shell. Click to reveal content." />
+  <Card title="Pricing card" href="/docs/components/pricing-card" description="Pricing tier display with optional highlighted state for the recommended plan." />
+</Cards>
+
 ## Still in Storybook
 
 The remaining components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for **Card family** (CardControl, CardList, CardTestimonial, CollapsibleCard, PricingCard), **Navigation** (TabBar, Breadcrumb, SidebarNavigation, Menu), and **Displays** sub-categories (Cards, Overlays, Notifications, Sheets, Table, Timeline, Calendar, Board, Charts).

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -65,6 +65,12 @@
     "sidebar-navigation",
     "tab-bar",
     "breadcrumb",
-    "menu"
+    "menu",
+    "---Card family---",
+    "card-control",
+    "card-list",
+    "card-testimonial",
+    "collapsible-card",
+    "pricing-card"
   ]
 }

--- a/docs-site/content/docs/components/pricing-card.mdx
+++ b/docs-site/content/docs/components/pricing-card.mdx
@@ -1,0 +1,150 @@
+---
+title: Pricing card
+description: Pricing tier display — title, price, features list, action. Optional highlighted state for the recommended plan.
+---
+
+PricingCard renders a single pricing tier — title, price + period, description, feature bullets, and call-to-action. Pair multiple in a [CardList](/docs/components/card-list) for the canonical 2-3-tier pricing grid.
+
+## Use it for
+
+- Pricing pages on marketing sites
+- Plan comparison tables in product apps
+- Free-vs-paid tier callouts
+- Pricing inside sales proposals or quotes
+
+## Import
+
+```tsx
+import { PricingCard } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Standard
+
+```tsx
+<PricingCard
+  title="Professional"
+  price="$49"
+  period="/month"
+  description="For growing businesses."
+  features={[
+    'Unlimited projects',
+    'Priority support',
+    'Custom branding',
+    'Advanced analytics',
+  ]}
+  action={<Button variant="primary" fullWidth>Get started</Button>}
+/>
+```
+
+### Highlighted (recommended plan)
+
+`highlighted` flags the plan as the recommended option — typically the middle tier in a 3-up grid. Pair with a `badge` for explicit attention.
+
+```tsx
+<PricingCard
+  title="Professional"
+  price="$49"
+  period="/month"
+  badge={<Badge>Most popular</Badge>}
+  features={features}
+  action={<Button variant="primary" fullWidth>Get started</Button>}
+  highlighted
+/>
+```
+
+### Free tier
+
+Use a string for `price` — it's not parsed.
+
+```tsx
+<PricingCard
+  title="Starter"
+  price="Free"
+  description="For solo creators and side projects."
+  features={['1 project', 'Community support']}
+  action={<Button variant="outline" fullWidth>Start free</Button>}
+/>
+```
+
+### One-time pricing
+
+```tsx
+<PricingCard
+  title="Lifetime"
+  price="$199"
+  period="one-time"
+  description="Pay once, use forever."
+  features={['All current and future features']}
+  action={<Button variant="primary" fullWidth>Buy now</Button>}
+/>
+```
+
+## Pattern: 3-tier pricing grid
+
+The canonical layout — three plans side by side, middle tier highlighted.
+
+```tsx
+<CardList orientation="horizontal" gap="lg">
+  <PricingCard
+    title="Starter"
+    price="Free"
+    features={['1 project', 'Community support']}
+    action={<Button variant="outline" fullWidth>Start free</Button>}
+  />
+
+  <PricingCard
+    title="Professional"
+    price="$49"
+    period="/month"
+    badge={<Badge>Most popular</Badge>}
+    features={['Unlimited projects', 'Priority support', 'Advanced analytics']}
+    action={<Button variant="primary" fullWidth>Get started</Button>}
+    highlighted
+  />
+
+  <PricingCard
+    title="Enterprise"
+    price="Custom"
+    description="Tailored for your team."
+    features={['Everything in Professional', 'SSO + SAML', 'Dedicated CSM']}
+    action={<Button variant="outline" fullWidth>Contact sales</Button>}
+  />
+</CardList>
+```
+
+## When *not* to use
+
+- **Don't use PricingCard for non-pricing content.** It's a specialized layout — use [Card](/docs/components/card) for general-purpose grouping.
+- **Don't highlight more than one plan.** "Recommended" should be unambiguous; multiple highlights defeat the visual cue.
+- **Don't use PricingCard for ≥5 tiers.** The pricing-grid pattern breaks down past 4 columns. Use a comparison Table instead.
+
+## Accessibility
+
+- Renders a real `<article>` with the tier title as a heading.
+- Features list renders as `<ul>` with proper semantics.
+- The action element keeps its own button/link semantics.
+- Highlighted state is communicated visually + via `aria-label` ("Recommended plan: Professional").
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `string` *(required)* | — |
+| `price` | `string` *(required)* | — |
+| `period` | `string` | — |
+| `description` | `string` | — |
+| `features` | `string[]` | — |
+| `action` | `ReactNode` | — |
+| `badge` | `ReactNode` | — |
+| `highlighted` | `boolean` | `false` |
+
+Plus standard `<div>` HTML attributes.
+
+## Related
+
+- [Card](/docs/components/card) — flexible-content alternative
+- [CardList](/docs/components/card-list) — for the multi-tier grid layout
+- [Badge](/docs/components/badge) — common `badge` content ("Most popular")
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-card-pricing-card--overview)**


### PR DESCRIPTION
## Summary

First sub-batch of the **Displays** migration — the 5 Card-family components that didn't ship in the [Structure PR](https://github.com/brikdesigns/brik-bds/pull/281).

| Page | Notes |
|---|---|
| [\`card-control\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-cards/docs-site/content/docs/components/card-control.mdx) | Settings control card. Documents that both \`<CardControl>\` **and** \`<Card preset="control">\` ship as first-class APIs per the 2026-04-24 reversal of [ADR-004](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md)'s consolidation recommendation. |
| [\`card-list\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-cards/docs-site/content/docs/components/card-list.mdx) | Layout wrapper for stacking cards. \`orientation\`, \`gap\`, \`fitContent\`. Settings panel pattern with CardControl children, 3-tier pricing grid pattern with PricingCard children. |
| [\`card-testimonial\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-cards/docs-site/content/docs/components/card-testimonial.mdx) | Customer testimonial card. Brand + outlined variants, optional 1-5 star rating. |
| [\`collapsible-card\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-cards/docs-site/content/docs/components/collapsible-card.mdx) | Card + Accordion mash-up. Section label + title header, controlled/uncontrolled, header actions slot. |
| [\`pricing-card\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-cards/docs-site/content/docs/components/pricing-card.mdx) | Pricing tier display. \`highlighted\` for the recommended plan, free / monthly / one-time pricing patterns. |

CardSummary doesn't ship as a separate component — it's already folded into `<Card preset="summary">` per ADR-004 (and CardSummary is `@deprecated`). That migration is documented on the [Card](/docs/components/card) page from PR [#281](https://github.com/brikdesigns/brik-bds/pull/281).

## State of the migration

| Group | Status |
|---|---|
| Action | 6/6 ✅ |
| Indicator | 10/10 ✅ |
| Form / Inputs | 10/10 ✅ |
| Form / Structure | 4/4 ✅ |
| Feedback | 6/6 ✅ |
| Control | 7/7 ✅ |
| Addable | 4/4 ✅ |
| Structure | 3/3 ✅ |
| Navigation | 5/5 ✅ |
| **Displays / Card family** | **5/5 ✅ (this PR)** |
| Displays / Overlays | 0/? |
| Displays / Notifications | 0/? |
| Displays / Sheets | 0/? |
| Displays / Table | 0/? |
| Displays / Timeline | 0/? |
| Displays / Calendar | 0/? |
| Displays / Board | 0/? |
| Displays / Charts | 0/? |

After this lands: **89 docs-site routes**, **60 component pages**.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds
- [ ] \`/docs/components\` shows a Card family card grid below Navigation
- [ ] \`/docs/components/card-control\` — the both-APIs-ship callout reads correctly
- [ ] \`/docs/components/card-list\` — settings panel pattern + horizontal pricing grid pattern both render code cleanly
- [ ] \`/docs/components/pricing-card\` — three-tier grid example uses CardList correctly
- [ ] All Storybook deep-links resolve

## Out of scope (next sub-batches)

After this PR merges, the remaining Displays sub-batches are:

1. **Overlays / Notifications** — likely Modal, Drawer, Popover, Notification stack
2. **Sheets** — Sheet (the slide-in panel pattern), possibly SheetSection / SheetHeader children
3. **Table** — Table primitive, TableRow, TableHeader (data display)
4. **Timeline / Calendar / Board** — content surfaces
5. **Charts** — likely the most isolated set

I'll inventory each sub-batch as we hit it. Order can shift based on which is most-referenced from existing pages.

Plus the deferred:
- Motion foundation port
- Remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)