### PR TITLE
feat(bds): add TabBar variant=text-underline

### DIFF
--- a/components/ui/TabBar/TabBar.mdx
+++ b/components/ui/TabBar/TabBar.mdx
@@ -5,7 +5,7 @@ import * as Stories from './TabBar.stories';
 
 # Tab bar
 
-Horizontal tab navigation with three style variants: text, tab (underline), and box (filled). Supports on-color backgrounds and disabled tabs.
+Horizontal tab navigation with four style variants: text, text-underline, tab (bordered bar), and box (filled). Supports on-color backgrounds and disabled tabs.
 
 ---
 
@@ -17,10 +17,11 @@ Use the Controls panel to explore all props interactively.
 
 ## Variants
 
-All three variants, on-color backgrounds, disabled tabs, and compact tab bars.
+All four variants, on-color backgrounds, disabled tabs, and compact tab bars.
 
-- **`text`** — plain labels with brand color for active tab
-- **`tab`** — underline indicator with bottom border
+- **`text`** — plain labels with brand color for active tab; no indicator
+- **`text-underline`** — `text` color behavior + per-tab brand-color underline below the active tab. Use for app-level page headers that want both the brand-active text emphasis and an underline indicator
+- **`tab`** — bottom-border bar with neutral-color active text and a brand-color underline that sits over the bar's baseline border
 - **`box`** — filled background for active, bordered for inactive
 
 <Canvas of={Stories.Variants} />

--- a/components/ui/TabBar/TabBar.stories.tsx
+++ b/components/ui/TabBar/TabBar.stories.tsx
@@ -35,7 +35,7 @@ function InteractiveTabBar({
   labels = tabLabels,
   disabledIndices = [],
 }: {
-  variant?: 'text' | 'tab' | 'box';
+  variant?: 'text' | 'text-underline' | 'tab' | 'box';
   onColor?: boolean;
   labels?: string[];
   disabledIndices?: number[];
@@ -64,7 +64,7 @@ const meta: Meta<typeof TabBar> = {
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
-    variant: { control: 'select', options: ['text', 'tab', 'box'] },
+    variant: { control: 'select', options: ['text', 'text-underline', 'tab', 'box'] },
     onColor: { control: 'boolean' },
   },
 };
@@ -109,10 +109,15 @@ export const Playground: Story = {
 export const Variants: Story = {
   render: () => (
     <Stack>
-      {/* All three variants */}
+      {/* All four variants */}
       <div>
         <SectionLabel>Text</SectionLabel>
         <InteractiveTabBar variant="text" />
+      </div>
+
+      <div>
+        <SectionLabel>Text — underline</SectionLabel>
+        <InteractiveTabBar variant="text-underline" />
       </div>
 
       <div>
@@ -133,6 +138,15 @@ export const Variants: Story = {
       }}>
         <SectionLabel>Text — on color</SectionLabel>
         <InteractiveTabBar variant="text" onColor />
+      </div>
+
+      <div style={{
+        backgroundColor: 'var(--background-brand-primary)',
+        padding: 'var(--padding-xl)',
+        borderRadius: 'var(--border-radius-md)',
+      }}>
+        <SectionLabel>Text underline — on color</SectionLabel>
+        <InteractiveTabBar variant="text-underline" onColor />
       </div>
 
       <div style={{

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -17,7 +17,7 @@ export interface TabItem {
 }
 
 /** Visual variant matching Figma spec */
-export type TabBarVariant = 'text' | 'tab' | 'box';
+export type TabBarVariant = 'text' | 'text-underline' | 'tab' | 'box';
 
 /**
  * TabBar component props
@@ -47,6 +47,7 @@ const barBase: CSSProperties = {
 
 const barVariantStyles: Record<TabBarVariant, CSSProperties> = {
   text: { ...barBase, gap: 'var(--gap-xl)' },
+  'text-underline': { ...barBase, gap: 'var(--gap-xl)' },
   tab: { ...barBase, gap: 0, borderBottom: 'var(--border-width-xl) solid var(--border-secondary)' },
   box: { ...barBase, gap: 0 },
 };
@@ -80,6 +81,31 @@ function getTextStyles(active: boolean, onColor: boolean): CSSProperties {
   return {
     ...tabBase,
     color: active ? 'var(--text-brand-primary)' : 'var(--text-secondary)',
+  };
+}
+
+function getTextUnderlineStyles(active: boolean, onColor: boolean): CSSProperties {
+  /* `text-underline` = `text` color behavior + per-tab brand-color underline.
+     No container border (unlike `tab`) and no horizontal padding — gap-xl
+     between tabs comes from the bar container. Used by app-level page
+     headers that want the brand-active text emphasis AND an underline. */
+  const borderWidth = 'var(--border-width-md)';
+  if (onColor) {
+    const borderColor = active ? 'var(--border-on-color-dark)' : 'transparent';
+    return {
+      ...tabBase,
+      color: 'var(--text-on-color-dark)',
+      opacity: active ? 1 : 0.6,
+      borderBottom: `${borderWidth} solid ${borderColor}`,
+      paddingBottom: 'var(--padding-sm)',
+    };
+  }
+  const borderColor = active ? 'var(--border-brand-primary)' : 'transparent';
+  return {
+    ...tabBase,
+    color: active ? 'var(--text-brand-primary)' : 'var(--text-secondary)',
+    borderBottom: `${borderWidth} solid ${borderColor}`,
+    paddingBottom: 'var(--padding-sm)',
   };
 }
 
@@ -139,6 +165,7 @@ function getBoxStyles(active: boolean, onColor: boolean): CSSProperties {
 
 const styleBuilders: Record<TabBarVariant, (active: boolean, onColor: boolean) => CSSProperties> = {
   text: getTextStyles,
+  'text-underline': getTextUnderlineStyles,
   tab: getTabStyles,
   box: getBoxStyles,
 };
@@ -146,9 +173,10 @@ const styleBuilders: Record<TabBarVariant, (active: boolean, onColor: boolean) =
 /**
  * TabBar — BDS horizontal tab navigation
  *
- * Three visual variants matching Figma:
- * - **text** (default): plain text links with brand color for active
- * - **tab**: underline indicator with bottom border
+ * Four visual variants:
+ * - **text** (default): plain text links with brand color for active; no indicator
+ * - **text-underline**: text variant + per-tab brand-color underline below the active tab
+ * - **tab**: bottom-border bar with neutral active color and brand-color underline
  * - **box**: filled background for active, bordered for inactive
  *
  * Use `onColor` for placement on dark/brand backgrounds.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Workstream B from the post-cleanup-audit followups. Closes the BDS variant gap that PR renew-pms#75 flagged when it swapped PageHeader's hand-rolled hybrid to `<TabBar variant="text">` (which dropped the underline as an acknowledged regression).

Adds a fourth `TabBar` variant: `text-underline` — `text` color behavior + per-tab brand-color underline below the active tab.

## Variant taxonomy after this change

| Variant | Color (active) | Indicator | Use case |
|---|---|---|---|
| `text` | brand | none | Compact in-page tabs, sub-navigation where text emphasis alone is enough |
| `text-underline` ← new | brand | per-tab underline | App-level page headers wanting both brand emphasis AND an underline indicator |
| `tab` | neutral | underline + baseline border across the bar | Bordered bar pattern (common settings/billing surfaces) |
| `box` | inverse text on filled bg | filled background | Filter/segmented-control patterns |

## Why a separate variant rather than a prop

Considered `underline?: boolean` as a prop on the `text` variant, but rejected because:
- `tab` already encodes its own underline behavior (with a different active-color story); a generic `underline` prop on `text` would be ambiguous when applied to other variants.
- Variant names map 1:1 to Figma component variants, which is the existing convention for the four primitives.
- Discoverability via the Storybook controls panel — a fourth named variant shows up in the dropdown; a boolean prop would hide behind ALL_VARIANTS × {true, false}.

The decision parallels how `Button` exposes distinct `variant=primary | ghost | secondary | …` rather than a `Button variant=base ghost?: boolean`.

## What changed

- `TabBar.tsx` — extend `TabBarVariant` union, add `getTextUnderlineStyles()` builder, register in `barVariantStyles` + `styleBuilders`, update JSDoc.
- `TabBar.stories.tsx` — add `text-underline` to `argTypes.options`, the `InteractiveTabBar` variant union, and the `Variants` story (light + on-color rows).
- `TabBar.mdx` — update the variant list with usage guidance.
- `package.json` — bump `0.45.0` → `0.46.0` (new public API surface).

## Visual verification

Storybook story `TabBar / Variants` renders all four variants stacked. Light + on-color rows for `text-underline` confirm:
- inactive tabs: `text-secondary` color, transparent border-bottom (no layout shift)
- active tab: `text-brand-primary` color, `border-brand-primary` underline at `border-width-md`
- on-color: `text-on-color-dark` for both inactive/active with opacity, `border-on-color-dark` underline when active

## Verified

- [x] `npm run typecheck` clean
- [x] `node scripts/lint-tokens.js --errors-only` clean
- [x] `npm run lint-jsdoc` clean
- [x] `npm run validate:blueprints` clean

## Followup

`renew-pms#80` (sibling, opening immediately after this) swaps `PageHeader.tsx` from `variant="text"` to `variant="text-underline"` once 0.46.0 publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)