### PR TITLE
chore(docs-site): add netlify.toml for design.brikdesigns.com deploy

### DIFF
--- a/docs-site/netlify.toml
+++ b/docs-site/netlify.toml
@@ -1,0 +1,54 @@
+# Netlify config for design.brikdesigns.com (BDS docs site).
+#
+# This file is consumed when the Netlify site has its base directory set to
+# `docs-site/` (configured in the Netlify site settings, not in this file).
+# The repo's root netlify.toml is owned by storybook.brikdesigns.com — they
+# are two separate Netlify sites pointing at the same GitHub repo.
+#
+# Workflow:
+#   main     → design.brikdesigns.com           (production)
+#   staging  → staging.design.brikdesigns.com   (staging)
+
+[build]
+  # Build runs in docs-site/ (the base directory).
+  # We need BDS root dist/ built before the docs-site Next.js build because
+  # docs-site has `"@brikdesigns/bds": "file:.."` and Next imports component
+  # source through the BDS package exports.
+  command = "cd .. && npm install --ignore-scripts --no-audit --no-fund && npm run build:lib && cd docs-site && npm install --ignore-scripts --no-audit --no-fund && npm run build"
+  publish = ".next"
+
+[build.environment]
+  NODE_VERSION = "22"
+  # --ignore-scripts skips husky postinstall (the BDS root postinstall fails
+  # under Netlify because it can't find husky in this hermetic install).
+  NPM_FLAGS = "--ignore-scripts --no-audit --no-fund"
+
+# ── Branch deploys ────────────────────────────────────────────────
+# main → production (design.brikdesigns.com)
+# staging → branch deploy (staging.design.brikdesigns.com)
+
+[context.staging]
+  command = "cd .. && npm install --ignore-scripts --no-audit --no-fund && npm run build:lib && cd docs-site && npm install --ignore-scripts --no-audit --no-fund && npm run build"
+
+[context.deploy-preview]
+  command = "cd .. && npm install --ignore-scripts --no-audit --no-fund && npm run build:lib && cd docs-site && npm install --ignore-scripts --no-audit --no-fund && npm run build"
+
+# ── Headers ───────────────────────────────────────────────────────
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+
+# Next.js static assets are content-hashed — cache forever.
+[[headers]]
+  for = "/_next/static/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Generated MDX manifest — revalidate every load so chunk references stay fresh.
+[[headers]]
+  for = "/_next/data/*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"


### PR DESCRIPTION
## Summary

Adds Netlify build config at \`docs-site/netlify.toml\` for the upcoming \`design.brikdesigns.com\` deploy. Doesn't change anything in production until you create the Netlify site and connect it.

The config:
- Scopes to \`docs-site/\` via the Netlify site's base directory setting
- Builds BDS dist first (\`npm run build:lib\` from parent), then the Next.js docs site
- Uses \`--ignore-scripts\` to skip the husky postinstall that fails under Netlify's hermetic install
- Sets up branch deploys: \`main → production\`, \`staging → staging.design.brikdesigns.com\`
- Long-caches \`_next/static/*\` (content-hashed), revalidates \`_next/data/*\` on every load

The repo's root \`netlify.toml\` stays owned by storybook.brikdesigns.com — the two are separate Netlify sites pointing at the same GitHub repo with different base directories.

Build verified locally (108 routes prerendered) before commit.

## Manual setup needed after merge

I can't create the Netlify site for you — that's modifying shared infrastructure. Once this PR merges to main, you do the following (~5 min):

### 1. Create the Netlify site

- Go to [app.netlify.com](https://app.netlify.com) → **Add new site** → **Import an existing project** → **GitHub** → select \`brikdesigns/brik-bds\`
- Configure:
  - **Site name**: \`brik-bds-docs\` (or any unique name — you'll point a custom domain at it next)
  - **Base directory**: \`docs-site\`
  - **Branch to deploy**: \`main\`
  - **Build command**: leave blank (the toml provides it)
  - **Publish directory**: leave blank (the toml provides it)
- Click **Deploy**

The first deploy will take ~3 minutes (BDS dist build + 108 page prerender). You can watch it in the Deploys tab.

### 2. Add the custom domain

In the new Netlify site → **Domain settings** → **Add custom domain** → enter \`design.brikdesigns.com\`.

Netlify will show a CNAME target like \`brik-bds-docs.netlify.app\` (or similar — depends on your site name).

### 3. Update DNS

Wherever you manage \`brikdesigns.com\` DNS:

| Type | Name | Value | TTL |
|---|---|---|---|
| CNAME | \`design\` | \`<your-site>.netlify.app\` | 3600 |

After DNS propagates (5-30 min usually), Netlify will issue a Let's Encrypt cert automatically and \`design.brikdesigns.com\` will be live.

### 4. (Optional) Configure staging branch

If you want \`staging.design.brikdesigns.com\` for branch previews:
- Site settings → **Branch deploys** → enable for \`staging\` branch
- Add \`staging.design\` as a CNAME pointing to the same Netlify site

## Test plan

- [ ] PR merges cleanly to main (no conflicts with the existing root \`netlify.toml\`)
- [ ] Manual setup steps above produce a working deploy
- [ ] First production deploy succeeds and prerenders 108 routes
- [ ] \`design.brikdesigns.com\` resolves and serves the docs site after DNS propagates
- [ ] Cert is issued (Netlify auto-issues via Let's Encrypt)

## Why this approach

I considered using the Netlify CLI to create the site directly. Per CLAUDE.md "executing actions with care" — creating Netlify sites is "modifying shared infrastructure," which warrants user confirmation rather than agent action. So this PR ships the config and you do the 5-minute UI flow.

If you'd prefer I do the CLI version, say so and I'll authenticate \`netlify login\` (it's installed at \`/opt/homebrew/bin/netlify\`) and create the site myself.

## Out of scope

- DNS registrar changes (you control your DNS provider; I don't have access)
- Netlify environment variables (none required for this site — no Supabase, no API keys)
- Sentry / analytics wiring (the docs site doesn't need them; pure static content)
- Storybook deploy changes (its toml at root is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)