### PR TITLE
fix(content-system): export realEstateCommercial by name + drop docs-site workaround

### DIFF
--- a/content-system/index.ts
+++ b/content-system/index.ts
@@ -33,6 +33,7 @@ export {
   industryPacks,
   dental,
   realEstateRvMhc,
+  realEstateCommercial,
   smallBusiness,
   getIndustryServices,
   getIndustryServicesCatalog,

--- a/docs-site/content/docs/content-system/industries/real-estate-commercial.mdx
+++ b/docs-site/content/docs/content-system/industries/real-estate-commercial.mdx
@@ -4,9 +4,7 @@ description: Boutique commercial real-estate brokerage with three co-equal audie
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
-import { industryPacks } from '@brikdesigns/bds/content-system';
-
-export const realEstateCommercial = industryPacks['real-estate-commercial'];
+import { realEstateCommercial } from '@brikdesigns/bds/content-system';
 
 <MetadataStrip
   items={[


### PR DESCRIPTION
## Summary

The other three industry packs (`dental`, `realEstateRvMhc`, `smallBusiness`) have always been exported by name from `@brikdesigns/bds/content-system`. `realEstateCommercial` was missing from that re-export list — caught when `docs-site/.../real-estate-commercial.mdx` failed to build with `The export realEstateCommercial was not found in module .../dist/content-system/index.js` (flagged in #329).

## Two changes

**`content-system/index.ts`** — adds `realEstateCommercial` to the existing named-exports list from `./industries`. The barrel at `industries/index.ts` already re-exports it; only the top-level public surface was missing. All downstream consumers benefit automatically — no PR needed elsewhere.

**`docs-site/.../real-estate-commercial.mdx`** — reverts the workaround #329 introduced. Drops:

```mdx
import { industryPacks } from '@brikdesigns/bds/content-system';
export const realEstateCommercial = industryPacks['real-estate-commercial'];
```

Uses:

```mdx
import { realEstateCommercial } from '@brikdesigns/bds/content-system';
```

Now matches the import shape of `dental.mdx`, `small-business.mdx`, and `real-estate-rv-mhc.mdx`.

## Test plan

- [x] `npm run build:content-system` passes
- [x] `npm run build:lib` passes
- [x] `realEstateCommercial` appears in `dist/content-system/index.js`
- [x] `npm run build` in docs-site passes — 133 static pages
- [ ] On deploy preview, walk `/docs/content-system/industries/real-estate-commercial` — confirm metadata strip + all 12 sections render with live pack data

Net diff: +2 / −3 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)