### PR TITLE
feat(docs-site): migrate Overlays + Sheets (6 components)

### DIFF
--- a/docs-site/content/docs/components/dialog.mdx
+++ b/docs-site/content/docs/components/dialog.mdx
@@ -1,0 +1,77 @@
+---
+title: Dialog
+description: DEPRECATED — use Modal preset="confirm" instead.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+<Callout type="error">
+  **Dialog is deprecated.** Migrate to [`Modal preset="confirm"`](/docs/components/modal#confirm-preset). This component is slated for deletion in a future major version per [ADR-004](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md).
+</Callout>
+
+## Migration
+
+Same shape, same defaults, same destructive flow — just renamed under Modal.
+
+```tsx
+// Before
+<Dialog
+  isOpen={open}
+  onClose={close}
+  title="Save changes?"
+  description="You have unsaved changes."
+  confirmLabel="Save"
+  onConfirm={handleSave}
+/>
+
+// After
+<Modal
+  isOpen={open}
+  onClose={close}
+  preset="confirm"
+  title="Save changes?"
+  description="You have unsaved changes."
+  confirmLabel="Save"
+  onConfirm={handleSave}
+/>
+```
+
+| Dialog prop | Modal preset="confirm" prop |
+|---|---|
+| `isOpen` | `isOpen` |
+| `onClose` | `onClose` |
+| `title` | `title` |
+| `description` | `description` |
+| `confirmLabel` | `confirmLabel` |
+| `cancelLabel` | `cancelLabel` |
+| `onConfirm` | `onConfirm` |
+| `variant="destructive"` | `confirmVariant="destructive"` |
+| `closeOnBackdrop` | `closeOnBackdrop` |
+
+The Modal preset adds `confirmDisabled` and `confirmLoading` props for in-flight requests, which Dialog never had.
+
+## Why the consolidation
+
+Dialog and Modal were two visually similar components doing the same job — modal overlay with confirm/cancel. Per ADR-004 component-bloat guardrails, two components with ≥70% overlap collapse into one with a prop. The result: [Modal](/docs/components/modal) with `preset="confirm"`.
+
+## Existing Dialog shape (frozen)
+
+For reference while migrating. New code should not use this component.
+
+| Prop | Type | Default |
+|---|---|---|
+| `isOpen` | `boolean` *(required)* | — |
+| `onClose` | `() => void` *(required)* | — |
+| `title` | `string` *(required)* | — |
+| `description` | `string` | — |
+| `children` | `ReactNode` | — |
+| `confirmLabel` | `string` | `'Confirm'` |
+| `cancelLabel` | `string` | `'Cancel'` |
+| `onConfirm` | `() => void` | — |
+| `variant` | `'default' \| 'destructive'` | `'default'` |
+| `closeOnBackdrop` | `boolean` | `true` |
+
+## Related
+
+- [Modal](/docs/components/modal) — the canonical replacement
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-overlay-dialog--overview)** *(legacy)*

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -148,6 +148,26 @@ Specialized card layouts that compose alongside the base [Card](/docs/components
   <Card title="Pricing card" href="/docs/components/pricing-card" description="Pricing tier display with optional highlighted state for the recommended plan." />
 </Cards>
 
+### Overlays
+
+Modal-shape surfaces — backdrop overlays for confirmations, focused tasks, and inline floating panels.
+
+<Cards>
+  <Card title="Modal" href="/docs/components/modal" description="Portal-rendered dialog overlay with backdrop, escape, scroll lock. Five sizes plus confirm preset." />
+  <Card title="Dialog" href="/docs/components/dialog" description="DEPRECATED — migrate to Modal preset='confirm'." />
+  <Card title="Popover" href="/docs/components/popover" description="Floating content panel anchored to a trigger. Click or hover, four placements." />
+</Cards>
+
+### Sheets
+
+Sliding-panel detail views with the SheetSection wrapper and four locked typography primitives for body composition.
+
+<Cards>
+  <Card title="Sheet" href="/docs/components/sheet" description="Sliding panel anchored to a screen edge. Read/edit modes, tabs, secondary action, floating variant." />
+  <Card title="Sheet section" href="/docs/components/sheet-section" description="Named wrapper for content blocks inside a Sheet body. Heading + locked vertical rhythm." />
+  <Card title="Sheet typography" href="/docs/components/sheet-typography" description="Four locked text primitives — SectionTitle, FieldLabel, FieldValue, HelperText." />
+</Cards>
+
 ## Still in Storybook
 
 The remaining components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for **Card family** (CardControl, CardList, CardTestimonial, CollapsibleCard, PricingCard), **Navigation** (TabBar, Breadcrumb, SidebarNavigation, Menu), and **Displays** sub-categories (Cards, Overlays, Notifications, Sheets, Table, Timeline, Calendar, Board, Charts).

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -71,6 +71,14 @@
     "card-list",
     "card-testimonial",
     "collapsible-card",
-    "pricing-card"
+    "pricing-card",
+    "---Overlays---",
+    "modal",
+    "dialog",
+    "popover",
+    "---Sheets---",
+    "sheet",
+    "sheet-section",
+    "sheet-typography"
   ]
 }

--- a/docs-site/content/docs/components/modal.mdx
+++ b/docs-site/content/docs/components/modal.mdx
@@ -1,0 +1,136 @@
+---
+title: Modal
+description: Portal-rendered dialog overlay with backdrop, escape key, and scroll lock. Five sizes plus a confirm preset.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Modal is the canonical dialog overlay. Portal-rendered (escapes the source DOM), backdrop with optional click-to-close, Escape key dismissal, scroll lock on the underlying page. Five sizes plus a `preset="confirm"` for destructive/confirmation flows.
+
+## Use it for
+
+- Focused tasks (forms, multi-step flows)
+- Confirmations and destructive-action prompts (`preset="confirm"`)
+- Any modal interaction where the user needs to commit or cancel before continuing
+
+For sliding panels anchored to a screen edge (detail views, edit workflows), use [Sheet](/docs/components/sheet). For floating content panels anchored to a trigger, use [Popover](/docs/components/popover).
+
+## Import
+
+```tsx
+import { Modal } from '@brikdesigns/bds';
+```
+
+## Default mode
+
+```tsx
+import { useState } from 'react';
+const [open, setOpen] = useState(false);
+
+<Modal
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  title="Edit profile"
+  footer={
+    <>
+      <Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
+      <Button variant="primary" onClick={handleSave}>Save</Button>
+    </>
+  }
+>
+  <p>Form content here…</p>
+</Modal>
+```
+
+### Sizes
+
+| Size | Use case |
+|---|---|
+| `sm` | Compact messages, simple confirms |
+| `md` (default) | Standard dialogs |
+| `lg` | Extended content |
+| `xl` | Data-heavy views |
+| `full` | Full-screen takeover |
+
+## Confirm preset
+
+`preset="confirm"` collapses the legacy [Dialog](/docs/components/dialog) component into Modal. Sets `role="alertdialog"`, locks to a tighter 440px width, hides the X close button, and auto-renders Cancel / Confirm buttons.
+
+```tsx
+<Modal
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  preset="confirm"
+  title="Delete this item?"
+  description="This action cannot be undone."
+  confirmLabel="Delete"
+  confirmVariant="destructive"
+  onConfirm={handleDelete}
+/>
+```
+
+### Confirm preset props
+
+- `confirmLabel` / `cancelLabel` — button labels (defaults: "Confirm" / "Cancel")
+- `confirmVariant` — `'primary'` (default) or `'destructive'` for delete-style actions
+- `confirmDisabled` — disables the confirm button (e.g. while form is invalid)
+- `confirmLoading` — shows loading state on the confirm button (in-flight request)
+- `onConfirm` — called when the user confirms
+
+Pass a custom `footer` to override the auto-rendered actions while keeping the rest of the preset.
+
+<Callout type="warn">
+  **The standalone `Dialog` component is `@deprecated`** and slated for deletion in a future major version. Migrate to `Modal preset="confirm"` — same prop names, same behavior. See [ADR-004](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-004-component-bloat-guardrails.md).
+</Callout>
+
+## When *not* to use
+
+- **Don't use Modal for persistent state.** Modals interrupt the user. For background notifications, use [Toast](/docs/components/toast). For persistent alerts, use [Banner](/docs/components/banner).
+- **Don't use Modal for ephemeral hover content.** Use [Tooltip](/docs/components/tooltip) or [Popover](/docs/components/popover).
+- **Don't nest Modals.** Modal-on-modal indicates a flow problem. Refactor as a single multi-step Modal or as a [Sheet](/docs/components/sheet) push-stack.
+- **Don't put navigation in a Modal.** Modals are for *committing* — back-out flows belong on the page itself.
+
+## Accessibility
+
+- Renders `role="dialog"` (or `alertdialog` for confirm preset) with `aria-labelledby` linking the title.
+- Focus trap inside the modal — `Tab` cycles within, focus returns to the trigger on close.
+- `Escape` closes (auto). Backdrop click closes by default; opt out via `closeOnBackdrop={false}`.
+- Body scroll is locked while the modal is open.
+
+## API
+
+### Default mode
+
+| Prop | Type | Default |
+|---|---|---|
+| `isOpen` | `boolean` *(required)* | — |
+| `onClose` | `() => void` *(required)* | — |
+| `title` | `string` | — |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'md'` |
+| `children` | `ReactNode` | — |
+| `footer` | `ReactNode` | — |
+| `closeOnBackdrop` | `boolean` | `true` |
+| `closeOnEscape` | `boolean` | `true` |
+| `showCloseButton` | `boolean` | `true` |
+
+### Confirm preset
+
+| Prop | Type | Default |
+|---|---|---|
+| `preset` | `'confirm'` *(required)* | — |
+| `title` | `string` *(required)* | — |
+| `description` | `string` | — |
+| `confirmLabel` | `string` | `'Confirm'` |
+| `cancelLabel` | `string` | `'Cancel'` |
+| `confirmVariant` | `'primary' \| 'destructive'` | `'primary'` |
+| `confirmDisabled` | `boolean` | `false` |
+| `confirmLoading` | `boolean` | `false` |
+| `onConfirm` | `() => void` | — |
+
+## Related
+
+- [Dialog](/docs/components/dialog) *(deprecated)* — migrate to `Modal preset="confirm"`
+- [Sheet](/docs/components/sheet) — sliding panel alternative
+- [Popover](/docs/components/popover) — anchored-to-trigger alternative
+- [Banner](/docs/components/banner) — persistent state alerts
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-overlay-modal--overview)**

--- a/docs-site/content/docs/components/popover.mdx
+++ b/docs-site/content/docs/components/popover.mdx
@@ -1,0 +1,124 @@
+---
+title: Popover
+description: Floating content panel anchored to a trigger. Click or hover trigger, four placements, controlled or uncontrolled.
+---
+
+Popover is a floating content panel anchored to a trigger element. More flexible than [Tooltip](/docs/components/tooltip) (rich content allowed, focusable interactive children) but less heavy than [Modal](/docs/components/modal) (no backdrop, no scroll lock, dismisses on outside click).
+
+## Use it for
+
+- Notification settings and inline preferences
+- Inline action panels ("More options")
+- Form-aware help (when a Tooltip's plain text isn't enough)
+- Anything that needs more than a Tooltip but less than a Modal
+
+For brief hover-revealed text, use [Tooltip](/docs/components/tooltip). For dropdown-style action menus, use [Menu](/docs/components/menu). For backdrop-modal flows, use [Modal](/docs/components/modal).
+
+## Import
+
+```tsx
+import { Popover } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Click trigger (default)
+
+```tsx
+<Popover content={<p>Additional details here.</p>}>
+  <button>More info</button>
+</Popover>
+```
+
+### Hover trigger
+
+For richer-than-tooltip help that still reveals on hover.
+
+```tsx
+<Popover
+  content={<p>Tooltip-style content with more detail.</p>}
+  trigger="hover"
+  placement="top"
+>
+  <span>Hover me</span>
+</Popover>
+```
+
+### Placements
+
+`top`, `bottom`, `left`, `right`. Pick based on the trigger's surroundings — top is safest for inline elements; bottom is safest for headers/toolbars.
+
+```tsx
+<Popover content={...} placement="top">...</Popover>
+<Popover content={...} placement="right">...</Popover>
+```
+
+### Controlled
+
+For programmatic open/close (e.g. opening from a parent state machine).
+
+```tsx
+import { useState } from 'react';
+const [open, setOpen] = useState(false);
+
+<Popover
+  content={<NotificationSettings />}
+  isOpen={open}
+  onOpenChange={setOpen}
+>
+  <Button>Settings</Button>
+</Popover>
+```
+
+### Rich content
+
+`content` accepts any ReactNode — paragraphs, forms, action menus.
+
+```tsx
+<Popover
+  content={
+    <>
+      <h4>Notification preferences</h4>
+      <Switch label="Email" defaultChecked />
+      <Switch label="SMS" />
+      <Button size="sm" variant="primary">Save</Button>
+    </>
+  }
+>
+  <Button>Settings</Button>
+</Popover>
+```
+
+## When *not* to use
+
+- **Don't use Popover for plain-text hover help.** Use [Tooltip](/docs/components/tooltip) — lighter shape, semantically correct.
+- **Don't use Popover for action menus.** Use [Menu](/docs/components/menu) — handles dismiss-on-action and focus management for menu semantics.
+- **Don't use Popover for required confirmations.** Modal/Dialog flows are for "you must commit"; Popover dismisses on outside click and could be missed.
+- **Don't put navigation inside a Popover.** Popover dismisses easily; nav clicks should reach their target reliably.
+
+## Accessibility
+
+- The trigger receives `aria-haspopup="dialog"` and `aria-expanded` reflecting Popover state.
+- Content panel uses `role="dialog"` with `aria-labelledby` (or `aria-label` if no obvious label).
+- Click outside or `Escape` dismisses (auto).
+- Focus moves into the popover on open with click trigger; stays on trigger with hover trigger.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `children` | `ReactNode` *(required, the trigger)* | — |
+| `content` | `ReactNode` *(required)* | — |
+| `placement` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'bottom'` |
+| `trigger` | `'click' \| 'hover'` | `'click'` |
+| `isOpen` | `boolean` (controlled) | — |
+| `onOpenChange` | `(open: boolean) => void` | — |
+
+Plus standard `<div>` HTML attributes (excluding `content`).
+
+## Related
+
+- [Tooltip](/docs/components/tooltip) — plain-text hover help
+- [Menu](/docs/components/menu) — action menu sibling
+- [Modal](/docs/components/modal) — backdrop-modal alternative
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-overlay-popover--overview)**

--- a/docs-site/content/docs/components/sheet-section.mdx
+++ b/docs-site/content/docs/components/sheet-section.mdx
@@ -1,0 +1,125 @@
+---
+title: Sheet section
+description: Named wrapper for a content block inside a Sheet. Pairs uppercase heading with locked vertical rhythm.
+---
+
+SheetSection is the only structural wrapper you should need inside a [Sheet](/docs/components/sheet) body. Pairs an uppercase section heading with content and locks the spacing between sections. Replaces the ad-hoc flex-column + raw `<h3>` + `detail.sectionHeading` patterns.
+
+## Use it for
+
+- Each logical grouping of fields inside a [Sheet](/docs/components/sheet) body
+- Lead paragraphs at the top of a sheet (heading omitted, description-only)
+- Section breaks between Brand Identity / Color / Typography blocks in a brand sheet
+
+## Import
+
+```tsx
+import { SheetSection } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Heading + content
+
+```tsx
+<SheetSection heading="Color Primitives">
+  <FieldGrid columns={4}>
+    <Field label="Gold">#c49a2f</Field>
+    <Field label="Gray">#b0b0b0</Field>
+    <Field label="White">#ffffff</Field>
+    <Field label="Black">#000000</Field>
+  </FieldGrid>
+</SheetSection>
+```
+
+### Heading + description
+
+```tsx
+<SheetSection
+  heading="Brand Voice"
+  description="Confident, direct, occasionally playful. Never corporate."
+>
+  <Field label="Approved CTAs">
+    <BulletList items={['Book a consultation', 'Start your project']} />
+  </Field>
+</SheetSection>
+```
+
+### Description-only (sheet lead)
+
+When `heading` is omitted, the section renders as an intro paragraph. Use as the first SheetSection inside a sheet to introduce the content.
+
+```tsx
+<SheetSection description="Birdwell & Mutlak presents a bold, editorial identity grounded in legal-industry trust signals." />
+```
+
+### Empty shell
+
+`children` is optional. Use to reserve a slot when content is loading or conditionally rendered.
+
+```tsx
+<SheetSection heading="Activity" spacing="md">
+  {activity.length ? <ActivityList items={activity} /> : <EmptyState title="No activity yet" />}
+</SheetSection>
+```
+
+### Spacing
+
+`spacing="md"` for tighter rhythm in dense sheets; `spacing="lg"` (default) elsewhere.
+
+## Pattern: full sheet layout
+
+The canonical "Brand Identity" sheet — lead description followed by named sections.
+
+```tsx
+<Sheet title="Brand Identity">
+  <SheetSection description="Birdwell & Mutlak presents a bold, editorial identity..." />
+
+  <SheetSection heading="Color Primitives">
+    <FieldGrid columns={4}>
+      <Field label="Gold">#c49a2f</Field>
+      <Field label="Gray">#b0b0b0</Field>
+      <Field label="White">#ffffff</Field>
+      <Field label="Black">#000000</Field>
+    </FieldGrid>
+  </SheetSection>
+
+  <SheetSection heading="Typography">
+    <Table columns={typographyCols} rows={typographyRows} />
+  </SheetSection>
+
+  <SheetSection heading="Mode Recommendations">
+    <Field label="Spacing">Comfortable</Field>
+    <Field label="Density">Relaxed</Field>
+  </SheetSection>
+</Sheet>
+```
+
+## Rules
+
+- **Headings are uppercase labels**, not headings. They read as "this is the label for the block below."
+- **Don't nest SheetSections.** If you need sub-structure, use [Field](/docs/components/field) or [FieldGrid](/docs/components/field-grid) inside one section.
+- **No raw `<h3>` / `<h4>` inside a Sheet body.** Use SheetSection's `heading` prop or [Field](/docs/components/field)'s `label` prop.
+
+## Accessibility
+
+- Renders a `<section>` with the heading as a `<h3>` semantic by default.
+- Uppercase styling is visual only — screen readers receive the original case.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `heading` | `string` | — |
+| `description` | `ReactNode` | — |
+| `children` | `ReactNode` | — |
+| `spacing` | `'md' \| 'lg'` | `'lg'` |
+
+Plus standard `<section>` HTML attributes (excluding `title`).
+
+## Related
+
+- [Sheet](/docs/components/sheet) — parent container
+- [Field](/docs/components/field) / [FieldGrid](/docs/components/field-grid) — common content
+- [Sheet typography](/docs/components/sheet-typography) — modern alternative for inline labels and values
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-sheet-sheet-section--overview)**

--- a/docs-site/content/docs/components/sheet-typography.mdx
+++ b/docs-site/content/docs/components/sheet-typography.mdx
@@ -1,0 +1,173 @@
+---
+title: Sheet typography
+description: Four locked text primitives for Sheet body content. Bind to one tier each — readers can't render a label larger than its section heading.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Sheet typography is **four primitives** for Sheet-context content. Each binds to one typography tier defined in [LAYOUT-CONTEXTS.md](https://github.com/brikdesigns/brik-bds/blob/main/docs/LAYOUT-CONTEXTS.md). Consumers that use these primitives **cannot render a label larger than its section heading** — the common bug this family exists to prevent.
+
+| Primitive | Tier | Use |
+|---|---|---|
+| `<SheetSectionTitle>` | `--heading-sm` | Top of each Sheet body section. Renders as `<h3>` by default. |
+| `<SheetFieldLabel>` | `--label-sm` | Field label. Smaller than the section title (tier rule). |
+| `<SheetFieldValue>` | `--body-md` | Read-mode value display. Auto empty-state handling. |
+| `<SheetHelperText>` | `--label-xs` | Caption / error text. Always smallest tier. |
+
+## Use them for
+
+- Modernizing a Sheet body that still uses the legacy `detail.*` style presets from `@/lib/styles`
+- New Sheet bodies where `<SheetSection heading=...>` + `<Field label=...>` doesn't fit (custom layouts, mixed inline content)
+- Anywhere you need text-tier guarantees beyond what raw HTML provides
+
+For most Sheet bodies, [SheetSection](/docs/components/sheet-section) + [Field](/docs/components/field) is sufficient. Reach for these primitives when you need direct text control inside or alongside those wrappers.
+
+## Import
+
+```tsx
+import {
+  SheetSectionTitle,
+  SheetFieldLabel,
+  SheetFieldValue,
+  SheetHelperText,
+} from '@brikdesigns/bds';
+```
+
+## Tier hierarchy
+
+The four tiers stack from largest to smallest:
+
+```
+SheetSectionTitle    --heading-sm   semibold  primary  no transform
+SheetFieldLabel      --label-sm     semibold  muted    Title Case
+SheetFieldValue      --body-md      regular   primary  preserves whitespace
+SheetHelperText      --label-xs     regular   muted    (or red when tone="error")
+```
+
+The tier order is **non-bypassable** — a `<SheetFieldLabel>` cannot render larger than a `<SheetSectionTitle>` because the tokens lock the sizes.
+
+## SheetSectionTitle
+
+Top of each section. Renders as `<h3>` by default (below the Sheet's own `<h2>` title); pass `level="h2"` / `"h4"` to adjust the outline.
+
+```tsx
+<SheetSectionTitle>CTA Language</SheetSectionTitle>
+
+<SheetSectionTitle level="h4">Tagline variations</SheetSectionTitle>
+```
+
+Distinct from:
+- `<Sheet title="...">` — the top-level sheet title at `--heading-md`
+- `<SheetSection heading="...">` — legacy `--label-sm` uppercase eyebrow treatment; kept for existing consumers but new sheets should use `<SheetSectionTitle>`
+
+## SheetFieldLabel
+
+Label for a single field. Renders as `<label>` when `htmlFor` is provided so screen readers associate it with its input; `<span>` otherwise.
+
+```tsx
+<SheetFieldLabel htmlFor="tagline-input">Tagline</SheetFieldLabel>
+<input id="tagline-input" type="text" />
+```
+
+```tsx
+<SheetFieldLabel>Approved CTAs</SheetFieldLabel>
+<SheetFieldValue>Book a Consultation · Start Your Smile Journey</SheetFieldValue>
+```
+
+## SheetFieldValue
+
+Read-mode display of a field value. Handles empty state automatically — pass `null` or an empty string and the primitive renders the `empty` fallback (defaults to `"Not set"`). Pass `empty={null}` to suppress entirely.
+
+```tsx
+<SheetFieldValue>Brik Designs</SheetFieldValue>
+
+<SheetFieldValue empty="Independent">{value}</SheetFieldValue>
+
+<SheetFieldValue empty={null}>{value}</SheetFieldValue>
+```
+
+## SheetHelperText
+
+Caption or error text under a field. Always the smallest tier so it never competes with the label or value.
+
+```tsx
+<SheetHelperText>Shown under the hero headline on the homepage.</SheetHelperText>
+
+<SheetHelperText tone="error">Required field.</SheetHelperText>
+```
+
+## Composition
+
+Full section using all four primitives:
+
+```tsx
+<SheetSectionTitle>CTA Language</SheetSectionTitle>
+
+<SheetFieldLabel htmlFor="tagline-input">Tagline</SheetFieldLabel>
+<input id="tagline-input" type="text" />
+<SheetHelperText>Shown under the hero headline.</SheetHelperText>
+
+<SheetFieldLabel>Approved CTAs</SheetFieldLabel>
+<SheetFieldValue>Book a Consultation · Start Your Smile Journey</SheetFieldValue>
+
+<SheetFieldLabel>Anti-messages</SheetFieldLabel>
+<SheetFieldValue empty="None defined">{antiMessages}</SheetFieldValue>
+```
+
+## Migration from portal `detail.*` presets
+
+Portal's `src/lib/styles.ts` still exports the legacy `detail.*` style presets (`detail.label`, `detail.value`, `detail.sectionHeading`, `detail.fieldHeading`, `detail.subHeading`, `detail.sectionLabel`). The 2026-Q2 canary audit counted 197 uses of `detail.label` + `detail.value` alone.
+
+Direct replacements:
+
+| Legacy preset | Replacement |
+|---|---|
+| `detail.sectionHeading` | `<SheetSectionTitle>` |
+| `detail.fieldHeading` | `<SheetSectionTitle level="h4">` (or `<SheetFieldLabel>` if it's really a field label, not a subsection) |
+| `detail.label` | `<SheetFieldLabel>` |
+| `detail.value` | `<SheetFieldValue>` |
+| `detail.empty` | `<SheetFieldValue empty="...">` (empty prop instead of separate branch) |
+| `detail.subHeading` | No direct replacement — uppercase eyebrow is retired per the layout-contexts doc; use `<SheetSectionTitle level="h4">` for subsection hierarchy |
+
+Migration is incremental — the portal presets keep working until every consumer has moved.
+
+<Callout type="info">
+  **Tokens used:** `--heading-sm`, `--label-sm`, `--label-xs`, `--body-md` for typography. `--font-family-heading`, `--font-family-label`, `--font-family-body` for families. `--font-weight-semi-bold` / `--font-weight-regular` for weight. `--text-primary` / `--text-muted` / `--text-accent-red` for color. `--font-line-height-snug` / `--font-line-height-tight` / `--font-line-height-normal` for line height.
+</Callout>
+
+## API
+
+### SheetSectionTitle
+
+| Prop | Type | Default |
+|---|---|---|
+| `level` | `'h2' \| 'h3' \| 'h4'` | `'h3'` |
+| `children` | `ReactNode` *(required)* | — |
+
+### SheetFieldLabel
+
+| Prop | Type | Default |
+|---|---|---|
+| `htmlFor` | `string` | — |
+| `children` | `ReactNode` *(required)* | — |
+
+### SheetFieldValue
+
+| Prop | Type | Default |
+|---|---|---|
+| `empty` | `ReactNode \| null` | `'Not set'` |
+| `children` | `ReactNode` | — |
+
+### SheetHelperText
+
+| Prop | Type | Default |
+|---|---|---|
+| `tone` | `'default' \| 'error'` | `'default'` |
+| `children` | `ReactNode` *(required)* | — |
+
+## Related
+
+- [Sheet](/docs/components/sheet) — parent context
+- [SheetSection](/docs/components/sheet-section) — wrapper that uses these primitives internally
+- [Field](/docs/components/field) — high-level label+value primitive (uses these under the hood)
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-sheet-sheet-typography--overview)**

--- a/docs-site/content/docs/components/sheet.mdx
+++ b/docs-site/content/docs/components/sheet.mdx
@@ -1,0 +1,218 @@
+---
+title: Sheet
+description: Sliding panel anchored to a screen edge. Read / edit modes, tabs, secondary action, floating variant.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Sheet is the canonical detail-view panel — slides in from a screen edge for record views, edit workflows, and secondary content that shouldn't replace the current page. Mode-driven footer (Read / Edit) auto-renders the right action set; pass tabs for provenance/history surfaces; pair with [SheetSection](/docs/components/sheet-section) and the [Sheet typography primitives](/docs/components/sheet-typography) for a locked-down body composition.
+
+## Use it for
+
+- Record detail views (company profile, project brief, contact card)
+- Edit workflows that compose multi-section forms
+- Drilldowns from table rows or dashboard tiles
+- Anywhere a [Modal](/docs/components/modal) would feel too interruptive but the content needs more space than a [Popover](/docs/components/popover)
+
+## Import
+
+```tsx
+import { Sheet, SheetSection } from '@brikdesigns/bds';
+```
+
+## Modes
+
+Sheet has two modes that map to the most common UX pattern across the product suite:
+
+- **`read`** — view-only display. Footer (when shown) renders `[Close] [Edit]`.
+- **`edit`** — active form state. Footer renders `[Cancel] [Save]`.
+
+The canonical pattern: open in `read`, click Edit to switch to `edit`, Save / Cancel returns to `read`. Mirrors the renew-pms convention.
+
+```tsx
+import { useState } from 'react';
+
+function CompanySheet() {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<'read' | 'edit'>('read');
+
+  return (
+    <Sheet
+      isOpen={open}
+      onClose={() => setOpen(false)}
+      subtitle="Company"
+      title="Brik Designs"
+      description="Active · Updated 2 days ago"
+      mode={mode}
+      onEdit={() => setMode('edit')}
+      onSave={async () => { await save(); setMode('read'); }}
+      onCancel={() => setMode('read')}
+    >
+      {mode === 'read' ? <ReadOnlyFields /> : <EditFormFields />}
+    </Sheet>
+  );
+}
+```
+
+<Callout type="warn">
+  **Don't put Edit as a button in the body.** Use `mode="read"` + `onEdit` so it surfaces in the auto-footer where users expect primary actions.
+</Callout>
+
+## Header
+
+The header composes four optional pieces:
+
+- **`subtitle`** — uppercase eyebrow above the title (entity type, parent record). Renders in `text-muted`.
+- **`title`** — main heading, rendered as `<h2>`.
+- **`description`** — long-form secondary text below the title (record state, timestamps).
+- **`onBack`** — back button for nested sheet navigation. Pair with your sheet stack controller.
+
+```tsx
+<Sheet
+  subtitle="Strategic Brief"
+  title="Birdwell & Mutlak"
+  description="Draft · Last edited 3 days ago"
+  onBack={popSheet}
+>
+  ...
+</Sheet>
+```
+
+## Sides
+
+- **`right`** (default) — slides from right edge
+- **`left`** — for navigation or sidebar panels
+- **`bottom`** — full-width drawer, mobile-friendly
+
+```tsx
+<Sheet side="bottom">...</Sheet>
+```
+
+## Variants
+
+- **`default`** — full-height overlay with backdrop (forms, edit workflows)
+- **`floating`** — rounded floating panel with elevation, no backdrop (read-only detail views, inline drill-ins from a table row)
+
+```tsx
+<Sheet variant="floating" mode="read" onEdit={...}>...</Sheet>
+```
+
+## Tabs
+
+Tabs render below the header. When `tabs` is supplied, `children` is ignored — each tab supplies its own content. Use for separating Details from Sources / History / Activity.
+
+```tsx
+<Sheet
+  title="Birdwell & Mutlak"
+  tabs={[
+    { id: 'details', label: 'Details', content: <DetailsTab /> },
+    { id: 'sources', label: 'Sources', content: <SourcesTab /> },
+    { id: 'history', label: 'History', content: <HistoryTab /> },
+  ]}
+  activeTab={tab}
+  onTabChange={setTab}
+/>
+```
+
+Keep the first tab's id stable (e.g. `'details'`) — it's the default active tab when `activeTab` is uncontrolled.
+
+## Secondary action
+
+For ancillary actions next to the primary Edit / Save (e.g. *Refresh Brief*, *Run Extraction*), pass `secondaryAction` instead of composing a custom footer.
+
+```tsx
+<Sheet
+  mode="read"
+  onEdit={() => setMode('edit')}
+  secondaryAction={{
+    label: 'Refresh brief',
+    onClick: handleRefresh,
+    iconBefore: <RefreshIcon />,
+  }}
+>
+  ...
+</Sheet>
+```
+
+Behavior:
+
+- **Read mode** — renders `[Secondary] . . . [Close] [Edit]`
+- **Edit mode** — secondary action is suppressed (Save's commit surface stays unambiguous)
+- **Custom `footer`** — wins over `secondaryAction`
+
+## Body composition
+
+Inside a Sheet body, reach for the **sheet primitive set** first. Don't invent ad-hoc markup.
+
+| Primitive | Use for |
+|---|---|
+| [SheetSection](/docs/components/sheet-section) | Named section wrapper. One per logical grouping. |
+| [Field](/docs/components/field) | Label + value pair. |
+| [FieldGrid](/docs/components/field-grid) | 2/3/4-column grid of Fields or Cards. |
+| [TagGroup](/docs/components/tag-group) | Tag clusters inside a Field. |
+| [BulletList](/docs/components/bullet-list) | Short-item lists. |
+| [Card](/docs/components/card) / [CardList](/docs/components/card-list) | Entity rows. |
+| [Table](/docs/components/table) | Tabular data. |
+| [Accordion](/docs/components/accordion) | Collapsible groups when a section has many rows. |
+| [EmptyState](/docs/components/empty-state) | Whole-section "no data" treatment. |
+
+Don't reach for raw `<h3>` / `<table>` / `<ul>` inside a Sheet body — each has a primitive that locks the type scale and spacing. Use the [Sheet typography primitives](/docs/components/sheet-typography) for inline labels and values.
+
+## When to use which treatment
+
+| Scenario | Variant | Footer |
+|---|---|---|
+| Read-only metadata, no CTA | `floating` | none |
+| Read detail with edit capability | `default`, `mode="read"` + `onEdit` | `[Close] [Edit]` (auto) |
+| Active form / edit workflow | `default`, `mode="edit"` + `onSave` | `[Cancel] [Save]` (auto) |
+| Read + ancillary action | `mode="read"` + `onEdit` + `secondaryAction` | `[Refresh] . . . [Close] [Edit]` |
+| Record with provenance / history | any mode + `tabs` | mode-driven |
+| Non-standard action set | any | custom `footer` |
+
+## When *not* to use
+
+- **Don't use Sheet for short confirmations.** Use [Modal preset="confirm"](/docs/components/modal#confirm-preset).
+- **Don't use Sheet without a clear reason to leave the page.** If the content fits inline, render it on the page directly.
+- **Don't nest Sheets visually.** Use `onBack` push-stack navigation — Sheets stack semantically, not visually.
+
+## Accessibility
+
+- Renders `role="dialog"` with `aria-labelledby` linking the title.
+- Focus trap inside the sheet; focus returns to the trigger on close.
+- `Escape` closes (default `closeOnEscape={true}`); backdrop click closes (default `closeOnBackdrop={true}` — no effect on `floating` variant since there's no backdrop).
+- Auto-footer Save button announces `aria-busy` while `saveLoading={true}`.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `isOpen` | `boolean` *(required)* | — |
+| `onClose` | `() => void` *(required)* | — |
+| `children` | `ReactNode` | — |
+| `side` | `'right' \| 'left' \| 'bottom'` | `'right'` |
+| `title` | `ReactNode` | — |
+| `subtitle` | `ReactNode` | — |
+| `description` | `ReactNode` | — |
+| `width` | `string` | `'400px'` |
+| `variant` | `'default' \| 'floating'` | `'default'` |
+| `closeOnBackdrop` | `boolean` | `true` |
+| `closeOnEscape` | `boolean` | `true` |
+| `showCloseButton` | `boolean` | `true` |
+| `onBack` | `() => void` | — |
+| `mode` | `'read' \| 'edit'` | — |
+| `onEdit` / `onSave` / `onCancel` | `() => void` | — |
+| `editLabel` / `saveLabel` / `cancelLabel` / `closeLabel` | `string` | label defaults |
+| `saveDisabled` / `saveLoading` | `boolean` | `false` |
+| `footer` | `ReactNode` (overrides auto-footer) | — |
+| `secondaryAction` | `SheetSecondaryAction` | — |
+| `tabs` | `SheetTab[]` | — |
+| `activeTab` | `string` (controlled) | first tab id |
+| `onTabChange` | `(tabId: string) => void` | — |
+
+## Related
+
+- [SheetSection](/docs/components/sheet-section) — body section wrapper
+- [Sheet typography](/docs/components/sheet-typography) — locked text primitives for sheet bodies
+- [Modal](/docs/components/modal) — interrupting-overlay alternative
+- [Popover](/docs/components/popover) — anchored-floating alternative
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-sheet-sheet--overview)**


### PR DESCRIPTION
## Summary

Second sub-batch of the **Displays** migration. **Overlays** (Modal, Dialog, Popover) plus the **Sheets** primitive set (Sheet, SheetSection, SheetTypography).

| Page | Notes |
|---|---|
| [\`modal\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-rest/docs-site/content/docs/components/modal.mdx) | Portal-rendered dialog overlay. Five sizes + \`preset="confirm"\` replacing the legacy Dialog. |
| [\`dialog\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-rest/docs-site/content/docs/components/dialog.mdx) | Minimal deprecation page — migration table to Modal preset. Mirrors the AlertBanner→Banner pattern. |
| [\`popover\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-rest/docs-site/content/docs/components/popover.mdx) | Floating content panel anchored to a trigger. Click or hover, four placements. |
| [\`sheet\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-rest/docs-site/content/docs/components/sheet.mdx) | The canonical detail-view panel. Read/edit modes, tabs, secondary action, floating variant, body composition rules. |
| [\`sheet-section\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-rest/docs-site/content/docs/components/sheet-section.mdx) | Named wrapper for Sheet body content. Locks vertical rhythm. |
| [\`sheet-typography\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-displays-rest/docs-site/content/docs/components/sheet-typography.mdx) | Four locked text primitives. Migration table from portal's \`detail.*\` legacy presets (197 uses to migrate). |

After this lands: **95 docs-site routes**, **66 component pages**.

## State of the migration

| Group | Status |
|---|---|
| Action / Indicator / Form / Feedback / Control / Addable / Structure / Navigation | 55/55 ✅ |
| Displays / Card family | 5/5 ✅ |
| **Displays / Overlays + Sheets** | **6/6 ✅ (this PR)** |
| Displays / Table | 0/1 |
| Displays / Board, Calendar, ActivityTimeline, DataSection, Meter, NotificationList | 0/6 |
| Misc cleanup (Avatar, Icons, Footer, PageHeader, BulletList, TaskConsole) | 0/6 |

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds
- [ ] \`/docs/components\` shows two new sub-grids — Overlays + Sheets
- [ ] \`/docs/components/dialog\` opens with the prominent deprecation \`<Callout type="error">\`
- [ ] \`/docs/components/sheet\` — read/edit mode pattern + body composition table render correctly
- [ ] \`/docs/components/sheet-typography\` — tier hierarchy table + migration table from \`detail.*\` legacy presets are accurate
- [ ] All Storybook deep-links resolve

## Heads-up

The **Sheet typography migration table** is the most opinionated piece. It documents the canonical replacement for portal's `detail.*` style presets (which the 2026-Q2 audit counted at 197 uses for `detail.label` + `detail.value` alone). If the team's mental model for that migration is different, flag and I'll revise.

## Out of scope (next sub-batches)

After this merges, remaining Displays work:

1. **Table + Board + Calendar + ActivityTimeline + DataSection + Meter + NotificationList** — the data-display surfaces. Will inventory and split appropriately. NotificationList has no MDX (write fresh from .tsx).
2. **Misc cleanup** — Avatar (Foundations/Assets), Icons (Foundations/Assets), Footer (Navigation/Primary), PageHeader (Navigation/Secondary), BulletList (Components/List), TaskConsole (Components/Feedback). These have proper homes already; just need pages.

Plus the deferred:
- Motion foundation port
- Remaining Industry packs / Voices / Atmospheres
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)