### PR TITLE
feat(docs-site): migrate Data Displays sub-batch (7 components)

### DIFF
--- a/docs-site/content/docs/components/activity-timeline.mdx
+++ b/docs-site/content/docs/components/activity-timeline.mdx
@@ -1,0 +1,79 @@
+---
+title: Activity timeline
+description: Vertical chronological list of events. Top-to-bottom newest-first display for activity feeds.
+---
+
+ActivityTimeline renders a chronological list of events as a vertical timeline — activity feeds, audit logs, change history. Each event is rendered top-to-bottom in chronological order (newest first by convention).
+
+## Use it for
+
+- Activity feeds on user / company / project records
+- Audit logs of state changes
+- Change history (e.g. "Status changed from Pending to Active")
+- Comment threads with timestamps
+
+For non-chronological grouped items, use [Board](/docs/components/board). For tabular activity, use [Table](/docs/components/table).
+
+## Import
+
+```tsx
+import { ActivityTimeline } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { ActivityTimeline } from '@brikdesigns/bds';
+
+const events = [
+  {
+    id: '1',
+    timestamp: '2 minutes ago',
+    actor: 'Sarah Chen',
+    action: 'updated',
+    target: 'Brand Identity',
+  },
+  {
+    id: '2',
+    timestamp: '1 hour ago',
+    actor: 'Marcus Lee',
+    action: 'commented on',
+    target: 'Project Brief',
+  },
+  // ...
+];
+
+<ActivityTimeline events={events} />
+```
+
+### Custom event content
+
+The exact fields and rendering of each event are determined by the `TimelineEvent` shape. Pass any structure your data layer provides.
+
+## When *not* to use
+
+- **Don't use ActivityTimeline for short lists** (≤3 events) — a plain list reads more cleanly without the timeline marker.
+- **Don't use ActivityTimeline for unstructured comments.** A comment thread with replies and reactions is its own pattern; timeline is for atomic events.
+- **Don't use ActivityTimeline as a feed of unrelated content.** Each event should share an actor + action + target shape.
+
+## Accessibility
+
+- Renders an `<ol>` with each event as `<li>` — semantically a chronological list.
+- Each event's timestamp uses `<time>` for proper screen reader announcement.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `events` | `TimelineEvent[]` *(required)* | — |
+| `className` | `string` | — |
+
+The `TimelineEvent` shape is defined alongside the component — typically `{ id, timestamp, actor, action, target }` with optional metadata fields.
+
+## Related
+
+- [Board](/docs/components/board) — non-chronological grouped alternative
+- [Table](/docs/components/table) — tabular activity log
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-timeline-activity-timeline--overview)**

--- a/docs-site/content/docs/components/board.mdx
+++ b/docs-site/content/docs/components/board.mdx
@@ -1,0 +1,192 @@
+---
+title: Board
+description: Kanban-style board layout. Horizontal columns of grouped items with avatar + progress.
+---
+
+Board is a composite layout for displaying grouped items in horizontal columns — task management, staff overviews, any workflow that benefits from a column-based view. It composes existing BDS primitives ([Avatar](/docs/components/avatar), [ProgressBar](/docs/components/progress-bar)) into a reusable layout pattern without introducing new visual atoms.
+
+## Use it for
+
+- Task / project boards (To do / In progress / Done)
+- Staff schedule overviews (per-shift availability)
+- Pipeline views (Lead / Qualified / Proposal / Won)
+- Status-based workflows where horizontal columns map to states
+
+For row-based data, use [Table](/docs/components/table). For card grids without column groupings, use [CardList](/docs/components/card-list) `orientation="horizontal"`.
+
+## Import
+
+```tsx
+import { Board, BoardColumn, BoardHeader } from '@brikdesigns/bds';
+```
+
+## Anatomy
+
+Three composable components:
+
+| Component | Role |
+|---|---|
+| `Board` | Outer horizontal-scroll container. |
+| `BoardColumn` | Vertical lane with title, count, and item stack. |
+| `BoardHeader` | Card with avatar / name / subtitle / optional progress. Composes Avatar + ProgressBar. |
+
+## Variants
+
+### Default
+
+```tsx
+<Board>
+  <BoardColumn title="Opening" count={2}>
+    <BoardHeader
+      name="Cassidy Moore"
+      subtitle="Dental Hygienist"
+      avatarSrc="/cassidy.jpg"
+      progress={37}
+    />
+    <BoardHeader
+      name="Alex Rivera"
+      subtitle="Receptionist"
+      progress={62}
+    />
+  </BoardColumn>
+
+  <BoardColumn title="Mid-shift" count={3}>
+    {/* ... */}
+  </BoardColumn>
+
+  <BoardColumn title="Closing" count={1}>
+    {/* ... */}
+  </BoardColumn>
+</Board>
+```
+
+### Single column
+
+A board can render a single column for focused views.
+
+```tsx
+<Board>
+  <BoardColumn title="Today's roster" count={5}>
+    <BoardHeader name="..." />
+    <BoardHeader name="..." />
+  </BoardColumn>
+</Board>
+```
+
+### Avatar fallback
+
+`BoardHeader` accepts an `avatarSrc` prop. When omitted, [Avatar](/docs/components/avatar) falls back to initials generated from the `name`.
+
+```tsx
+<BoardHeader name="Cassidy Moore" subtitle="Hygienist" />
+{/* Avatar shows "CM" */}
+
+<BoardHeader name="Alex Rivera" subtitle="Receptionist" avatarSrc="/alex.jpg" />
+{/* Avatar shows the photo */}
+```
+
+### Empty column
+
+Columns gracefully handle zero items.
+
+```tsx
+<BoardColumn title="Closing" count={0}>
+  {/* No headers — column renders the title and an empty state */}
+</BoardColumn>
+```
+
+### Header actions
+
+`BoardColumn` accepts `headerAction` for buttons or menus in the column header (typically an "+ Add" or overflow menu).
+
+```tsx
+<BoardColumn
+  title="Opening"
+  count={2}
+  headerAction={<IconButton icon={<PlusIcon />} label="Add to Opening" size="sm" variant="ghost" />}
+>
+  ...
+</BoardColumn>
+```
+
+### Children inside BoardHeader
+
+`BoardHeader` accepts children for additional per-card content (badges, action buttons, task counts).
+
+```tsx
+<BoardHeader name="Cassidy Moore" subtitle="Hygienist" progress={37}>
+  <Badge size="sm" status="warning">Late start</Badge>
+</BoardHeader>
+```
+
+## Design decisions
+
+- **Horizontal scroll** — `scroll-snap-type: x proximity` snaps to column boundaries on mobile and trackpad.
+- **Flexible columns** — Each column flexes between `280px` min and `400px` max — responsive without media queries.
+- **Avatar size** locked to `lg` (48px) per the Figma spec.
+- **Progress bar alignment** — left-padded past the avatar width so the bar visually aligns with text, not avatar.
+
+## When *not* to use
+
+- **Don't use Board for tabular data.** Use [Table](/docs/components/table).
+- **Don't use Board with >5 columns.** Horizontal scroll with 6+ columns becomes unusable on most screens. Split into multiple boards or switch to a list view.
+- **Don't use BoardHeader for non-person entities** without considering the avatar's semantics. Avatar fallback uses initials of the `name` — fine for people, awkward for "Project Alpha."
+
+## Accessibility
+
+- Board renders a `<div role="region">` with `aria-label` describing the board.
+- Each `BoardColumn` is a `<section>` with the title as a heading.
+- `BoardHeader` cards are real `<div>`s — wrap in `<a>` or pass `onClick` to make them interactive.
+- Progress bars carry `aria-valuenow` for screen-reader announcement.
+
+## API
+
+### Board
+
+| Prop | Type | Default |
+|---|---|---|
+| `children` | `ReactNode` (BoardColumns) *(required)* | — |
+
+### BoardColumn
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `string` *(required)* | — |
+| `count` | `number` | — |
+| `headerAction` | `ReactNode` | — |
+| `children` | `ReactNode` (BoardHeaders) | — |
+
+### BoardHeader
+
+| Prop | Type | Default |
+|---|---|---|
+| `name` | `string` *(required)* | — |
+| `subtitle` | `string` | — |
+| `avatarSrc` | `string` | — |
+| `progress` | `number` (0–100) | — |
+| `progressLabel` | `string` (a11y) | — |
+| `children` | `ReactNode` | — |
+
+## CSS Override API
+
+| Variable | Default | Controls |
+|---|---|---|
+| `--bds-board-card-accent` | `var(--border-primary)` | Left border accent per card |
+| `--board-card-hover-translate-y` | `-1px` | Upward lift on card hover |
+
+```css
+.priority-column .bds-board-card {
+  --bds-board-card-accent: var(--background-status-error);
+}
+
+.compact-board {
+  --board-card-hover-translate-y: 0;
+}
+```
+
+## Related
+
+- [Avatar](/docs/components/avatar) — used inside BoardHeader
+- [ProgressBar](/docs/components/progress-bar) — used inside BoardHeader
+- [Table](/docs/components/table) — row-based alternative
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-board-board--overview)**

--- a/docs-site/content/docs/components/calendar.mdx
+++ b/docs-site/content/docs/components/calendar.mdx
@@ -1,0 +1,33 @@
+---
+title: Calendar
+description: Date-based display for scheduling and event views. Currently in development.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+<Callout type="warn">
+  **Calendar is a work-in-progress placeholder.** The component is not yet implemented in BDS — only the directory + skeleton stories exist. New code should not depend on Calendar's API; it will change before stable release.
+</Callout>
+
+Calendar is reserved for date-based display surfaces — month / week / day views, event grids, scheduling overlays. Tracking placeholder so consumers don't reach for raw HTML calendar implementations while the proper component is being designed.
+
+## Until Calendar ships
+
+For date *picking*, use [DatePicker](/docs/components/date-picker) — it's implemented and stable.
+
+For event lists chronologically, use [ActivityTimeline](/docs/components/activity-timeline) (implemented).
+
+For board-style scheduling (per-shift staff coverage), use [Board](/docs/components/board).
+
+## Status
+
+| Status | Notes |
+|---|---|
+| **WIP** | Component not implemented — placeholder only. |
+
+## Related
+
+- [DatePicker](/docs/components/date-picker) — for date picking
+- [ActivityTimeline](/docs/components/activity-timeline) — chronological events
+- [Board](/docs/components/board) — column-based scheduling
+- **[Storybook placeholder](https://storybook.brikdesigns.com/?path=/docs/displays-calendar-calendar--overview)**

--- a/docs-site/content/docs/components/data-section.mdx
+++ b/docs-site/content/docs/components/data-section.mdx
@@ -1,0 +1,170 @@
+---
+title: Data section
+description: Page-side wrapper for a titled block of read-mode data. Pairs heading + subtitle + actions slot.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+DataSection is the page analog to [SheetSection](/docs/components/sheet-section). Where SheetSection uses an uppercase label heading appropriate inside a sheet, **DataSection uses a real section title in the page outline**. Pairs a heading-tier title with optional subtitle + actions slot (typically a `[View]/[Edit]` toggle), then yields the body to whatever composes inside — usually a `<FieldGrid>` of `<Field>`s.
+
+## Use it for
+
+- Read-mode page sections on detail views (Identity / Brand / Services / Locations on a company page)
+- Settings page sections with a per-section View/Edit toggle
+- Any page-level grouping where the section title is part of the page outline
+
+For Sheet body sections, use [SheetSection](/docs/components/sheet-section). For tabular data inside a section, compose a [Table](/docs/components/table) inside DataSection's body.
+
+## Import
+
+```tsx
+import { DataSection } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Title only
+
+```tsx
+<DataSection title="Identity">
+  <FieldGrid columns={2}>
+    <Field label="Business Name">Brik Designs</Field>
+    <Field label="Industry">Design Services</Field>
+  </FieldGrid>
+</DataSection>
+```
+
+### Title + subtitle
+
+```tsx
+<DataSection
+  title="Brand Voice"
+  subtitle="Confident, direct, occasionally playful. Never corporate."
+>
+  <Field label="Approved CTAs">
+    <BulletList items={['Book a consultation', 'Start your project']} />
+  </Field>
+</DataSection>
+```
+
+### With actions
+
+The canonical Read-Mode Page composition — each section has a `[View] [Edit]` button group in the actions slot.
+
+```tsx
+<DataSection
+  title="Identity"
+  actions={
+    <ButtonGroup>
+      <Button size="sm" variant="secondary" onClick={openInViewMode}>View</Button>
+      <Button size="sm" variant="secondary" onClick={openInEditMode}>Edit</Button>
+    </ButtonGroup>
+  }
+>
+  <FieldGrid columns={2}>
+    <Field label="Business Name">{client.name}</Field>
+    <Field label="Industry">{client.industry}</Field>
+    <Field label="Care Philosophy">
+      <p>{client.carePhilosophy}</p>
+    </Field>
+    <Field label="Secondary Categories">
+      <BulletList items={client.secondaryCategories} />
+    </Field>
+  </FieldGrid>
+</DataSection>
+```
+
+### Single-button actions
+
+```tsx
+<DataSection
+  title="Linked Accounts"
+  actions={<Button size="sm" variant="primary">Connect</Button>}
+>
+  ...
+</DataSection>
+```
+
+### Title element override
+
+Default `title` renders as `<h2>` — the common case is one DataSection sibling of the page's `<h1>`. Use `titleAs="h3"` only when nested under an existing `<h2>`.
+
+```tsx
+<DataSection title="Service line health" titleAs="h3">
+  ...
+</DataSection>
+```
+
+## Pattern: read-mode page
+
+Consecutive DataSections show a divider automatically — the sibling combinator handles it. Don't place a `<Divider />` between DataSections manually.
+
+```tsx
+<DataSection title="Identity" actions={<ViewEditToggle ... />}>
+  <FieldGrid columns={2}>
+    <Field label="Business Name">{client.name}</Field>
+    <Field label="Industry">{client.industry}</Field>
+  </FieldGrid>
+</DataSection>
+
+<DataSection title="Locations" actions={<ViewEditToggle ... />}>
+  <FieldGrid columns={3}>
+    {locations.map((l) => <Field key={l.id} label={l.name}>{l.address}</Field>)}
+  </FieldGrid>
+</DataSection>
+
+<DataSection title="Services" actions={<ViewEditToggle ... />}>
+  <FieldGrid columns={2}>
+    <Field label="Care Philosophy">
+      <p>{client.carePhilosophy}</p>
+    </Field>
+    <Field label="Secondary Categories">
+      <BulletList items={client.secondaryCategories} />
+    </Field>
+  </FieldGrid>
+</DataSection>
+```
+
+## Rules
+
+<Callout type="warn">
+  **Don't use DataSection inside a Sheet.** Use [SheetSection](/docs/components/sheet-section) there — the two are siblings, not substitutes. DataSection's title is part of the page outline; SheetSection's heading is an uppercase label inside the sheet.
+</Callout>
+
+- **`title` is a real heading.** Default `<h2>`. It IS part of the page outline. Use `titleAs="h3"` only when nested under an `<h2>`.
+- **Title ≠ heading.** The BEM class is `__title` (role); the HTML element (`h2` / `h3`) is picked by outline position, not by the class name.
+- **`actions` is a slot, not a label.** Put a `<ButtonGroup>` or `<Button>` in it.
+- **Don't nest DataSection inside DataSection.** Use [Field](/docs/components/field) or [FieldGrid](/docs/components/field-grid) inside one section instead.
+- **Empty per-field content is a Field concern.** [Field](/docs/components/field) renders "Not set" inline when its children are empty — don't hand-roll a placeholder inside DataSection.
+
+## When *not* to use
+
+- **Don't use DataSection for non-page-level sections** — the heading is part of the page outline; misuse pollutes the outline.
+- **Don't use DataSection without a title.** The component's job is "titled section" — if you need a wrapper without title semantics, use a plain `<section>` or [Card](/docs/components/card).
+
+## Accessibility
+
+- Renders a `<section>` with the title as `<h2>` (or `<h3>`) — proper landmark + outline.
+- Subtitle renders as a `<p>` directly below the heading.
+- Actions slot keeps its own semantics (Button is a button, link is a link).
+- Auto-divider between consecutive sections is `border-top: var(--border-width-sm) solid var(--border-muted)` — visual only, not announced.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `string` | — |
+| `subtitle` | `ReactNode` | — |
+| `actions` | `ReactNode` | — |
+| `children` | `ReactNode` | — |
+| `spacing` | `'md' \| 'lg'` | `'lg'` |
+| `titleAs` | `'h2' \| 'h3'` | `'h2'` |
+
+Plus standard `<section>` HTML attributes (excluding `title`).
+
+## Related
+
+- [SheetSection](/docs/components/sheet-section) — Sheet-context sibling
+- [Field](/docs/components/field) / [FieldGrid](/docs/components/field-grid) — common content
+- [ButtonGroup](/docs/components/button-group) — for the actions slot
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-data-data-section--overview)**

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -168,9 +168,23 @@ Sliding-panel detail views with the SheetSection wrapper and four locked typogra
   <Card title="Sheet typography" href="/docs/components/sheet-typography" description="Four locked text primitives — SectionTitle, FieldLabel, FieldValue, HelperText." />
 </Cards>
 
+### Data displays
+
+Tables, kanban boards, calendars, timelines, gauges, and notification lists. The Displays / Data + Displays / Charts surfaces.
+
+<Cards>
+  <Card title="Table" href="/docs/components/table" description="Data table with composable subcomponents. Sorting, selection, striped rows. Cell pattern standards for buttons + links + tooltips." />
+  <Card title="Data section" href="/docs/components/data-section" description="Page-side wrapper with title + subtitle + actions slot. The page analog to SheetSection." />
+  <Card title="Board" href="/docs/components/board" description="Kanban board layout — horizontal columns of grouped items with avatar + progress." />
+  <Card title="Calendar" href="/docs/components/calendar" description="Date-based display. WIP placeholder — not yet implemented." />
+  <Card title="Activity timeline" href="/docs/components/activity-timeline" description="Vertical chronological list of events. Activity feeds, audit logs." />
+  <Card title="Meter" href="/docs/components/meter" description="Visual gauge for a value within a known range. Status colors, three sizes." />
+  <Card title="Notification list" href="/docs/components/notification-list" description="Vertical list of clickable notification items with empty state." />
+</Cards>
+
 ## Still in Storybook
 
-The remaining components haven't migrated yet. Until they land here, [Storybook → Components](https://storybook.brikdesigns.com/?path=/docs/overview-welcome--overview) is the canonical reference for **Card family** (CardControl, CardList, CardTestimonial, CollapsibleCard, PricingCard), **Navigation** (TabBar, Breadcrumb, SidebarNavigation, Menu), and **Displays** sub-categories (Cards, Overlays, Notifications, Sheets, Table, Timeline, Calendar, Board, Charts).
+The remaining ~6 components haven't migrated yet — Avatar, Icons (Foundations/Assets), Footer, PageHeader (Navigation), BulletList (Components/List), and TaskConsole (Components/Feedback). They live in different categories than Displays and will land in a final misc cleanup PR.
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -79,6 +79,14 @@
     "---Sheets---",
     "sheet",
     "sheet-section",
-    "sheet-typography"
+    "sheet-typography",
+    "---Data displays---",
+    "table",
+    "data-section",
+    "board",
+    "calendar",
+    "activity-timeline",
+    "meter",
+    "notification-list"
   ]
 }

--- a/docs-site/content/docs/components/meter.mdx
+++ b/docs-site/content/docs/components/meter.mdx
@@ -1,0 +1,116 @@
+---
+title: Meter
+description: Visual gauge for a value within a known range. Status colors, three sizes, label position.
+---
+
+Meter is a gauge primitive — a value within a known range, rendered as a horizontal bar with status color and optional label. Use for scores, completion rates, performance metrics, and health indicators.
+
+## Use it for
+
+- Score displays (compliance score, health score)
+- Performance metrics (page-speed, contrast ratio)
+- Completion percentages on multi-criteria evaluations
+- Health indicators (battery, capacity)
+
+For task progress that updates over time, use [ProgressBar](/docs/components/progress-bar) — it's percent-only and process-oriented; Meter is value-within-range and judgment-oriented.
+
+## Import
+
+```tsx
+import { Meter } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Status colors
+
+Four status colors map to fill colors via system tokens.
+
+```tsx
+<Meter value={6} max={7} status="positive" label="Pass" />
+<Meter value={4} max={7} status="warning" label="Fair" />
+<Meter value={2} max={7} status="error" label="Fail" />
+<Meter value={5} max={7} status="neutral" />
+```
+
+| Status | Use |
+|---|---|
+| `positive` | Meets threshold (green) |
+| `warning` | Borderline value (yellow) |
+| `error` | Below acceptable range (red) |
+| `neutral` | No judgment applied (gray) |
+
+### Sizes
+
+Three sizes for different layout contexts.
+
+| Size | Bar height | Use |
+|---|---|---|
+| `sm` | 8px | Compact metric strips |
+| `md` (default) | 12px | Standard cards and rows |
+| `lg` | 16px | Prominent dashboard tiles |
+
+### Label position
+
+`above` or `below` (default).
+
+```tsx
+<Meter value={82} max={100} label="Score" labelPosition="above" />
+<Meter value={82} max={100} label="Score" labelPosition="below" />
+```
+
+### Custom value formatter
+
+By default, Meter renders the value as `{value}/{max}`. Use `valueFormatter` to format differently — percentages, currency, custom strings.
+
+```tsx
+<Meter
+  value={0.73}
+  max={1}
+  status="warning"
+  label="Completion"
+  valueFormatter={(v) => `${Math.round(v * 100)}%`}
+/>
+```
+
+### Without value label
+
+Set `showValue={false}` to hide the displayed value.
+
+```tsx
+<Meter value={45} max={100} status="warning" showValue={false} />
+```
+
+## When *not* to use
+
+- **Don't use Meter for measurable task progress.** Use [ProgressBar](/docs/components/progress-bar) — process-oriented (percent done) reads differently from judgment-oriented (value-within-range).
+- **Don't use Meter for binary states.** Active/inactive is a [Badge](/docs/components/badge); on/off is a [Switch](/docs/components/switch).
+- **Don't use Meter for time-series data.** It's a single-value gauge — for trends use a chart.
+
+## Accessibility
+
+- Renders a `<div role="meter">` with `aria-valuenow`, `aria-valuemin="0"`, `aria-valuemax`.
+- The label (when provided) becomes the accessible name via `aria-labelledby`.
+- Status is communicated via color and via the label/value text — never color alone.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `value` | `number` *(required)* | — |
+| `max` | `number` *(required)* | — |
+| `status` | `'positive' \| 'warning' \| 'error' \| 'neutral'` | `'neutral'` |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
+| `label` | `string` | — |
+| `showValue` | `boolean` | `true` |
+| `valueFormatter` | `(value: number, max: number) => string` | renders as `{value}/{max}` |
+| `labelPosition` | `'above' \| 'below'` | `'below'` |
+
+Plus standard `<div>` HTML attributes (excluding `children`).
+
+## Related
+
+- [ProgressBar](/docs/components/progress-bar) — task-progress sibling
+- [Badge](/docs/components/badge) — discrete status
+- [Counter](/docs/components/counter) — discrete numeric
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-charts-meter--overview)**

--- a/docs-site/content/docs/components/notification-list.mdx
+++ b/docs-site/content/docs/components/notification-list.mdx
@@ -1,0 +1,124 @@
+---
+title: Notification list
+description: Vertical list of clickable notification items with empty state.
+---
+
+NotificationList renders a stack of notification entries — for in-app inbox panels, header dropdowns, and notification centers. Each item is clickable; the consumer owns the click handling.
+
+## Use it for
+
+- Header notification dropdown ("3 unread" → click bell → list)
+- Dedicated notification center pages
+- Per-record activity inboxes
+- Any vertical list of clickable status items with empty state
+
+For chronological activity feeds, use [ActivityTimeline](/docs/components/activity-timeline). For floating temporary notifications, use [Toast](/docs/components/toast). For persistent alert banners, use [Banner](/docs/components/banner).
+
+## Import
+
+```tsx
+import { NotificationList } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+```tsx
+import { NotificationList } from '@brikdesigns/bds';
+
+const notifications = [
+  { id: '1', title: 'New comment on Project Alpha', timestamp: '2m ago', read: false },
+  { id: '2', title: 'Brand brief approved', timestamp: '1h ago', read: false },
+  { id: '3', title: 'Welcome to Brik', timestamp: '2d ago', read: true },
+];
+
+<NotificationList
+  notifications={notifications}
+  onItemClick={(notification) => navigate(notification.url)}
+/>
+```
+
+### Empty state
+
+Pass `emptyMessage` to customize the empty fallback. When `notifications` is empty, the list renders the message in place of the item stack.
+
+```tsx
+<NotificationList
+  notifications={[]}
+  emptyMessage="You're all caught up — no new notifications."
+/>
+```
+
+### Custom click handling
+
+The `onItemClick` callback receives the full notification item. The consumer decides what to do — navigate, mark read, dismiss, etc.
+
+```tsx
+<NotificationList
+  notifications={notifications}
+  onItemClick={(item) => {
+    markAsRead(item.id);
+    navigate(item.url);
+  }}
+/>
+```
+
+## Pattern: dropdown panel
+
+The canonical header-bell pattern. Pair NotificationList inside a [Popover](/docs/components/popover) or floating [Sheet](/docs/components/sheet) `variant="floating"`.
+
+```tsx
+import { useState } from 'react';
+import { Popover, IconButton, NotificationList, Counter } from '@brikdesigns/bds';
+
+const [open, setOpen] = useState(false);
+const unreadCount = notifications.filter((n) => !n.read).length;
+
+<Popover
+  isOpen={open}
+  onOpenChange={setOpen}
+  content={
+    <NotificationList
+      notifications={notifications}
+      onItemClick={handleClick}
+      emptyMessage="No notifications"
+    />
+  }
+>
+  <IconButton icon={<BellIcon />} label="Notifications">
+    {unreadCount > 0 && <Counter count={unreadCount} status="brand" size="xs" />}
+  </IconButton>
+</Popover>
+```
+
+## When *not* to use
+
+- **Don't use NotificationList for ephemeral toasts.** Use [Toast](/docs/components/toast) — temporary, auto-dismiss.
+- **Don't use NotificationList for chronological activity feeds.** Use [ActivityTimeline](/docs/components/activity-timeline) — explicitly time-ordered with timestamps as a primary affordance.
+- **Don't use NotificationList for persistent alerts.** Use [Banner](/docs/components/banner) for site-wide notices.
+
+## Accessibility
+
+- Renders an `<ul>` with each notification as a clickable `<li>`.
+- Each item has a focus ring and Enter/Space activation when interactive.
+- Empty state is rendered as plain text — no special semantics.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `notifications` | `NotificationItemData[]` *(required)* | — |
+| `onItemClick` | `(notification: NotificationItemData) => void` | — |
+| `emptyMessage` | `string` | `'No notifications'` |
+| `className` | `string` | — |
+
+The `NotificationItemData` shape is defined alongside the component — typically `{ id, title, timestamp, read }` plus consumer-specific metadata.
+
+## Related
+
+- [Toast](/docs/components/toast) — ephemeral sibling
+- [Banner](/docs/components/banner) — persistent-alert sibling
+- [ActivityTimeline](/docs/components/activity-timeline) — chronological alternative
+- [Popover](/docs/components/popover) — common parent for the bell-dropdown pattern
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-notifications-notification-list--overview)**

--- a/docs-site/content/docs/components/table.mdx
+++ b/docs-site/content/docs/components/table.mdx
@@ -1,0 +1,211 @@
+---
+title: Table
+description: Data table with composable subcomponents. Sorting, selection, striped rows, size variants.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Table is a composable data-display primitive. The container plus six subcomponents (`TableHeader`, `TableBody`, `TableRow`, `TableHead`, `TableCell`) handle the structural HTML; the consumer composes cells with whatever content the row needs — text, badges, links, action buttons.
+
+## Use it for
+
+- Tabular records with consistent columns (users, projects, invoices)
+- Sortable lists where the user picks a column to order by
+- Comparison tables on settings or pricing pages
+- Any "rows of structured data" where columns share semantics across rows
+
+For card-like rows where each entry is its own self-contained block, use [CardList](/docs/components/card-list). For settings panels with action-per-row, use [CardControl](/docs/components/card-control).
+
+## Import
+
+```tsx
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Sizes
+
+```tsx
+<Table size="default">...</Table>      {/* compact, dense data */}
+<Table size="comfortable">...</Table>  {/* generous padding, 72px cell height */}
+```
+
+### Striped
+
+Alternating row backgrounds for readability on dense tables.
+
+```tsx
+<Table striped>...</Table>
+```
+
+### Flush
+
+`flush` removes the left padding on the first cell and right padding on the last — use when the table aligns to a container's edge with no internal padding.
+
+```tsx
+<Table flush>...</Table>
+```
+
+### Sortable headers
+
+`TableHead` accepts `sortable` and `sortDirection`. The consumer owns the click handler and sort state.
+
+```tsx
+<TableHead sortable sortDirection="asc" onClick={() => sortBy('name')}>
+  Name
+</TableHead>
+```
+
+### Selected rows
+
+`TableRow` accepts a `selected` boolean for highlight styling.
+
+```tsx
+<TableRow selected>
+  <TableCell>Active row</TableCell>
+</TableRow>
+```
+
+## Cell pattern standards
+
+These patterns recur often enough to standardize. Don't reach for raw `<a>` or `<button>` inside a TableCell — use the BDS components below.
+
+### Action buttons
+
+Use **`size="sm"`** for all buttons inside cells.
+
+```tsx
+{/* Text button */}
+<Button variant="primary" size="sm">View</Button>
+
+{/* Icon buttons — always IconButton, never raw <button> */}
+<IconButton variant="primary" size="sm" icon={<EditIcon />} label="Edit" />
+<IconButton variant="danger" size="sm" icon={<TrashIcon />} label="Delete" />
+```
+
+Common icon-button variants for table actions:
+
+| Variant | Use |
+|---|---|
+| `primary` | Primary action (edit, open) |
+| `secondary` | Neutral (download, copy) |
+| `ghost` | Low emphasis (overflow menu) |
+| `danger` | Destructive (delete, remove) |
+
+### Text links
+
+Use **`<TextLink size="small">`** for in-cell navigation. Never use raw `<a>` or full-size text links.
+
+```tsx
+<TextLink href="/profile/123" size="small">View profile</TextLink>
+
+<TextLink href="#" size="small" iconAfter={<ExternalLinkIcon />}>
+  Open
+</TextLink>
+```
+
+**Text link vs button:**
+
+- **TextLink** — navigation that takes you somewhere (View profile, Open document)
+- **Button** — actions that change state (Approve, Assign, Archive)
+
+### Tooltip indicators
+
+Wrap info icons in a [Tooltip](/docs/components/tooltip) so they reveal context on hover/focus. Use `cursor: help` to signal interactivity.
+
+```tsx
+<Tooltip content="Primary contact email" placement="top">
+  <span style={{ cursor: 'help' }}>
+    <Icon icon="ph:info" />
+  </span>
+</Tooltip>
+```
+
+### Icon-left cells
+
+Pair a 24px icon with text using `gap: var(--gap-xs)`.
+
+```tsx
+<span style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-xs)' }}>
+  <Icon icon="ph:palette" />
+  Design
+</span>
+```
+
+## When *not* to use
+
+- **Don't use Table for self-contained card grids.** Cards belong in [CardList](/docs/components/card-list).
+- **Don't use Table for settings rows.** Use [CardControl](/docs/components/card-control) — locked layout for badge + title + description + action.
+- **Don't use Table for narrow mobile views.** Tables don't gracefully wrap; consider a card-list layout for mobile-first data.
+
+## Accessibility
+
+- Renders real `<table>` / `<thead>` / `<tbody>` / `<tr>` / `<th>` / `<td>` — semantics are platform-native.
+- Sortable headers carry `aria-sort` reflecting the current sort direction.
+- Selected rows use `aria-selected`.
+- Action buttons in cells are real buttons — keyboard, focus, screen reader announce normally.
+
+## API
+
+### Table
+
+| Prop | Type | Default |
+|---|---|---|
+| `striped` | `boolean` | `false` |
+| `size` | `'default' \| 'comfortable'` | `'default'` |
+| `flush` | `boolean` | `false` |
+| `children` | `ReactNode` *(required)* | — |
+
+Plus standard `<table>` HTML attributes.
+
+### Subcomponents
+
+| Component | Element | Notable props |
+|---|---|---|
+| `TableHeader` | `<thead>` | — |
+| `TableBody` | `<tbody>` | — |
+| `TableRow` | `<tr>` | `selected: boolean` |
+| `TableHead` | `<th>` | `sortable: boolean`, `sortDirection: 'asc' \| 'desc'` |
+| `TableCell` | `<td>` | — |
+
+All subcomponents accept their respective HTML attributes.
+
+## Usage
+
+```tsx
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@brikdesigns/bds';
+import { Badge, Button, IconButton, TextLink } from '@brikdesigns/bds';
+
+<Table striped size="comfortable">
+  <TableHeader>
+    <TableRow>
+      <TableHead sortable sortDirection="asc">Name</TableHead>
+      <TableHead>Email</TableHead>
+      <TableHead>Status</TableHead>
+      <TableHead>Profile</TableHead>
+      <TableHead style={{ textAlign: 'right' }}>Actions</TableHead>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    <TableRow>
+      <TableCell>Alice Chen</TableCell>
+      <TableCell>alice@example.com</TableCell>
+      <TableCell><Badge status="positive" size="sm">Active</Badge></TableCell>
+      <TableCell><TextLink href="#" size="small">View profile</TextLink></TableCell>
+      <TableCell style={{ textAlign: 'right' }}>
+        <IconButton variant="primary" size="sm" icon={<EditIcon />} label="Edit" />
+        <IconButton variant="danger" size="sm" icon={<TrashIcon />} label="Delete" />
+      </TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+```
+
+## Related
+
+- [CardList](/docs/components/card-list) — card grid alternative
+- [CardControl](/docs/components/card-control) — settings-row pattern
+- [Pagination](/docs/components/pagination) — pair below large tables
+- [Badge](/docs/components/badge) / [Tag](/docs/components/tag) — common cell content
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/displays-table-table--overview)**


### PR DESCRIPTION
## Summary

Third sub-batch of the **Displays** migration — all the table-ish surfaces that aren't Card / Overlay / Sheet. Closes out Displays except for the misc-cleanup tail.

| Page | Notes |
|---|---|
| [\`table\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-data-displays/docs-site/content/docs/components/table.mdx) | Composable data table. Six subcomponents (TableHeader/Body/Row/Head/Cell). Documents the cell pattern standards: \`size="sm"\` for in-cell buttons, IconButton-only for icons, \`TextLink size="small"\` for nav, Tooltip wrapping for info icons. |
| [\`data-section\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-data-displays/docs-site/content/docs/components/data-section.mdx) | Page-side wrapper with title + subtitle + actions slot. Page analog of [SheetSection](/docs/components/sheet-section). Auto-divider between consecutive sections. |
| [\`board\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-data-displays/docs-site/content/docs/components/board.mdx) | Kanban-style composite (Board / BoardColumn / BoardHeader). Composes Avatar + ProgressBar. CSS Override API for accent + hover. |
| [\`calendar\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-data-displays/docs-site/content/docs/components/calendar.mdx) | **WIP placeholder.** Component not yet implemented. Steers users to DatePicker / ActivityTimeline / Board for date-based use cases. |
| [\`activity-timeline\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-data-displays/docs-site/content/docs/components/activity-timeline.mdx) | Chronological event list. **No source MDX** in Storybook — written fresh from .tsx props. |
| [\`meter\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-data-displays/docs-site/content/docs/components/meter.mdx) | Gauge primitive for value-within-range. Status colors + three sizes + label position + custom formatter. |
| [\`notification-list\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-data-displays/docs-site/content/docs/components/notification-list.mdx) | Clickable list with empty state. **No source MDX** — written fresh. Includes Popover-anchored bell-dropdown pattern. |

## State of the migration

| Group | Status |
|---|---|
| Action / Indicator / Form / Feedback / Control / Addable / Structure / Navigation | 55/55 ✅ |
| Displays / Card family | 5/5 ✅ |
| Displays / Overlays + Sheets | 6/6 ✅ |
| **Displays / Data + Charts + Notifications** | **7/7 ✅ (this PR)** |
| Misc cleanup (Avatar, Icons, Footer, PageHeader, BulletList, TaskConsole) | 0/6 |

Total docs-site routes: **102**. Total component pages: **73**.

## MDX trap caught

\`meter.mdx\` had \`\`(v, m) => \`${v}/${m}\`\`\` inside a table cell — the inner template-literal backticks ate their own surrounding backticks, exposing \`${v}\` to MDX as an undefined-variable reference. Same root cause as the recurring \`{x}\`-in-prose traps. Rewrote the cell to avoid nested backticks. The page-templates doc covers the simpler version of this trap; might be worth adding a "nested backticks in tables" note next session.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds
- [ ] \`/docs/components\` shows a Data displays card grid below Sheets
- [ ] \`/docs/components/table\` — cell pattern standards section reads cleanly (button vs IconButton vs TextLink decision)
- [ ] \`/docs/components/data-section\` — distinguished clearly from SheetSection
- [ ] \`/docs/components/calendar\` — WIP placeholder is honest about state
- [ ] \`/docs/components/activity-timeline\` and \`/notification-list\` — written-from-tsx pages reflect intent
- [ ] \`/docs/components/meter\` — table renders correctly without the nested-backtick issue
- [ ] All Storybook deep-links resolve

## Heads-up

ActivityTimeline and NotificationList have **no source MDX** — I wrote both fresh from the .tsx props. The narrative parts (when-to-use, when-not-to, accessibility) are inferred. Worth a review pass to confirm the framing matches intent. The Popover-anchored bell-dropdown pattern on NotificationList is a guess at the canonical use case — flag if it's wrong.

## Out of scope (final cleanup)

After this merges, only the misc-cleanup batch remains:

- **Avatar** (Foundations/Assets) — likely pairs with Icons
- **Icons** (Foundations/Assets) — Foundations subcategory
- **Footer** (Navigation/Primary) — pairs with NavBar
- **PageHeader** (Navigation/Secondary) — pairs with Breadcrumb
- **BulletList** (Components/List) — referenced from Field, SheetSection, DataSection
- **TaskConsole** (Components/Feedback) — possibly deprecated; verify before writing

Plus the deferred:
- Motion foundation port — the deferred big lift
- Remaining Industry packs (real-estate-rv-mhc, real-estate-commercial, small-business)
- Voices (×8) and Atmospheres (×7) for the Content System section
- Netlify deploy + \`design.brikdesigns.com\` DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)