### PR TITLE
feat(tokens): canonicalize --color-system-error/success/warning/link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",

--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -68,6 +68,24 @@
   --color-system-green-surface: var(--color-system-green-light);
   --color-system-blue-surface:  var(--color-system-blue-light);
 
+  /* System color semantic aliases — canonical app-meaning names ──
+     Sit alongside the color-name primitives (--color-system-red/green/yellow/
+     blue). Apps consume the meaning (`error`, `success`) rather than the
+     paint (`red`, `green`) so brand themes can override per-context without
+     touching every callsite. Consumers may override the right-hand side
+     per-theme (e.g. portal sets --color-system-link to a brand-blue, dark
+     mode shifts it lighter). Backed by Style Dictionary primitives, NOT by
+     hex literals — keep the alias chain intact so theme overrides flow.
+
+     Promoted from per-app theme files (portal `theme-brik.css`,
+     `theme-brik-portal.css`, `public/themes/theme-renew.css`) where these
+     names existed as parallel taxonomy. Adding them here makes them
+     canonical so portal's --color-* audit gate (PR #TBD) lands clean. */
+  --color-system-error:   var(--color-system-red);
+  --color-system-success: var(--color-system-green);
+  --color-system-warning: var(--color-system-yellow);
+  --color-system-link:    var(--color-system-blue);
+
   /* ── Slider Component Variables ──
      CSS custom properties set dynamically by the Slider component via JS.
      Defined here so the linter knows they are intentional component vars. */


### PR DESCRIPTION
## Summary
Promotes 4 semantic-meaning aliases from per-app theme files into BDS canonical via `tokens/gap-fills.css`:

```css
--color-system-error:   var(--color-system-red);
--color-system-success: var(--color-system-green);
--color-system-warning: var(--color-system-yellow);
--color-system-link:    var(--color-system-blue);
```

## Why
These names existed as parallel taxonomy across multiple Brik consumers but never in BDS:

- `brik-client-portal/src/styles/theme-brik.css` + `theme-brik-portal.css` — defines all 4
- `brik-client-portal/public/themes/theme-renew.css` — defines and consumes all 4
- `brik-client-portal/src/lib/theming/generate-theme-css.ts:545` — emits `--color-system-link` into every client theme
- `brik-client-portal/tailwind.config.ts` — `brik-success/warning/error/link` Tailwind utilities reference them

Portal is extending its canonical-token audit to scan the `--color-*` prefix (PR brikdesigns/brik-client-portal#TBD, follow-up to vale-partners#10). Without the names being canonical in BDS, that audit fails on the 4 pre-existing aliases. This PR closes the gap by ratifying them as canonical.

The defaults sit alongside the existing color-name primitives (`--color-system-red/green/yellow/blue`) so apps can consume the meaning rather than the paint, and brand themes can override per-theme without touching every callsite. The alias chain is preserved (no hex literals) so existing theme overrides flow through unchanged.

## Bump
`0.49.0 → 0.50.0` (minor, additive).

## Test plan
- [x] `npm run build:all-tokens` produces `dist/tokens.css` containing the 4 new names.
- [x] `npm run lint-tokens` passes (0 errors; 6 unrelated pre-existing warnings).
- [x] Pre-commit hooks (typecheck, anti-slop) pass.
- [ ] Reviewer: confirm gap-fills.css is the right home (vs figma-tokens.css). Per BDS rules figma-tokens.css is auto-generated by Style Dictionary, so net-new semantic aliases belong in gap-fills.

## Follow-up
Once this lands and is published, the portal audit extension PR can bump `@brikdesigns/bds` and merge. Other consumers (renew-pms client themes) gain canonical status for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)