### PR TITLE
docs(site): fill in Hooks, Utilities, and Patterns parked stubs

### DIFF
--- a/docs-site/content/docs/hooks.mdx
+++ b/docs-site/content/docs/hooks.mdx
@@ -1,6 +1,181 @@
 ---
 title: Hooks
-description: React hooks shipped with BDS for behavior reuse.
+description: React hooks shipped from @brikdesigns/bds for theme access, sheet stack management, suggestion-filter behavior, and the dev-bar API.
 ---
 
-> Placeholder. BDS currently exposes a small set of behavior hooks (focus management, popover positioning via Radix, theme detection). Pages here will document each.
+import { Callout } from 'fumadocs-ui/components/callout';
+
+BDS ships seven React hooks — three context-bound (theme + sheet stack), one for combobox filter behavior, two for the BrikDevBar slot API, and one headless-config helper for sheet view authoring. All are exported from the package root.
+
+```ts
+import {
+  useTheme,
+  useSheetStack,
+  useConfigureSheet,
+  useSheetConfig,
+  useSuggestionFilter,
+  useDevBarSlot,
+  useDevBarApi,
+} from '@brikdesigns/bds';
+```
+
+<Callout type="info">
+  **Hooks belong in the consumer's component tree, not in MDX or server components.** Wrap the relevant subtree in `<ThemeProvider>` or `<SheetStackProvider>` (or both — they're independent) and call the hooks from React components below.
+</Callout>
+
+## `useTheme` — read + set the active theme
+
+Returns the active theme number, label, dark-mode flag, and a setter that updates the body class + `<html data-theme>` attribute. Persists the choice in `localStorage` under the `bds-theme` key.
+
+```ts
+function useTheme(): {
+  themeNumber: ThemeNumber;            // 1–8 + 'brik' / 'brik-dark' / 'client-sim'
+  setThemeNumber: (n: ThemeNumber) => void;
+  themeClasses: string;                // class list to apply on body
+  theme: BDSThemeConfig;               // full config object
+  themeName: string;
+  themeDescription: string;
+  isDark: boolean;
+}
+```
+
+**When to use:** anywhere you need to read the active theme (gating dark-only effects, swapping iconography, building a theme-switcher UI). Must be called from a descendant of `<ThemeProvider>`.
+
+```tsx
+import { ThemeProvider, useTheme } from '@brikdesigns/bds';
+
+function ThemeSwitcher() {
+  const { themeNumber, setThemeNumber, isDark } = useTheme();
+  return (
+    <button onClick={() => setThemeNumber(isDark ? 'brik' : 'brik-dark')}>
+      {isDark ? 'Light' : 'Dark'}
+    </button>
+  );
+}
+```
+
+## `useSheetStack` — read + control the sheet navigation stack
+
+Returns the current sheet stack, open/exit state, and methods to push, pop, open fresh, and close all. Stack semantics let related sheets drill into one another (open `client-detail` → push `notes-list` → push `note-edit`) and animate back/forward together.
+
+```ts
+function useSheetStack(): {
+  stack: SheetFrame[];                          // last = topmost
+  isOpen: boolean;                              // any sheet open
+  isExiting: boolean;                           // topmost animating out
+  direction: 'forward' | 'back';                // current transition
+  openSheet: (type, props, opts?) => void;      // clear + open one
+  pushSheet: (type, props, opts?) => void;      // drill into
+  back: () => void;                             // pop topmost (animated)
+  closeAll: () => void;                         // close immediately
+}
+```
+
+**When to use:** triggering sheet flows from outside the sheet (a "View Notes" button on a card opens the Notes sheet; a "Save" inside a sheet triggers `back()` to return to the parent). Must be a descendant of `<SheetStackProvider>`.
+
+```tsx
+const { pushSheet, back } = useSheetStack();
+
+// Drill in
+<button onClick={() => pushSheet('note-edit', { noteId: '123' }, { variant: 'detail', title: 'Edit Note' })}>
+  Edit
+</button>
+
+// Return
+<button onClick={back}>Back</button>
+```
+
+## `useConfigureSheet` — register a headless sheet config
+
+Returns a setter that registers a `SheetConfig` for the current sheet view. Sheet view components call this on mount to declare their title, subtitle, actions, and tabs without rendering chrome themselves — the parent `<Sheet>` reads the config and renders the chrome.
+
+```ts
+function useConfigureSheet(): (config: SheetConfig) => void;
+```
+
+**When to use:** authoring a sheet view that should expose its title + actions + tabs to the surrounding `<Sheet>` shell. The "headless mode" pattern keeps view files focused on body content.
+
+```tsx
+function ClientDetailSheet({ clientId }) {
+  const configureSheet = useConfigureSheet();
+  useEffect(() => {
+    configureSheet({
+      title: 'Client Detail',
+      actions: [{ label: 'Edit', onClick: handleEdit }],
+      tabs: [{ id: 'overview', label: 'Overview' }, { id: 'notes', label: 'Notes' }],
+    });
+  }, [configureSheet]);
+  return <ClientBody clientId={clientId} />;
+}
+```
+
+## `useSheetConfig` — read the current sheet's headless config
+
+Reads back what `useConfigureSheet` wrote. Used by the `<Sheet>` shell internally; rarely needed in view code.
+
+```ts
+function useSheetConfig(): SheetConfig;
+```
+
+## `useSuggestionFilter` — combobox / typeahead filter behavior
+
+Encapsulates the filter logic shared across `AddableTagList`, `AddableComboList`, `AddableEntryList`, and any custom typeahead. Handles input state, suggestion filtering, keyboard navigation, strict-mode rejection, duplicate detection, primary-vs-secondary commit semantics, and backspace-on-empty deletion.
+
+```ts
+function useSuggestionFilter(options: {
+  suggestions: string[];
+  selectedValues: string[];
+  strict?: boolean;                   // reject inputs not in suggestions
+  onCommit: (value: string) => void;
+  onCancel?: () => void;
+  onStrictReject?: (value: string) => void;
+  onDuplicate?: (value: string) => void;
+  onPrimaryCommitted?: () => void;    // for entry lists with name + secondary fields
+  onBackspaceEmpty?: () => void;      // delete last selected on backspace-when-empty
+}): UseSuggestionFilterReturn;
+```
+
+**When to use:** building any combobox, typeahead, or tag-input that needs the same filter + commit + delete semantics the Addable family uses. Saves authoring ~150 lines of custom state per consumer.
+
+The full prop / return shape is documented in source — see [`components/ui/shared/useSuggestionFilter.ts`](https://github.com/brikdesigns/brik-bds/blob/main/components/ui/shared/useSuggestionFilter.ts).
+
+## `useDevBarSlot` — register a slot in the BrikDevBar
+
+Lets a feature flag, env switch, or debug widget mount itself into the dev toolbar without owning the toolbar layout. The dev bar reads registered slots and renders them in declared order.
+
+```ts
+function useDevBarSlot(def: DevBarSlotDef | null): void;
+```
+
+**When to use:** product apps wiring `BrikDevBar` for development. Each slot calls this once on mount with its definition; passing `null` unregisters.
+
+## `useDevBarApi` — read the BrikDevBar API
+
+Returns the dev bar's API (or `null` if no `<BrikDevBar>` is mounted) — used by slots that need to programmatically open the bar, focus a slot, or query other registered slots.
+
+```ts
+function useDevBarApi(): DevBarApi | null;
+```
+
+Most consumer code uses `useDevBarSlot` only; `useDevBarApi` is for the internals.
+
+## Hooks vs components
+
+Three of the seven (`useTheme`, `useSheetStack`, `useConfigureSheet` / `useSheetConfig`) are paired with components — `<ThemeProvider>`, `<SheetStackProvider>`, `<Sheet>` — and only work inside that component's subtree. The provider components belong at app-root level; the hooks are how downstream views read or write the shared state.
+
+The remaining four (`useSuggestionFilter`, `useDevBarSlot`, `useDevBarApi`) don't require a provider — they're behavior helpers paired with specific components (Addable family, BrikDevBar) and can be called anywhere those components mount.
+
+## Adding a new hook
+
+The bar for shipping a new hook from BDS is:
+
+1. **It's used by ≥ 2 components** in the BDS codebase (or has an obvious second consumer in a product app).
+2. **It encapsulates a non-trivial behavior contract** — keyboard handling, focus management, multi-step state — that consumers would otherwise re-implement and drift on.
+3. **It pairs with components, not raw DOM manipulation.** Hooks that wrap a `useEffect` over `document.body` belong in the component using them, not the package surface.
+
+Hooks that don't clear all three bars stay private to their component file (`components/ui/{Component}/use{Behavior}.ts`) and are not exported from `components/ui/{Component}/index.ts`.
+
+## Related
+
+- [Components](/docs/components) — the components these hooks pair with
+- [Theming → Client Themes](/docs/theming/client-themes) — what `useTheme` exposes is the brand layer

--- a/docs-site/content/docs/patterns.mdx
+++ b/docs-site/content/docs/patterns.mdx
@@ -1,16 +1,141 @@
 ---
 title: Patterns
-description: Cross-component recipes — how multiple BDS pieces compose into common product moments.
+description: Cross-component recipes — how multiple BDS pieces compose into the product moments that show up in every Brik build.
 ---
 
-Patterns answer the question "I'm building X, what does BDS recommend?" Each pattern is a reusable composition with a recommended structure, the components it uses, and notes on accessibility and edge cases.
+import { Callout } from 'fumadocs-ui/components/callout';
 
-## Planned patterns
+Patterns answer the question "I'm building X — what does BDS recommend?" Each pattern is a reusable composition: which BDS components to reach for, the shape they take, and the accessibility + edge-case notes that don't fit on a single component page.
 
-- **Forms** — single-column, multi-step wizard, inline edit, sheet-driven edit
-- **Empty states** — no data, error, permission denied, search no-results
-- **Page templates** — dashboard shell, settings page, list-detail, two-pane editor
-- **Navigation** — primary nav, sidebar, breadcrumbs, pagination
-- **Notifications** — toast, banner, inline alert, modal confirmation
+Patterns are recipes, not new components. If a recipe gets used in 3+ places without meaningful variation, it graduates to a real component (see [Utilities → Adopt / Extend / Graduate](/docs/utilities#adopt--extend--graduate)).
 
-> Patterns are the next major content fill-in. Most are documented partially in `stories/foundation/theming/Blueprints.mdx` and the Recipes section of Storybook — both should consolidate here.
+## Forms
+
+The single most-built pattern across portal, renew-pms, and brikdesigns. BDS ships the full vocabulary — `<Form>`, `<Field>`, `<FieldGrid>`, the input primitives, plus the Addable family for tag/entry inputs.
+
+**Composition:**
+
+```tsx
+<Form onSubmit={handleSubmit}>
+  <FieldGrid columns={2}>
+    <Field label="First name" required>
+      <Input name="firstName" />
+    </Field>
+    <Field label="Last name" required>
+      <Input name="lastName" />
+    </Field>
+    <Field label="Role" helper="Used for in-product permissions">
+      <Select name="role" options={roles} />
+    </Field>
+    <Field label="Tags">
+      <AddableTagList suggestions={tagSuggestions} />
+    </Field>
+  </FieldGrid>
+  <ButtonGroup>
+    <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+    <Button variant="primary" type="submit">Save</Button>
+  </ButtonGroup>
+</Form>
+```
+
+**Variants Brik builds repeatedly:**
+
+| Variant | When to use | Composition note |
+| --- | --- | --- |
+| **Single-column** | Onboarding, simple settings | `<FieldGrid columns={1}>` — drop the grid for under 4 fields |
+| **Two-column** | Profile / company / address forms | `<FieldGrid columns={2}>` — required fields top-left first |
+| **Sheet-driven edit** | Editing one record from a list | Wrap in `<Sheet>` with the [`useSheetStack`](/docs/hooks#usesheetstack--read--control-the-sheet-navigation-stack) hook for back/save flow |
+| **Multi-step wizard** | Onboarding, contracts | Tabs in the sheet config (see [Hooks → useConfigureSheet](/docs/hooks#useconfiguresheet--register-a-headless-sheet-config)) |
+
+**Accessibility:**
+
+- Every input lives inside a `<Field>` — the label association is automatic.
+- Required fields use the `required` prop on `<Field>`, not `*` characters in the label.
+- Errors surface via the `error` prop on `<Field>`, not as inline `<p>` siblings — placement + ARIA wiring is owned by `<Field>`.
+
+## Empty states
+
+The shape an app takes when there's no data, the user lacks permission, search returns nothing, or a request errors. BDS ships `<EmptyState>` for the canonical case — patterns below show when to reach for it vs. extend.
+
+**Canonical:**
+
+```tsx
+<EmptyState
+  icon={<InboxIcon />}
+  title="No clients yet"
+  description="Add your first client to start tracking projects."
+  action={<Button variant="primary" onClick={openNewClient}>Add client</Button>}
+/>
+```
+
+**Four shapes that recur:**
+
+| Shape | When | What changes |
+| --- | --- | --- |
+| **No data** | First run, fresh table | Primary action that creates the first record |
+| **No results** | Search / filter returned nothing | Secondary action: "Clear filters" — never a primary CTA |
+| **Permission denied** | RLS or role gate | No action — explain *why*, link to admin/owner contact |
+| **Error** | Fetch failed, network issue | Secondary action: "Retry" — keep the chrome around it (don't blank the page) |
+
+<Callout type="warn">
+  **Don't blank a page on error.** Render the empty state inside the existing layout chrome (sidebar + header still visible). Replacing the whole route with a white error screen erases the user's mental map.
+</Callout>
+
+## Page templates
+
+Three templates cover roughly 95% of the product surface. Treat them as a starting frame, not a constraint — every page in the portal and renew-pms is one of these.
+
+| Template | Used for | BDS components |
+| --- | --- | --- |
+| **List + Detail Sheet** | Index pages where rows drill into a sheet (clients, contracts, leads) | `<Table>` or `<CardList>` + `<Sheet>` + `<SheetStackProvider>` |
+| **Settings Shell** | Multi-section settings, profile, company config | `<SidebarNavigation>` + `<Sheet>` for sub-edits |
+| **Dashboard Shell** | Landing pages, overview screens | `<Card>` grid + `<EmptyState>` per cell when data missing |
+
+**Layout chrome lives once, at app root** — `<NavBar>` + `<SidebarNavigation>` + `<BrikDevBar>` (dev only). Templates render *inside* that chrome via Next.js layout files. Don't re-mount the chrome inside a route.
+
+## Navigation
+
+Three navigation surfaces, three components — keep them straight. They are not interchangeable.
+
+| Surface | Component | When |
+| --- | --- | --- |
+| **Top app bar** | `<NavBar>` | Global brand + primary destinations + user menu |
+| **Section sidebar** | `<SidebarNavigation>` | Within an app section (Settings, Admin) — collapsible groups |
+| **Within-page** | `<Breadcrumb>` + `<Pagination>` | Position + page-by-page traversal |
+
+**Breadcrumbs** appear in detail views where the user drilled in (`Clients › Acme › Contracts › #4821`). They do **not** appear in flat lists or top-level pages — that creates noise.
+
+**Pagination** is for paged data. For infinite scroll or load-more, use the relevant data-loading pattern (not in this doc).
+
+**Mobile nav** collapses the top bar into a hamburger and the sidebar into a `<Sheet>` (default variant) — the sheet stack handles the drawer animation; the route layout decides when to mount it.
+
+## Notifications
+
+Four notification surfaces — match severity and persistence to the pattern, not the other way around.
+
+| Pattern | Component | Persistence | When |
+| --- | --- | --- | --- |
+| **Toast** | `<Toast>` | Auto-dismiss (5s) | Confirmation of a user action ("Saved", "Copied") |
+| **Banner** | `<Banner>` | Until dismissed by user | System-wide state (maintenance window, plan limit) |
+| **Inline alert** | `<AlertBanner>` | Until resolved | Page-scoped state (form error, validation) |
+| **Modal confirmation** | `<Sheet variant="floating">` with confirm + cancel actions | Until decided | Destructive actions (delete, discard, sign-out) |
+
+**Severity colors** come from semantic surface tokens — `--surface-success`, `--surface-warning`, `--surface-danger`, `--surface-info`. Each notification component reads them automatically; you don't pick a hex.
+
+**Don't double-notify.** A toast + banner + inline alert all firing for the same event is a bug, not thoroughness. Pick one surface based on persistence: ephemeral (toast), session (banner), page (inline alert), gate (modal).
+
+## Adding a pattern here
+
+The bar for adding a new pattern doc is:
+
+1. **It's been built ≥ 3 times** across Brik repos with the same shape — recipes that have only happened once belong in the consumer's notes.
+2. **It composes existing BDS components** — if the recipe needs a brand-new component, build the component first, then document the recipe.
+3. **It has decisions worth writing down** — accessibility wiring, severity choice, mobile collapse rules. A pattern with no decisions is just example code.
+
+Patterns that don't clear all three bars stay in the consumer codebase as-is.
+
+## Related
+
+- [Components](/docs/components) — the building blocks every pattern composes
+- [Hooks](/docs/hooks) — `useSheetStack` and `useConfigureSheet` power the sheet-driven recipes here
+- [Theming → Blueprints](/docs/theming/blueprints) — full-page layout primitives (different layer — patterns compose components, blueprints compose sections)

--- a/docs-site/content/docs/utilities.mdx
+++ b/docs-site/content/docs/utilities.mdx
@@ -1,6 +1,225 @@
 ---
 title: Utilities
-description: Token-aware helpers for use in app code.
+description: Token-aware helpers for use in app code — the @/lib/tokens + @/lib/styles consumer pattern, the Style Dictionary build pipeline, and the bds-find component-discovery CLI.
 ---
 
-> Placeholder. The `@/lib/tokens` and `@/lib/styles` helpers (required in every consumer) are documented here, plus the Style Dictionary build pipeline and the `bds-find` CLI.
+import { Callout } from 'fumadocs-ui/components/callout';
+
+BDS ships visual + content tokens, but consumers don't reach for `var(--text-primary)` directly in TSX. Three utility surfaces sit between the raw token files and feature code:
+
+1. **`@/lib/tokens`** — TypeScript map of every CSS variable, so editor autocomplete prevents typos.
+2. **`@/lib/styles`** — composed `CSSProperties` presets that pair font family + size + line-height correctly.
+3. **`bds-find`** — CLI that answers "does BDS already have a component for this?" before you build.
+
+The first two live **in each consumer repo** (BDS does not ship them — the registry is per-product). The third ships from the BDS package itself.
+
+## `@/lib/tokens` — TypeScript token map
+
+A flat object that mirrors `tokens/figma-tokens.css`. Every CSS variable is a value-side `var(--...)` string keyed under a semantic path.
+
+```ts
+// src/lib/tokens.ts (excerpt — every consumer ships their own copy)
+export const color = {
+  text: {
+    primary: 'var(--text-primary)',
+    secondary: 'var(--text-secondary)',
+    muted: 'var(--text-muted)',
+    inverse: 'var(--text-on-color-light)',
+  },
+  background: {
+    page: 'var(--background-page)',
+    brand: { primary: 'var(--background-brand-primary)' },
+  },
+  surface: {
+    primary: 'var(--surface-primary)',
+    secondary: 'var(--surface-secondary)',
+    inverse: 'var(--surface-inverse)',
+  },
+  border: { primary: 'var(--border-primary)' },
+} as const;
+
+export const font = {
+  family: {
+    heading: 'var(--font-family-heading)',
+    body: 'var(--font-family-body)',
+    label: 'var(--font-family-label)',
+  },
+  size: {
+    body: { sm: 'var(--font-size-100)', md: 'var(--font-size-200)' },
+    heading: { tiny: 'var(--heading-tiny)', sm: 'var(--heading-sm)' },
+  },
+} as const;
+
+export const space = {
+  sm: 'var(--padding-sm)',
+  md: 'var(--padding-md)',
+  lg: 'var(--padding-lg)',
+} as const;
+
+export const radius = { sm: 'var(--border-radius-sm)', md: 'var(--border-radius-md)' } as const;
+```
+
+**Why a TS map and not raw `var()` in JSX:** typos are silent. `style={{ color: 'var(--text-primry)' }}` produces no error, no warning — just an inherited color in production. `style={{ color: color.text.primry }}` is a TypeScript error at write time.
+
+```tsx
+// ❌ Wrong
+style={{ color: 'var(--text-primary)', fontSize: '16px' }}
+
+// ✅ Right
+import { color, font } from '@/lib/tokens';
+style={{ color: color.text.primary, fontSize: font.size.body.md }}
+```
+
+## `@/lib/styles` — composed presets
+
+Bundles font family + size + line-height + letter-spacing into pre-baked `CSSProperties` so callers can't mismatch family with the wrong scale.
+
+```ts
+// src/lib/styles.ts
+import type { CSSProperties } from 'react';
+import { color, font } from './tokens';
+
+export const text = {
+  body: {
+    fontFamily: font.family.body,
+    fontSize: font.size.body.md,
+    lineHeight: 'var(--line-height-body)',
+    color: color.text.primary,
+  } satisfies CSSProperties,
+  meta: {
+    fontFamily: font.family.label,
+    fontSize: font.size.body.sm,
+    color: color.text.muted,
+  } satisfies CSSProperties,
+} as const;
+
+export const heading = {
+  sm: {
+    fontFamily: font.family.heading,
+    fontSize: font.size.heading.sm,
+    lineHeight: 'var(--line-height-heading)',
+    color: color.text.primary,
+  } satisfies CSSProperties,
+} as const;
+```
+
+```tsx
+// ❌ Wrong — heading family with body size scale
+style={{ fontFamily: font.family.heading, fontSize: font.size.body.md }}
+
+// ✅ Right — one preset, family + size always paired correctly
+import { heading } from '@/lib/styles';
+style={heading.sm}
+```
+
+<Callout type="warn">
+  **Heading scale starts at 18px.** `--heading-tiny` = 18px. `font-size/100` = 16px is body/label territory — never use it on a heading element. The composed presets enforce this so you can't.
+</Callout>
+
+## Required consumer files
+
+Every product or marketing-site consumer ships these four files. The reference implementation is **brik-client-portal**.
+
+| File | Purpose |
+| --- | --- |
+| `src/lib/tokens.ts` | CSS `var()` mapping for TypeScript autocomplete. |
+| `src/lib/styles.ts` | Composed `CSSProperties` presets — `text.*`, `heading.*`, `meta`, `label`. |
+| `src/components/prose.tsx` | Shared markdown renderer — applies `text.body` + token-aware spacing to `<p>`, `<ul>`, `<h2>` etc. so MDX/CMS copy inherits BDS typography. |
+| `.husky/pre-commit` | Token compliance gate. Runs `scripts/token-audit.sh --canonical-only` to block hex literals + non-canonical token names from landing. |
+
+When starting a new consumer, copy these four files from the portal as the seed and adapt the token map to the consumer's needs (e.g. add domain-specific clusters under `color.department.*` or `color.service.*`).
+
+## Style Dictionary build pipeline
+
+BDS owns the source-of-truth pipeline. Consumers never run these — they consume the compiled outputs via `@brikdesigns/bds`. Knowing the pipeline matters when a token is missing or a rename is in flight.
+
+```
+Figma Variables
+   │ (export via dev plugin + WebSocket relay :3055)
+   ▼
+design-tokens/tokens-studio.json
+   │ (Style Dictionary)
+   ▼
+tokens/figma-tokens.css        ← light mode CSS (consumed everywhere)
+tokens/figma-tokens-dark.css   ← dark mode CSS (scoped to [data-theme="dark"])
+build/figma/js/tokens.mjs      ← JS object form
+build/figma/swift/*.swift      ← iOS sync
+```
+
+| Command | Input | Output |
+| --- | --- | --- |
+| `npm run build:sd-figma` | `design-tokens/tokens-studio.json` | `tokens/figma-tokens.css`, JS, Swift |
+| `npm run build:sd-dark` | same JSON, `color=dark` mode | `tokens/figma-tokens-dark.css` |
+| `npm run build:all-tokens` | both | full rebuild (light + dark) |
+| `npm run build:lib` | full repo | publishable `dist/` |
+
+<Callout type="warn">
+  **Never hand-edit `tokens/figma-tokens.css`.** It's regenerated on every build and your edit will silently disappear. Add the token in Figma → re-export tokens-studio.json → rerun `build:sd-figma`. The only manual token file is `tokens/gap-fills.css`, for tokens that are not yet in Figma.
+</Callout>
+
+See [Primitives → Color](/docs/primitives/color) for the canonical token registry, and [Theming → Atmospheres](/docs/theming/atmospheres) for the dark / atmosphere overlay contract.
+
+## `bds-find` — component discoverability CLI
+
+A CLI that queries the BDS component manifest (`dist/bds-manifest.json`) to answer the question every product agent should ask before building UI: **does BDS already have a component for this?**
+
+```bash
+# Fuzzy search — the most common usage
+bds-find "tag input with autocomplete"
+
+# Filter by tag
+bds-find --tag form
+
+# Exact lookup
+bds-find --exact AddableTagList
+
+# Dump everything (JSON)
+bds-find --list
+```
+
+### Adopt / Extend / Graduate
+
+`bds-find`'s exit codes map to the cascade product agents follow when they hit a UI gap:
+
+| Exit code | Match confidence | Decision |
+| --- | --- | --- |
+| `0` | ≥ 0.85 (high) | **Adopt** — use the BDS component as-is. |
+| `1` | 0.5 – 0.85 (partial) | **Extend** — upstream a PR to BDS rather than rebuild. |
+| `2` | under 0.5 (no match) | **Graduate** — build in the consumer, log to `.bds-gaps.log` for later upstream. |
+| `3` | internal error (manifest missing) | run `npm run build:inspector-manifest` first. |
+
+The cascade prevents two failure modes:
+
+- **Reinventing existing components** (silent duplication of `AddableTagList` because the agent didn't know it existed).
+- **Forking BDS in the consumer** (one-off card variants that drift from canonical). Extending upstream keeps the system narrow and shared.
+
+### Output formats
+
+`bds-find` auto-detects: human-readable Markdown when output is a TTY, JSON when piped. Force one with `--format=md` or `--format=json`. JSON is what agent tooling parses; markdown is what humans skim.
+
+```bash
+# Human-readable (default in a terminal)
+bds-find form
+
+# Structured (default when piped — what agents consume)
+bds-find form | jq '.matches[0]'
+```
+
+## Adding a utility
+
+The bar for shipping a new utility from BDS itself is high. Most "utility" needs belong in the **consumer's** lib layer (`@/lib/tokens`, `@/lib/styles`, helpers above those) — that keeps the BDS surface narrow.
+
+A utility belongs in BDS only when:
+
+1. **It depends on the BDS source of truth** (component manifest, token registry, content-system enums) and would drift if forked.
+2. **It's used by ≥ 2 consumers** (or has an obvious second consumer in a product app).
+3. **It's stateless and side-effect-free** — no global runtime state, no DOM mutation. CLI scripts and pure functions only. Stateful behavior belongs in a [hook](/docs/hooks) paired with a component.
+
+Utilities that don't clear all three bars stay in the consumer.
+
+## Related
+
+- [Primitives → Color](/docs/primitives/color) — canonical token registry that `@/lib/tokens` mirrors
+- [Theming → Atmospheres](/docs/theming/atmospheres) — the dark / atmosphere overlay system the build pipeline emits
+- [Components](/docs/components) — what `bds-find` searches against
+- [Hooks](/docs/hooks) — the stateful counterpart to these stateless utilities


### PR DESCRIPTION
## Summary

Replaces the three single-line placeholders left during the IA restructure with full reference content. All three were marked \"Patterns are the next major content fill-in\" / \"Placeholder\" in their parked state.

- **Hooks** — 7 actual `@brikdesigns/bds` exports documented: `useTheme`, `useSheetStack`, `useConfigureSheet`, `useSheetConfig`, `useSuggestionFilter`, `useDevBarSlot`, `useDevBarApi`. Each section has signature + when-to-use + example, plus a closing \"hooks vs components\" note and the bar for shipping a new hook.
- **Utilities** — the `@/lib/tokens` + `@/lib/styles` consumer-side pattern (with the four required consumer files: `tokens.ts`, `styles.ts`, `prose.tsx`, `.husky/pre-commit`), the Style Dictionary build pipeline (Figma → tokens-studio.json → SD → CSS/JS/Swift), and the `bds-find` CLI with the Adopt / Extend / Graduate exit-code cascade.
- **Patterns** — five compositional recipes: Forms, Empty States, Page Templates, Navigation, Notifications. Compositions reference real BDS exports only (`Form`, `Field`, `FieldGrid`, `ButtonGroup`, `Sheet`, `Table`, `CardList`, `NavBar`, `SidebarNavigation`, `Toast`, `Banner`, `AlertBanner`, `EmptyState`). Sheet variants kept honest at `default | floating`.

## Test plan

- [x] Local fumadocs build passes — 133 static pages generated, `hooks.html`, `utilities.html`, `patterns.html` present in `.next/server/app/docs/`.
- [x] Component / API references verified against source (no fabricated `Form.Actions`, no fake Sheet `'confirm' | 'navigation'` variants, etc.).
- [ ] Visual review on Netlify preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)