### PR TITLE
feat(bds): add InteractiveListItem — clickable row with leading + title + subtitle + trailing

### DIFF
--- a/components/ui/InteractiveListItem/InteractiveListItem.css
+++ b/components/ui/InteractiveListItem/InteractiveListItem.css
@@ -1,0 +1,103 @@
+@layer bds-components {
+  /* ─── InteractiveListItem ───────────────────────────────────────
+     Clickable horizontal row: leading + (title + subtitle) + trailing.
+     The whole row is a <button> — single click target, native focus,
+     native Space/Enter.
+
+     Distinct from CardControl (which is a settings card whose trailing
+     action is the click target, not the card). Use this when the row
+     itself drills into something.
+  ───────────────────────────────────────────────────────────────── */
+
+  .bds-interactive-list-item {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-md);
+    width: 100%;
+    padding: var(--padding-md) var(--padding-lg);
+    background: none;
+    border: none;
+    border-radius: var(--border-radius-md);
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+    font: inherit;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      transform var(--duration-fast) var(--ease-out);
+  }
+
+  .bds-interactive-list-item:hover:not(:disabled) {
+    background-color: var(--surface-secondary);
+  }
+
+  .bds-interactive-list-item:active:not(:disabled) {
+    transform: scale(0.99);
+  }
+
+  .bds-interactive-list-item:focus-visible {
+    outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
+    outline-offset: 2px;
+  }
+
+  .bds-interactive-list-item--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* ─── Leading slot ─────────────────────────────────────────────
+     Fixed-size (whatever consumer renders), doesn't shrink. */
+
+  .bds-interactive-list-item__leading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  /* ─── Text block (title + subtitle) ──────────────────────────── */
+
+  .bds-interactive-list-item__text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-tiny);
+    min-width: 0;
+    flex: 1;
+  }
+
+  .bds-interactive-list-item__title {
+    font-family: var(--font-family-label);
+    font-size: var(--label-md);
+    font-weight: var(--font-weight-semi-bold);
+    line-height: var(--font-line-height-tight);
+    color: var(--text-primary);
+    /* Truncate single-line titles — but allow wrap if consumer needs it */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .bds-interactive-list-item__subtitle {
+    /* ReactNode — consumer controls structure (string / multi-line / inline badges).
+       Default styling is muted body text; consumer's own elements (StatusBadge,
+       PriorityBadge, etc.) preserve their own styling within. */
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-tiny);
+    font-family: var(--font-family-body);
+    font-size: var(--body-xs);
+    line-height: var(--font-line-height-normal);
+    color: var(--text-secondary);
+  }
+
+  /* ─── Trailing slot ─────────────────────────────────────────────
+     Fixed-size, doesn't shrink. */
+
+  .bds-interactive-list-item__trailing {
+    display: flex;
+    align-items: center;
+    gap: var(--gap-sm);
+    flex-shrink: 0;
+    color: var(--text-secondary);
+  }
+}

--- a/components/ui/InteractiveListItem/InteractiveListItem.mdx
+++ b/components/ui/InteractiveListItem/InteractiveListItem.mdx
@@ -1,0 +1,93 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './InteractiveListItem.stories';
+
+<Meta of={Stories} />
+
+# InteractiveListItem
+
+Clickable horizontal row composed of leading + (title + subtitle) + trailing slots. The whole row is the click target — single `<button>` for native a11y (focus ring, `Space` / `Enter` activation, `disabled`).
+
+Use when a list row drills into something — clicking a member opens their profile, clicking an activity item opens the related task, clicking a persona switches the dev session.
+
+**Distinct from `CardControl`.** `CardControl` is a settings card whose **trailing action** (Switch / Button / link) is the click target — the card itself is *not* interactive. `InteractiveListItem` is the inverse — the **whole row** is interactive, the trailing slot is decorative (a Tag, Badge, progress block, or caret indicator). If you need both — a row that drills in AND a switch in the trailing — you have a UX conflict; pick one click target.
+
+---
+
+## Playground
+
+<Canvas of={Stories.Playground} />
+
+## Variants
+
+<Canvas of={Stories.Variants} />
+
+- **Title only** — minimal row, just leading + title
+- **Title + subtitle** — adds a single-line subtitle (string or simple ReactNode)
+- **Full row** — leading + title + subtitle + trailing
+- **Disabled** — muted styling, no interaction, no hover/active
+
+## Patterns
+
+<Canvas of={Stories.Patterns} />
+
+An activity feed inside a sheet. Each row drills into the related request. The subtitle slot here is a `ReactNode` carrying multi-line metadata: the first line is text (submitter · timestamp), the second line is a row of inline `<Badge>`s. The trailing slot shows a caret indicator.
+
+---
+
+## Props
+
+<ArgTypes of={Stories} />
+
+---
+
+## Usage
+
+```tsx
+import { InteractiveListItem } from '@brikdesigns/bds';
+
+<InteractiveListItem
+  leading={<UserAvatar name={member.name} size="md" />}
+  title={member.name}
+  subtitle={`${member.role} · ${member.department}`}
+  trailing={<Badge status="info">New hire</Badge>}
+  onClick={() => openProfile(member.id)}
+/>
+```
+
+### Multi-line subtitle with badges
+
+When the subtitle needs structured content (timestamps, status badges, multiple lines), pass a `ReactNode`:
+
+```tsx
+<InteractiveListItem
+  leading={<StatusIcon resolved={req.resolved} />}
+  title={req.title}
+  subtitle={
+    <>
+      <span>{req.submitter} · {timeAgo(req.created_at)}</span>
+      <span style={{ display: 'flex', gap: 'var(--gap-sm)' }}>
+        <StatusBadge status={req.status} size="xs" />
+        <PriorityBadge priority={req.urgency} size="xs" />
+      </span>
+    </>
+  }
+  trailing={<Icon icon="ph:caret-right" />}
+  onClick={() => openRequest(req.id)}
+/>
+```
+
+The component applies muted body-text styling to the subtitle wrapper but consumer elements (`<StatusBadge>`, `<PriorityBadge>`) preserve their own visual identity.
+
+## When to use
+
+- "Drill into" rows — clicking a member opens their profile sheet
+- Activity feeds — clicking an item opens the related task / request
+- Persona / mode switchers — clicking a persona swaps the dev session
+- Any row pattern with a leading visual + primary text + optional secondary + optional trailing badge/indicator
+
+## When not to use
+
+- Settings cards with a Switch / Button as the action target → use `CardControl` (or `Card preset="control"`)
+- Form selections / multi-select → use `Checkbox` or `MenuItem`
+- Completion-state toggle rows → use `ChecklistItem`
+- Two-cell key-value rows in a read-mode field list → use `ReadOnlyField` (in renew-pms)

--- a/components/ui/InteractiveListItem/InteractiveListItem.stories.tsx
+++ b/components/ui/InteractiveListItem/InteractiveListItem.stories.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { InteractiveListItem } from './InteractiveListItem';
+import { Avatar } from '../Avatar';
+import { Badge } from '../Badge';
+import { Tag } from '../Tag';
+
+/* ─── Layout helpers (story-only) ────────────────────────────────── */
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <div
+    style={{
+      fontFamily: 'var(--font-family-label)',
+      fontSize: 'var(--body-xs)', // bds-lint-ignore
+      textTransform: 'uppercase' as const,
+      letterSpacing: '0.05em',
+      marginBottom: 'var(--gap-md)',
+      color: 'var(--text-muted)',
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Stack = ({
+  children,
+  gap = 'var(--gap-tiny)',
+}: {
+  children: React.ReactNode;
+  gap?: string;
+}) => <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>;
+
+/* ─── Meta ───────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof InteractiveListItem> = {
+  title: 'Components/Display/InteractiveListItem',
+  component: InteractiveListItem,
+  tags: ['surface-shared'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    title: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InteractiveListItem>;
+
+/* ═══════════════════════════════════════════════════════════════
+   1. PLAYGROUND
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Interactive playground for prop tweaking */
+export const Playground: Story = {
+  args: {
+    title: 'Emily Rivera',
+    subtitle: 'Hygienist · 2 years',
+    disabled: false,
+  },
+  render: (args) => (
+    <div style={{ minWidth: 360 }}>
+      <InteractiveListItem
+        {...args}
+        leading={<Avatar name="Emily Rivera" size="md" />}
+        trailing={<Badge status="info">New hire</Badge>}
+        onClick={() => console.log('clicked')}
+      />
+    </div>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   2. VARIANTS
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Slot combinations side by side */
+export const Variants: Story = {
+  render: () => (
+    <div style={{ minWidth: 480 }}>
+      <Stack>
+        <InteractiveListItem
+          leading={<Avatar name="Emily Rivera" size="md" />}
+          title="Title only"
+          onClick={() => {}}
+        />
+        <InteractiveListItem
+          leading={<Avatar name="Emily Rivera" size="md" />}
+          title="Title + subtitle"
+          subtitle="Single-line metadata"
+          onClick={() => {}}
+        />
+        <InteractiveListItem
+          leading={<Avatar name="Emily Rivera" size="md" />}
+          title="Full row"
+          subtitle="Hygienist · 2 years"
+          trailing={<Badge status="info">New hire</Badge>}
+          onClick={() => {}}
+        />
+        <InteractiveListItem
+          leading={<Avatar name="Tyler Nguyen" size="md" />}
+          title="Disabled"
+          subtitle="No interaction"
+          trailing={<Tag size="sm">Inactive</Tag>}
+          disabled
+          onClick={() => {}}
+        />
+      </Stack>
+    </div>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   3. PATTERNS
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Real-world: an activity feed inside a sheet (request rows) */
+export const Patterns: Story = {
+  render: () => (
+    <div style={{ minWidth: 520 }}>
+      <SectionLabel>Activity feed (drill-down rows)</SectionLabel>
+      <Stack gap="0">
+        <InteractiveListItem
+          leading={
+            <span
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 'var(--border-radius-circle)',
+                backgroundColor: 'var(--surface-secondary)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 'var(--body-md)',
+              }}
+              aria-hidden="true"
+            >
+              📋
+            </span>
+          }
+          title="Restock surgical gloves"
+          subtitle={
+            <>
+              <span>Acme Dental Supply · Submitted 2d ago</span>
+              <span style={{ display: 'flex', gap: 'var(--gap-sm)' }}>
+                <Badge status="warning" size="xs">In review</Badge>
+                <Badge status="error" size="xs">High</Badge>
+              </span>
+            </>
+          }
+          trailing={<span aria-hidden="true">›</span>}
+          onClick={() => {}}
+        />
+        <InteractiveListItem
+          leading={
+            <span
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 'var(--border-radius-circle)',
+                backgroundColor: 'var(--surface-positive, var(--surface-secondary))',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 'var(--body-md)',
+              }}
+              aria-hidden="true"
+            >
+              ✓
+            </span>
+          }
+          title="Replace HEPA filter, Operatory 3"
+          subtitle={
+            <>
+              <span>Sarah Mitchell · Resolved 5d ago</span>
+              <span style={{ display: 'flex', gap: 'var(--gap-sm)' }}>
+                <Badge status="positive" size="xs">Resolved</Badge>
+              </span>
+            </>
+          }
+          trailing={<span aria-hidden="true">›</span>}
+          onClick={() => {}}
+        />
+      </Stack>
+    </div>
+  ),
+};

--- a/components/ui/InteractiveListItem/InteractiveListItem.tsx
+++ b/components/ui/InteractiveListItem/InteractiveListItem.tsx
@@ -1,0 +1,104 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import { bdsClass } from '../../utils';
+import './InteractiveListItem.css';
+
+export interface InteractiveListItemProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'title'> {
+  /**
+   * Leading slot — typically a `UserAvatar`, an icon inside a colored
+   * circle, or a status indicator. Fixed width; doesn't shrink.
+   */
+  leading?: ReactNode;
+  /** Primary title text. Required. */
+  title: string;
+  /**
+   * Optional secondary content. `ReactNode` so callers can compose
+   * multi-line metadata, embedded badges, timestamp + author, etc.
+   * Single-line strings are also valid.
+   */
+  subtitle?: ReactNode;
+  /**
+   * Optional trailing slot — typically a `Tag`, `Badge`, progress
+   * block, or caret indicator. Fixed width; doesn't shrink.
+   */
+  trailing?: ReactNode;
+  /** Disable the row. Applies muted styling and blocks click. */
+  disabled?: boolean;
+}
+
+/**
+ * InteractiveListItem — clickable horizontal row with leading + title +
+ * optional subtitle + optional trailing slot. The whole row is the
+ * click target.
+ *
+ * Use for "row that drills into something" — clicking a member opens
+ * their profile sheet, clicking an activity item opens the related
+ * task, clicking a persona switches the dev session. Distinct from
+ * `CardControl` (which is a settings card with a switch / button as
+ * its trailing action — the card itself is *not* the click target).
+ *
+ * Renders as `<button type="button">` for proper a11y — native focus
+ * ring, native `Space` / `Enter` activation, native `disabled`. Don't
+ * nest interactive elements inside the slots; if the trailing slot
+ * needs to be its own click target, use `CardControl` instead.
+ *
+ * @example
+ * ```tsx
+ * <InteractiveListItem
+ *   leading={<UserAvatar name="Emily Rivera" size="md" />}
+ *   title="Emily Rivera"
+ *   subtitle="Hygienist · 2 years"
+ *   trailing={<Badge status="info">New hire</Badge>}
+ *   onClick={() => openProfile(member.id)}
+ * />
+ * ```
+ *
+ * @summary Clickable horizontal row — leading + title + subtitle + trailing
+ */
+export const InteractiveListItem = forwardRef<HTMLButtonElement, InteractiveListItemProps>(
+  (
+    {
+      leading,
+      title,
+      subtitle,
+      trailing,
+      disabled = false,
+      className,
+      onClick,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={bdsClass(
+          'bds-interactive-list-item',
+          disabled && 'bds-interactive-list-item--disabled',
+          className,
+        )}
+        disabled={disabled}
+        onClick={onClick}
+        {...props}
+      >
+        {leading !== undefined && (
+          <span className="bds-interactive-list-item__leading">{leading}</span>
+        )}
+        <span className="bds-interactive-list-item__text">
+          <span className="bds-interactive-list-item__title">{title}</span>
+          {subtitle !== undefined && subtitle !== null && (
+            <span className="bds-interactive-list-item__subtitle">{subtitle}</span>
+          )}
+        </span>
+        {trailing !== undefined && (
+          <span className="bds-interactive-list-item__trailing">{trailing}</span>
+        )}
+      </button>
+    );
+  },
+);
+
+InteractiveListItem.displayName = 'InteractiveListItem';
+
+export default InteractiveListItem;

--- a/components/ui/InteractiveListItem/index.ts
+++ b/components/ui/InteractiveListItem/index.ts
@@ -1,0 +1,2 @@
+export { InteractiveListItem, type InteractiveListItemProps } from './InteractiveListItem';
+export { default } from './InteractiveListItem';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -46,6 +46,7 @@ export * from './FilterToggle';
 export * from './Footer';
 export * from './Form';
 export * from './Icons';
+export * from './InteractiveListItem';
 export * from './Menu';
 export * from './Meter';
 export * from './Modal';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(bds): add InteractiveListItem — clickable row with leading + title + subtitle + trailing

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)