### PR TITLE
feat(docs-site): port Foundations Naming Conventions + expand Design Tokens overview

### DIFF
--- a/docs-site/content/docs/primitives/index.mdx
+++ b/docs-site/content/docs/primitives/index.mdx
@@ -1,20 +1,151 @@
 ---
 title: Design Tokens
-description: Tokens — the design language every BDS component reads from.
+description: The single source of truth for every visual decision — color, type, spacing, radius, shadow, motion. Authored in Figma, exported via Tokens Studio, transformed by Style Dictionary, shipped as @brikdesigns/bds/tokens.css.
 ---
 
 import { Cards, Card } from 'fumadocs-ui/components/card';
 import { Callout } from 'fumadocs-ui/components/callout';
 
-BDS primitives are a flat token vocabulary covering color, typography, spacing, motion, radius, shadow, and border. They're authored in Figma, exported via Tokens Studio, transformed by Style Dictionary, and shipped as `@brikdesigns/bds/tokens.css`.
-
-Each page below explains one primitive group: what tokens exist, what they mean semantically, and the rules for using them outside their category (don't).
+Design tokens are the single source of truth for every visual decision in the Brik ecosystem — color, type, spacing, radius, shadow, motion. A token gives a value a name and a purpose. Components never reference raw values; they reference tokens. This means a component built once works correctly across every Brik client without touching its code.
 
 <Callout type="warn">
   **Token source of truth lives in Figma.** This site documents what's available and how to use it. To add a new token, edit Figma first — don't add it to CSS directly.
 </Callout>
 
-## Foundations
+## Two-tier architecture (client projects)
+
+Client portals, SaaS apps, and marketing sites use a **2-tier** model:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  TIER 1 — BDS Foundations  (brik-bds, never edited by consumers)        │
+│                                                                         │
+│  figma-tokens.css  — SD-generated primitives + semantic tokens          │
+│  gap-fills.css     — gap-fill tokens not yet promoted to Figma          │
+│                                                                         │
+│  --color-poppy-light  --space-400  --background-brand-primary           │
+│  --background-status-error  --icon-md  --shadow-sm                      │
+└──────────────────────────────┬──────────────────────────────────────────┘
+                               │  CSS cascade (client globals.css)
+┌──────────────────────────────▼──────────────────────────────────────────┐
+│  TIER 2 — Client Theme  (theme-{client}.css in consuming project)       │
+│                                                                         │
+│  Same semantic token names as Tier 1, different values for this brand.  │
+│  One file per client. Cascade wins. Components are untouched.           │
+│                                                                         │
+│  :root { --background-brand-primary: #2563EB; --font-family-heading: …} │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**The key rule:** token names are fixed in Tier 1. Only values change in Tier 2. A component written against `--background-brand-primary` works for every client brand with zero code changes.
+
+## CSS import cascade
+
+Client projects load tokens in the same order:
+
+```css
+/* 1. Generated tokens (light + dark + Brik defaults) */
+@import '@brikdesigns/bds/tokens.css';
+
+/* 2. Client brand — same token names, different values */
+@import './styles/theme-{client}.css';
+
+/* 3. Component CSS bundle */
+@import '@brikdesigns/bds/styles.css';
+```
+
+For the theming system as a whole — Brik's three built-in themes, the override matrix, and how to author a client brand — see [Theming](/docs/theming).
+
+## Token types: primitives vs semantic
+
+| Type | Purpose | Example | Used in |
+|------|---------|---------|---------|
+| **Primitive** | Raw scale value — the number or color itself | `--color-poppy-light: #e35335` | Never in components |
+| **Semantic** | Purpose-bound alias pointing to a primitive | `--background-brand-primary: var(--color-poppy-light)` | Components, always |
+
+Primitives define the palette. Semantics define the intent. Components only know intent.
+
+```css
+/* ✅ Correct — semantic, works across all themes */
+.bds-button { background: var(--background-brand-primary); }
+
+/* ❌ Wrong — hardcoded, breaks in every non-default theme */
+.bds-button { background: #e35335; }
+
+/* ❌ Wrong — primitive, breaks the abstraction */
+.bds-button { background: var(--color-poppy-light); }
+```
+
+## Naming convention
+
+```
+--[category]-[role]-[variant]
+```
+
+| Category | Pattern | Examples |
+|---|---|---|
+| Background | `--background-{role}` | `--background-brand-primary`, `--background-primary-hover`, `--background-info` |
+| Text | `--text-{role}` | `--text-primary`, `--text-brand-primary`, `--text-info` |
+| Surface | `--surface-{role}` | `--surface-primary`, `--surface-secondary`, `--surface-info` |
+| Border | `--border-{role}` | `--border-primary`, `--border-brand-primary`, `--border-info` |
+| Page | `--page-{role}` | `--page-primary`, `--page-secondary` |
+| Font family | `--font-family-{role}` | `--font-family-heading`, `--font-family-body`, `--font-family-label` |
+| Typography | `--{style}-{size}` | `--heading-lg`, `--body-md`, `--label-sm` |
+| Spacing | `--padding-{size}`, `--gap-{size}` | `--padding-lg`, `--gap-md` |
+| Border radius | `--border-radius-{size}` | `--border-radius-sm`, `--border-radius-md` |
+| Shadow | `--shadow-{size}` | `--shadow-sm`, `--shadow-lg` |
+| Scale step | `--{category}-{index}` | `--space-400`, `--font-size-700`, `--color-grayscale-dark` |
+
+Full vocabulary rules — title vs heading, label family, axes, no-unclassed-wrappers — in [Naming Conventions](/docs/primitives/naming-conventions).
+
+## Figma variable collections → CSS output
+
+Figma organises variables into named collections. Each collection has modes. Style Dictionary flattens the active mode of each collection into `figma-tokens.css`.
+
+| Figma collection | Active mode | What it generates |
+|---|---|---|
+| `primitives` | `value` | Raw scale: `--color-poppy-*`, `--space-*`, `--font-size-*`, `--border-radius-*`, `--shadow-blur-*` |
+| `color` | `light` / `dark` | Semantic roles: `--background-*`, `--text-*`, `--surface-*`, `--border-*`, `--page-*` |
+| `typography` | `default` | Composite tokens: `--heading-lg`, `--body-md`, `--label-sm`, `--font-family-*` |
+| `spacing` | `default` | `--padding-*`, `--gap-*` |
+| `border-radius` | `soft` | `--border-radius-sm/md/lg` |
+| `border-width` | `default` | `--border-width-sm/md/lg` |
+| `elevation` | `subtle` | `--shadow-sm/md/lg/xl`, `--blur-radius-*` |
+| `breakpoint` | `default` | `--breakpoint-web/tablet/mobile` |
+
+**Light vs dark mode:** `figma-tokens.css` uses the `light` mode of the `color` collection. `figma-tokens-dark.css` uses the `dark` mode. Both files use identical variable names — consuming projects import dark after light, and the browser applies whichever matches `[data-theme="dark"]`.
+
+## Style Dictionary pipeline
+
+Figma is the only place tokens are edited. The pipeline:
+
+```
+1. Designer edits variables in Figma (Foundations file)
+         ↓
+2. Agent runs pull-variables.js with channel ID
+   → /tmp/figma-vars.json  (raw Figma variable data)
+         ↓
+3. node scripts/sync-figma-mcp.js /tmp/figma-vars.json --build
+   → patches design-tokens/tokens-studio.json (W3C DTCG format)
+   → runs npm run build:all-tokens
+         ↓
+4. scripts/flatten-tokens-studio.js
+   → design-tokens/tokens-figma.json  (flattened, mode-resolved)
+         ↓
+5. Style Dictionary
+   → tokens/figma-tokens.css          ← Tier 1, imported by all projects
+   → tokens/figma-tokens-dark.css     ← dark mode variant
+   → build/figma/js/tokens.mjs        ← JS / TypeScript
+   → build/figma/swift/*.swift        ← iOS
+```
+
+<Callout type="warn">
+  Never manually edit `tokens/figma-tokens.css`. It is generated on every sync. Use `tokens/gap-fills.css` for gap-fill tokens that aren't in Figma yet.
+</Callout>
+
+## Browse the token categories
+
+417 tokens across all collections. Each page below explains one primitive group: what tokens exist, what they mean semantically, and the rules for using them outside their category (don't).
 
 <Cards>
   <Card title="Color" href="/docs/primitives/color" description="Semantic color roles + interaction states + status + the primitive palettes." />
@@ -24,36 +155,51 @@ Each page below explains one primitive group: what tokens exist, what they mean 
   <Card title="Border radius" href="/docs/primitives/border-radius" description="Corner rounding from sharp (0) to pill (999) to fully circular." />
   <Card title="Border width" href="/docs/primitives/border-width" description="Line thickness for borders, dividers, and outlines." />
   <Card title="Shadow" href="/docs/primitives/shadow" description="Elevation tokens — composed semantic shadows + primitive blur/spread scales." />
-  <Card title="Motion" href="/docs/primitives/motion" description="Duration, easing, keyframes, and the three-tier motion system." />
+  <Card title="Naming Conventions" href="/docs/primitives/naming-conventions" description="The vocabulary that keeps the system tight — title vs heading, label family, axes." />
 </Cards>
 
-## Still in Storybook
+## Theming
 
-These foundation pages haven't been migrated yet. Until they land here, view them in Storybook and treat the contents as canonical.
+A client brand is a single CSS file (~12–27 token overrides) that redefines semantic tokens. Components never change. See [Theming](/docs/theming) for the four-layer cascade, [Client Themes](/docs/theming/client-themes) for the override matrix and minimal template, and [Atmospheres](/docs/theming/atmospheres) for the visual character layer.
 
-| Page | Where |
-|---|---|
-| Motion (full) | [Storybook → Motion](https://storybook.brikdesigns.com/?path=/docs/motion-overview--docs) — overview, tiers, effects, vocabulary |
-| Naming Conventions | [Storybook → Naming Conventions](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-naming-conventions--docs) |
-| Design Tokens overview | [Storybook → Design Tokens](https://storybook.brikdesigns.com/?path=/docs/foundations-design-tokens-overview--docs) |
+**Validate with Client Sim:** Switch to `Client Sim` in the Storybook toolbar. It assigns Georgia / Verdana / Courier New to heading / body / label families — any component using the wrong `--font-family-*` token becomes immediately visible.
 
-## How tokens flow into your app
+## Adding a new token
 
-```text
-Figma Variables
-      ↓
-design-tokens/tokens-studio.json    (build input)
-      ↓
-Style Dictionary
-      ↓
-tokens/figma-tokens.css             (auto-generated)
-tokens/figma-tokens-dark.css        (auto-generated, dark mode)
-tokens/gap-fills.css                (manual, interaction states)
-      ↓
-Consumer projects:
-  @import '@brikdesigns/bds/tokens.css';
-  @import './styles/theme-{client}.css';
-  @import '@brikdesigns/bds/styles.css';
+**Always start in Figma — never in CSS.**
+
+1. Add the variable to the correct collection in the Figma Foundations file
+2. Connect Claude with the Figma dev plugin (provide channel ID)
+3. Run the sync: `bun scripts/pull-variables.js <channel> > /tmp/vars.json && node scripts/sync-figma-mcp.js /tmp/vars.json --build`
+4. Verify the token appears in `tokens/figma-tokens.css`
+5. Add it to the consuming project's `src/lib/tokens.ts` export map
+
+**Exception:** tokens that aren't ready for Figma yet go in `tokens/gap-fills.css` with a `TODO: promote to Figma` comment.
+
+## What NOT to do
+
+```css
+/* ❌ Never use a primitive in a component */
+.card { color: var(--color-grayscale-darkest); }
+/* ✅ Use the semantic alias */
+.card { color: var(--text-primary); }
+
+/* ❌ Never hardcode a value */
+.button { background: #e35335; }
+/* ✅ Use the semantic token */
+.button { background: var(--background-brand-primary); }
+
+/* ❌ Never edit figma-tokens.css manually */
+/* ✅ Edit in Figma → run sync → regenerates automatically */
+
+/* ❌ Never skip the TypeScript layer in consuming projects */
+style={{ color: 'var(--text-primary)' }}
+/* ✅ Import from the token map */
+import { color } from '@/lib/tokens';
+style={{ color: color.text.primary }}
+
+/* ❌ Never hand-author dark-mode overrides */
+[data-theme="dark"] { --background-primary: #111; }
+/* ✅ Dark mode ships generated from Figma — bundled into @brikdesigns/bds/tokens.css */
+@import '@brikdesigns/bds/tokens.css';
 ```
-
-See [the cascade rules](/docs/getting-started/cascade) for how the three layers interact.

--- a/docs-site/content/docs/primitives/meta.json
+++ b/docs-site/content/docs/primitives/meta.json
@@ -8,6 +8,7 @@
     "size",
     "border-radius",
     "border-width",
-    "shadow"
+    "shadow",
+    "naming-conventions"
   ]
 }

--- a/docs-site/content/docs/primitives/naming-conventions.mdx
+++ b/docs-site/content/docs/primitives/naming-conventions.mdx
@@ -1,0 +1,190 @@
+---
+title: Naming Conventions
+description: The vocabulary that keeps the system tight — title vs heading, label family, action vs button-label, axes, and the no-unclassed-wrappers rule.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+The words we use have to be tight or the system drifts. This page names the pieces of a BDS component and the rules that govern each word. Every term here is load-bearing — it picks a token scale, picks a BEM class, or picks an HTML element. Reach for this list before you invent a name.
+
+## The principle — intent, not shape
+
+Every word below describes a **role** or a **slot**. It does not dictate the visual shape and, critically, it does not dictate the HTML element. The HTML element is chosen by *semantic intent* at the call site — is this thing part of the document outline? Is it interactive? Is it prose? The BEM class names the role; semantics name the element.
+
+This distinction is especially load-bearing for titles and headings (below) — get it wrong and you render outline-invisible content that looks correct visually.
+
+## Title vs heading
+
+`title` and `heading` refer to the same typographic role at different layers. They are **not** substitutes for each other.
+
+| Layer | Word | Example |
+|---|---|---|
+| Typography tokens (scale) | `heading` | `--heading-md`, `--font-family-heading` |
+| BEM (role/position) | `title` | `.bds-page-header__title`, `.bds-data-section__title`, `.bds-card-display__title` |
+| HTML element | `h1`–`h3`, or `div`/`p` | Chosen by outline position, not by class name |
+
+### The rule
+
+> Name the role `__title` in BEM. Scale its typography with `--heading-*` tokens. Pick the HTML element at the call site based on whether it is a document outline node.
+
+**When a title IS an outline node** (most cases on a page — `<DataSection title="Identity">` inside the Overview tab is an outline sibling of the page's `<h1>`) → render as `<h2>` (or `<h3>` when nested). Screen readers walk these.
+
+**When a title is NOT an outline node** (decorative card in a grid of many cards, metric tile, repeating marker) → render as `<div>` or `<p>`. It still uses `__title` BEM and heading-tier tokens.
+
+Never pick the HTML tag by guessing from the BEM name. `<div class="bds-card__title">` and `<h3 class="bds-card__title">` are both valid — choose by outline intent.
+
+## Subtitle
+
+The secondary line paired with a title. Always `subtitle`. Never `eyebrow`.
+
+- BEM: `.bds-*__subtitle`
+- Usage: `PageHeader`, `Sheet`, `SheetSection`, `BoardCard`, `DataSection`.
+- Rendered as: `<p>` by default.
+
+"Eyebrow" is a common term in marketing-site design systems. It is not a term in BDS. If a design spec uses it, translate to `subtitle` before writing code.
+
+## Description
+
+Explanatory prose under a title or subtitle — longer and more neutral than a subtitle.
+
+- BEM: `.bds-*__description`
+- Usage: `Form`, `Banner`, `SheetSection`.
+- Rendered as: `<p>`.
+
+Use when a component needs a short paragraph of context below its title. Not a legal equivalent to subtitle — subtitle is visual chrome, description is content.
+
+## The label family
+
+`label` is the umbrella suffix for **any text that names or identifies a discrete thing**. When you're adding a new named text element, reach for a `-label` name before inventing a term.
+
+| Term | What it names | Current implementation |
+|---|---|---|
+| `field-label` | The name on a data pair (`<Field label="Business Name">`) | `.bds-field__label`, `.bds-sheet-field-label` |
+| `card-summary__label` | Label on a metric or stat | `.bds-card-summary__label` |
+| `chip__label` | Text inside a `Chip` | `.bds-chip__label` |
+| `meter__label`, `progress-stepper__label` | Label for progress / measurement markers | existing BEM |
+| `button-label` | The text on a `<Button>` | passed as `children` today — concept-only |
+| `tab-label` | The text on a `<TabBar>` tab | `label: string` prop on Sheet tabs |
+| `paragraph-label` | Scoped label above a paragraph or bullet list (e.g. "Care Philosophy") | not a separate component — use `<Field>` with a paragraph or `<BulletList>` as its value |
+
+### Rules
+
+- New named text element? Use a `-label` term before inventing one.
+- `button-label` and `tab-label` are concepts, not classes. Don't rush to add `label` props to `<Button>` or `<TabBar>`; `children` is fine. Name them in specs and docs.
+- `paragraph-label` describes a *usage of Field* (label + paragraph or list value). There is no `ParagraphField` or `ListField` — `Field` accepts any `ReactNode` as its value and covers both cases.
+
+## Action vs button-label (different layers)
+
+One category mistake we avoid: calling a button "an action."
+
+- **`action` / `actions`** — the **slot** inside a component that holds one or more buttons. `.bds-page-header__actions`, `.bds-card-display__action`, `.bds-data-section__actions`. It is a `<div>` that receives a `<Button>` or `<ButtonGroup>`.
+- **`button-label`** — the **text on each button** inside that slot. Passed as `children` today.
+
+The slot is not the text. Don't conflate them. When documenting a section header with a `[View]` / `[Edit]` toggle:
+
+- The **slot** holding the toggle is `actions`.
+- The **component** rendering the two buttons is `ButtonGroup`.
+- The **text** on each button is a button-label.
+
+## Value
+
+The datum paired with a label.
+
+- BEM: `.bds-*__value` (e.g. `.bds-field__value`, `.bds-card-summary__value`).
+- Rendered as: `<div>` or `<span>` depending on whether the value is block-level content (paragraph, list) or inline text.
+
+`Field` handles the inline vs block distinction internally — put any `ReactNode` as `children`. `CardSummary` renders values as heading-tier typography (it's a stat tile, not a form field) — don't confuse the two.
+
+## Section vs card vs board
+
+These are containers, not text. Different words because they have different responsibilities.
+
+| Container | Purpose | When |
+|---|---|---|
+| `DataSection` | Titled block of read-mode data on a **page** | Overview / profile tabs, client-detail pages |
+| `SheetSection` | Titled block inside a **sheet** body (uppercase label heading) | Any block grouping inside `<Sheet>` |
+| `Card` (and variants — `CardSummary`, `CardControl`, `CardTestimonial`, `CollapsibleCard`, `PricingCard`) | Bordered, self-contained unit of content | Grids of comparable items, dashboards, marketing |
+| `Board` (`BoardColumn`, `BoardCard`) | Kanban-style container | Task boards |
+| `Dialog` / `Modal` / `Sheet` | Overlay containers | Focused interactions |
+
+Don't reach for a `Card` when a `DataSection` is right. Cards are self-contained units in a grid; `DataSection` is one region of a larger page.
+
+## Elements that render `<h*>` vs elements that don't
+
+Quick reference. HTML element shown first — it is the load-bearing fact.
+
+| Element | Typical use | BEM role |
+|---|---|---|
+| `<h1>` | Page title (one per page) | `.bds-page-header__title` |
+| `<h2>` | Section title on a page | `.bds-data-section__title` |
+| `<h3>` | Sheet section heading (uppercase label) | `.bds-sheet-section__heading` — different role, different style |
+| `<p>` | Subtitle, description, field-label (when standalone), body prose | `.bds-*__subtitle`, `.bds-*__description` |
+| `<span>` | Inline label (e.g. metadata pair inside a page header) | `.bds-*__label` when inline |
+| `<label>` | Form-control label when `htmlFor` is set | `.bds-sheet-field-label` for form inputs |
+| `<div>` | Slots, containers, wrappers | `__actions`, `__content`, `__header`, `__titles` |
+
+Screen readers walk `<h*>` elements to build the outline. Every `<h*>` decision is an a11y decision. Don't reach for `<h3>` because it "looks right" — use outline position.
+
+## Axes — shared prop vocabulary across components
+
+Components with overlapping visual concerns share the same prop names and values. A prop is an **axis** when more than one component exposes it — the axis names belong to the system, not any single component.
+
+| Axis | Values | Meaning | Components |
+|---|---|---|---|
+| `size` | `xs` · `sm` · `md` · `lg` | Physical dimensions on a shared scale (e.g. Badge + Tag + Chip align by height at every tier). | Badge, Tag, Chip, BadgeGroup, TagGroup, Button, IconButton, Field, Sheet, most form controls |
+| `status` | `positive` · `warning` · `error` · `info` · `progress` · `brand` | Semantic value judgment — which system color tier applies. Indicator-only. | Badge, AlertBanner, Dot |
+| `variant` (hierarchy) | `primary` · `secondary` | How much attention the element commands inside a cluster. Not a fill style. | Chip, Button |
+| `appearance` (fill) | `solid` · `subtle` · `outline` | How the shape is filled vs. bordered. Each component supports the subset that has a real visual meaning. | Badge (`solid` / `subtle`), Chip (`solid` / `outline`), Tag (`solid` / `subtle`) |
+
+### The rule
+
+> `variant` describes **hierarchy**. `appearance` describes **fill**. Never conflate them — a chip can be both `variant="primary"` and `appearance="outline"`, and the combination is meaningful.
+
+### Why `solid | subtle | outline` (not `dark | light`)
+
+The older `dark | light` vocabulary was ambiguous with dark-mode theming — `--dark` could mean either "saturated fill" or "variant used on dark themes." `solid | subtle | outline` names the *fill form* explicitly and never collides with the theme axis:
+
+- **`solid`** — filled background, typically saturated or neutral.
+- **`subtle`** — filled with a pastel or tinted background, lower emphasis.
+- **`outline`** — transparent background, visible border.
+
+### Axis coverage matrix
+
+| Component | `variant` | `appearance` values | `status` | Notes |
+|---|---|---|---|---|
+| Badge | — | `solid` (default) · `subtle` | required axis | Outline never made sense for status indicators — low contrast. |
+| Tag | — | `solid` (default) · `subtle` | — | Neutral categorization — no status axis. |
+| Chip | `primary` · `secondary` | `solid` (default) · `outline` | — | Two axes: hierarchy (variant) × fill (appearance). |
+
+Adding a new pill component? Reuse the axis names above. Don't invent `kind`, `style`, `flavor`, etc. — the axes exist so a reader knows what to expect.
+
+## Elements — no unclassed wrappers
+
+The element / BEM table above lists which HTML elements each role maps to. The implicit rule is that **every element in a BDS component tree carries a role name** — either a `bds-*` class (when the element belongs to the system) or a `data-*` attribute (when the consumer needs to override something). A `<div>` with no class and no role is drift: it tells the next reader nothing about why the element exists.
+
+### The rule
+
+> Every element in a BDS component tree names its role. Bare `<div>` with no class, no role, no reason to exist is drift — replace it with the correct BEM slot (`__content`, `__actions`, `__header`, etc.) or remove it.
+
+**Acceptable unclassed elements:**
+
+- Short-lived rendering helpers inside a Storybook story file (they don't ship).
+- Children passed in by the consumer (`{children}`) — the consumer owns those names.
+- Fragments (`<>...</>`) — no wrapper exists.
+
+**Not acceptable:**
+
+- `<div>` wrapping a component's output because "it needs a flex container" — name the slot.
+- `<span>` around an icon + label pair — use `__icon` / `__label`.
+- `<div className={classes}>` where `classes` is empty or conditionally empty — ship the class or don't ship the wrapper.
+
+<Callout type="info">
+  This is a discipline rule, not a build-time lint (yet). If a wrapper is ambiguous about its role, add a BEM class with the role name before you add any CSS.
+</Callout>
+
+## Related
+
+- [Design Tokens overview](/docs/primitives) — the architecture these names sit inside
+- [Color tokens](/docs/primitives/color) — semantic role categories
+- [Typography tokens](/docs/primitives/typography) — heading vs body vs label scales
+- [Components](/docs/components) — every component implements the axes above


### PR DESCRIPTION
## Summary

Closes the two real gaps in Foundations vs Storybook so the entire Foundations corner of Storybook docs can retire.

### Gap 1 — Naming Conventions (entirely missing in fumadocs)

Full port from `stories/foundation/NamingConventions.mdx` to `docs-site/content/docs/primitives/naming-conventions.mdx`. Covers the load-bearing vocabulary the system depends on:

- **Title vs heading** — BEM role (`__title`) vs typography scale (`--heading-*`) vs HTML element (`<h*>` or `<div>` chosen by outline intent)
- **Subtitle / description / value** — never `eyebrow`
- **The label family** — `field-label`, `button-label`, `paragraph-label`, etc.
- **Action vs button-label** — the slot is not the text
- **Section vs card vs board** containers — when to reach for which
- **`<h*>` / `<p>` / `<span>` / `<div>` mapping** to BEM roles
- **Axes** — `size`, `status`, `variant` (hierarchy), `appearance` (fill); why `solid`/`subtle`/`outline` replaced `dark`/`light`
- **No-unclassed-wrappers rule** — every element names its role

### Gap 2 — Design Tokens overview (was a thin Cards-only landing page)

Replaced [primitives/index.mdx](docs-site/content/docs/primitives/index.mdx) with the full Storybook-equivalent overview:

- 2-tier architecture diagram (BDS Foundations + Client Theme)
- CSS import cascade (using package exports per #290)
- Primitive vs semantic distinction with do/don't examples
- Naming convention table
- Figma collection → CSS output mapping
- Style Dictionary pipeline (Figma → tokens-studio.json → SD → CSS/JS/Swift)
- Browse-by-category Cards
- Theming pointer + Client Sim validation
- Adding-a-new-token process
- "What NOT to do" anti-patterns block

### What was already done (no re-port needed)

The other 6 primitives — Color, Typography, Spacing, Size, Shadow, BorderRadius, BorderWidth — were already fully ported with the same MDX viz components Storybook uses (registered globally in [lib/mdx-components.tsx](docs-site/lib/mdx-components.tsx)): `ColorGrid`, `SpacingScale`, `SemanticSpacing`, `TypographyScale`, `FontFamilyShowcase`, `SemanticTypographyTable`, `FontWeightShowcase`, `BorderRadiusPreview`, `BorderWidthPreview`, `ShadowScale`. The earlier "stub" classification was misleading — it counted words and missed the JSX-rendered content.

## Test plan

- [x] `npm run build` — 122 static pages, no errors (was 121; +1 = naming-conventions)
- [ ] `/docs/primitives` renders the full Design Tokens overview (architecture diagram, naming convention table, Figma→CSS mapping, pipeline diagram, "What NOT to do" block)
- [ ] `/docs/primitives/naming-conventions` resolves and renders the full vocabulary reference
- [ ] Sidebar shows `Primitives > Design Tokens · Color · Typography · Spacing · Size · Border Radius · Border Width · Shadow · Naming Conventions`

## Storybook retirement readiness

After this merges, every page under Storybook's `Foundations/Design Tokens/*` and `Foundations/Naming Conventions` has a fumadocs equivalent. Ready to delete the corresponding `.mdx` files from Storybook in a follow-up cleanup PR (the `.stories.tsx` files stay — Storybook keeps the live playground).

🤖 Generated with [Claude Code](https://claude.com/claude-code)