### PR TITLE
infra: cleanup script remote sweep

### DIFF
--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
-# cleanup-merged-worktrees.sh — Remove worktrees whose PR is merged or whose branch ref is missing.
+# cleanup-merged-worktrees.sh — Remove worktrees + remote refs whose PR is merged.
 #
 # Run this after merging PRs. Safe by default: prints a plan, asks "y" to apply.
-# Skips:
-#   - The primary worktree (the one git worktree list lists first)
-#   - Any worktree whose branch has an OPEN PR
+# Two phases:
+#   1. Worktree sweep — remove local worktrees whose PR is MERGED/CLOSED, plus
+#      their local branch and (unless --no-remote-sweep) their origin ref.
+#   2. Orphan-remote sweep — origin/task/* refs with no local worktree whose
+#      PR is MERGED/CLOSED also get deleted (skipped under --no-remote-sweep).
+# Spares:
+#   - The primary worktree (git worktree list's first entry)
+#   - Any branch whose PR is OPEN
 #   - Worktrees with a dirty working tree (uncommitted changes)
-#   - Worktrees whose branch never had a PR (could be lost work — manual review)
+#   - Branches that never had a PR (could be lost work — manual review)
 #   - Worktrees explicitly named via --keep
 #
 # Usage:
-#   ./scripts/cleanup-merged-worktrees.sh                # interactive
-#   ./scripts/cleanup-merged-worktrees.sh --yes          # apply without prompt
-#   ./scripts/cleanup-merged-worktrees.sh --dry-run      # show plan only
-#   ./scripts/cleanup-merged-worktrees.sh --keep foo     # spare a specific worktree
+#   ./scripts/cleanup-merged-worktrees.sh                  # interactive
+#   ./scripts/cleanup-merged-worktrees.sh --yes            # apply without prompt
+#   ./scripts/cleanup-merged-worktrees.sh --dry-run        # show plan only
+#   ./scripts/cleanup-merged-worktrees.sh --keep foo       # spare a specific worktree
+#   ./scripts/cleanup-merged-worktrees.sh --no-remote-sweep  # skip phase 2 + remote deletes
 
 set -euo pipefail
 
@@ -26,14 +32,16 @@ NC='\033[0m'
 DRY_RUN=0
 ASSUME_YES=0
 KEEP_LIST=()
+REMOTE_SWEEP=1
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run) DRY_RUN=1; shift ;;
-    --yes|-y)  ASSUME_YES=1; shift ;;
-    --keep)    KEEP_LIST+=("$2"); shift 2 ;;
-    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
-    *)         echo -e "${RED}Unknown flag: $1${NC}"; exit 1 ;;
+    --dry-run)         DRY_RUN=1; shift ;;
+    --yes|-y)          ASSUME_YES=1; shift ;;
+    --keep)            KEEP_LIST+=("$2"); shift 2 ;;
+    --no-remote-sweep) REMOTE_SWEEP=0; shift ;;
+    -h|--help)         sed -n '2,23p' "$0"; exit 0 ;;
+    *)                 echo -e "${RED}Unknown flag: $1${NC}"; exit 1 ;;
   esac
 done
 
@@ -66,21 +74,22 @@ done < <(git worktree list --porcelain | awk '
   END              {if (wt && wt != primary) print wt "\t" br "\t" det}
 ' primary="$PRIMARY_PATH")
 
-if [ ${#WORKTREE_LINES[@]} -eq 0 ]; then
-  echo -e "${GREEN}No non-primary worktrees. Nothing to clean.${NC}"
-  exit 0
-fi
-
 TO_REMOVE=()
 SPARED=()
 SPARED_REASONS=()
+TO_REMOVE_ORPHAN_REMOTE=()  # entries: branch_name|||reason
+# branches we've already classified via worktree iteration; orphan-remote
+# sweep skips these to avoid double-counting.
+SEEN_BRANCHES=()
 
+if [ ${#WORKTREE_LINES[@]} -gt 0 ]; then
 for line in "${WORKTREE_LINES[@]}"; do
   wt_path="$(echo "$line" | cut -f1)"
   branch_ref="$(echo "$line" | cut -f2)"
   detached="$(echo "$line" | cut -f3)"
   wt_name="$(basename "$wt_path")"
   branch_name="${branch_ref#refs/heads/}"
+  [ -n "$branch_name" ] && SEEN_BRANCHES+=("$branch_name")
 
   # --keep
   keep_match=0
@@ -129,6 +138,33 @@ for line in "${WORKTREE_LINES[@]}"; do
       ;;
   esac
 done
+fi
+
+# Phase 2 — orphan-remote sweep: origin/task/* refs with no local worktree.
+if [ "$REMOTE_SWEEP" = "1" ]; then
+  while IFS= read -r remote_branch; do
+    [ -z "$remote_branch" ] && continue
+
+    # Skip branches already classified by the worktree pass
+    seen=0
+    if [ ${#SEEN_BRANCHES[@]} -gt 0 ]; then
+      for sb in "${SEEN_BRANCHES[@]}"; do
+        if [ "$sb" = "$remote_branch" ]; then seen=1; break; fi
+      done
+    fi
+    [ "$seen" = "1" ] && continue
+
+    pr_json="$(gh pr list --repo "$REPO_SLUG" --state all --head "$remote_branch" --limit 1 --json number,state 2>/dev/null || echo '[]')"
+    pr_state="$(echo "$pr_json" | jq -r '.[0].state // empty')"
+    pr_number="$(echo "$pr_json" | jq -r '.[0].number // empty')"
+
+    case "$pr_state" in
+      MERGED) TO_REMOVE_ORPHAN_REMOTE+=("$remote_branch|||PR #${pr_number} MERGED") ;;
+      CLOSED) TO_REMOVE_ORPHAN_REMOTE+=("$remote_branch|||PR #${pr_number} CLOSED (rejected)") ;;
+      # OPEN / "" / unknown → leave alone (active or lost work)
+    esac
+  done < <(git for-each-ref 'refs/remotes/origin/task/*' --format='%(refname:lstrip=3)')
+fi
 
 echo -e "${BLUE}=========================================${NC}"
 echo -e "${BLUE}  Worktree cleanup plan${NC}"
@@ -145,18 +181,32 @@ if [ ${#SPARED[@]} -gt 0 ]; then
   echo ""
 fi
 
-if [ ${#TO_REMOVE[@]} -eq 0 ]; then
+if [ ${#TO_REMOVE[@]} -eq 0 ] && [ ${#TO_REMOVE_ORPHAN_REMOTE[@]} -eq 0 ]; then
   echo -e "${GREEN}Nothing to remove.${NC}"
   exit 0
 fi
 
-echo -e "${RED}Will remove (${#TO_REMOVE[@]}):${NC}"
-for entry in "${TO_REMOVE[@]}"; do
-  wt_path="${entry%%|||*}"; rest="${entry#*|||}"
-  branch_name="${rest%%|||*}"; reason="${rest#*|||}"
-  printf "  - %s\n      branch: %s\n      reason: %s\n" "$(basename "$wt_path")" "${branch_name:-<none>}" "$reason"
-done
-echo ""
+if [ ${#TO_REMOVE[@]} -gt 0 ]; then
+  echo -e "${RED}Will remove worktrees (${#TO_REMOVE[@]}):${NC}"
+  for entry in "${TO_REMOVE[@]}"; do
+    wt_path="${entry%%|||*}"; rest="${entry#*|||}"
+    branch_name="${rest%%|||*}"; reason="${rest#*|||}"
+    printf "  - %s\n      branch: %s\n      reason: %s\n" "$(basename "$wt_path")" "${branch_name:-<none>}" "$reason"
+    if [ "$REMOTE_SWEEP" = "1" ] && [ -n "$branch_name" ] && git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
+      printf "      ${RED}also deleting remote: origin/%s${NC}\n" "$branch_name"
+    fi
+  done
+  echo ""
+fi
+
+if [ ${#TO_REMOVE_ORPHAN_REMOTE[@]} -gt 0 ]; then
+  echo -e "${RED}Will delete orphan remote branches (${#TO_REMOVE_ORPHAN_REMOTE[@]}):${NC}"
+  for entry in "${TO_REMOVE_ORPHAN_REMOTE[@]}"; do
+    branch_name="${entry%%|||*}"; reason="${entry#*|||}"
+    printf "  - origin/%s\n      reason: %s\n" "$branch_name" "$reason"
+  done
+  echo ""
+fi
 
 if [ "$DRY_RUN" = "1" ]; then
   echo -e "${BLUE}Dry-run only. No changes made.${NC}"
@@ -172,19 +222,46 @@ if [ "$ASSUME_YES" != "1" ]; then
 fi
 
 echo ""
-for entry in "${TO_REMOVE[@]}"; do
-  wt_path="${entry%%|||*}"; rest="${entry#*|||}"
-  branch_name="${rest%%|||*}"
-  echo -e "${YELLOW}~ Removing $(basename "$wt_path")...${NC}"
 
-  if ! git worktree remove --force "$wt_path" 2>/dev/null; then
-    rm -rf "$wt_path"
-  fi
+# Collect remote branches to delete in one push (worktree-attached + orphans)
+REMOTE_DELETE_BATCH=()
 
-  if [ -n "$branch_name" ] && git show-ref --verify --quiet "refs/heads/$branch_name"; then
-    git branch -D "$branch_name" >/dev/null 2>&1 || true
-  fi
-done
+if [ ${#TO_REMOVE[@]} -gt 0 ]; then
+  for entry in "${TO_REMOVE[@]}"; do
+    wt_path="${entry%%|||*}"; rest="${entry#*|||}"
+    branch_name="${rest%%|||*}"
+    echo -e "${YELLOW}~ Removing $(basename "$wt_path")...${NC}"
+
+    if ! git worktree remove --force "$wt_path" 2>/dev/null; then
+      rm -rf "$wt_path"
+    fi
+
+    if [ -n "$branch_name" ] && git show-ref --verify --quiet "refs/heads/$branch_name"; then
+      git branch -D "$branch_name" >/dev/null 2>&1 || true
+    fi
+
+    if [ "$REMOTE_SWEEP" = "1" ] && [ -n "$branch_name" ] && git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
+      REMOTE_DELETE_BATCH+=("$branch_name")
+    fi
+  done
+fi
+
+if [ "$REMOTE_SWEEP" = "1" ] && [ ${#TO_REMOVE_ORPHAN_REMOTE[@]} -gt 0 ]; then
+  for entry in "${TO_REMOVE_ORPHAN_REMOTE[@]}"; do
+    branch_name="${entry%%|||*}"
+    REMOTE_DELETE_BATCH+=("$branch_name")
+  done
+fi
+
+if [ ${#REMOTE_DELETE_BATCH[@]} -gt 0 ]; then
+  echo -e "${YELLOW}~ Deleting ${#REMOTE_DELETE_BATCH[@]} remote branch(es) on origin...${NC}"
+  # Single push to delete all in one round-trip; tolerate per-ref failures.
+  push_args=("origin")
+  for br in "${REMOTE_DELETE_BATCH[@]}"; do
+    push_args+=("--delete" "$br")
+  done
+  git push "${push_args[@]}" 2>&1 | sed 's/^/    /' || true
+fi
 
 git worktree prune
 echo ""


### PR DESCRIPTION
## Summary
Synced enhancement from `vale-partners` PR #26 — the cleanup script now sweeps stale remote `task/*` branches in addition to local worktrees.

## What changed
**Phase 1 — worktree sweep** (existing): remove local worktrees whose PR is `MERGED` or `CLOSED`, plus their local branch. Now also deletes the corresponding `origin/task/<slug>` ref.

**Phase 2 — orphan-remote sweep** (new): `origin/task/*` refs with no local worktree whose PR is `MERGED` or `CLOSED` also get deleted. OPEN PRs and refs with no PR (could be lost work / another agent's active work) are spared.

`--no-remote-sweep` opts out (worktrees only, original behavior). Default is interactive prompt; `--dry-run` and `--yes` available. Remote deletes are batched into a single `git push` round-trip.

## Why
Stale `origin/task/*` refs were piling up after every merge — the prior version of this script only removed local worktrees, leaving the remote refs to be deleted manually. Validated against current BDS state:

| | |
|---|---|
| `docs-client-product-service-tokens` | worktree, PR #310 MERGED → would be removed |
| `docs-llm-stack-pointer` | worktree, dirty → spared |
| `bcs-populate-visual-style-image-urls` | orphan, PR #125 CLOSED → would be deleted |
| `bcs-visual-style-reference-images` | orphan, PR #120 MERGED → would be deleted |
| `bds-theme-brand-consolidation` | orphan, PR #105 MERGED → would be deleted |
| `bds-worktree-safeguards` | orphan, PR #173 MERGED → would be deleted |

Six other orphan remote refs with OPEN PRs are correctly spared (active work).

## Cross-repo
- **vale-partners** PR #26 — same change, ready
- **brik-client-portal** — deferred until in-flight infra PRs (#597–#601) settle; tracked in BACKLOG

## Test plan
- [ ] After merge, run `./scripts/cleanup-merged-worktrees.sh --dry-run` from primary on `main` — confirm plan output matches what's actually queued
- [ ] Apply (`--yes`) — confirm 1 worktree removed + 4 remote refs deleted, dirty worktree spared
- [ ] Verify `--no-remote-sweep` falls back to original behavior (worktrees only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)