### PR TITLE
feat(docs-site): native Motion viz components — drop Storybook redirects

### DIFF
--- a/docs-site/components/mdx/motion/effect-demos.tsx
+++ b/docs-site/components/mdx/motion/effect-demos.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useState, useEffect, type CSSProperties, type ReactNode } from 'react';
+
+const demoFrame: CSSProperties = {
+  position: 'relative',
+  overflow: 'hidden',
+  borderRadius: 'var(--border-radius-md)',
+  border: '1px solid var(--border-muted)',
+  backgroundColor: 'var(--surface-secondary)',
+};
+
+const darkFrame: CSSProperties = {
+  ...demoFrame,
+  backgroundColor: 'var(--surface-inverse)',
+  color: 'var(--text-on-color-dark)',
+};
+
+const replayButton: CSSProperties = {
+  marginTop: 8,
+  padding: '4px 12px',
+  fontSize: 12,
+  border: '1px solid var(--border-muted)',
+  borderRadius: 'var(--border-radius-sm)',
+  background: 'var(--surface-primary)',
+  color: 'var(--text-secondary)',
+  cursor: 'pointer',
+};
+
+/** Responsive grid wrapper for a row of demo tiles. */
+export function EffectGrid({
+  children,
+  columns = 2,
+}: {
+  children: ReactNode;
+  columns?: number;
+}) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${columns}, 1fr)`,
+        gap: 16,
+        marginBottom: 24,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Frame with replay button so visitors can re-trigger the wrapped animation. */
+export function AnimationDemo({
+  children,
+  dark = false,
+  height = 200,
+  label,
+}: {
+  children: ReactNode;
+  dark?: boolean;
+  height?: number;
+  label?: string;
+}) {
+  const [key, setKey] = useState(0);
+
+  return (
+    <div style={{ marginBottom: 24 }}>
+      {label && (
+        <div
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            marginBottom: 8,
+            color: 'var(--text-primary)',
+          }}
+        >
+          {label}
+        </div>
+      )}
+      <div
+        key={key}
+        style={{
+          ...(dark ? darkFrame : demoFrame),
+          minHeight: height,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 24,
+        }}
+      >
+        {children}
+      </div>
+      <button
+        type="button"
+        onClick={() => setKey((k) => k + 1)}
+        style={replayButton}
+      >
+        Replay
+      </button>
+    </div>
+  );
+}
+
+/** Demonstrates a `clip-{type}-reveal` class. Toggles `is-visible` after mount. */
+export function ClipRevealDemo({ type }: { type: string }) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 300);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <div
+      className={`clip-${type}-reveal ${visible ? 'is-visible' : ''}`}
+      style={{
+        width: '100%',
+        height: 160,
+        borderRadius: 'var(--border-radius-md)',
+        background:
+          'linear-gradient(135deg, var(--background-brand-primary), var(--background-brand-secondary))',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'var(--text-on-color-dark)',
+        fontWeight: 600,
+        fontSize: 14,
+      }}
+    >
+      .clip-{type}-reveal
+    </div>
+  );
+}
+
+/** Tile demonstrating a `grain-overlay[-{variant}]` class. */
+export function GrainDemo({ variant = '' }: { variant?: string }) {
+  const cls = variant ? `grain-overlay grain-overlay--${variant}` : 'grain-overlay';
+  const isHeavy = variant === 'heavy';
+  return (
+    <div
+      className={cls}
+      style={{
+        width: '100%',
+        height: 160,
+        borderRadius: 'var(--border-radius-md)',
+        backgroundColor: isHeavy ? 'var(--surface-inverse)' : 'var(--surface-secondary)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: isHeavy ? 'var(--text-on-color-dark)' : 'var(--text-primary)',
+        fontSize: 13,
+        fontWeight: 500,
+        position: 'relative',
+      }}
+    >
+      <span style={{ position: 'relative', zIndex: 2 }}>.{cls.replace(/ /g, '.')}</span>
+    </div>
+  );
+}
+
+/** Tile demonstrating a `glass[--{variant}]` class on a brand-gradient backdrop. */
+export function GlassDemo({ variant = '' }: { variant?: string }) {
+  const cls = variant ? `glass--${variant}` : 'glass';
+  const isDark = variant === 'dark';
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: 200,
+        borderRadius: 'var(--border-radius-lg)',
+        background:
+          'linear-gradient(135deg, var(--background-brand-primary) 0%, var(--background-brand-secondary) 100%)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        position: 'relative',
+      }}
+    >
+      <div
+        className={cls}
+        style={{
+          padding: '24px 32px',
+          borderRadius: 16,
+          textAlign: 'center',
+          color: isDark ? 'var(--text-on-color-dark)' : 'var(--text-primary)',
+        }}
+      >
+        <div style={{ fontWeight: 600, fontSize: 16, marginBottom: 4 }}>.{cls}</div>
+        <div style={{ fontSize: 12, opacity: 0.8 }}>
+          Frosted glass effect with backdrop-filter
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Heading-tier text effect demo (gradient, stroke, glow, highlight). */
+export function TextEffectDemo({
+  className,
+  label,
+  dark = false,
+}: {
+  className: string;
+  label: string;
+  dark?: boolean;
+}) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 300);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <div
+      style={{
+        padding: '24px 32px',
+        backgroundColor: dark ? 'var(--surface-inverse)' : 'var(--surface-secondary)',
+        borderRadius: 'var(--border-radius-md)',
+        textAlign: 'center',
+        color: dark ? 'var(--text-on-color-dark)' : 'var(--text-primary)',
+      }}
+    >
+      <span
+        className={`${className} ${visible ? 'is-visible' : ''}`}
+        style={{
+          fontSize: 32,
+          fontWeight: 700,
+          fontFamily: 'var(--font-family-heading)',
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/** Hover-effect tile. The wrapped class drives the actual animation. */
+export function HoverDemo({ className, label }: { className: string; label: string }) {
+  return (
+    <div
+      className={className}
+      style={{
+        padding: '16px 24px',
+        backgroundColor: 'var(--surface-primary)',
+        border: '1px solid var(--border-muted)',
+        borderRadius: 'var(--border-radius-md)',
+        textAlign: 'center',
+        cursor: 'pointer',
+        fontWeight: 500,
+        fontSize: 14,
+      }}
+    >
+      {label} — hover me
+    </div>
+  );
+}
+
+/** Static placeholder for `video-bg[--{variant}]` overlay variants. */
+export function VideoDemo({ variant = '' }: { variant?: string }) {
+  const cls = variant ? `video-bg video-bg--${variant}` : 'video-bg';
+  const blurb =
+    variant === 'gradient' ? 'Top-to-bottom gradient overlay'
+    : variant === 'light' ? '20% dark overlay'
+    : variant === 'heavy' ? '65% dark overlay'
+    : '45% dark overlay (default)';
+
+  return (
+    <div
+      className={cls}
+      style={{
+        width: '100%',
+        height: 240,
+        borderRadius: 'var(--border-radius-md)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'relative',
+        overflow: 'hidden',
+        background: 'var(--surface-inverse)',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background:
+            'linear-gradient(135deg, var(--background-brand-secondary) 0%, var(--background-brand-primary) 100%)',
+          opacity: 0.6,
+          zIndex: 0,
+        }}
+      />
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 2,
+          color: 'var(--text-on-color-dark)',
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ fontWeight: 600, fontSize: 18, marginBottom: 4 }}>
+          .{cls.replace(/ /g, '.')}
+        </div>
+        <div style={{ fontSize: 12, opacity: 0.7 }}>{blurb}</div>
+      </div>
+    </div>
+  );
+}
+
+/** Section theming preset — dark/light/warm/brand backgrounds. */
+export function SectionThemeDemo({
+  className,
+  label,
+}: {
+  className: string;
+  label: string;
+}) {
+  return (
+    <div
+      className={className}
+      style={{
+        padding: '32px 24px',
+        borderRadius: 'var(--border-radius-md)',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontWeight: 600, fontSize: 16, marginBottom: 4 }}>.{className}</div>
+      <div style={{ fontSize: 13, opacity: 0.7 }}>{label}</div>
+    </div>
+  );
+}

--- a/docs-site/components/mdx/motion/tier-badge.tsx
+++ b/docs-site/components/mdx/motion/tier-badge.tsx
@@ -1,0 +1,42 @@
+import { type CSSProperties } from 'react';
+
+const badgeStyle: CSSProperties = {
+  display: 'inline-block',
+  fontSize: 11,
+  fontWeight: 600,
+  padding: '2px 8px',
+  borderRadius: 999,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  marginLeft: 8,
+  verticalAlign: 'middle',
+};
+
+const TIER_STYLES: Record<TierName, { bg: string; color: string; label: string }> = {
+  lightweight: {
+    bg: 'var(--background-brand-secondary)',
+    color: 'var(--text-on-color-light)',
+    label: 'Lightweight',
+  },
+  gsap: {
+    bg: 'var(--background-brand-primary)',
+    color: 'var(--text-on-color-dark)',
+    label: 'GSAP',
+  },
+  premium: {
+    bg: 'var(--background-status-purple)',
+    color: 'var(--text-on-color-dark)',
+    label: 'Premium',
+  },
+};
+
+export type TierName = 'lightweight' | 'gsap' | 'premium';
+
+export function TierBadge({ tier }: { tier: TierName }) {
+  const t = TIER_STYLES[tier];
+  return (
+    <span style={{ ...badgeStyle, backgroundColor: t.bg, color: t.color }}>
+      {t.label}
+    </span>
+  );
+}

--- a/docs-site/content/docs/motion/effects/hover.mdx
+++ b/docs-site/content/docs/motion/effects/hover.mdx
@@ -4,12 +4,22 @@ description: Micro-interactions for buttons, cards, and links. CSS hover classes
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
 
 Micro-interactions for buttons, cards, and links. CSS-only effects are in `css/animations.css` — no JS. Magnetic cursor and cursor trail effects require the [Premium tier](/docs/motion/tiers/premium).
 
-## CSS hover classes (Lightweight tier)
+## CSS hover classes <TierBadge tier="lightweight" />
 
 Apply to any interactive element. All transitions use BDS duration and easing tokens.
+
+<EffectGrid columns={3}>
+  <HoverDemo className="hover-lift" label=".hover-lift" />
+  <HoverDemo className="hover-scale" label=".hover-scale" />
+  <HoverDemo className="hover-glow" label=".hover-glow" />
+  <HoverDemo className="hover-dim" label=".hover-dim" />
+  <HoverDemo className="hover-underline" label=".hover-underline" />
+  <HoverDemo className="hover-lift click-press" label=".hover-lift.click-press" />
+</EffectGrid>
 
 ```html
 <!-- Button lifts on hover, presses down on click -->
@@ -36,7 +46,7 @@ Apply to any interactive element. All transitions use BDS duration and easing to
 | `.hover-underline` | Animated underline grows from left | Text links |
 | `.click-press` | `scale(0.97)` on `:active` | Pair with `.hover-lift` on buttons |
 
-## Magnetic cursor buttons (Premium tier)
+## Magnetic cursor buttons <TierBadge tier="premium" />
 
 Buttons attract the cursor within a defined radius, creating a tactile feel. Requires `premium-scroll.js`.
 
@@ -57,7 +67,7 @@ Buttons attract the cursor within a defined radius, creating a tactile feel. Req
   Magnetic effects are best on **isolated primary CTAs** — do not apply to every button on the page. The effect draws attention to the element; overuse neutralizes it.
 </Callout>
 
-## Cursor trail (Premium tier)
+## Cursor trail <TierBadge tier="premium" />
 
 A custom cursor dot that trails the mouse with a spring feel. Enabled globally by the `cursor-trail` class on the body.
 
@@ -69,10 +79,6 @@ A custom cursor dot that trails the mouse with a spring feel. Enabled globally b
 ```
 
 Exclude specific elements from the trail with `data-cursor-default` — useful for text inputs and selects where the system cursor should display normally.
-
-<Callout type="info">
-  **Live demos are in Storybook.** Each hover class renders an interactive example with hover state. See **Motion → Effects → Hover** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com).
-</Callout>
 
 ## Related
 

--- a/docs-site/content/docs/motion/effects/overlays.mdx
+++ b/docs-site/content/docs/motion/effects/overlays.mdx
@@ -4,12 +4,19 @@ description: Atmosphere overlays — film grain and glassmorphism. ::after pseud
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
 
-Atmosphere overlays in `css/premium-effects.css`. Film grain adds tactile texture. Glassmorphism creates depth for floating UI panels. Both use `::after` pseudo-elements — no additional DOM nodes required.
+<TierBadge tier="premium" /> Atmosphere overlays in `css/premium-effects.css`. Film grain adds tactile texture. Glassmorphism creates depth for floating UI panels. Both use `::after` pseudo-elements — no additional DOM nodes required.
 
 ## Grain
 
 Film grain adds analogue texture to sections. The `::after` pseudo-element applies a tiling noise texture at low opacity. Use it on hero sections, dark sections, and feature blocks to add character.
+
+<EffectGrid columns={3}>
+  <GrainDemo />
+  <GrainDemo variant="heavy" />
+  <GrainDemo variant="light" />
+</EffectGrid>
 
 ```html
 <!-- Standard grain (4% opacity) — use on light or mid-tone sections -->
@@ -42,6 +49,12 @@ Film grain adds analogue texture to sections. The `::after` pseudo-element appli
 ## Glassmorphism
 
 Frosted glass panels using `backdrop-filter: blur()`. Three variants — default, light, and dark — for different background luminance levels.
+
+<EffectGrid columns={3}>
+  <GlassDemo />
+  <GlassDemo variant="light" />
+  <GlassDemo variant="dark" />
+</EffectGrid>
 
 ```html
 <!-- Default glass — 50% white background, 8px blur -->
@@ -81,10 +94,6 @@ Grain and glass compose. A dark glass nav panel with grain texture reads as prem
   Navigation links
 </nav>
 ```
-
-<Callout type="info">
-  **Live demos are in Storybook.** Each grain and glass variant renders an interactive comparison. See **Motion → Effects → Overlays** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com).
-</Callout>
 
 ## Related
 

--- a/docs-site/content/docs/motion/effects/scroll-reveals.mdx
+++ b/docs-site/content/docs/motion/effects/scroll-reveals.mdx
@@ -4,8 +4,9 @@ description: Clip-path reveals, fade and slide entrances, stagger patterns, para
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
 
-All scroll reveal effects are in `css/animations.css` and triggered by toggling `.is-visible` on the element when it enters the viewport. The trigger mechanism is a plain IntersectionObserver — no library required.
+<TierBadge tier="lightweight" /> All scroll reveal effects are in `css/animations.css` and triggered by toggling `.is-visible` on the element when it enters the viewport. The trigger mechanism is a plain IntersectionObserver — no library required.
 
 See [Lightweight tier](/docs/motion/tiers/lightweight) for the observer snippet and full import order.
 
@@ -21,6 +22,15 @@ Cinematic unveils for images and section containers. Each class defines a `clip-
 | `.clip-rise-reveal` | Rise from bottom |
 | `.clip-diagonal-reveal` | Diagonal sweep |
 | `.clip-diamond-reveal` | Diamond expand from center |
+
+<EffectGrid columns={3}>
+  <ClipRevealDemo type="circle" />
+  <ClipRevealDemo type="curtain" />
+  <ClipRevealDemo type="wipe" />
+  <ClipRevealDemo type="rise" />
+  <ClipRevealDemo type="diagonal" />
+  <ClipRevealDemo type="diamond" />
+</EffectGrid>
 
 ```html
 <!-- Circle expand from center -->
@@ -94,10 +104,6 @@ Apply `.parallax-element` to an element with a `data-parallax-speed` attribute (
   <img src="background.jpg" alt="...">
 </div>
 ```
-
-<Callout type="info">
-  **Live demos are in Storybook.** All six clip-path reveals + the four fade/slide variants render interactive examples. See **Motion → Effects → Scroll Reveals** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com).
-</Callout>
 
 ## Related
 

--- a/docs-site/content/docs/motion/effects/typography.mdx
+++ b/docs-site/content/docs/motion/effects/typography.mdx
@@ -4,8 +4,18 @@ description: Gradient fill, stroke, glow, animated highlight. Heading-level only
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
 
-CSS text decoration classes in `css/animations.css`. These apply to heading elements only — paired with `--font-family-heading` and heading-scale sizes. Never apply to body copy or labels.
+<TierBadge tier="lightweight" /> CSS text decoration classes in `css/animations.css`. These apply to heading elements only — paired with `--font-family-heading` and heading-scale sizes. Never apply to body copy or labels.
+
+<EffectGrid columns={2}>
+  <TextEffectDemo className="text-gradient" label="Gradient Text" />
+  <TextEffectDemo className="text-gradient--brand" label="Brand Gradient" />
+  <TextEffectDemo className="text-stroke" label="Stroke Text" />
+  <TextEffectDemo className="text-glow" label="Glowing Text" dark />
+  <TextEffectDemo className="text-highlight" label="Highlighted" />
+  <TextEffectDemo className="text-stroke--thick" label="Thick Stroke" />
+</EffectGrid>
 
 ## Class reference
 
@@ -46,15 +56,11 @@ CSS text decoration classes in `css/animations.css`. These apply to heading elem
   **Validate font family.** Test with the Font Audit theme in the Storybook toolbar to verify heading font family is correct — gradient-clip only works if `-webkit-background-clip: text` applies to a heading-family element.
 </Callout>
 
-## GSAP text splitting (GSAP tier)
+## GSAP text splitting <TierBadge tier="gsap" />
 
 For letter-by-letter or word-by-word animated reveals, use GSAP SplitText instead of CSS classes. See [GSAP Tier](/docs/motion/tiers/gsap) for the splitting pattern.
 
 The CSS classes above and GSAP SplitText are composable — you can apply `.text-gradient` to a heading and also split it with SplitText. The gradient applies to each character span GSAP creates.
-
-<Callout type="info">
-  **Live demos are in Storybook.** Each text effect renders an interactive example. See **Motion → Effects → Typography** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com).
-</Callout>
 
 ## Related
 

--- a/docs-site/content/docs/motion/effects/video.mdx
+++ b/docs-site/content/docs/motion/effects/video.mdx
@@ -4,8 +4,9 @@ description: Full-bleed video sections with configurable overlay darkness. Premi
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
 
-Full-bleed video sections with configurable overlay darkness. The CSS classes live in `css/premium-effects.css`. Video backgrounds carry performance cost — use only in hero sections, never in below-the-fold cards.
+<TierBadge tier="premium" /> Full-bleed video sections with configurable overlay darkness. The CSS classes live in `css/premium-effects.css`. Video backgrounds carry performance cost — use only in hero sections, never in below-the-fold cards.
 
 ## Overlay variants
 
@@ -15,6 +16,13 @@ Full-bleed video sections with configurable overlay darkness. The CSS classes li
 | `.video-bg--light` | 20% dark | High-contrast footage with pale backgrounds |
 | `.video-bg--heavy` | 65% dark | Dark-theme sections needing strong text contrast |
 | `.video-bg--gradient` | Top-to-bottom gradient | Prefer gradient over flat overlays for editorial look |
+
+<EffectGrid columns={2}>
+  <VideoDemo />
+  <VideoDemo variant="light" />
+  <VideoDemo variant="heavy" />
+  <VideoDemo variant="gradient" />
+</EffectGrid>
 
 ## Implementation
 
@@ -47,13 +55,9 @@ Full-bleed video sections with configurable overlay darkness. The CSS classes li
 - **Preload behavior:** `preload="none"` (default) defers the video download until play begins. `preload="metadata"` loads the poster frame and duration only. `preload="auto"` loads the full file on page load — avoid for below-the-fold or conditional sections.
 - **Poster image:** add `poster="hero-poster.jpg"` to display a still frame while the video loads. Without it, some browsers show a black rectangle.
 
-## Scroll-scrubbed video (Premium JS)
+## Scroll-scrubbed video <TierBadge tier="premium" />
 
 Video playback tied to scroll position — user scrolls to advance the video frame-by-frame. Requires `premium-scroll.js` and GSAP. See [Premium tier](/docs/motion/tiers/premium) for the implementation pattern.
-
-<Callout type="info">
-  **Live demos are in Storybook.** Each overlay variant renders with sample footage. See **Motion → Effects → Video** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com).
-</Callout>
 
 ## Related
 

--- a/docs-site/content/docs/motion/index.mdx
+++ b/docs-site/content/docs/motion/index.mdx
@@ -53,10 +53,6 @@ Two locked enums pair the Motion system to the client portal. When a client's an
   <Card title="Vocabulary" href="/docs/motion/vocabulary" description="Animation Tier and Image Mood — locked enums the portal captures and the motion worker reads." />
 </Cards>
 
-<Callout type="info">
-  **Live demos are in Storybook.** Each tier and effect has interactive examples — see **Motion** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com). Native demo components in this site land in a follow-up.
-</Callout>
-
 ## Related
 
 - [Primitives](/docs/primitives) — the `--duration-*` and `--ease-*` motion tokens live here

--- a/docs-site/content/docs/motion/tiers/gsap.mdx
+++ b/docs-site/content/docs/motion/tiers/gsap.mdx
@@ -4,8 +4,9 @@ description: Adds scroll choreography — pinning, scrubbing, horizontal scroll,
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
 
-Add GSAP when the design calls for scroll pinning, scroll-scrubbed animations, horizontal scroll panels, or text splitting. Everything from the [Lightweight tier](/docs/motion/tiers/lightweight) still applies — GSAP adds runtime control on top of CSS effects.
+<TierBadge tier="gsap" /> Add GSAP when the design calls for scroll pinning, scroll-scrubbed animations, horizontal scroll panels, or text splitting. Everything from the [Lightweight tier](/docs/motion/tiers/lightweight) still applies — GSAP adds runtime control on top of CSS effects.
 
 ## Files to load
 

--- a/docs-site/content/docs/motion/tiers/lightweight.mdx
+++ b/docs-site/content/docs/motion/tiers/lightweight.mdx
@@ -4,8 +4,9 @@ description: No JavaScript library. Pure CSS animations + a minimal Intersection
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
 
-No JavaScript library. Every effect in this tier runs on CSS transitions, CSS animations using the BDS keyframe library, and a minimal IntersectionObserver snippet to toggle `.is-visible`. This is the default for all mockups.
+<TierBadge tier="lightweight" /> No JavaScript library. Every effect in this tier runs on CSS transitions, CSS animations using the BDS keyframe library, and a minimal IntersectionObserver snippet to toggle `.is-visible`. This is the default for all mockups.
 
 ## Files to load
 
@@ -99,7 +100,18 @@ Cinematic image and section unveils. Implemented in CSS — no library dependenc
 </div>
 ```
 
-Six variants: `clip-circle-reveal`, `clip-curtain-reveal`, `clip-wipe-reveal`, `clip-rise-reveal`, `clip-diagonal-reveal`, `clip-diamond-reveal`. See [Scroll Reveals](/docs/motion/effects/scroll-reveals) for the full effect reference.
+Six variants: `clip-circle-reveal`, `clip-curtain-reveal`, `clip-wipe-reveal`, `clip-rise-reveal`, `clip-diagonal-reveal`, `clip-diamond-reveal`.
+
+<EffectGrid columns={3}>
+  <ClipRevealDemo type="circle" />
+  <ClipRevealDemo type="curtain" />
+  <ClipRevealDemo type="wipe" />
+  <ClipRevealDemo type="rise" />
+  <ClipRevealDemo type="diagonal" />
+  <ClipRevealDemo type="diamond" />
+</EffectGrid>
+
+See [Scroll Reveals](/docs/motion/effects/scroll-reveals) for the full effect reference.
 
 ## Hover effects
 
@@ -114,6 +126,15 @@ CSS-only micro-interactions. No JS required.
 | `.hover-underline` | Animated underline grows from left | Text links |
 | `.click-press` | `scale(0.97)` on `:active` | Pair with `.hover-lift` on buttons |
 
+<EffectGrid columns={3}>
+  <HoverDemo className="hover-lift" label=".hover-lift" />
+  <HoverDemo className="hover-scale" label=".hover-scale" />
+  <HoverDemo className="hover-glow" label=".hover-glow" />
+  <HoverDemo className="hover-dim" label=".hover-dim" />
+  <HoverDemo className="hover-underline" label=".hover-underline" />
+  <HoverDemo className="hover-lift click-press" label=".hover-lift.click-press" />
+</EffectGrid>
+
 See [Hover Effects](/docs/motion/effects/hover) for magnetic and cursor-trail variants (those require Premium JS).
 
 ## Section theming
@@ -126,6 +147,13 @@ Section color presets. Combine with grain, glass, and dividers.
 | `.section-light` | Light background |
 | `.section-warm` | Warm / cream background |
 | `.section-brand` | Brand primary background |
+
+<EffectGrid columns={2}>
+  <SectionThemeDemo className="section-dark" label="Dark background" />
+  <SectionThemeDemo className="section-light" label="Light background" />
+  <SectionThemeDemo className="section-warm" label="Warm/cream background" />
+  <SectionThemeDemo className="section-brand" label="Brand primary background" />
+</EffectGrid>
 
 ## Attention animations
 
@@ -145,10 +173,6 @@ Draw the eye to a changed state without motion sickness risk. These loop continu
 ## Reduced motion
 
 `tokens/animations.css` includes a `prefers-reduced-motion` override that disables all animations and transitions for users who have enabled this OS preference. No additional work needed.
-
-<Callout type="info">
-  **Live demos are in Storybook.** Each effect renders an interactive example. See **Motion → Tiers → Lightweight** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com).
-</Callout>
 
 ## Related
 

--- a/docs-site/content/docs/motion/tiers/premium.mdx
+++ b/docs-site/content/docs/motion/tiers/premium.mdx
@@ -4,8 +4,9 @@ description: Atmosphere effects — grain, glass, magnetic cursor, hero sequence
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
 
-Premium effects handle atmosphere — the qualitative texture that separates a premium website from a well-styled one. Film grain, glassmorphism, magnetic cursor buttons, orchestrated hero sequences, and scroll-scrubbed video all live here. Premium builds on both [Lightweight](/docs/motion/tiers/lightweight) and [GSAP](/docs/motion/tiers/gsap).
+<TierBadge tier="premium" /> Premium effects handle atmosphere — the qualitative texture that separates a premium website from a well-styled one. Film grain, glassmorphism, magnetic cursor buttons, orchestrated hero sequences, and scroll-scrubbed video all live here. Premium builds on both [Lightweight](/docs/motion/tiers/lightweight) and [GSAP](/docs/motion/tiers/gsap).
 
 ## Files to load
 
@@ -28,6 +29,12 @@ See [Overlays](/docs/motion/effects/overlays) for the full grain and glass refer
 
 ### Grain overlays
 
+<EffectGrid columns={3}>
+  <GrainDemo />
+  <GrainDemo variant="heavy" />
+  <GrainDemo variant="light" />
+</EffectGrid>
+
 ```html
 <!-- Standard grain (4% opacity) -->
 <section class="grain-overlay">Content</section>
@@ -40,6 +47,12 @@ See [Overlays](/docs/motion/effects/overlays) for the full grain and glass refer
 ```
 
 ### Glassmorphism
+
+<EffectGrid columns={3}>
+  <GlassDemo />
+  <GlassDemo variant="light" />
+  <GlassDemo variant="dark" />
+</EffectGrid>
 
 ```html
 <div class="glass">Default frosted glass</div>
@@ -151,10 +164,6 @@ Signature compositions mapped to design references. See `ANIMATION-REFERENCE.md`
 | **Legend.xyz** | `section-dark`, `glass-card`, `text-gradient`, `data-scroll-batch`, `divider-gradient`, `cursor-spotlight`, `hover-glow` |
 | **Luxury / Law** | `grain-overlay--light`, `ken-burns--slow`, `clip-curtain-reveal`, `morph-light-to-dark`, `text-stroke`, `glass--light` nav |
 | **Modern Medical** | `video-bg--gradient` hero, `data-premium-hero`, `data-premium-counter`, `image-reveal`, `section-warm`, `text-highlight` |
-
-<Callout type="info">
-  **Live demos are in Storybook.** Each effect category renders interactive examples. See **Motion → Tiers → Premium** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com).
-</Callout>
 
 ## Related
 

--- a/docs-site/lib/mdx-components.tsx
+++ b/docs-site/lib/mdx-components.tsx
@@ -21,6 +21,18 @@ import {
   BorderWidthPreview,
   ShadowScale,
 } from '@/components/mdx/foundation/radius-shadow';
+import { TierBadge } from '@/components/mdx/motion/tier-badge';
+import {
+  EffectGrid,
+  AnimationDemo,
+  ClipRevealDemo,
+  GrainDemo,
+  GlassDemo,
+  TextEffectDemo,
+  HoverDemo,
+  VideoDemo,
+  SectionThemeDemo,
+} from '@/components/mdx/motion/effect-demos';
 import * as BDS from '@brikdesigns/bds';
 
 /**
@@ -56,6 +68,16 @@ export function getMDXComponents(extra?: MDXComponents): MDXComponents {
     BorderRadiusPreview,
     BorderWidthPreview,
     ShadowScale,
+    TierBadge,
+    EffectGrid,
+    AnimationDemo,
+    ClipRevealDemo,
+    GrainDemo,
+    GlassDemo,
+    TextEffectDemo,
+    HoverDemo,
+    VideoDemo,
+    SectionThemeDemo,
     // The BDS namespace export includes hooks (useTheme) alongside components.
     // MDX's component-map type rejects that mix; cast since MDX only ever calls
     // the JSX entries (`<BDS.Button>`), never the hooks.


### PR DESCRIPTION
## Summary

Ports the Motion visualization components from `stories/foundation/motion/_components/` to `docs-site/components/mdx/motion/` so the docs site renders interactive demos natively. After this lands, the eight Motion pages no longer redirect readers to Storybook for visual examples.

## New components

`docs-site/components/mdx/motion/tier-badge.tsx`:
- `TierBadge` — pill badge inline with section headings to mark which tier each effect category belongs to (`lightweight` / `gsap` / `premium`)

`docs-site/components/mdx/motion/effect-demos.tsx`:
- `EffectGrid` — responsive grid wrapper for demo tiles
- `AnimationDemo` — frame with replay button (re-runs animation on click)
- `ClipRevealDemo` — six clip-path reveal classes
- `GrainDemo` — grain-overlay variants (default / heavy / light)
- `GlassDemo` — glassmorphism variants (default / light / dark)
- `TextEffectDemo` — gradient / stroke / glow / highlight typography effects
- `HoverDemo` — interactive hover-effect tile
- `VideoDemo` — `video-bg` overlay variants
- `SectionThemeDemo` — `section-{dark,light,warm,brand}` presets

All components reference only **canonical BDS tokens** (`--surface-*`, `--background-*`, `--text-on-color-*`, `--border-*`). No raw hex values, no parallel taxonomies. Contrast tokens picked correctly per surface — `--text-on-color-dark` = white text for dark surfaces, `--text-on-color-light` = black for light surfaces.

Registered in [`lib/mdx-components.tsx`](docs-site/lib/mdx-components.tsx) so they're available to every MDX page without explicit imports — same pattern as the Foundation viz components (`ColorGrid`, `SpacingScale`, `TypographyScale`, etc.).

## MDX pages updated

| Page | Change |
|---|---|
| `motion/index.mdx` | Drop "Live demos in Storybook" callout |
| `motion/tiers/lightweight.mdx` | `<TierBadge>` + EffectGrids for clip-paths, hover, sections |
| `motion/tiers/gsap.mdx` | `<TierBadge tier="gsap" />` |
| `motion/tiers/premium.mdx` | `<TierBadge>` + EffectGrids for grain + glass |
| `motion/effects/hover.mdx` | `<TierBadge>` on each H2 + EffectGrid of hover demos |
| `motion/effects/scroll-reveals.mdx` | `<TierBadge>` + EffectGrid of all six clip-path reveals |
| `motion/effects/overlays.mdx` | `<TierBadge>` + EffectGrids for grain + glass |
| `motion/effects/typography.mdx` | `<TierBadge>` on each H2 + EffectGrid of all six text effects |
| `motion/effects/video.mdx` | `<TierBadge>` + EffectGrid of all four overlay variants |

## Implementation note

`TierBadge` is referenced **inline within paragraph text** (`<TierBadge ... /> No JavaScript library...`). MDX v3 doesn't reliably resolve inline JSX through the registry — only block-form JSX does. The other viz components are used in block form and resolve via the registry; TierBadge gets an explicit per-file import in each affected MDX. This is a known MDX quirk and matches the pattern other docs use (e.g. `Callout` is also explicitly imported per file).

## Test plan

- [x] `npm run build` — 130 static pages, no errors
- [ ] On deploy preview, walk through all 8 Motion sub-pages — verify each `<TierBadge>` renders inline with correct tier color, EffectGrids render the demos
- [ ] Verify `<HoverDemo>` cards actually animate on hover
- [ ] Verify `<ClipRevealDemo>` tiles auto-trigger their reveal on mount
- [ ] Verify `<TextEffectDemo>` shows the gradient/stroke/glow correctly
- [ ] Verify `<VideoDemo>` overlay variants render with correct darkness levels

## Follow-up (separate PR)

**Theming viz components** — `AtmospherePreview` and `NavigationIASpec` from `stories/foundation/_components/`. AtmospherePreview is more complex: it uses iframes loading atmosphere CSS files via Vite `?url` imports. Porting needs a build-time CSS bundling strategy (the atmosphere CSS files ship in `@brikdesigns/bds/atmospheres/{slug}.css` but aren't yet plumbed into docs-site's iframe srcdoc). NavigationIASpec needs `content-system/schema` imports; that's straightforward but tied to the AtmospherePreview work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)