### PR TITLE
feat(bds): add MenuItemData.description for 2-line menu items

### DIFF
--- a/components/ui/Menu/Menu.css
+++ b/components/ui/Menu/Menu.css
@@ -86,4 +86,38 @@
   color: var(--text-primary);
   flex-shrink: 0;
 }
+
+/* ─── Text block (label + optional description) ─────── */
+
+.bds-menu__text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-tiny);
+  min-width: 0;
+  flex: 1;
+}
+
+.bds-menu__label {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: var(--font-line-height-tight);
+  color: inherit;
+}
+
+.bds-menu__description {
+  font-family: var(--font-family-body);
+  font-size: var(--body-xs);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-secondary);
+  text-transform: none;
+}
+
+/* When description is present, align icon to the top of the text
+   block so it sits with the label rather than centering between
+   label + description, and bump padding for breathing room. */
+.bds-menu__item--with-description {
+  align-items: flex-start;
+  padding: var(--padding-sm);
+}
 }

--- a/components/ui/Menu/Menu.mdx
+++ b/components/ui/Menu/Menu.mdx
@@ -23,9 +23,26 @@ With icons, text-only with disabled item, and active item highlight.
 
 ## Patterns
 
-Real-world usage: `FilterButton` trigger and `Button` trigger with action menu.
+Real-world usage: `FilterButton` trigger, `Button` trigger with action menu, and an "Add" menu where each item has a label + description (the 2-line `MenuItemData.description` variant).
 
 <Canvas of={Stories.Patterns} />
+
+### Items with description
+
+Pass `description?: string` on a `MenuItemData` to render a second-line description below the label. Used for "what does this option do?" affordance — common in "Add new ___" menus where each option is a different kind of thing (e.g. *Checklist — Recurring to-do lists*, *Procedure — Step-by-step workflows*).
+
+```tsx
+<Menu
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  items={[
+    { id: 'checklist', label: 'Checklist', description: 'Recurring to-do lists', onClick: ... },
+    { id: 'procedure', label: 'Procedure', description: 'Step-by-step workflows', onClick: ... },
+  ]}
+/>
+```
+
+When `description` is absent, the item renders as a single-line label (existing behavior, unchanged).
 
 ---
 

--- a/components/ui/Menu/Menu.stories.tsx
+++ b/components/ui/Menu/Menu.stories.tsx
@@ -134,6 +134,7 @@ export const Patterns: Story = {
     function MenuPatterns() {
       const [filterValue, setFilterValue] = useState<string | undefined>();
       const [actionOpen, setActionOpen] = useState(false);
+      const [addOpen, setAddOpen] = useState(false);
 
       return (
         <Stack>
@@ -163,6 +164,25 @@ export const Patterns: Story = {
                   { id: '4', label: 'Delete', disabled: true },
                 ]}
                 style={{ top: '100%', left: 0, marginTop: 'var(--gap-md)' }}
+              />
+            </div>
+          </div>
+
+          <div>
+            <SectionLabel>Add menu — items with description</SectionLabel>
+            <div style={{ position: 'relative', display: 'inline-block' }}>
+              <Button variant="primary" onClick={() => setAddOpen(!addOpen)}>
+                + Add Task
+              </Button>
+              <Menu
+                isOpen={addOpen}
+                onClose={() => setAddOpen(false)}
+                items={[
+                  { id: 'checklist', label: 'Checklist', description: 'Recurring to-do lists', onClick: () => setAddOpen(false) },
+                  { id: 'procedure', label: 'Procedure', description: 'Step-by-step workflows', onClick: () => setAddOpen(false) },
+                  { id: 'compliance', label: 'Compliance', description: 'Regulatory & safety tasks', onClick: () => setAddOpen(false) },
+                ]}
+                style={{ top: '100%', left: 0, marginTop: 'var(--gap-md)', minWidth: 280 }}
               />
             </div>
           </div>

--- a/components/ui/Menu/Menu.tsx
+++ b/components/ui/Menu/Menu.tsx
@@ -16,6 +16,11 @@ export interface MenuItemData {
   id: string;
   /** Display label */
   label: string;
+  /**
+   * Optional secondary description rendered below the label as a
+   * second line. When omitted, the item is single-line.
+   */
+  description?: string;
   /** Optional icon before the label */
   icon?: ReactNode;
   /** Disabled state */
@@ -52,6 +57,7 @@ export interface MenuItemProps extends HTMLAttributes<HTMLButtonElement> {
  * MenuItem - Single menu option (exported for direct use)
  */
 export function MenuItem({ item, isActive, className, style, ...props }: MenuItemProps) {
+  const hasDescription = !!item.description;
   return (
     <button
       type="button"
@@ -62,13 +68,19 @@ export function MenuItem({ item, isActive, className, style, ...props }: MenuIte
         'bds-menu__item',
         isActive && 'bds-menu__item--active',
         item.disabled && 'bds-menu__item--disabled',
+        hasDescription && 'bds-menu__item--with-description',
         className,
       )}
       style={style}
       {...props}
     >
       {item.icon && <span className="bds-menu__icon">{item.icon}</span>}
-      <span>{item.label}</span>
+      <span className="bds-menu__text">
+        <span className="bds-menu__label">{item.label}</span>
+        {hasDescription && (
+          <span className="bds-menu__description">{item.description}</span>
+        )}
+      </span>
     </button>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(bds): add MenuItemData.description for 2-line menu items

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)