### PR TITLE
feat(tokens): canonical --border-width-{thin,standard,bold} via gap-fills

### DIFF
--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -209,6 +209,23 @@
   --background-service-service-secondary: var(--services--orange-dark);
   --text-service-service: var(--services--orange-dark);
 
+  /* ── Border-width semantic aliases (mode-catalog names) ──
+     The borderWidth mode catalog (websites/shared/MODE-ARCHITECTURE.md) names
+     picks "thin / standard / bold". Without aliases at these names, client
+     theme files invent --border-width-default and friends (see brik-bds#302
+     and brik-llm#52). Adding them as canonical removes that invention pressure.
+
+     Values mirror the standard mode's effective widths: thin=1px, standard=2px,
+     bold=3px. These are FIXED-VALUE aliases — when a client picks a different
+     borderWidth mode, the modulation should happen on --border-width-sm/md/lg,
+     not here. (borderWidth modes are documented but not yet implemented in BDS
+     CSS overrides — see MODE-ARCHITECTURE.md.)
+
+     Promote to Figma when borderWidth mode overrides are wired into theme CSS. */
+  --border-width-thin:     1px;
+  --border-width-standard: 2px;
+  --border-width-bold:     3px;
+
   /* ── Interaction state overlays (gap-fill — add to Figma when interaction tokens land) */
   --state-hover-overlay: rgba(0, 0, 0, 0.04); /* bds-lint-ignore — rgba overlay, no token equivalent */
   --state-pressed-overlay: rgba(0, 0, 0, 0.08); /* bds-lint-ignore — rgba overlay, no token equivalent */


### PR DESCRIPTION
Closes #302.

## Why

The `borderWidth` mode catalog in [`websites/shared/MODE-ARCHITECTURE.md`](https://github.com/brikdesigns/brik-llm/blob/main/websites/shared/MODE-ARCHITECTURE.md) names the picks **thin / standard / bold**. Without canonical tokens at those names, client theme files invent things like `--border-width-default` — exactly the parallel-taxonomy failure mode the canonical token registry rule is meant to prevent. Surfaced by `brik-themes::lint_tokens` on `birdwell-mutlak/mockups/tokens.css` (see [brik-llm#52](https://github.com/brikdesigns/brik-llm/issues/52)).

## What changed

One file: `tokens/gap-fills.css`. Adds three FIXED-VALUE aliases:

```css
--border-width-thin:     1px;
--border-width-standard: 2px;
--border-width-bold:     3px;
```

No behavioral change to any existing token. No component code touched.

## Why gap-fills.css instead of Figma

Per [`tokens/CASCADE.md`](tokens/CASCADE.md) decision tree:

> Add a semantic token Figma doesn't export → `gap-fills.css`

The Figma path requires the dev plugin connected and a re-pull cycle. Gap-fills is the documented bridge for exactly this case. The block has a `// Promote to Figma when borderWidth mode overrides are wired into theme CSS` note for the eventual migration.

## Why fixed values, not mode-aware aliases

The mode catalog's full table uses thin/standard/bold as **mode names** that re-map `sm/md/lg` t-shirt sizes. But `borderWidth` modes aren't actually implemented anywhere in BDS CSS overrides today — `MODE-ARCHITECTURE.md` documents them, but no `data-mode-borderwidth` selector or `theme-brand-brik.css` block remaps `--border-width-*` per mode. Verified by grepping the repo: zero references to `--border-width-thin/standard/bold` and zero `data-mode-borderwidth` selectors.

So these aliases land as fixed-value semantic tokens (like `--shadow-sm`/`md`/`lg`/`xl` already do in this same file). When borderWidth modes get wired up, the modulation should target `sm/md/lg`, not these — which is why the comment is explicit about that.

## Update to the issue body's claims

The issue claimed `--border-width-lg` was missing, recommending it be added alongside the new aliases. Verified `--border-width-lg: 2px` is **already** in `figma-tokens.css` (along with `-huge` and `-none`). Issue body was outdated; this PR doesn't add `lg`.

## Verification

- [x] `npm run build:dist-tokens` — succeeds; new tokens land in `dist/tokens.css` at the expected line range
- [x] `npm run lint-tokens` — 0 errors, 6 pre-existing warnings (hardcoded fontSize/lineHeight in unrelated story files)
- [x] `npm test` — 420 individual tests pass; 11 failed test files are pre-existing Storybook-vitest plugin infra issues ("Vitest failed to find the runner"), unrelated to this change

## Consumer sync after merge

Token addition only — no breaking changes for consumers. Standard sync:

- [ ] Portal: `npm update @brikdesigns/bds` (wait for next BDS publish)
- [ ] renew-pms: submodule bump
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Follow-up

After this lands, the per-client cleanup in [brik-llm#52](https://github.com/brikdesigns/brik-llm/issues/52) becomes a simple find/replace (birdwell's `--border-width-default` → `--border-width-standard` for the corresponding usage). Re-run `brik-themes::lint_tokens` on birdwell to confirm the suspicious-semantic count drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)