### PR TITLE
chore(scripts): rename brik-marketing → brikdesigns in drift consumer list

### DIFF
--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -22,7 +22,7 @@ const BDS_HEAD_SHA = sh('git rev-parse HEAD').slice(0, 7);
 
 const SUBMODULE_CONSUMERS = [
   { name: 'brik-llm',    repo: 'brikdesigns/brik-llm',       submodulePath: 'foundations/brik-bds' },
-  { name: 'brikdesigns', repo: 'brikdesigns/brik-marketing', submodulePath: 'brik-bds' },
+  { name: 'brikdesigns', repo: 'brikdesigns/brikdesigns', submodulePath: 'brik-bds' },
 ];
 
 const NPM_CONSUMERS = [


### PR DESCRIPTION
## Summary

The marketing site repo was renamed \`brikdesigns/brik-marketing\` → \`brikdesigns/brikdesigns\` on 2026-04-30 to align with the local folder name and the brand. GitHub auto-redirects keep the old URL working, but explicit > implicit for the drift-check consumer list.

One-line change in [scripts/check-drift.mjs](scripts/check-drift.mjs).

## Test plan

- [x] \`node scripts/check-drift.mjs\` runs end-to-end with the new repo name, returns the expected drift report (both \`brikdesigns\` and \`brik-llm\` submodule consumers resolve correctly).

## Related PRs

- brik-llm: https://github.com/brikdesigns/brik-llm/pull/87
- brikdesigns repo (the one that was renamed): opening shortly

🤖 Generated with [Claude Code](https://claude.com/claude-code)