### PR TITLE
feat(docs-site): close out misc cleanup batch — migration complete

### DIFF
--- a/docs-site/content/docs/components/avatar.mdx
+++ b/docs-site/content/docs/components/avatar.mdx
@@ -1,0 +1,118 @@
+---
+title: Avatar
+description: User profile image with automatic initials fallback. Four sizes and four presence states.
+---
+
+Avatar renders a user's profile photo, falling back to generated initials when no image is available. Four sizes plus optional presence indicators (online / busy / away / offline).
+
+## Use it for
+
+- User identity in cards, comments, and lists
+- Profile headers and account settings
+- Stacked avatar groups (team rosters, comment threads)
+- Anywhere a person needs visual identification
+
+For non-person entities (companies, projects), use [Card](/docs/components/card) with a logo or [Icons](/docs/components/icons). For status without identity, use [Dot](/docs/components/dot).
+
+## Import
+
+```tsx
+import { Avatar } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### With image
+
+```tsx
+<Avatar src="/users/alice.jpg" alt="Alice Chen" name="Alice Chen" />
+```
+
+`alt` is the accessible name for the image. `name` provides the initials fallback if the image fails to load.
+
+### Initials fallback
+
+When `src` is omitted (or fails to load), Avatar generates initials from `name`.
+
+```tsx
+<Avatar name="Alice Chen" />        {/* AC */}
+<Avatar name="John Doe" />          {/* JD */}
+<Avatar name="Maria Lopez Garcia" />  {/* ML */}
+```
+
+### Sizes
+
+| Size | Diameter | Use |
+|---|---|---|
+| `sm` | 32px | Compact lists, inline mentions |
+| `md` (default) | 40px | Cards, comments |
+| `lg` | 48px | Profile headers, featured users, [Board](/docs/components/board) |
+| `xl` | 64px | Hero profiles, account settings |
+
+### Presence status
+
+`status` adds a colored dot in the bottom-right corner.
+
+```tsx
+<Avatar name="Alice" status="online" />
+<Avatar name="Bob" status="away" />
+<Avatar name="Charlie" status="busy" />
+<Avatar name="Diana" status="offline" />
+```
+
+| Status | Color |
+|---|---|
+| `online` | Green |
+| `away` | Yellow |
+| `busy` | Red |
+| `offline` | Gray |
+
+## Pattern: stacked avatar group
+
+Negative-margin stack for "10 people commented" indicators.
+
+```tsx
+<div style={{ display: 'flex' }}>
+  {users.slice(0, 4).map((u, i) => (
+    <Avatar
+      key={u.id}
+      src={u.avatar}
+      name={u.name}
+      style={{ marginLeft: i === 0 ? 0 : -8, border: '2px solid white' }}
+    />
+  ))}
+  {users.length > 4 && (
+    <Avatar name={`+${users.length - 4}`} style={{ marginLeft: -8 }} />
+  )}
+</div>
+```
+
+## When *not* to use
+
+- **Don't use Avatar for non-person identity.** Companies, projects, or rooms have their own visual languages — use [Card](/docs/components/card) with a logo or [Icons](/docs/components/icons).
+- **Don't use Avatar without `name` or `alt`.** Both serve as accessible labels — without them, screen readers announce nothing useful.
+
+## Accessibility
+
+- Renders a `<div>` with the image inside. The image's `alt` becomes the accessible name.
+- Initials fallback inherits the `name` for accessibility (`aria-label`).
+- Status indicator carries `aria-label="Online"` (etc.) so screen readers announce the state.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `src` | `string` | — |
+| `alt` | `string` | — |
+| `name` | `string` | — |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` |
+| `status` | `'online' \| 'offline' \| 'busy' \| 'away'` | — |
+
+Plus standard `<div>` HTML attributes.
+
+## Related
+
+- [Board → BoardHeader](/docs/components/board) — uses Avatar internally
+- [Dot](/docs/components/dot) — status without identity
+- [Icons](/docs/components/icons) — for non-person identity
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/foundations-assets-avatar--overview)**

--- a/docs-site/content/docs/components/bullet-list.mdx
+++ b/docs-site/content/docs/components/bullet-list.mdx
@@ -1,0 +1,137 @@
+---
+title: Bullet list
+description: Structured short-item list. Replaces raw <ul> with locked spacing and three marker styles.
+---
+
+BulletList is a thin wrapper for short-item lists — anti-messages, proof points, approved CTAs, brand rules. Replaces the raw `<ul style={{ margin: 0, paddingLeft, listStyleType }}>` pattern that grew across portal sheets.
+
+Pass `marker="decimal"` for numbered lists; the underlying element switches to `<ol>` automatically.
+
+## Use it for
+
+- Short bullet items inside a [Field](/docs/components/field) value
+- Numbered process / step lists where order matters
+- Anti-messages and approved-CTA lists in brand sheets
+- Brand rules, proof points, or any short-text catalogue
+
+For multi-paragraph content, render `<p>` tags directly. For longer-form list items with descriptions, use [AddableEntryList](/docs/components/addable-entry-list) (editable) or [Field](/docs/components/field) with composed children.
+
+## Import
+
+```tsx
+import { BulletList } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default (disc marker)
+
+```tsx
+<BulletList
+  items={[
+    'No price-first positioning',
+    'No corporate-clinic language',
+    'No "best in class" superlatives',
+  ]}
+/>
+```
+
+### Numbered (decimal marker)
+
+```tsx
+<BulletList
+  marker="decimal"
+  items={[
+    'Identify the canonical token',
+    'Replace inline values with var() references',
+    'Run lint-tokens to verify no drift',
+  ]}
+/>
+```
+
+### No marker
+
+For list-shaped content that doesn't need the visual bullet (e.g. service catalog).
+
+```tsx
+<BulletList
+  marker="none"
+  items={[
+    'Brand identity design',
+    'Marketing strategy',
+    'Web development',
+  ]}
+/>
+```
+
+### Density
+
+`compact` for tight stat-like lists, `comfortable` (default) for content lists.
+
+```tsx
+<BulletList density="compact" items={['Item one', 'Item two']} />
+<BulletList density="comfortable" items={['Item one', 'Item two']} />
+```
+
+## Pattern: inside a Field
+
+The canonical use — a [Field](/docs/components/field) value expressed as a short bullet list.
+
+```tsx
+<Field label="Anti-messages">
+  <BulletList items={[
+    'No price-first positioning',
+    'No corporate-clinic language',
+  ]} />
+</Field>
+```
+
+## Pattern: brand rules in a Sheet
+
+Stack BulletList inside [SheetSection](/docs/components/sheet-section) for sheet-body brand-rule content.
+
+```tsx
+<SheetSection heading="Approved CTAs">
+  <BulletList items={[
+    'Book a Consultation',
+    'Start Your Smile Journey',
+    'Schedule Your Visit',
+  ]} />
+</SheetSection>
+
+<SheetSection heading="Anti-messages">
+  <BulletList items={[
+    'No corporate-clinic language',
+    'No "industry-leading" superlatives',
+    'No comparison to competitors by name',
+  ]} />
+</SheetSection>
+```
+
+## Rules
+
+- **Use `items` prop, not `<li>` children.** Keeps call sites short and prevents accidental markup drift.
+- **Don't use BulletList for long prose.** If items run multi-paragraph, you want [SheetSection](/docs/components/sheet-section) with `<p>` children, or [AddableEntryList](/docs/components/addable-entry-list) for primary+description rows.
+
+## Accessibility
+
+- Renders a real `<ul>` (or `<ol>` for `marker="decimal"`) — semantically a list.
+- `marker="none"` removes the visual bullet but keeps the list semantics for screen readers.
+- Each item is a `<li>` regardless of marker style.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `items` | `ReactNode[]` *(required)* | — |
+| `marker` | `'disc' \| 'decimal' \| 'none'` | `'disc'` |
+| `density` | `'compact' \| 'comfortable'` | `'comfortable'` |
+
+Plus standard `<ul>` HTML attributes (excluding `children`).
+
+## Related
+
+- [Field](/docs/components/field) — most common parent container
+- [SheetSection](/docs/components/sheet-section) — for stacking BulletLists inside sheet bodies
+- [AddableEntryList](/docs/components/addable-entry-list) — editable primary+description list
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-list-bullet-list--overview)**

--- a/docs-site/content/docs/components/footer.mdx
+++ b/docs-site/content/docs/components/footer.mdx
@@ -1,0 +1,180 @@
+---
+title: Footer
+description: Site-wide footer with logo, navigation columns, social links, and copyright. Default and brand variants.
+---
+
+Footer is the canonical site-wide footer for marketing sites and product landing pages. Logo + tagline on the left, navigation columns in the middle, copyright + social on the bottom bar. Pairs with [NavBar](/docs/components/nav-bar) at the top of the page.
+
+## Use it for
+
+- Marketing site footers (Features / Pricing / About / Legal columns)
+- Product landing page footers
+- Any layout where horizontal column-based navigation rounds out the page
+- Sites that need consistent branding + legal copy on every page
+
+For app shell footers (where users persist on the page), use a custom layout — Footer is for marketing/content sites where the user has reached the end of the page.
+
+## Import
+
+```tsx
+import { Footer } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+Primary background with a top border. The standard treatment for most sites.
+
+```tsx
+<Footer
+  logo={<img src="/logo.svg" alt="Acme" />}
+  tagline="Building better products."
+  columns={[
+    {
+      heading: 'Product',
+      links: [
+        { label: 'Features', href: '/features' },
+        { label: 'Pricing', href: '/pricing' },
+      ],
+    },
+    {
+      heading: 'Company',
+      links: [
+        { label: 'About', href: '/about' },
+        { label: 'Contact', href: '/contact' },
+      ],
+    },
+  ]}
+  copyright="© 2026 Acme Inc."
+/>
+```
+
+### Brand
+
+Brand-colored background with inverse text. Use for marketing pages where the footer is part of the brand expression rather than a quiet wrap-up.
+
+```tsx
+<Footer
+  variant="brand"
+  logo={<Logo />}
+  columns={[...]}
+  copyright="© 2026 Acme Inc."
+/>
+```
+
+### Social links
+
+`socialLinks` accepts ReactNode — typically a row of [IconButton](/docs/components/button#iconbutton)s linking to social profiles.
+
+```tsx
+<Footer
+  logo={<Logo />}
+  columns={[...]}
+  socialLinks={
+    <>
+      <IconButton icon={<TwitterIcon />} label="Twitter" variant="ghost" />
+      <IconButton icon={<LinkedInIcon />} label="LinkedIn" variant="ghost" />
+      <IconButton icon={<GitHubIcon />} label="GitHub" variant="ghost" />
+    </>
+  }
+  copyright="© 2026 Acme Inc."
+/>
+```
+
+### Minimal
+
+`logo`, `tagline`, `columns`, `copyright`, and `socialLinks` are all optional. A minimal footer is just a logo + copyright.
+
+```tsx
+<Footer
+  logo={<Logo />}
+  copyright="© 2026 Acme Inc."
+/>
+```
+
+## Pattern: full marketing footer
+
+The canonical 4-column layout — Product, Resources, Company, Legal.
+
+```tsx
+<Footer
+  logo={<img src="/logo.svg" alt="Brik" />}
+  tagline="Design + content systems for healthcare practices."
+  columns={[
+    {
+      heading: 'Services',
+      links: [
+        { label: 'Brand Design', href: '/services/brand' },
+        { label: 'Marketing', href: '/services/marketing' },
+        { label: 'Content', href: '/services/content' },
+      ],
+    },
+    {
+      heading: 'Resources',
+      links: [
+        { label: 'Blog', href: '/blog' },
+        { label: 'Case studies', href: '/case-studies' },
+        { label: 'Documentation', href: 'https://docs.brikdesigns.com' },
+      ],
+    },
+    {
+      heading: 'Company',
+      links: [
+        { label: 'About', href: '/about' },
+        { label: 'Contact', href: '/contact' },
+        { label: 'Careers', href: '/careers' },
+      ],
+    },
+    {
+      heading: 'Legal',
+      links: [
+        { label: 'Privacy', href: '/privacy' },
+        { label: 'Terms', href: '/terms' },
+      ],
+    },
+  ]}
+  socialLinks={socialIcons}
+  copyright="© 2026 Brik Designs LLC."
+/>
+```
+
+## When *not* to use
+
+- **Don't use Footer for product app shells.** App-shell footers (with copyright + version + status) are a different pattern — render directly in the layout, not via this component.
+- **Don't pair Footer with another footer-like surface.** One footer per page; if you need a sticky CTA strip above it, that's a different pattern.
+
+## Accessibility
+
+- Renders a `<footer>` landmark.
+- Each column heading is an `<h3>` (or `<h4>` depending on context).
+- Links are real `<a>` elements with full anchor semantics.
+- Social link [IconButton](/docs/components/button#iconbutton)s carry `aria-label` (required) for screen-reader announcement.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `logo` | `ReactNode` | — |
+| `tagline` | `string` | — |
+| `columns` | `FooterColumn[]` | — |
+| `copyright` | `string` | — |
+| `socialLinks` | `ReactNode` | — |
+| `variant` | `'default' \| 'brand'` | `'default'` |
+
+Plus standard `<footer>` HTML attributes.
+
+### FooterColumn
+
+```ts
+interface FooterColumn {
+  heading: string;
+  links: { label: string; href: string }[];
+}
+```
+
+## Related
+
+- [NavBar](/docs/components/nav-bar) — top-of-page partner
+- [TextLink](/docs/components/text-link) — alternative to FooterColumn for inline link lists
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-primary-footer--overview)**

--- a/docs-site/content/docs/components/icons.mdx
+++ b/docs-site/content/docs/components/icons.mdx
@@ -1,0 +1,145 @@
+---
+title: Icons
+description: Iconify + Phosphor icon reference. Inline SVGs via @iconify/react, no CDN calls.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+BDS uses [Phosphor](https://phosphoricons.com/) icons via [`@iconify/react`](https://iconify.design/docs/icon-components/react/). Icons render as inline SVGs — no CDN, no flash-of-unstyled-icon, no bundle bloat from importing all icons.
+
+## Setup
+
+| Package | Purpose |
+|---|---|
+| `@iconify/react` | Renders any Iconify icon as a React `<Icon>` component |
+| `@iconify-json/ph` | Phosphor icon data (bundled for offline / SSR) |
+
+BDS registers the Phosphor collection at startup in `.storybook/preview.tsx` via `addCollection()`. No CDN calls needed.
+
+## Use it for
+
+- Inline icons in buttons, badges, tooltips, fields
+- Decorative icons in cards and headers
+- Status / state markers paired with text
+- Anywhere a small (≤ 32px) glyph carries meaning
+
+For larger illustrations and brand marks, use a static SVG asset directly. For non-icon visual primitives ([ServiceBadge](/docs/components/service-badge), avatar fallbacks), use the dedicated component.
+
+## Import
+
+```tsx
+import { Icon } from '@iconify/react';
+```
+
+For BDS-internal usage, prefer the named constants in `components/icons.ts`:
+
+```tsx
+import { Star } from '@brikdesigns/bds/icons';
+
+<Icon icon={Star} />
+```
+
+## Usage
+
+### Direct string reference
+
+The `icon` prop accepts a `collection:name` string. Phosphor icons use the `ph:` prefix.
+
+```tsx
+<Icon icon="ph:star-fill" />
+<Icon icon="ph:check" />
+<Icon icon="ph:x-circle" />
+```
+
+Find available icons at [phosphoricons.com](https://phosphoricons.com/).
+
+### BDS icon constants
+
+For commonly-used icons in BDS components, prefer the named constants — protects against typos and centralizes the icon vocabulary.
+
+```tsx
+import { Star, Check, XCircle } from '@brikdesigns/bds/icons';
+
+<Icon icon={Star} />
+<Icon icon={Check} />
+<Icon icon={XCircle} />
+```
+
+Constants follow the pattern `export const Name = 'ph:icon-name'`.
+
+### Sizing
+
+Iconify icons inherit `font-size` from their parent or accept explicit `width` / `height` props.
+
+```tsx
+{/* Inherits parent font-size — recommended */}
+<span style={{ fontSize: 24 }}>
+  <Icon icon="ph:star-fill" />
+</span>
+
+{/* Explicit size */}
+<Icon icon="ph:star-fill" width={24} height={24} />
+```
+
+For inline icons inside text, use `1em` sizing so the icon scales with the surrounding text:
+
+```tsx
+<button>
+  <Icon icon="ph:plus" style={{ fontSize: '1em' }} />
+  Add item
+</button>
+```
+
+## Phosphor weights
+
+Phosphor provides six weights per icon. BDS primarily uses the regular and fill variants.
+
+| Weight | Suffix | Use |
+|---|---|---|
+| Regular | `ph:name` | Default. Most contexts. |
+| Bold | `ph:name-bold` | Emphasis, IconButton labels at sm size |
+| Fill | `ph:name-fill` | Active/selected states, status badges |
+| Light | `ph:name-light` | Decorative or quiet contexts |
+| Thin | `ph:name-thin` | Rare; very specific design intent |
+| Duotone | `ph:name-duotone` | Empty states, illustrations |
+
+```tsx
+<Icon icon="ph:star" />          {/* outline, default weight */}
+<Icon icon="ph:star-fill" />     {/* solid */}
+<Icon icon="ph:star-bold" />     {/* heavier outline */}
+```
+
+## Adding icons to BDS
+
+1. Find the icon name at [phosphoricons.com](https://phosphoricons.com/) — copy the kebab-case name.
+2. Add a named constant to `components/icons.ts` using the `ph:icon-name` format.
+3. (Optional) Add the icon to a category in the Storybook stories so other contributors can find it.
+
+```ts
+// components/icons.ts
+export const Heart = 'ph:heart';
+export const HeartFill = 'ph:heart-fill';
+```
+
+## When *not* to use
+
+<Callout type="warn">
+  **Don't use raw SVG inline.** Iconify provides 200,000+ icons across multiple collections — you almost never need a one-off SVG. If the design calls for a non-Phosphor icon, evaluate whether a Phosphor alternative is acceptable before committing a custom asset.
+</Callout>
+
+- **Don't use Icons for brand marks.** Logos and brand-specific illustrations are static SVG assets, not icon-system components.
+- **Don't use Icons without semantic context.** An icon-only button needs an `aria-label`; an icon next to text doesn't.
+
+## Accessibility
+
+- Iconify icons render `<svg aria-hidden="true">` by default — appropriate for decorative use next to text.
+- For icon-only triggers (icon-only buttons), pair with [IconButton](/docs/components/button#iconbutton) which adds the required `aria-label`.
+- For meaningful icons that aren't paired with text, set `aria-label` directly on the surrounding element.
+
+## Related
+
+- [IconButton](/docs/components/button#iconbutton) — accessible wrapper for icon-only buttons
+- [Avatar](/docs/components/avatar) — for person identity
+- [ServiceBadge](/docs/components/service-badge) — for Brik service-line icons
+- **[Storybook icon catalog](https://storybook.brikdesigns.com/?path=/docs/foundations-assets-icons--overview)**
+- **External**: [phosphoricons.com](https://phosphoricons.com/) — find icon names

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -182,9 +182,29 @@ Tables, kanban boards, calendars, timelines, gauges, and notification lists. The
   <Card title="Notification list" href="/docs/components/notification-list" description="Vertical list of clickable notification items with empty state." />
 </Cards>
 
-## Still in Storybook
+### Assets + utilities
 
-The remaining ~6 components haven't migrated yet — Avatar, Icons (Foundations/Assets), Footer, PageHeader (Navigation), BulletList (Components/List), and TaskConsole (Components/Feedback). They live in different categories than Displays and will land in a final misc cleanup PR.
+Identity primitives, icon reference, page-level chrome, list and console utilities. The long tail that lives outside the main component categories.
+
+<Cards>
+  <Card title="Avatar" href="/docs/components/avatar" description="User profile image with initials fallback. Four sizes, four presence states." />
+  <Card title="Icons" href="/docs/components/icons" description="Iconify + Phosphor icon reference. Inline SVGs, no CDN, six weights per icon." />
+  <Card title="Footer" href="/docs/components/footer" description="Site-wide footer with logo, columns, social links, copyright. Default + brand variants." />
+  <Card title="Page header" href="/docs/components/page-header" description="Composable page-level header. Title + breadcrumbs + actions + tabs + metadata + stats." />
+  <Card title="Bullet list" href="/docs/components/bullet-list" description="Structured short-item list. disc / decimal / none markers, two density modes." />
+  <Card title="Task console" href="/docs/components/task-console" description="Floating progress console for long-running batch operations. Per-item state, auto-dismiss." />
+</Cards>
+
+## Migration complete ✅
+
+Every shipped BDS component has a docs page. The migration from Storybook MDX to design.brikdesigns.com is done. Storybook becomes the playground for live prop exploration; this site is the canonical guidance surface.
+
+Remaining work tracked separately:
+
+- **Motion foundation port** (the deferred big lift in the Foundations section)
+- **Industry packs** for the Content System (Real Estate RV/MHC, Real Estate Commercial, Small Business)
+- **Voice patterns** (×8) and **Atmospheres** (×7) for the Content System
+- **Netlify deploy** + `design.brikdesigns.com` DNS
 
 ## Page template
 

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -87,6 +87,13 @@
     "calendar",
     "activity-timeline",
     "meter",
-    "notification-list"
+    "notification-list",
+    "---Assets + utilities---",
+    "avatar",
+    "icons",
+    "footer",
+    "page-header",
+    "bullet-list",
+    "task-console"
   ]
 }

--- a/docs-site/content/docs/components/page-header.mdx
+++ b/docs-site/content/docs/components/page-header.mdx
@@ -1,0 +1,225 @@
+---
+title: Page header
+description: Composable page-level header. Title + subtitle + breadcrumbs + actions + tabs + metadata + stats.
+---
+
+PageHeader is the standard page-top header — composes [Breadcrumb](/docs/components/breadcrumb), [Button](/docs/components/button), [TabBar](/docs/components/tab-bar), and a metadata grid into one component. Inherits background from parent context (no surface of its own), so it works on pages with any background.
+
+## Use it for
+
+- Detail page headers (company / project / record pages)
+- Section headers that need breadcrumbs + page title + primary action
+- Dashboards with metadata + stat tiles + tab navigation
+- Any page where the top region groups identity + navigation + primary CTA
+
+For Sheet headers (inside a `<Sheet>`), the [Sheet](/docs/components/sheet) component composes its own — don't reach for PageHeader inside a Sheet body.
+
+## Import
+
+```tsx
+import { PageHeader } from '@brikdesigns/bds';
+```
+
+## Anatomy
+
+PageHeader has six optional regions plus a required title. From top to bottom:
+
+1. **`breadcrumbs`** — [Breadcrumb](/docs/components/breadcrumb) above the title row
+2. **`badge`** + **`title`** — service icon (left) + page H1
+3. **`subtitle`** — supporting paragraph under the title
+4. **`actions`** — right-aligned action buttons (typically a [Button](/docs/components/button) or [ButtonGroup](/docs/components/button-group))
+5. **`metadata`** — built-in key/value grid (Owner, Status, Updated)
+6. **`stats`** — summary content (e.g. stat-tile [Card preset="summary"](/docs/components/card#summary-preset) grid)
+7. **`tabs`** — [TabBar](/docs/components/tab-bar) for in-page section nav
+
+## Variants
+
+### Title only
+
+```tsx
+<PageHeader title="Dashboard" />
+```
+
+### Title + subtitle
+
+```tsx
+<PageHeader
+  title="My account"
+  subtitle="Manage your membership plan and billing."
+/>
+```
+
+### With breadcrumbs and actions
+
+```tsx
+<PageHeader
+  title="Birdwell & Mutlak"
+  breadcrumbs={
+    <Breadcrumb items={[
+      { label: 'Clients', href: '/clients' },
+      { label: 'Birdwell & Mutlak' },
+    ]} />
+  }
+  actions={<Button variant="primary">Edit</Button>}
+/>
+```
+
+### With service badge
+
+[ServiceBadge](/docs/components/service-badge) renders to the left of the title for service-line pages.
+
+```tsx
+<PageHeader
+  title="Website Design"
+  subtitle="Custom web development and design."
+  badge={<ServiceBadge category="marketing" serviceName="Custom Web Development" size="lg" />}
+  actions={<Button variant="primary">Edit Service</Button>}
+/>
+```
+
+### With metadata
+
+`metadata` is a built-in key/value grid for page-level facts.
+
+```tsx
+<PageHeader
+  title="Brand Refresh"
+  metadata={[
+    { label: 'Owner', value: 'Sarah Chen' },
+    { label: 'Status', value: <Badge status="positive">Active</Badge> },
+    { label: 'Updated', value: '2 days ago' },
+  ]}
+/>
+```
+
+### With stats
+
+`stats` renders summary content between metadata and tabs — typically a row of stat tiles.
+
+```tsx
+<PageHeader
+  title="Q1 Performance"
+  stats={
+    <CardList orientation="horizontal" gap="md">
+      <Card preset="summary" label="Revenue" value={48250.75} type="price" />
+      <Card preset="summary" label="New clients" value={12} />
+      <Card preset="summary" label="Projects" value={34} />
+    </CardList>
+  }
+/>
+```
+
+### With tabs
+
+```tsx
+<PageHeader
+  title="My Account"
+  subtitle="Manage your membership plan."
+  tabs={
+    <TabBar items={[
+      { label: 'Overview', active: true },
+      { label: 'Billing' },
+      { label: 'Security' },
+    ]} />
+  }
+/>
+```
+
+### Sizes
+
+`size` controls the title scale. Default `lg`.
+
+```tsx
+<PageHeader title="Compact dashboard header" size="sm" />
+<PageHeader title="Standard page header" size="md" />
+<PageHeader title="Hero detail page" size="lg" />
+```
+
+### Flush layout
+
+`flush` removes horizontal padding for layouts that provide their own.
+
+```tsx
+<PageHeader title="..." flush />
+```
+
+## Pattern: full company detail page
+
+The canonical layout — breadcrumb + service badge + title + actions + metadata + tabs.
+
+```tsx
+<PageHeader
+  title="Birdwell & Mutlak"
+  subtitle="Active client · Dental"
+  breadcrumbs={
+    <Breadcrumb items={[
+      { label: 'Clients', href: '/clients' },
+      { label: 'Birdwell & Mutlak' },
+    ]} />
+  }
+  badge={<ServiceBadge category="dental" size="lg" />}
+  actions={<ButtonGroup>
+    <Button variant="ghost">Archive</Button>
+    <Button variant="primary">Edit</Button>
+  </ButtonGroup>}
+  metadata={[
+    { label: 'Owner', value: 'Nick Stanerson' },
+    { label: 'Industry', value: 'Dental' },
+    { label: 'Updated', value: '3 days ago' },
+  ]}
+  tabs={
+    <TabBar items={[
+      { label: 'Brand', active: true },
+      { label: 'Services' },
+      { label: 'Locations' },
+      { label: 'Activity' },
+    ]} />
+  }
+/>
+```
+
+## When *not* to use
+
+- **Don't use PageHeader inside a Sheet.** Use [Sheet](/docs/components/sheet)'s built-in header instead — different shape, different semantics.
+- **Don't use PageHeader without a `title`.** It's required and serves as the page H1; without it, the page outline breaks.
+- **Don't put complex JSX in `metadata` values.** Metadata is for short pinned facts. For richer per-section content, use [DataSection](/docs/components/data-section).
+
+## Accessibility
+
+- Renders a real `<header>` landmark.
+- The title is the page's `<h1>` — only one PageHeader per page.
+- Breadcrumb, TabBar, and action elements keep their own semantics.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `string` *(required)* | — |
+| `subtitle` | `string` | — |
+| `badge` | `ReactNode` | — |
+| `breadcrumbs` | `ReactNode` | — |
+| `actions` | `ReactNode` | — |
+| `tabs` | `ReactNode` | — |
+| `metadata` | `MetadataItem[]` | — |
+| `stats` | `ReactNode` | — |
+| `showDivider` | `boolean` | `true` |
+| `flush` | `boolean` | `false` |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'lg'` |
+
+### MetadataItem
+
+```ts
+interface MetadataItem {
+  label: string;
+  value: ReactNode;
+}
+```
+
+## Related
+
+- [Breadcrumb](/docs/components/breadcrumb) — common breadcrumbs prop content
+- [TabBar](/docs/components/tab-bar) — common tabs prop content
+- [ServiceBadge](/docs/components/service-badge) — common badge prop content
+- [DataSection](/docs/components/data-section) — for body sections below the header
+- [Sheet](/docs/components/sheet) — has its own header for in-Sheet contexts
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-secondary-page-header--overview)**

--- a/docs-site/content/docs/components/task-console.mdx
+++ b/docs-site/content/docs/components/task-console.mdx
@@ -1,0 +1,146 @@
+---
+title: Task console
+description: Floating progress console for long-running batch operations. Per-item state, auto-dismiss, position-pinned.
+---
+
+TaskConsole is the floating progress panel for long-running multi-item operations — generating 14 pages, syncing 32 records, processing a CSV upload. Pins to a screen corner, shows per-item completion state, and auto-dismisses when all items finish.
+
+For ephemeral confirmations, use [Toast](/docs/components/toast). For persistent banners, use [Banner](/docs/components/banner). For single-task progress, use [ProgressBar](/docs/components/progress-bar).
+
+## Use it for
+
+- Batch generation jobs ("Generating 14 pages")
+- Multi-record sync or import operations
+- Long-running content scrapes or audits
+- Any background task that produces multiple discrete sub-results the user benefits from seeing as they complete
+
+## Import
+
+```tsx
+import { TaskConsole } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Default
+
+The console accepts a list of `items`, each with its own state. As items complete, the console updates in real-time.
+
+```tsx
+import { useState } from 'react';
+
+const [items, setItems] = useState([
+  { id: '1', label: 'Generating /home', status: 'pending' },
+  { id: '2', label: 'Generating /about', status: 'pending' },
+  { id: '3', label: 'Generating /contact', status: 'pending' },
+]);
+
+<TaskConsole
+  isOpen={isRunning}
+  title="Generating 14 pages"
+  subtitle="Less than a minute left"
+  items={items}
+  onDismiss={() => setIsRunning(false)}
+/>
+```
+
+### Position
+
+Pin to the bottom-right (default) or bottom-left.
+
+```tsx
+<TaskConsole position="bottom-left" {...props} />
+<TaskConsole position="bottom-right" {...props} />
+```
+
+### Default collapsed
+
+Start the console minimized. The user can expand to see per-item state.
+
+```tsx
+<TaskConsole defaultCollapsed {...props} />
+```
+
+### Auto-dismiss
+
+Set `autoDismissDelay` (ms) to auto-close the console after all items complete. `0` disables auto-dismiss (user dismisses manually).
+
+```tsx
+<TaskConsole autoDismissDelay={3000} {...props} />
+```
+
+## Pattern: live batch generation
+
+The canonical pattern — open the console on job start, update items as each completes, auto-dismiss at the end.
+
+```tsx
+async function generatePages(slugs: string[]) {
+  const items = slugs.map((slug) => ({
+    id: slug,
+    label: `Generating /${slug}`,
+    status: 'pending' as const,
+  }));
+
+  setConsoleState({ isOpen: true, items });
+
+  for (const slug of slugs) {
+    setConsoleState((prev) => ({
+      ...prev,
+      items: prev.items.map((i) =>
+        i.id === slug ? { ...i, status: 'in-progress' } : i
+      ),
+    }));
+
+    await generatePage(slug);
+
+    setConsoleState((prev) => ({
+      ...prev,
+      items: prev.items.map((i) =>
+        i.id === slug ? { ...i, status: 'complete' } : i
+      ),
+    }));
+  }
+}
+
+<TaskConsole
+  isOpen={consoleState.isOpen}
+  title={`Generating ${slugs.length} pages`}
+  items={consoleState.items}
+  autoDismissDelay={3000}
+  onDismiss={() => setConsoleState({ isOpen: false, items: [] })}
+/>
+```
+
+## When *not* to use
+
+- **Don't use TaskConsole for single-task progress.** Use [ProgressBar](/docs/components/progress-bar) — it's the right shape for "one task, % complete."
+- **Don't use TaskConsole for instantaneous operations.** If a job completes in under 1 second, the console flashes uselessly. Use [Toast](/docs/components/toast) for the completion confirmation.
+- **Don't run multiple TaskConsoles simultaneously.** Pin one at a time; queue subsequent operations or aggregate them in one console.
+
+## Accessibility
+
+- Renders a `<div role="status" aria-live="polite">` so screen readers announce progress without interrupting current speech.
+- Per-item state changes are announced as items move from pending → in-progress → complete.
+- The collapse / dismiss buttons carry `aria-label`s.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `title` | `ReactNode` *(required)* | — |
+| `items` | `TaskConsoleItem[]` *(required)* | — |
+| `isOpen` | `boolean` | `true` |
+| `position` | `'bottom-right' \| 'bottom-left'` | `'bottom-right'` |
+| `onDismiss` | `() => void` | — |
+| `defaultCollapsed` | `boolean` | `false` |
+| `autoDismissDelay` | `number` (ms) | `0` (no auto-dismiss) |
+| `subtitle` | `ReactNode` | — |
+
+The `TaskConsoleItem` shape is defined alongside the component — typically `{ id, label, status: 'pending' \| 'in-progress' \| 'complete' \| 'error' }`.
+
+## Related
+
+- [ProgressBar](/docs/components/progress-bar) — single-task alternative
+- [Toast](/docs/components/toast) — short-confirmation alternative
+- [NotificationList](/docs/components/notification-list) — for completed-task review after the fact
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-feedback-task-console--overview)**


### PR DESCRIPTION
## Summary

**Final cleanup batch.** After this merges, every shipped BDS component has a docs page on \`design.brikdesigns.com\` (eventually). The migration from Storybook MDX to the docs site is done.

| Page | Notes |
|---|---|
| [\`avatar\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-misc-cleanup/docs-site/content/docs/components/avatar.mdx) | User profile image with initials fallback. Four sizes, four presence states. Stacked-avatar-group pattern documented. |
| [\`icons\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-misc-cleanup/docs-site/content/docs/components/icons.mdx) | Iconify + Phosphor reference. Inline SVGs, no CDN, six weights per icon, BDS constants pattern. |
| [\`footer\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-misc-cleanup/docs-site/content/docs/components/footer.mdx) | Site-wide footer. Logo + columns + social + copyright. Default + brand variants. Pairs with NavBar. |
| [\`page-header\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-misc-cleanup/docs-site/content/docs/components/page-header.mdx) | Composable page-level header. Breadcrumbs + ServiceBadge + title + actions + metadata + stats + tabs. |
| [\`bullet-list\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-misc-cleanup/docs-site/content/docs/components/bullet-list.mdx) | Structured short-item list. disc / decimal / none markers. Replaces raw \`<ul>\` patterns. |
| [\`task-console\`](https://github.com/brikdesigns/brik-bds/blob/task/docs-misc-cleanup/docs-site/content/docs/components/task-console.mdx) | Floating batch-progress console. **No source MDX** — written fresh from .tsx. Live-batch-generation pattern documented. |

## Final state — every shipped component covered

| Group | Pages |
|---|---|
| Action | 6 ✅ |
| Indicator | 10 ✅ |
| Form / Inputs | 10 ✅ |
| Form / Structure | 4 ✅ |
| Feedback | 6 ✅ |
| Control | 7 ✅ |
| Addable | 4 ✅ |
| Structure | 3 ✅ |
| Navigation | 5 ✅ |
| Displays / Card family | 5 ✅ |
| Displays / Overlays + Sheets | 6 ✅ |
| Displays / Data displays | 7 ✅ |
| **Assets + utilities** | **6 ✅ (this PR)** |

**79 component pages**, **108 docs-site routes** total.

## What's done after this merges

- Every BDS component shipped to date has a guidance page
- The components index has 13 sub-grids (one per group)
- Storybook becomes the playground; docs-site is the canonical guidance surface — exactly the split we set out for in the foundational PR ([#274](https://github.com/brikdesigns/brik-bds/pull/274))

## What's left (non-component work)

The remaining work is **content** + **infrastructure**, not components:

- **Motion foundation port** — the deferred big lift in the Foundations section (~20K of viz code)
- **Industry packs** for the Content System — Real Estate RV/MHC, Real Estate Commercial, Small Business (Dental is done in [#274](https://github.com/brikdesigns/brik-bds/pull/274))
- **Voice patterns** (×8) and **Atmospheres** (×7) for the Content System
- **Netlify deploy** + \`design.brikdesigns.com\` DNS

## MDX trap caught (final tally)

\`task-console.mdx\` had \`<1 second\` in prose — MDX v3 parses \`<\` followed by anything as a JSX tag opening, and \`1\` is invalid as a tag name. Same root rule as the [BCS discipline](https://github.com/brikdesigns/brik-bds/blob/main/CLAUDE.md#bcs-discipline) "no literal \`<\` in MDX copy" — fixed by writing "under 1 second."

Recurring MDX traps caught across the migration:

1. \`{x}\` in prose — Counter \`{n}\`, MultiSelect \`{label}\`, CatalogPicker \`{name}\`
2. Nested backticks in tables — Meter \`(v, m) => \`${v}/${m}\`\`
3. Literal \`<\` in prose — TaskConsole \`<1 second\`

The page-templates doc covers #1 explicitly. Worth a follow-up to add #2 and #3 — three is a pattern, and these will keep biting future authors otherwise.

## Test plan

- [ ] \`cd docs-site && npm run build\` succeeds
- [ ] \`/docs/components\` shows 13 sub-grids covering every group
- [ ] \`/docs/components/avatar\` — initials-fallback explanation is clear
- [ ] \`/docs/components/icons\` — Phosphor weight table + BDS constants pattern reads correctly
- [ ] \`/docs/components/page-header\` — full anatomy (breadcrumbs / badge / title / metadata / stats / tabs) renders
- [ ] \`/docs/components/task-console\` — written-from-tsx page reflects intent (no source MDX existed)
- [ ] All Storybook deep-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)