### PR TITLE
ci: add Release workflow — tag-triggered publish to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+# Publishes @brikdesigns/bds to GitHub Packages on tag push.
+#
+# Until 2026-04-28 the publish was a manual `npm publish` from a maintainer's
+# laptop. Two recent BDS releases (0.43.0, 0.45.0) were missed at first
+# because the maintainer assumed the merge had published — see PR #74 / #77
+# coordination notes in renew-pms. Tagging is the explicit gesture; this
+# workflow turns the tag into the publish.
+#
+# Trigger: push of a tag matching `v*.*.*`. The expected flow on a release PR is:
+#   1. Bump `version` in `package.json` as part of the change PR.
+#   2. After PR merges to main: `git tag v0.46.0 && git push origin v0.46.0`
+#      (or `npm version <patch|minor|major>` to bump+tag in one step before PR).
+#   3. This workflow validates that `package.json` matches the tag, runs the
+#      same `npm run validate` that pre-commit runs, and publishes.
+#
+# Re-runnable: a failed publish can be re-triggered via workflow_dispatch with
+# the same version string. The `concurrency` block does NOT cancel in-flight
+# runs — half-published packages are worse than a queued duplicate.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (must match package.json — e.g. 0.46.0)"
+        required: true
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js (with GitHub Packages registry)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@brikdesigns"
+          cache: "npm"
+
+      - name: Resolve target version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            REF="${GITHUB_REF#refs/tags/v}"
+          else
+            REF="${{ github.event.inputs.version }}"
+            REF="${REF#v}"
+          fi
+          PKG=$(node -p "require('./package.json').version")
+          echo "tag=$REF" >> "$GITHUB_OUTPUT"
+          echo "pkg=$PKG" >> "$GITHUB_OUTPUT"
+          echo "Tag/input version: $REF"
+          echo "package.json:      $PKG"
+          if [ "$PKG" != "$REF" ]; then
+            echo "::error::package.json version ($PKG) does not match tag/input ($REF). Bump package.json before tagging."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate (lint-tokens errors-only + jsdoc + blueprints + typecheck)
+        # Skip `build-storybook` from the full `validate` script — Chromatic
+        # has its own workflow and rerunning it here adds ~3 min per release
+        # for no gain. The `prepublishOnly` script (rm -rf dist + build:lib)
+        # runs as part of `npm publish` and is the publish-blocking build.
+        run: |
+          node scripts/lint-tokens.js --errors-only
+          npm run lint-jsdoc
+          npm run validate:blueprints
+          npm run typecheck
+
+      - name: Publish to GitHub Packages
+        run: npm publish --access restricted
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## Released @brikdesigns/bds@${{ steps.version.outputs.pkg }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Consumers (portal, renew-pms, brikdesigns) can now bump:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "npm install @brikdesigns/bds@${{ steps.version.outputs.pkg }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,20 @@ These rules apply in every project that imports BDS tokens (portal, renew-pms, b
    git commit -m "Update brik-bds submodule"
    ```
 
+## Releasing to GitHub Packages
+
+Consumer repos pull `@brikdesigns/bds` from GitHub Packages. Publishing is triggered by **pushing a version tag** — the `Release` workflow at [`.github/workflows/release.yml`](.github/workflows/release.yml) handles validation + `npm publish`.
+
+```bash
+# After landing your changes on main and bumping `package.json`:
+git tag v0.46.0 && git push origin v0.46.0
+
+# Or in one step inside a release PR:
+npm version minor -m 'chore(release): %s' && git push && git push --tags
+```
+
+Full flow + re-run guidance: [`docs/RELEASE.md`](docs/RELEASE.md).
+
 ## Figma Variables Sync
 
 **One method: Dev plugin + WebSocket relay → sync script → Style Dictionary.**

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,70 @@
+# Releasing `@brikdesigns/bds`
+
+BDS is published to **GitHub Packages** at `https://npm.pkg.github.com/` under
+the `@brikdesigns` scope. Consumers (`brik-client-portal`, `renew-pms`,
+`brikdesigns`, `freedom-client-portal`) install via the same registry — auth
+is handled by each repo's `.npmrc` + a `GITHUB_TOKEN` (or scoped PAT).
+
+## When to release
+
+A release is appropriate when one or more of the following are true since the
+last published version:
+
+- A new component (or component prop) has landed and a consumer needs it.
+- A token name or value changed in `dist/tokens.css`.
+- A bug fix to an existing component is needed by a consumer.
+
+If the change is contained inside Storybook docs or to internal scripts, no
+release is needed — Chromatic's separate workflow already keeps the docs site
+fresh.
+
+## Flow
+
+1. **Land the change on `main`.** Normal PR flow — review, merge, squash.
+2. **Bump `package.json` `version`** on `main`. Either as part of the change
+   PR (preferred for one-PR-one-release) or in a follow-up PR (acceptable for
+   batched releases). Use semver:
+   - **patch** (0.45.0 → 0.45.1) — bug fix, no API change
+   - **minor** (0.45.0 → 0.46.0) — new component or new prop on existing component
+   - **major** (0.45.0 → 1.0.0) — breaking change to a component API or token name
+3. **Tag and push.** From the tip of `main`:
+   ```bash
+   git pull --ff-only
+   git tag v0.46.0
+   git push origin v0.46.0
+   ```
+   Or, in a single step before PR:
+   ```bash
+   npm version minor -m 'chore(release): %s'   # bumps + commits + tags
+   git push && git push --tags
+   ```
+4. **Watch the workflow.** The `Release` workflow at
+   `.github/workflows/release.yml` runs on the tag push:
+   - Validates that `package.json` version matches the tag.
+   - Runs `lint-tokens --errors-only`, `lint-jsdoc`, `validate:blueprints`, `typecheck`.
+   - Runs `npm publish` (which triggers `prepublishOnly` → `rm -rf dist && npm run build:lib`).
+
+5. **Bump consumers.** Each consumer needs `npm install @brikdesigns/bds@0.46.0`
+   in a follow-up PR. The release workflow's job summary surfaces the exact
+   install command.
+
+## Re-running a failed publish
+
+If the workflow fails after `npm publish` ran (e.g. validate passed but a
+network blip dropped the publish step), you can either:
+
+- Re-tag with `-1`, `-2` suffix (e.g. `v0.46.0-rerun.1`) — wasteful, avoid.
+- Re-run via `Actions → Release → Run workflow → enter version` — this hits
+  the tag-already-published guard from npm itself, which is the safe failure
+  mode (publish is idempotent on the registry side).
+
+Most recoverable failures show up in `npm run validate` and abort before any
+publish — fix the underlying issue, push a new commit, re-tag.
+
+## What got automated when
+
+- **Before 2026-04-28:** publish was a manual `npm publish` from a maintainer's
+  laptop. Two recent releases (0.43.0, 0.45.0) were initially missed because
+  the maintainer assumed merging the PR also published.
+- **2026-04-28:** introduced this workflow (`task/infra-release-workflow`).
+  The tag is now the explicit publish gesture — no-tag means no-publish.


### PR DESCRIPTION
## Summary

Workstream C from the post-cleanup-audit followups (Workstream A landed in renew-pms#79 — sibling PR). Automates the manual `npm publish` step that has been missed twice in the last two BDS releases (0.43.0 and 0.45.0 were initially un-published until a maintainer noticed and re-ran the command).

- New workflow `.github/workflows/release.yml` triggers on `v*.*.*` tag push (or `workflow_dispatch` re-run).
- New doc `docs/RELEASE.md` covers the version-bump → tag → push flow and re-run guidance.
- `CLAUDE.md` Workflow section gains a "Releasing to GitHub Packages" subsection pointing at the workflow + doc.

## Why this design

**Tag-push, not main-merge.** Auto-publishing on every main merge would force every PR (docs, internal scripts, refactors) to also be a release. Tagging is the explicit "this should ship to consumers" gesture. `npm version <patch|minor|major>` bumps + commits + tags in one step before PR — no extra cognitive load.

**Skip Storybook build in validate.** The `validate` script runs `build-storybook`, which adds ~3 min per release. Chromatic has its own workflow that publishes Storybook on main pushes; rerunning it during release is duplicate work. Release runs the publish-blocking pieces only: `lint-tokens --errors-only`, `lint-jsdoc`, `validate:blueprints`, `typecheck`. The actual build for npm comes from `prepublishOnly` (`rm -rf dist && npm run build:lib`) which `npm publish` itself triggers.

**`concurrency: cancel-in-progress: false`.** A canceled `npm publish` mid-upload could leave a half-published version on the registry. Queueing a duplicate run is the safer failure mode — npm itself rejects re-publish of an existing version.

**Permissions scoped narrowly.** `contents: read` (no write — we don't tag or commit from the workflow) + `packages: write` (publish only).

## Verification before merge

This PR can't fully verify itself — the workflow only fires on tag push. Pre-merge checks I've done:

- [x] YAML parses cleanly (prettier-formatted)
- [x] Action references match those used in `chromatic.yml` (`actions/checkout@v4`, `actions/setup-node@v4`)
- [x] `registry-url` + `scope` match `package.json` `publishConfig.registry`
- [x] Validation steps (`lint-tokens --errors-only`, `lint-jsdoc`, `validate:blueprints`, `typecheck`) all map to existing scripts in `package.json`
- [x] `prepublishOnly` exists and rebuilds dist before publish
- [x] No incidental `node_modules` changes staged

Post-merge verification (next release):

1. Bump `package.json` version on a follow-up change PR (e.g. for the next BDS feature).
2. After merge, `git tag v0.46.0 && git push origin v0.46.0`.
3. Watch the Release workflow run and verify the package shows up at https://github.com/orgs/brikdesigns/packages.

If something goes wrong on the first real release, the failure modes are well-bounded: package.json/tag mismatch fails before publish (no side effect), validation failure fails before publish, network blip during publish either succeeds (registry returns idempotent OK) or fails with a re-runnable workflow_dispatch path.

## Test plan

- [x] YAML lints clean via prettier
- [x] All referenced npm scripts (`lint-tokens`, `lint-jsdoc`, `validate:blueprints`, `typecheck`) exist and run locally
- [x] `prepublishOnly` runs `rm -rf dist && npm run build:lib` (matches what manual `npm publish` does)
- [ ] First post-merge release (any patch bump) confirms tag-triggered publish lands on GitHub Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)