### PR TITLE
feat(docs-site): native Theming viz — AtmospherePreview + NavigationIASpec

### DIFF
--- a/docs-site/components/mdx/theming/atmosphere-preview.tsx
+++ b/docs-site/components/mdx/theming/atmosphere-preview.tsx
@@ -1,0 +1,279 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ATMOSPHERE_MANIFEST,
+  type Atmosphere,
+} from '@brikdesigns/bds/content-system';
+
+/**
+ * Server component. Renders a sandboxed iframe preview of an atmosphere
+ * by inlining the BDS token cascade + the atmosphere CSS into the
+ * iframe's srcDoc at SSG time. The iframe isolates atmosphere rules
+ * from the docs shell — atmosphere CSS targets :root, body, and
+ * data-* selectors on sections, which would otherwise restyle the
+ * whole docs page.
+ *
+ * Resolves the BDS package via the conventional node_modules path
+ * relative to docs-site cwd at build time. Works for local + Netlify
+ * builds (both run `npm run build` from docs-site).
+ */
+
+// turbopackIgnore: process.cwd() is intentional — this server component reads
+// CSS at SSG time and the cwd is docs-site/ in both local + Netlify builds.
+const bdsRoot = join(
+  /* turbopackIgnore: true */ process.cwd(),
+  'node_modules',
+  '@brikdesigns',
+  'bds',
+);
+
+// Cache token CSS — read once per process.
+const tokensCss = readFileSync(join(bdsRoot, 'dist/tokens.css'), 'utf8');
+
+const atmosphereCssCache = new Map<Atmosphere, string>();
+function getAtmosphereCss(slug: Atmosphere): string {
+  let css = atmosphereCssCache.get(slug);
+  if (!css) {
+    css = readFileSync(join(bdsRoot, `content-system/atmospheres/${slug}.css`), 'utf8');
+    atmosphereCssCache.set(slug, css);
+  }
+  return css;
+}
+
+const COMPOSITE_STYLES = `
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    font-family: var(--font-family-body, system-ui, sans-serif);
+    color: var(--text-primary);
+    background: var(--background-primary);
+    overflow: hidden;
+  }
+  .preview-root {
+    padding: var(--padding-lg, 16px);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md, 12px);
+  }
+  .preview-hero {
+    position: relative;
+    border-radius: var(--border-radius-md, 8px);
+    padding: var(--padding-lg, 20px);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    min-height: 140px;
+    background: var(--surface-primary);
+    border: 1px solid var(--border-primary);
+  }
+  .preview-eyebrow {
+    font-family: var(--font-family-label, system-ui, sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-brand-primary);
+    margin-bottom: var(--gap-xs, 8px);
+  }
+  .preview-h1 {
+    font-family: var(--font-family-heading, Georgia, serif);
+    font-size: 22px;
+    line-height: 1.15;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    color: var(--text-primary);
+    max-width: 22ch;
+  }
+  .preview-h1 em {
+    color: var(--text-brand-primary);
+    font-style: italic;
+  }
+  .preview-sub {
+    margin-top: var(--gap-xs, 8px);
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-family: var(--font-family-body, system-ui, sans-serif);
+  }
+  .preview-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--gap-sm, 12px);
+    flex: 1;
+  }
+  .preview-card {
+    position: relative;
+    border-radius: var(--border-radius-sm, 6px);
+    padding: var(--padding-md, 14px);
+    border: 1px solid var(--border-muted);
+    background: var(--surface-secondary);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+  .preview-card-icon {
+    width: 22px;
+    height: 22px;
+    border-radius: var(--border-radius-xs, 4px);
+    border: 1px solid var(--border-brand-primary);
+    margin-bottom: var(--gap-xs, 8px);
+  }
+  .preview-card h3 {
+    font-family: var(--font-family-heading, Georgia, serif);
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+  }
+  .preview-card p {
+    font-family: var(--font-family-body, system-ui, sans-serif);
+    font-size: 10px;
+    line-height: 1.4;
+    color: var(--text-secondary);
+  }
+  .preview-cta {
+    border-radius: var(--border-radius-sm, 6px);
+    padding: 12px 16px;
+    text-align: center;
+    background: var(--background-brand-primary);
+    color: var(--text-on-color-dark);
+    font-family: var(--font-family-label, system-ui, sans-serif);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+`;
+
+function buildSrcDoc(slug: Atmosphere, atmosphereCss: string): string {
+  const dataTheme =
+    ATMOSPHERE_MANIFEST[slug].themeMode === 'dark' ? 'dark' : 'light';
+
+  return `<!doctype html>
+<html data-theme="${dataTheme}">
+<head>
+<meta charset="utf-8">
+<style>${tokensCss}</style>
+<style>${atmosphereCss}</style>
+<style>${COMPOSITE_STYLES}</style>
+</head>
+<body class="theme-brand-brik">
+<div class="preview-root">
+  <section class="preview-hero" data-ambient="top-right">
+    <div class="preview-eyebrow">${slug}</div>
+    <h1 class="preview-h1">Dentistry designed to make you <em>feel good</em> about your smile.</h1>
+    <p class="preview-sub">Two doctors. One practice. Find the fit that&apos;s right for you.</p>
+  </section>
+
+  <section class="preview-grid" data-ambient="split">
+    <div class="preview-card" data-spotlight>
+      <div class="preview-card-icon"></div>
+      <h3>Veneers</h3>
+      <p>Porcelain restorations photographed every stage.</p>
+    </div>
+    <div class="preview-card">
+      <div class="preview-card-icon"></div>
+      <h3>Preventive</h3>
+      <p>Cleanings, exams, family care.</p>
+    </div>
+    <div class="preview-card">
+      <div class="preview-card-icon"></div>
+      <h3>Restorative</h3>
+      <p>Crowns, bridges, full-mouth rehab.</p>
+    </div>
+  </section>
+
+  <div class="preview-cta">Request Your Appointment</div>
+</div>
+</body>
+</html>`;
+}
+
+export interface AtmospherePreviewProps {
+  atmosphere: Atmosphere;
+}
+
+export function AtmospherePreview({ atmosphere }: AtmospherePreviewProps) {
+  const entry = ATMOSPHERE_MANIFEST[atmosphere];
+  const atmosphereCss = getAtmosphereCss(atmosphere);
+  const srcDoc = buildSrcDoc(atmosphere, atmosphereCss);
+
+  return (
+    <div style={{ marginBottom: 'var(--padding-xl, 40px)' }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1.6fr 1fr',
+          gap: 'var(--gap-lg, 20px)',
+          marginBottom: 'var(--gap-md, 12px)',
+          alignItems: 'stretch',
+        }}
+      >
+        <div
+          style={{
+            borderRadius: 'var(--border-radius-lg, 12px)',
+            border: '1px solid var(--border-primary)',
+            overflow: 'hidden',
+            minHeight: 380,
+          }}
+        >
+          <iframe
+            title={`${atmosphere} atmosphere preview`}
+            sandbox="allow-same-origin"
+            srcDoc={srcDoc}
+            style={{ width: '100%', height: 380, border: 'none', display: 'block' }}
+          />
+        </div>
+
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 13,
+            margin: 0,
+          }}
+        >
+          <tbody>
+            <Row label="Slug" mono>{entry.slug}</Row>
+            <Row label="Theme mode" mono>{entry.themeMode ?? '(any)'}</Row>
+            <Row label="Blurb">{entry.blurb}</Row>
+            <Row label="Natural fit">{entry.naturalFit.join('  ·  ')}</Row>
+            <Row label="Surface profile" mono>{entry.surfaceProfile}</Row>
+            <Row label="Import" mono>{entry.cssPath}</Row>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  children,
+  mono = false,
+}: {
+  label: string;
+  children: React.ReactNode;
+  mono?: boolean;
+}) {
+  const cellStyle: React.CSSProperties = {
+    padding: '8px 10px',
+    borderBottom: '1px solid var(--border-muted)',
+    verticalAlign: 'top',
+  };
+  return (
+    <tr>
+      <td style={{ ...cellStyle, fontWeight: 600 }}>{label}</td>
+      <td
+        style={{
+          ...cellStyle,
+          fontFamily: mono
+            ? 'ui-monospace, SFMono-Regular, Menlo, monospace'
+            : 'inherit',
+          fontSize: mono ? 12 : 'inherit',
+        }}
+      >
+        {children}
+      </td>
+    </tr>
+  );
+}

--- a/docs-site/components/mdx/theming/navigation-ia-spec.tsx
+++ b/docs-site/components/mdx/theming/navigation-ia-spec.tsx
@@ -1,0 +1,378 @@
+import {
+  industryPacks,
+  type IndustrySlug,
+} from '@brikdesigns/bds/content-system';
+
+/**
+ * Server component. Renders an industry pack's `navigationIA` field as
+ * a static spec — mock header bar at the top, structured data table
+ * below, optional mega-menu preview if defined. Mirrors the Storybook
+ * NavigationIASpec component but consumes the pack via slug instead of
+ * taking the IA object directly, keeping the MDX surface tight.
+ */
+
+export interface NavigationIASpecProps {
+  /**
+   * Industry slug. Must exist in `industryPacks` from
+   * `@brikdesigns/bds/content-system`.
+   */
+  industry: IndustrySlug;
+  /**
+   * Display name for the brand placeholder in the mock header.
+   * Defaults to a title-cased version of the slug.
+   */
+  displayName?: string;
+}
+
+export function NavigationIASpec({
+  industry,
+  displayName,
+}: NavigationIASpecProps) {
+  const pack = industryPacks[industry];
+  const ia = pack?.navigationIA;
+  if (!ia) {
+    return (
+      <div
+        style={{
+          padding: 16,
+          border: '1px dashed var(--border-muted)',
+          borderRadius: 'var(--border-radius-md, 8px)',
+          color: 'var(--text-muted)',
+          fontSize: 13,
+        }}
+      >
+        No navigationIA declared for industry pack <code>{industry}</code>.
+      </div>
+    );
+  }
+
+  const brandLabel = displayName ?? toTitleCase(industry);
+  const isTransparentScroll =
+    ia.scrollBehavior === 'transparent-top-frosted-past-80';
+
+  return (
+    <div style={{ marginBottom: 'var(--padding-xl, 40px)' }}>
+      {/* ── Visual preview ──────────────────────────────────── */}
+      <div
+        style={{
+          borderRadius: 'var(--border-radius-lg, 12px)',
+          border: '1px solid var(--border-primary)',
+          overflow: 'hidden',
+          marginBottom: 'var(--gap-lg, 16px)',
+          background: 'var(--surface-secondary)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 24,
+            padding: '14px 20px',
+            borderBottom: '1px solid var(--border-primary)',
+            background: isTransparentScroll
+              ? 'var(--surface-inverse)'
+              : 'var(--surface-primary)',
+            color: isTransparentScroll
+              ? 'var(--text-on-color-dark)'
+              : 'var(--text-primary)',
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'var(--font-family-heading)',
+              fontWeight: 600,
+            }}
+          >
+            {brandLabel} Brand
+          </span>
+          <nav
+            style={{
+              display: 'flex',
+              gap: 20,
+              flex: 1,
+              fontSize: 13,
+            }}
+          >
+            {ia.servicesMegaMenu && (
+              <span style={{ opacity: 0.9 }}>
+                {ia.servicesMegaMenu.triggerLabel} ▾
+              </span>
+            )}
+            {ia.primaryLinks
+              .filter((l) => l.label !== (ia.servicesMegaMenu?.triggerLabel ?? ''))
+              .slice(
+                0,
+                ia.primaryLinkCount - (ia.servicesMegaMenu ? 1 : 0),
+              )
+              .map((l) => (
+                <span key={l.href} style={{ opacity: 0.8 }}>
+                  {l.label}
+                </span>
+              ))}
+          </nav>
+          <div
+            style={{
+              display: 'flex',
+              gap: 12,
+              alignItems: 'center',
+              fontSize: 13,
+            }}
+          >
+            {ia.utility.showPhone && (
+              <span style={{ opacity: 0.7 }}>(555) 000-0000</span>
+            )}
+            <span
+              style={{
+                padding: '6px 14px',
+                background:
+                  ia.utility.primaryCTA.variant === 'solid'
+                    ? 'var(--background-brand-primary)'
+                    : 'transparent',
+                border:
+                  ia.utility.primaryCTA.variant === 'ghost'
+                    ? '1px solid var(--border-brand-primary)'
+                    : 'none',
+                color:
+                  ia.utility.primaryCTA.variant === 'solid'
+                    ? 'var(--text-on-color-dark)'
+                    : 'var(--text-brand-primary)',
+                borderRadius: 'var(--border-radius-pill, 9999px)',
+                fontFamily: 'var(--font-family-label)',
+                fontSize: 11,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                fontWeight: 600,
+              }}
+            >
+              {ia.utility.primaryCTA.label}
+            </span>
+          </div>
+        </div>
+
+        <div
+          style={{
+            padding: '8px 20px',
+            fontSize: 11,
+            opacity: 0.55,
+            fontFamily: 'var(--font-family-label)',
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          Archetype: {ia.archetype} · {ia.primaryLinkCount} primary ·{' '}
+          {ia.scrollBehavior}
+        </div>
+      </div>
+
+      {/* ── Data table ──────────────────────────────────── */}
+      <table
+        style={{
+          width: '100%',
+          borderCollapse: 'collapse',
+          fontSize: 13,
+          marginBottom: 'var(--gap-lg, 16px)',
+        }}
+      >
+        <tbody>
+          <Row label="Archetype" mono>{ia.archetype}</Row>
+          <Row label="Primary link count" mono>{ia.primaryLinkCount}</Row>
+          <Row label="Primary links">
+            {ia.primaryLinks.map((l) => l.label).join('  ·  ')}
+          </Row>
+          <Row label="Services mega-menu">
+            {ia.servicesMegaMenu
+              ? `Yes — ${ia.servicesMegaMenu.columns} columns, ${ia.servicesMegaMenu.categories.length} categories`
+              : 'No'}
+          </Row>
+          <Row label="Utility cluster">
+            {[
+              ia.utility.showPhone ? 'phone' : null,
+              `${ia.utility.primaryCTA.variant} CTA "${ia.utility.primaryCTA.label}"`,
+              ia.utility.secondaryCTA
+                ? `+ ${ia.utility.secondaryCTA.label}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join('  ·  ')}
+          </Row>
+          <Row label="Scroll behavior" mono>{ia.scrollBehavior}</Row>
+          <Row label="Mobile drawer" mono>{ia.mobileDrawer}</Row>
+        </tbody>
+      </table>
+
+      {/* ── Mega-menu preview ──────────────────────────────────── */}
+      {ia.servicesMegaMenu && (
+        <div style={{ marginTop: 'var(--padding-lg, 24px)' }}>
+          <h4
+            style={{
+              fontFamily: 'var(--font-family-heading)',
+              fontSize: 'var(--heading-sm, 18px)',
+              marginBottom: 'var(--gap-md, 12px)',
+              color: 'var(--text-primary)',
+            }}
+          >
+            {ia.servicesMegaMenu.triggerLabel} mega-menu
+          </h4>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: `repeat(${ia.servicesMegaMenu.columns}, 1fr)`,
+              gap: 'var(--gap-lg, 16px)',
+              padding: 'var(--padding-md, 20px)',
+              border: '1px solid var(--border-primary)',
+              borderRadius: 'var(--border-radius-md, 8px)',
+              background: 'var(--surface-secondary)',
+            }}
+          >
+            {ia.servicesMegaMenu.categories.map((cat) => (
+              <div key={cat.heading}>
+                <p
+                  style={{
+                    fontFamily: 'var(--font-family-label)',
+                    fontSize: 11,
+                    letterSpacing: '0.2em',
+                    textTransform: 'uppercase',
+                    color: 'var(--text-brand-primary)',
+                    marginBottom: 12,
+                  }}
+                >
+                  {cat.heading}
+                </p>
+                <ul
+                  style={{
+                    listStyle: 'none',
+                    padding: 0,
+                    margin: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 10,
+                  }}
+                >
+                  {cat.items.map((item) => (
+                    <li key={item.href}>
+                      <div
+                        style={{
+                          fontSize: 14,
+                          fontWeight: 500,
+                          color: 'var(--text-primary)',
+                        }}
+                      >
+                        {item.label}
+                      </div>
+                      {item.note && (
+                        <div
+                          style={{
+                            fontSize: 12,
+                            color: 'var(--text-secondary)',
+                            marginTop: 2,
+                          }}
+                        >
+                          {item.note}
+                        </div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+            {ia.servicesMegaMenu.featured && (
+              <div
+                style={{
+                  background: 'var(--surface-brand-primary)',
+                  border: '1px solid var(--border-brand-primary)',
+                  borderRadius: 'var(--border-radius-md, 8px)',
+                  padding: 'var(--padding-md, 16px)',
+                }}
+              >
+                <p
+                  style={{
+                    fontFamily: 'var(--font-family-label)',
+                    fontSize: 10,
+                    letterSpacing: '0.2em',
+                    textTransform: 'uppercase',
+                    color: 'var(--text-brand-primary)',
+                    marginBottom: 8,
+                  }}
+                >
+                  {ia.servicesMegaMenu.featured.eyebrow}
+                </p>
+                <h5
+                  style={{
+                    fontFamily: 'var(--font-family-heading)',
+                    fontSize: 16,
+                    marginBottom: 8,
+                    lineHeight: 1.3,
+                    color: 'var(--text-primary)',
+                  }}
+                >
+                  {ia.servicesMegaMenu.featured.heading}
+                </h5>
+                <p
+                  style={{
+                    fontSize: 13,
+                    color: 'var(--text-secondary)',
+                    marginBottom: 12,
+                    lineHeight: 1.5,
+                  }}
+                >
+                  {ia.servicesMegaMenu.featured.body}
+                </p>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-family-label)',
+                    fontSize: 11,
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: 'var(--text-brand-primary)',
+                  }}
+                >
+                  {ia.servicesMegaMenu.featured.ctaLabel} →
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({
+  label,
+  children,
+  mono = false,
+}: {
+  label: string;
+  children: React.ReactNode;
+  mono?: boolean;
+}) {
+  const cellStyle: React.CSSProperties = {
+    padding: '8px 10px',
+    borderBottom: '1px solid var(--border-muted)',
+    verticalAlign: 'top',
+  };
+  return (
+    <tr>
+      <td style={{ ...cellStyle, fontWeight: 600 }}>{label}</td>
+      <td
+        style={{
+          ...cellStyle,
+          fontFamily: mono
+            ? 'ui-monospace, SFMono-Regular, Menlo, monospace'
+            : 'inherit',
+          fontSize: mono ? 12 : 'inherit',
+        }}
+      >
+        {children}
+      </td>
+    </tr>
+  );
+}
+
+function toTitleCase(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}

--- a/docs-site/content/docs/theming/atmospheres.mdx
+++ b/docs-site/content/docs/theming/atmospheres.mdx
@@ -35,41 +35,51 @@ The locked enum lives in `content-system/vocabularies/atmosphere.ts`.
 | `organic-textured` | light | MUA · organic beauty · artisan · natural products |
 | `none` | (any) | explicit no-op — fallback when atmosphere is null |
 
-<Callout type="info">
-  **Live previews are in Storybook.** Each atmosphere renders on the same compact composite (hero + services grid + CTA) so you can compare treatments side by side. The previews are iframed to isolate atmosphere `:root` / `body` rules and load the CSS verbatim from `content-system/atmospheres/`.
-
-  See **Theming → Atmospheres** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com). Native `<AtmospherePreview>` blocks land in this site in a follow-up.
-</Callout>
-
 ## Per-atmosphere reference
+
+Each atmosphere renders on the same compact composite (hero + services grid + CTA) so you can compare treatments side by side. Previews are iframed to isolate atmosphere `:root` / `body` rules from the docs shell — the atmosphere CSS loads verbatim from `@brikdesigns/bds/content-system/atmospheres/{slug}.css`.
 
 ### editorial-luxury
 
-The quiet-luxury dark treatment developed for Birdwell & Mutlak Dentistry. Pure near-black (`#08080a`) surfaces so DPR gradient banding doesn't appear; gold radial orbs driven by `data-ambient` attributes on sections; SVG Perlin film grain at 32% opacity with `mix-blend-mode: overlay`; cursor-tracking spotlight on elements with `data-spotlight`. Honors reduced-motion.
+The quiet-luxury dark treatment developed for Birdwell & Mutlak Dentistry. Pure near-black surfaces so DPR gradient banding doesn't appear; gold radial orbs driven by `data-ambient` attributes on sections; SVG Perlin film grain at 32% opacity with `mix-blend-mode: overlay`; cursor-tracking spotlight on elements with `data-spotlight`. Honors reduced-motion.
+
+<AtmospherePreview atmosphere="editorial-luxury" />
 
 ### cinematic-dramatic
 
-Theatrical dark — deeper navy-black (`#060612`) with an aurora-drift gradient at the top of the viewport (42s cycle, animated via `@property` interpolation) and a conic rotating spotlight on sections marked `data-ambient="spotlight"`. No grain. Heavier atmosphere is already doing the work. Fit for legal / agency / finance / dark-mode SaaS.
+Theatrical dark — deeper navy-black with an aurora-drift gradient at the top of the viewport (42s cycle, animated via `@property` interpolation) and a conic rotating spotlight on sections marked `data-ambient="spotlight"`. No grain. Heavier atmosphere is already doing the work. Fit for legal / agency / finance / dark-mode SaaS.
+
+<AtmospherePreview atmosphere="cinematic-dramatic" />
 
 ### minimal-clinical
 
 Pure white, zero atmospheric effects. Trust comes from typography and precision, not atmosphere. Intentionally small — picks the attribute vocabulary without layering anything visually. Healthcare practices that aren't aiming luxury, legal where gravitas matters more than editorial warmth, minimal SaaS.
 
+<AtmospherePreview atmosphere="minimal-clinical" />
+
 ### warm-soft
 
-Warm ivory (`#fbf7f0`) base with a single quiet rose vignette in the top-left corner and subtle paper-grade grain at 15% opacity. No motion, no spotlights, no depth orbs — anxiety-sensitive audiences (wellness, therapy, mental health, recovery) shouldn't see cinematic flourish.
+Warm ivory base with a single quiet rose vignette in the top-left corner and subtle paper-grade grain at 15% opacity. No motion, no spotlights, no depth orbs — anxiety-sensitive audiences (wellness, therapy, mental health, recovery) shouldn't see cinematic flourish.
+
+<AtmospherePreview atmosphere="warm-soft" />
 
 ### clean-bright
 
 Pure white with zero CSS effects. Brand lives entirely in typography, imagery, and color accents. Sister to `minimal-clinical` — same visual posture, different semantic intent (SaaS/tech vs healthcare/legal).
 
+<AtmospherePreview atmosphere="clean-bright" />
+
 ### organic-textured
 
-Warm cream (`#f5efe6`) base with SVG Perlin grain at 40% opacity applied with `mix-blend-mode: multiply` — the sepia-texture feel of recycled paper. Subtle earth-tone radial tint in the bottom-right. Fit for MUA / organic beauty / artisan / natural-products brands.
+Warm cream base with SVG Perlin grain at 40% opacity applied with `mix-blend-mode: multiply` — the sepia-texture feel of recycled paper. Subtle earth-tone radial tint in the bottom-right. Fit for MUA / organic beauty / artisan / natural-products brands.
+
+<AtmospherePreview atmosphere="organic-textured" />
 
 ### none
 
 Explicit no-op. Emits no rules. Fallback when `company_profiles.atmosphere` is null or a client doesn't want an atmospheric layer. Exists so the portal's theme generator can unconditionally emit an `@import` without branching.
+
+<AtmospherePreview atmosphere="none" />
 
 ## How to pick
 

--- a/docs-site/content/docs/theming/navigation-archetypes.mdx
+++ b/docs-site/content/docs/theming/navigation-archetypes.mdx
@@ -75,9 +75,21 @@ What each archetype is **for** — audience assumptions, conversion intent, and 
 
 **Avoid when:** the audience is in research / comparison mode — they'll need a mega-menu to survey options.
 
-<Callout type="info">
-  **Live previews are in Storybook.** Each industry pack renders its seeded `navigationIA` via the `<NavigationIASpec>` block. See **Theming → Navigation Archetypes** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com).
-</Callout>
+## Live pack previews
+
+Each current industry pack with its seeded `navigationIA` rendered as a structural mock + spec table.
+
+### Dental
+
+<NavigationIASpec industry="dental" displayName="Dental" />
+
+### Real Estate — RV Parks & MHC
+
+<NavigationIASpec industry="real-estate-rv-mhc" displayName="Real Estate" />
+
+### Small Business (general)
+
+<NavigationIASpec industry="small-business" displayName="Small Business" />
 
 ## How to pick
 

--- a/docs-site/lib/mdx-components.tsx
+++ b/docs-site/lib/mdx-components.tsx
@@ -33,6 +33,8 @@ import {
   VideoDemo,
   SectionThemeDemo,
 } from '@/components/mdx/motion/effect-demos';
+import { AtmospherePreview } from '@/components/mdx/theming/atmosphere-preview';
+import { NavigationIASpec } from '@/components/mdx/theming/navigation-ia-spec';
 import * as BDS from '@brikdesigns/bds';
 
 /**
@@ -78,6 +80,8 @@ export function getMDXComponents(extra?: MDXComponents): MDXComponents {
     HoverDemo,
     VideoDemo,
     SectionThemeDemo,
+    AtmospherePreview,
+    NavigationIASpec,
     // The BDS namespace export includes hooks (useTheme) alongside components.
     // MDX's component-map type rejects that mix; cast since MDX only ever calls
     // the JSX entries (`<BDS.Button>`), never the hooks.


### PR DESCRIPTION
## Summary

Closes the last "Live demos in Storybook" gap on the docs site. Theming pages now render atmosphere previews and navigation IA specs natively, matching the pattern Motion landed in #323. After this merges, every Theming and Motion page in fumadocs is fully self-sufficient — Storybook is the live React component playground; fumadocs is the canonical narrative + visual reference.

## New components

`docs-site/components/mdx/theming/atmosphere-preview.tsx` — **server component**:
- Renders a sandboxed iframe for any atmosphere slug
- Inlines BDS `tokens.css` + the atmosphere CSS into iframe `srcDoc` at SSG time so `:root`, `body`, and `data-*` selectors are isolated from the docs shell
- Composite shows hero + services grid + CTA — same template the Storybook version uses
- Reads CSS via `node:fs` at build time; path resolution uses `process.cwd()` (with `/* turbopackIgnore: true */` to silence Turbopack's static-analysis warning)
- Looks up entry metadata (`themeMode`, `blurb`, `naturalFit`, `surfaceProfile`, `cssPath`) from `ATMOSPHERE_MANIFEST` internally
- MDX: `<AtmospherePreview atmosphere="editorial-luxury" />`

`docs-site/components/mdx/theming/navigation-ia-spec.tsx` — pure-render server component:
- Takes an industry slug, looks up the pack's `navigationIA` from `industryPacks`
- Renders structural mock header bar + spec table + optional mega-menu preview
- **All colors flow through canonical BDS tokens** — `--background-brand-primary`, `--text-on-color-{light,dark}`, `--surface-{primary,secondary,brand-primary}`, `--border-brand-primary`. No `--color-gold` / `--color-black` inline fallbacks (the Storybook source's hex fallbacks were ports of dental-theme demo data; canonical tokens render correctly under any active theme)
- MDX: `<NavigationIASpec industry="dental" displayName="Dental" />`

Both registered in [`docs-site/lib/mdx-components.tsx`](docs-site/lib/mdx-components.tsx).

## MDX pages updated

| Page | Change |
|---|---|
| `theming/atmospheres.mdx` | Drops "Live previews are in Storybook" Callout. Every per-atmosphere section (editorial-luxury, cinematic-dramatic, minimal-clinical, warm-soft, clean-bright, organic-textured, none) now embeds an `<AtmospherePreview />` below its prose. |
| `theming/navigation-archetypes.mdx` | Drops "Live previews are in Storybook" Callout. Adds a "Live pack previews" section with three `<NavigationIASpec />` blocks for dental, real-estate-rv-mhc, and small-business — same coverage as the Storybook source. |

## Build resolution path

The Atmosphere CSS files ship in the BDS package at `content-system/atmospheres/{slug}.css` (per `package.json` `exports`). The docs-site uses `file:..` for `@brikdesigns/bds`, so the package lives at `docs-site/node_modules/@brikdesigns/bds/`. AtmospherePreview reads:
- `node_modules/@brikdesigns/bds/dist/tokens.css` — full token cascade
- `node_modules/@brikdesigns/bds/content-system/atmospheres/{slug}.css` — atmosphere overlay

Both local + Netlify builds run `npm run build` from `docs-site/`, so `process.cwd()` resolves correctly. Token CSS + atmosphere CSS are read once and inlined into the iframe `srcDoc` at SSG time — no runtime fetches, no client-side hydration of CSS text.

## Test plan

- [x] `npm run build` — 130 static pages, no errors, no Turbopack warnings
- [ ] On deploy preview, walk all 7 atmospheres on `/docs/theming/atmospheres` — confirm each iframe renders a unique visual treatment (grain, glass, vignette, color, etc.)
- [ ] On `/docs/theming/navigation-archetypes`, confirm three `<NavigationIASpec />` blocks render — dental shows mega-menu with Services categories, real-estate-rv-mhc shows utility-first, small-business shows minimal layout
- [ ] Verify iframe sandboxing — atmosphere CSS doesn't leak out of the preview frame onto the docs shell

## What's left after this

Storybook retirement is **complete** for Foundations + Theming + Motion. The "Live demos in Storybook" callouts are gone everywhere they appeared. Remaining docs-site work, ranked:

1. **Content System completion** — Voices Overview is a stub; non-Dental industry packs (`real-estate-rv-mhc`, `small-business`, `real-estate-commercial`) have stub `.mdx` pages despite full pack data.
2. **Component MDX consolidation** — 80 `components/ui/**/*.mdx` files exist on both surfaces. Each has different value (inline live previews + auto-generated prop tables in Storybook vs. cross-linked narrative in fumadocs). Decision deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)