### PR TITLE
inputs: credential defaults

### DIFF
--- a/components/ui/AddressInput/AddressInput.tsx
+++ b/components/ui/AddressInput/AddressInput.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  useId,
   type InputHTMLAttributes,
   type ReactNode,
   type CSSProperties,
@@ -293,8 +294,8 @@ export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
   ) => {
     const [isFocused, setIsFocused] = useState(false);
     const wrapperRef = useRef<HTMLDivElement>(null);
-    const inputId =
-      id || (label ? `address-${Math.random().toString(36).substring(2, 11)}` : undefined);
+    const generatedId = useId();
+    const inputId = id || (label ? `address-${generatedId}` : undefined);
 
     const showDropdown = isFocused && suggestions.length > 0;
 

--- a/components/ui/PasswordInput/PasswordInput.stories.tsx
+++ b/components/ui/PasswordInput/PasswordInput.stories.tsx
@@ -97,9 +97,9 @@ export const Patterns: Story = {
       <div>
         <SectionLabel>Change password form</SectionLabel>
         <Stack gap="var(--gap-lg)">
-          <PasswordInput label="Current password" placeholder="Enter current password" fullWidth />
-          <PasswordInput label="New password" placeholder="Enter new password" helperText="Must be at least 8 characters" fullWidth />
-          <PasswordInput label="Confirm password" placeholder="Re-enter new password" fullWidth />
+          <PasswordInput label="Current password" name="current-password" autoComplete="current-password" placeholder="Enter current password" fullWidth />
+          <PasswordInput label="New password" name="new-password" autoComplete="new-password" placeholder="Enter new password" helperText="Must be at least 8 characters" fullWidth />
+          <PasswordInput label="Confirm password" name="confirm-password" autoComplete="new-password" placeholder="Re-enter new password" fullWidth />
         </Stack>
       </div>
     </Stack>

--- a/components/ui/TextArea/TextArea.tsx
+++ b/components/ui/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import { type TextareaHTMLAttributes, type CSSProperties } from 'react';
+import { useId, type TextareaHTMLAttributes, type CSSProperties } from 'react';
 import { bdsClass } from '../../utils';
 import './TextArea.css';
 
@@ -158,7 +158,8 @@ export function TextArea({
   style,
   ...props
 }: TextAreaProps) {
-  const inputId = id || (label ? `textarea-${Math.random().toString(36).substring(2, 11)}` : undefined);
+  const generatedId = useId();
+  const inputId = id || (label ? `textarea-${generatedId}` : undefined);
   const hasError = Boolean(error);
   const sizeStyle = sizeStyles[size];
 

--- a/components/ui/TextInput/TextInput.stories.tsx
+++ b/components/ui/TextInput/TextInput.stories.tsx
@@ -151,8 +151,8 @@ export const Patterns: Story = {
       <div style={{ width: 320 }}>
         <SectionLabel>Login form</SectionLabel>
         <Stack gap="var(--gap-lg)">
-          <TextInput label="Email" type="email" placeholder="you@example.com" iconBefore={<Icon icon="ph:envelope" />} fullWidth />
-          <TextInput label="Password" type="password" placeholder="••••••••" iconBefore={<Icon icon="ph:lock" />} fullWidth />
+          <TextInput label="Email" type="email" name="email" autoComplete="username" placeholder="you@example.com" iconBefore={<Icon icon="ph:envelope" />} fullWidth />
+          <TextInput label="Password" type="password" name="password" autoComplete="current-password" placeholder="••••••••" iconBefore={<Icon icon="ph:lock" />} fullWidth />
         </Stack>
       </div>
     </Row>

--- a/components/ui/TextInput/TextInput.tsx
+++ b/components/ui/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type InputHTMLAttributes, type ReactNode, type CSSProperties } from 'react';
+import { forwardRef, useId, type InputHTMLAttributes, type ReactNode, type CSSProperties } from 'react';
 import { bdsClass } from '../../utils';
 import './TextInput.css';
 
@@ -161,9 +161,18 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     },
     ref
   ) => {
-    const inputId = id || `input-${Math.random().toString(36).substring(2, 11)}`;
+    const generatedId = useId();
+    const inputId = id || `input-${generatedId}`;
     const hasError = Boolean(error);
     const sizeStyle = sizeStyles[size];
+
+    // Suppress 1Password / LastPass prompts on non-credential text fields.
+    // A field is treated as credential-adjacent when its `type` signals
+    // username/password intent OR the consumer set any `autoComplete` value
+    // (an explicit signal of intent — including `off`).
+    const { type, autoComplete } = props;
+    const isCredentialField =
+      type === 'email' || type === 'password' || autoComplete !== undefined;
 
     const inputStyles: CSSProperties = {
       ...inputBaseStyles,
@@ -203,8 +212,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           )}
 
           <input
-            data-1p-ignore=""
-            data-lpignore="true"
+            data-1p-ignore={isCredentialField ? undefined : ''}
+            data-lpignore={isCredentialField ? undefined : 'true'}
             ref={ref}
             id={inputId}
             className="bds-text-input-field"


### PR DESCRIPTION
## Summary
- docs(claude): add rule — Brik internal service tokens stay out of client products (#310)
- fix(inputs): conditional 1p/lp ignore + useId for hydration-safe ids

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)