### PR TITLE
fix(docs-site): wire @netlify/plugin-nextjs so routes resolve

### DIFF
--- a/docs-site/netlify.toml
+++ b/docs-site/netlify.toml
@@ -52,3 +52,10 @@
   for = "/_next/data/*"
   [headers.values]
     Cache-Control = "public, max-age=0, must-revalidate"
+
+# ── Plugins ───────────────────────────────────────────────────────
+# @netlify/plugin-nextjs handles the Next.js App Router runtime —
+# without it, Netlify dumps the raw `.next/` build output and every
+# route 404s.
+[[plugins]]
+  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary

First successful Netlify build of `brik-bds-docs` deployed the raw `.next/` output and every route 404'd. Netlify needs `@netlify/plugin-nextjs` to wire up the App Router runtime.

## Why

Netlify only natively serves static files from the publish dir. For Next.js App Router (which this site uses), the runtime plugin is required to:
- Parse `.next/routes-manifest.json` and convert it to Netlify rewrites
- Bundle SSR/ISR routes as Netlify Functions
- Map dynamic segments to function invocations

Without the plugin, `https://brik-bds-docs.netlify.app/docs/components/button` 404s because Netlify has no rewrite from the route to the corresponding HTML in `.next/server/app/`.

## Test plan

- [ ] CI green (deploy preview)
- [ ] After merge: re-build `brik-bds-docs`, hit `https://brik-bds-docs.netlify.app/docs` and a sample component page — both should return 200 with HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)