### PR TITLE
fix(InteractiveListItem): tighten --sm font + horizontal padding

### DIFF
--- a/components/ui/InteractiveListItem/InteractiveListItem.css
+++ b/components/ui/InteractiveListItem/InteractiveListItem.css
@@ -39,7 +39,13 @@
 
   .bds-interactive-list-item--sm {
     gap: var(--gap-sm);
-    padding: var(--padding-sm) var(--padding-md);
+    padding: var(--padding-sm);
+  }
+
+  /* `sm` is for narrow contexts (DevBar slot panels, popovers) — the
+     default `--label-md` title crowds these layouts and reads as oversized. */
+  .bds-interactive-list-item--sm .bds-interactive-list-item__title {
+    font-size: var(--label-sm);
   }
 
   .bds-interactive-list-item:hover:not(:disabled) {


### PR DESCRIPTION
## Summary
- docs(primitives): pin Figma 6-stop tonal scale + state/tone separation (#318)
- fix(InteractiveListItem): tighten --sm font + horizontal padding

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)