### PR TITLE
feat(tokens): add --text-link clean canonical alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",

--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -115,6 +115,21 @@
   --surface-status-success:           var(--surface-positive);
   --surface-status-warning:           var(--surface-warning);
 
+  /* ── Forward-facing alias: hyperlink semantic ──
+     Figma defines this as `text/text-link` (node 22846-1906), backed by
+     `theme/blue/blue-light` → resolved to --brand-primary. Style Dictionary
+     emits the path-joined name `--text-text-link` (prefix `text` + token
+     `text-link` joined by `-`), which is awkward at consumer sites. This
+     alias gives consumers a clean canonical name while preserving the alias
+     chain — per-theme --brand-primary overrides still flow through.
+
+     ⚠️ Use ONLY for interactive hyperlinks (text that does something on
+     click). Categorically distinct from --background-info / --text-info
+     (static informational status, neutral/gray) and --background-status-info
+     (informational signal, blue). See the BDS Vocabulary docs and the
+     comment at line 118 for the info-family distinction. */
+  --text-link: var(--text-text-link);
+
   /* ── Info / Neutral / Purple / Orange status tokens (no Figma equivalent) ──
      Note: Figma's --background-info / --text-info / --surface-info map to system/neutral (gray),
      NOT blue. These blue "info" status tokens are a separate concept — keep as gap-fills. */


### PR DESCRIPTION
## Summary

Adds a one-line forward-facing alias `--text-link: var(--text-text-link)` to `tokens/gap-fills.css`.

## Why

The hyperlink semantic IS canonical in Figma (node `22846-1906`: `text/text-link` → `theme/blue/blue-light` → `--brand-primary`), but Style Dictionary's path-join emits it as `--text-text-link` (prefix `text` + token `text-link` joined by `-`). That name reads as a typo at every consumer site.

This alias gives consumers a clean canonical name without changing any semantic. The alias chain is preserved:

```
--text-link → --text-text-link → --brand-primary → (per-theme override or default poppy)
```

So portal/renew/vale per-theme overrides of `--brand-primary` still flow through unchanged.

## Why now

Portal is extending its canonical-token audit gate to scan the `--color-*` prefix (matches the same gap closed in `vale-partners#10`). Portal currently has `--color-system-link` as a parallel alias defined in per-app theme files — wrong namespace (`--color-*` is for primitives; semantic names live in `--text-*`/`--background-*`/`--surface-*`). Migrating it to canonical needs a clean canonical name to consume. Direct migration to `--text-text-link` is also valid but produces ugly call sites.

## Comment block context

The new section explicitly distinguishes `--text-link` from the info family so future consumers don't conflate categories:

| Token | Color | Affordance | Use case |
|---|---|---|---|
| `--*-info` | Neutral / gray | Static informational | Helper text, neutral notification banner |
| `--*-status-info` | Blue (system-blue) | Static informational signal | Sync-pending, "did you know" callouts |
| `--text-link` | Brand-primary (themed) | **Interactive** (clickable) | Hyperlinks |

## What this PR is NOT

- **Not** adding `--color-system-error/success/warning/link` (closed PR brikdesigns/brik-bds#316). Those names would extend a deprecated taxonomy — BDS uses `negative/positive/warning` per Figma, with `--background-status-error` etc. explicitly marked DEPRECATED. The portal-side migration moves those consumers DOWN to the existing canonical `--background/text/surface-{negative,positive,warning}` tokens, no BDS work needed.
- **Not** changing the SD path-join behavior. That's a larger SD config change with ripple effects to every other `text/foo` token.

## Bump

`0.49.0 → 0.50.0` (minor, additive alias — no breaking changes).

## Test plan

- [x] `npm run build:dist-tokens` produces `dist/tokens.css` with `--text-link: var(--text-text-link)` at line 802
- [x] `npm run lint-tokens` passes (0 errors, 6 unrelated pre-existing warnings)
- [x] Pre-commit hooks (typecheck + anti-slop) pass
- [ ] Reviewer: confirm gap-fills.css is the right home (vs adding `text-link` to Figma source as a clean name + regenerating). Per BDS rules `figma-tokens.css` is auto-generated; gap-fills.css is the right home for forward-facing aliases.

## Follow-up

Once published, `brik-client-portal` will:
- Migrate `--color-system-error/success/warning` consumers DOWN to existing canonical `--background/text/surface-{negative,positive,warning}`
- Migrate `--color-system-link` → `--text-link`
- Retire the parallel alias defs in `theme-brik.css`/`theme-brik-portal.css`
- Repoint Tailwind utilities to canonical names
- Land the `--color-*` audit-extension that motivated this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)