### PR TITLE
feat(InteractiveListItem): add size variant — sm | md (default md)

### DIFF
--- a/components/ui/InteractiveListItem/InteractiveListItem.css
+++ b/components/ui/InteractiveListItem/InteractiveListItem.css
@@ -12,9 +12,7 @@
   .bds-interactive-list-item {
     display: flex;
     align-items: center;
-    gap: var(--gap-md);
     width: 100%;
-    padding: var(--padding-md) var(--padding-lg);
     background: none;
     border: none;
     border-radius: var(--border-radius-md);
@@ -25,6 +23,23 @@
     transition:
       background-color var(--duration-fast) var(--ease-out),
       transform var(--duration-fast) var(--ease-out);
+  }
+
+  /* ─── Size variants ────────────────────────────────────────────
+     Both step through the BDS semantic spacing scale so they
+     compose with the global Base/Spacious spacing modes.
+     - md (default): full sheets and panels.
+     - sm: narrow contexts (DevBar slot panels, popovers) where the
+       default padding crowds the text column. */
+
+  .bds-interactive-list-item--md {
+    gap: var(--gap-md);
+    padding: var(--padding-md) var(--padding-lg);
+  }
+
+  .bds-interactive-list-item--sm {
+    gap: var(--gap-sm);
+    padding: var(--padding-sm) var(--padding-md);
   }
 
   .bds-interactive-list-item:hover:not(:disabled) {

--- a/components/ui/InteractiveListItem/InteractiveListItem.stories.tsx
+++ b/components/ui/InteractiveListItem/InteractiveListItem.stories.tsx
@@ -39,6 +39,7 @@ const meta: Meta<typeof InteractiveListItem> = {
   parameters: { layout: 'centered' },
   argTypes: {
     title: { control: 'text' },
+    size: { control: 'inline-radio', options: ['sm', 'md'] },
     disabled: { control: 'boolean' },
   },
 };
@@ -106,6 +107,57 @@ export const Variants: Story = {
         />
       </Stack>
     </div>
+  ),
+};
+
+/** @summary Size variants — `md` (default) and `sm` (narrow panels) */
+export const Sizes: Story = {
+  render: () => (
+    <Stack gap="var(--gap-lg)">
+      <div>
+        <SectionLabel>md (default) — full sheets and panels</SectionLabel>
+        <div style={{ width: 480 }}>
+          <InteractiveListItem
+            leading={<Avatar name="Emily Rivera" size="md" />}
+            title="Emily Rivera"
+            subtitle="Hygienist · 2 years"
+            trailing={<Badge status="info">New hire</Badge>}
+            onClick={() => {}}
+          />
+        </div>
+      </div>
+      <div>
+        <SectionLabel>sm — narrow panels (DevBar slot, popovers)</SectionLabel>
+        <div style={{ width: 280 }}>
+          <Stack gap="0">
+            <InteractiveListItem
+              size="sm"
+              leading={<Avatar name="Brik Admin" size="sm" />}
+              title="brik_admin"
+              subtitle="platform · admin"
+              trailing={<Badge status="info" size="xs">PLATFORM</Badge>}
+              onClick={() => {}}
+            />
+            <InteractiveListItem
+              size="sm"
+              leading={<Avatar name="Jordan Tran" size="sm" />}
+              title="manager · proficient"
+              subtitle="Practice manager"
+              trailing={<Badge size="xs">MANAGER</Badge>}
+              onClick={() => {}}
+            />
+            <InteractiveListItem
+              size="sm"
+              leading={<Avatar name="Rachel Foster" size="sm" />}
+              title="Rachel Foster"
+              subtitle="staff · proficient · frontdesk"
+              trailing={<Badge size="xs">STAFF</Badge>}
+              onClick={() => {}}
+            />
+          </Stack>
+        </div>
+      </div>
+    </Stack>
   ),
 };
 

--- a/components/ui/InteractiveListItem/InteractiveListItem.tsx
+++ b/components/ui/InteractiveListItem/InteractiveListItem.tsx
@@ -2,6 +2,8 @@ import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
 import './InteractiveListItem.css';
 
+export type InteractiveListItemSize = 'sm' | 'md';
+
 export interface InteractiveListItemProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'title'> {
   /**
@@ -22,6 +24,15 @@ export interface InteractiveListItemProps
    * block, or caret indicator. Fixed width; doesn't shrink.
    */
   trailing?: ReactNode;
+  /**
+   * Row size. Default `md` — full sheets and panels. Use `sm` for
+   * narrow contexts like DevBar slot panels, popovers, or any
+   * container narrower than ~360px where the default padding crowds
+   * the text column. Both variants step through the BDS semantic
+   * spacing scale, so they compose with the global Base/Spacious
+   * spacing modes.
+   */
+  size?: InteractiveListItemSize;
   /** Disable the row. Applies muted styling and blocks click. */
   disabled?: boolean;
 }
@@ -62,6 +73,7 @@ export const InteractiveListItem = forwardRef<HTMLButtonElement, InteractiveList
       title,
       subtitle,
       trailing,
+      size = 'md',
       disabled = false,
       className,
       onClick,
@@ -75,6 +87,7 @@ export const InteractiveListItem = forwardRef<HTMLButtonElement, InteractiveList
         type="button"
         className={bdsClass(
           'bds-interactive-list-item',
+          `bds-interactive-list-item--${size}`,
           disabled && 'bds-interactive-list-item--disabled',
           className,
         )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.42.0",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.42.0",
+      "version": "0.48.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Adds a `size` prop to `InteractiveListItem` that scales row chrome through the BDS semantic spacing scale. Default `md` preserves existing behavior — current four call sites in renew-pms (`TrainingCard`, `ViewInventorySheet`, `ViewContactSheet`, `DevPersonaSwitcher`) need no change.

- New: `size: 'sm' | 'md'` (default `'md'`)
- `sm` is for narrow contexts (DevBar slot panels, popovers, ≤ ~360px containers) — steps every chrome value down one rung on the semantic spacing scale
- Pure semantic tokens — composes cleanly with the global Base/Spacious spacing modes
- Subtitle wrap behavior unchanged; the `ReactNode` composition contract from #304 is preserved in both sizes

## Why

PR #304's row was sized for full sheets and panels using `--padding-md` / `--padding-lg` / `--gap-md`. In a 280px-wide context like renew-pms's DevBar persona panel, that chrome eats the title+subtitle column and short subtitles wrap ("manager · proficient" → two lines). Reported by Nick after PR #77 swapped the persona row to this primitive.

## API alignment

- `size` (not `density`) — matches `Button`, `FilterButton`, `TextInput`, `Dot`
- Values from the spacing scale — `'sm' | 'md'`. No `lg` until a consumer needs it.
- Implemented as CSS modifier classes (`.bds-interactive-list-item--sm`, `--md`) so future sizes are additive.

| | `md` (current default) | `sm` (new) |
|---|---|---|
| vertical padding | `--padding-md` | `--padding-sm` |
| horizontal padding | `--padding-lg` | `--padding-md` |
| slot gap | `--gap-md` | `--gap-sm` |

## Storybook

New **Sizes** story renders both variants side-by-side, with the `sm` column constrained to 280px (DevBar persona panel width) using persona-row content from the bug report so the regression and the fix are both visible.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint-tokens` (0 errors)
- [x] `npm run lint-jsdoc`
- [x] `npm run validate:blueprints`
- [x] `npm run build:lib`
- [x] `npm run build-storybook`
- [ ] Visual review of new **Sizes** story in Chromatic
- [ ] Visual review: confirm `md` rendering of the four existing renew-pms call sites is unchanged after consuming this build

## Follow-up

Renew-pms consumer PR (`size="sm"` on `DevPersonaSwitcher`) targets `staging` once this lands and the version bump propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)