### PR TITLE
feat(docs-site): native BlueprintLibrary catalog — finishes Theming surface

### DIFF
--- a/docs-site/components/mdx/theming/blueprint-library.tsx
+++ b/docs-site/components/mdx/theming/blueprint-library.tsx
@@ -1,0 +1,391 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Server component. Renders the canonical blueprint library
+ * (`@brikdesigns/bds/blueprints/library.json`) as a live catalog —
+ * library metadata, coverage matrix (section type × moods), and a
+ * collapsible per-blueprint details list grouped by section type.
+ *
+ * Reads the JSON via node:fs at SSG time. Same path-resolution pattern
+ * as AtmospherePreview — process.cwd() resolves to the docs-site root
+ * during both local and Netlify builds.
+ */
+
+interface Blueprint {
+  key: string;
+  name: string;
+  section_type: string;
+  industries: string[];
+  moods: string[];
+  layout_spec: string;
+  css_hints?: string;
+  source?: string;
+  tier: string;
+  is_active: boolean;
+  version: string;
+  last_reviewed: string;
+  required_facts?: string[];
+}
+
+interface Library {
+  version: string;
+  last_reviewed: string;
+  review_cadence: string;
+  blueprints: Blueprint[];
+}
+
+const libraryPath = join(
+  /* turbopackIgnore: true */ process.cwd(),
+  'node_modules',
+  '@brikdesigns',
+  'bds',
+  'blueprints',
+  'blueprint-library.json',
+);
+
+const library: Library = JSON.parse(readFileSync(libraryPath, 'utf8'));
+
+// Stable orderings derived from the data so cells stay consistent across renders.
+const SECTION_TYPES: string[] = Array.from(
+  new Set(library.blueprints.map((b) => b.section_type)),
+).sort();
+
+const MOODS: string[] = Array.from(
+  new Set(library.blueprints.flatMap((b) => b.moods)),
+).sort();
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 13,
+  marginBottom: 24,
+};
+const thStyle: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '8px 10px',
+  borderBottom: '2px solid var(--border-muted)',
+  fontWeight: 600,
+};
+const tdStyle: React.CSSProperties = {
+  padding: '8px 10px',
+  borderBottom: '1px solid var(--border-muted)',
+  verticalAlign: 'top',
+};
+const monoStyle: React.CSSProperties = {
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: 12,
+};
+
+export function BlueprintLibrary() {
+  return (
+    <div style={{ marginBottom: 'var(--padding-xl, 40px)' }}>
+      <Metadata />
+      <CoverageMatrix />
+      <GroupedLibrary />
+    </div>
+  );
+}
+
+function Metadata() {
+  const sectionTypesCovered = SECTION_TYPES.length;
+  return (
+    <table style={tableStyle}>
+      <tbody>
+        <tr>
+          <td style={{ ...tdStyle, fontWeight: 600 }}>Library version</td>
+          <td style={{ ...tdStyle, ...monoStyle }}>{library.version}</td>
+        </tr>
+        <tr>
+          <td style={{ ...tdStyle, fontWeight: 600 }}>Last reviewed</td>
+          <td style={tdStyle}>{library.last_reviewed}</td>
+        </tr>
+        <tr>
+          <td style={{ ...tdStyle, fontWeight: 600 }}>Review cadence</td>
+          <td style={tdStyle}>{library.review_cadence}</td>
+        </tr>
+        <tr>
+          <td style={{ ...tdStyle, fontWeight: 600 }}>Blueprint count</td>
+          <td style={tdStyle}>{library.blueprints.length}</td>
+        </tr>
+        <tr>
+          <td style={{ ...tdStyle, fontWeight: 600 }}>Section types</td>
+          <td style={tdStyle}>{sectionTypesCovered}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+function CoverageMatrix() {
+  return (
+    <div>
+      <h3 style={{ marginBottom: 12 }}>Coverage matrix</h3>
+      <p
+        style={{
+          fontSize: 13,
+          color: 'var(--text-secondary)',
+          marginBottom: 12,
+        }}
+      >
+        Cell value = blueprint count for that section / mood combination.
+        Empty cells (·) are gaps — opportunities to author.
+      </p>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th style={thStyle}>Section</th>
+              {MOODS.map((m) => (
+                <th
+                  key={m}
+                  style={{
+                    ...thStyle,
+                    fontSize: 11,
+                    textAlign: 'center',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {m}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {SECTION_TYPES.map((section) => {
+              const rowBlueprints = library.blueprints.filter(
+                (b) => b.section_type === section,
+              );
+              return (
+                <tr key={section}>
+                  <td style={{ ...tdStyle, ...monoStyle }}>{section}</td>
+                  {MOODS.map((m) => {
+                    const count = rowBlueprints.filter((b) =>
+                      b.moods.includes(m),
+                    ).length;
+                    return (
+                      <td
+                        key={m}
+                        style={{
+                          ...tdStyle,
+                          textAlign: 'center',
+                          color:
+                            count === 0
+                              ? 'var(--text-muted)'
+                              : 'var(--text-primary)',
+                          fontWeight: count > 0 ? 600 : 400,
+                        }}
+                      >
+                        {count || '·'}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function GroupedLibrary() {
+  const detailsBoxStyle: React.CSSProperties = {
+    border: '1px solid var(--border-muted)',
+    borderRadius: 'var(--border-radius-md, 8px)',
+    padding: '12px 16px',
+    marginBottom: 8,
+    background: 'var(--surface-secondary)',
+  };
+  const summaryStyle: React.CSSProperties = {
+    cursor: 'pointer',
+    fontWeight: 600,
+    color: 'var(--text-primary)',
+  };
+  const tagStyle: React.CSSProperties = {
+    display: 'inline-block',
+    padding: '2px 8px',
+    background: 'var(--surface-primary)',
+    border: '1px solid var(--border-muted)',
+    borderRadius: 'var(--border-radius-sm, 4px)',
+    fontSize: 11,
+    marginRight: 6,
+    marginBottom: 4,
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    color: 'var(--text-secondary)',
+  };
+
+  return (
+    <div>
+      <h3 style={{ marginBottom: 12 }}>Library</h3>
+      <p
+        style={{
+          fontSize: 13,
+          color: 'var(--text-secondary)',
+          marginBottom: 16,
+        }}
+      >
+        Grouped by section type. Expand any blueprint for moods, industries,
+        layout spec, and CSS hints.
+      </p>
+
+      {SECTION_TYPES.map((section) => {
+        const entries = library.blueprints.filter(
+          (b) => b.section_type === section,
+        );
+        if (entries.length === 0) return null;
+
+        return (
+          <div key={section} style={{ marginBottom: 32 }}>
+            <h4
+              style={{
+                marginBottom: 8,
+                textTransform: 'capitalize',
+                fontSize: 16,
+              }}
+            >
+              {section.replace(/_/g, ' ')}{' '}
+              <span
+                style={{
+                  color: 'var(--text-muted)',
+                  fontWeight: 400,
+                  fontSize: 13,
+                }}
+              >
+                ({entries.length})
+              </span>
+            </h4>
+
+            {entries.map((bp) => (
+              <details key={bp.key} style={detailsBoxStyle}>
+                <summary style={summaryStyle}>
+                  {bp.name}
+                  <code
+                    style={{
+                      marginLeft: 8,
+                      fontSize: 12,
+                      color: 'var(--text-muted)',
+                      fontWeight: 400,
+                    }}
+                  >
+                    {bp.key}
+                  </code>
+                  {!bp.is_active && (
+                    <span
+                      style={{
+                        marginLeft: 8,
+                        fontSize: 11,
+                        color: 'var(--text-error, #c00)',
+                      }}
+                    >
+                      inactive
+                    </span>
+                  )}
+                </summary>
+
+                <div
+                  style={{
+                    marginTop: 12,
+                    fontSize: 14,
+                    lineHeight: 1.6,
+                    color: 'var(--text-primary)',
+                  }}
+                >
+                  <div style={{ marginBottom: 10 }}>
+                    <strong>Moods:</strong>{' '}
+                    {bp.moods.map((m) => (
+                      <code key={m} style={tagStyle}>
+                        {m}
+                      </code>
+                    ))}
+                  </div>
+
+                  <div style={{ marginBottom: 10 }}>
+                    <strong>Industries:</strong>{' '}
+                    {bp.industries.map((i) => (
+                      <code key={i} style={tagStyle}>
+                        {i}
+                      </code>
+                    ))}
+                  </div>
+
+                  {bp.required_facts && bp.required_facts.length > 0 && (
+                    <div style={{ marginBottom: 10 }}>
+                      <strong>Required facts:</strong>{' '}
+                      {bp.required_facts.map((f) => (
+                        <code key={f} style={tagStyle}>
+                          {f}
+                        </code>
+                      ))}
+                    </div>
+                  )}
+
+                  <div style={{ marginBottom: 10 }}>
+                    <strong>Layout spec:</strong>
+                    <p
+                      style={{
+                        margin: '4px 0 0',
+                        color: 'var(--text-secondary)',
+                      }}
+                    >
+                      {bp.layout_spec}
+                    </p>
+                  </div>
+
+                  {bp.css_hints && (
+                    <details style={{ marginBottom: 10 }}>
+                      <summary
+                        style={{
+                          cursor: 'pointer',
+                          fontSize: 12,
+                          color: 'var(--text-muted)',
+                        }}
+                      >
+                        CSS hints
+                      </summary>
+                      <pre
+                        style={{
+                          fontSize: 11,
+                          background: 'var(--surface-primary)',
+                          padding: 10,
+                          borderRadius: 'var(--border-radius-sm, 4px)',
+                          border: '1px solid var(--border-muted)',
+                          overflow: 'auto',
+                          marginTop: 6,
+                          color: 'var(--text-primary)',
+                        }}
+                      >
+                        {bp.css_hints}
+                      </pre>
+                    </details>
+                  )}
+
+                  <div
+                    style={{
+                      fontSize: 12,
+                      color: 'var(--text-muted)',
+                      marginTop: 10,
+                      paddingTop: 8,
+                      borderTop: '1px solid var(--border-muted)',
+                    }}
+                  >
+                    <strong>Tier:</strong> {bp.tier}
+                    {bp.source && (
+                      <>
+                        {' '}
+                        · <strong>Source:</strong> {bp.source}
+                      </>
+                    )}
+                    {' '}· <strong>v{bp.version}</strong> · reviewed{' '}
+                    {bp.last_reviewed}
+                  </div>
+                </div>
+              </details>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/docs-site/content/docs/theming/blueprints.mdx
+++ b/docs-site/content/docs/theming/blueprints.mdx
@@ -9,10 +9,6 @@ Named layout + interaction patterns that ground AI mockup generation with concre
 
 See [`blueprints/ARCHITECTURE.md`](https://github.com/brikdesigns/brik-bds/blob/main/blueprints/ARCHITECTURE.md) for the two-taxonomy model, bridge rules, and v1 / v2 coexistence.
 
-<Callout type="info">
-  **Live library catalog is in Storybook.** The full enumerated list of blueprint entries — with moods, industries, layout spec, CSS hints, version, last-reviewed dates — is rendered dynamically from `blueprints/blueprint-library.json`. See **Theming → Blueprints** in [storybook.brikdesigns.com](https://storybook.brikdesigns.com). Native rendering of the library JSON in this site lands in a follow-up.
-</Callout>
-
 ## Two taxonomies
 
 Authors hand-write match tags (`moods`, `industries`). Client-axis projections (`personality`, `visual_style`, `industry_slugs`) are derived at load time via the bridges — never stored in source JSON, never authored by hand.
@@ -49,11 +45,11 @@ Authors hand-write match tags (`moods`, `industries`). Client-axis projections (
 | `legal` | `small-business` (until graduated) |
 | `universal` | *universal sentinel — no pack lookup* |
 
-## Coverage
+## Catalog
 
-The library tracks coverage across section types × moods. Cells with `0` are gaps — opportunities to author. The full matrix renders in Storybook from live JSON.
+The full enumerated library — every blueprint with moods, industries, layout spec, CSS hints, version, last-reviewed dates — rendered live from `@brikdesigns/bds/blueprints/library.json`. Coverage matrix shows section type × mood density at a glance; cells with `·` are gaps to author.
 
-The shipped section types include: `hero` · `services` · `about` · `stats` · `testimonials` · `cta` · `gallery` · `process` · `team` · `pricing` · `faq` · `contact`.
+<BlueprintLibrary />
 
 ## Implementation — `@brikdesigns/bds/blueprints-astro`
 

--- a/docs-site/lib/mdx-components.tsx
+++ b/docs-site/lib/mdx-components.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/components/mdx/motion/effect-demos';
 import { AtmospherePreview } from '@/components/mdx/theming/atmosphere-preview';
 import { NavigationIASpec } from '@/components/mdx/theming/navigation-ia-spec';
+import { BlueprintLibrary } from '@/components/mdx/theming/blueprint-library';
 import * as BDS from '@brikdesigns/bds';
 
 /**
@@ -82,6 +83,7 @@ export function getMDXComponents(extra?: MDXComponents): MDXComponents {
     SectionThemeDemo,
     AtmospherePreview,
     NavigationIASpec,
+    BlueprintLibrary,
     // The BDS namespace export includes hooks (useTheme) alongside components.
     // MDX's component-map type rejects that mix; cast since MDX only ever calls
     // the JSX entries (`<BDS.Button>`), never the hooks.


### PR DESCRIPTION
## Summary

Replaces the static "Coverage" prose + "Live library catalog is in Storybook" callout on `/docs/theming/blueprints` with a server-rendered catalog reading the canonical `@brikdesigns/bds/blueprints/library.json`. After this merges, the Theming surface is fully self-sufficient — every Theming page renders its visual + structural content natively, Storybook redirect callouts are gone from every Theming page.

## New component

`docs-site/components/mdx/theming/blueprint-library.tsx` — **server component**:
- Reads `@brikdesigns/bds/blueprints/blueprint-library.json` via `node:fs` at SSG time (same `/* turbopackIgnore: true */` + `process.cwd()` pattern as AtmospherePreview from #324)
- All colors flow through canonical BDS tokens (`--surface-primary/secondary`, `--border-muted`, `--text-primary/secondary/muted`). No raw hex.

Renders three blocks:

1. **Library metadata** — version, last_reviewed, review_cadence, blueprint count, section types covered
2. **Coverage matrix** — section_type rows × moods columns; cells show blueprint count; gaps render as `·`
3. **Library grouped by section type** — each blueprint is a `<details>` with name, key, moods, industries, required_facts, layout_spec, css_hints, tier, source, version, last_reviewed

Registered in [`docs-site/lib/mdx-components.tsx`](docs-site/lib/mdx-components.tsx).

## MDX page updates

`theming/blueprints.mdx`:
- Drops "Live library catalog is in Storybook" Callout
- Replaces the static "## Coverage" prose-only section with a new "## Catalog" section that embeds `<BlueprintLibrary />`
- The shipped-blueprints v0.1 list, contract, CSS overrides, and verification sections are preserved — they're authoring/contract docs, not catalog data

## Test plan

- [x] `npm run build` — 130 static pages, no errors, no Turbopack warnings
- [ ] On deploy preview, walk `/docs/theming/blueprints` — confirm metadata table shows current version + counts
- [ ] Verify Coverage matrix renders 10 sections × 11 moods with correct blueprint counts
- [ ] Verify each blueprint expands to show its layout_spec + CSS hints
- [ ] Spot check: `hero_split_60_40` should show under hero, with industries `universal · healthcare · real_estate · legal · finance · saas`

## Storybook redirect status — Theming complete

Track of "Live demos / catalog in Storybook" callouts removed:

- ✅ Foundations (#290, #292)
- ✅ Theming → Atmospheres (#324)
- ✅ Theming → Navigation Archetypes (#324)
- ✅ Theming → Blueprints (this PR)
- ✅ Motion → Tiers + Effects (#323)

Theming + Motion + Foundations are 100% self-sufficient in fumadocs.

## What's left

- **Content System completion** — Voices Overview + non-Dental industry packs (`real-estate-rv-mhc`, `small-business`, `real-estate-commercial`) have stub `.mdx` pages despite full pack data. Authoring work, not porting.
- **Component MDX consolidation** — 80 `components/ui/**/*.mdx` exist on both surfaces. Defer until you have a strong opinion on which becomes canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)