### PR TITLE
fix(build): make husky prepare script safe-fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "populate-notion": "node scripts/populate-notion-tokens.js",
     "propagate": "bash scripts/propagate.sh",
     "propagate:dry": "bash scripts/propagate.sh --dry-run",
-    "prepare": "husky",
+    "prepare": "husky || true",
     "prepublishOnly": "rm -rf dist && npm run build:lib",
     "verify:blueprints-astro": "node scripts/verify-blueprints-astro-exports.mjs"
   },


### PR DESCRIPTION
## Summary

One-line change: `"prepare": "husky"` → `"prepare": "husky || true"`.

## Why

When a consumer (e.g. `docs-site/` with `"@brikdesigns/bds": "file:.."`) runs `npm install`, npm processes the parent package as a file dep — including its `prepare` lifecycle script — *before* the parent's devDependencies are installed. `husky` isn't on PATH yet, so the install fails with:

```
npm error code 127
npm error path /opt/build/repo
npm error command sh -c husky
npm error sh: 1: husky: not found
```

This blocked the new `design.brikdesigns.com` Netlify build at the "Install dependencies" stage. `--ignore-scripts` didn't help because Netlify auto-installs at the repo root with its own flags.

## Fix

`husky || true` is the canonical husky-recommended pattern for monorepos and CI environments where husky may or may not be available. Locally, husky still installs git hooks normally; in fresh CI installs, it no-ops.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-trigger the brik-bds-docs Netlify build — should pass "Install dependencies" stage and continue into the build command

🤖 Generated with [Claude Code](https://claude.com/claude-code)