### PR TITLE
feat(tokens): wire borderWidth mode CSS overrides (closes #313)

### DIFF
--- a/scripts/build-dist-tokens.js
+++ b/scripts/build-dist-tokens.js
@@ -63,12 +63,20 @@ if (fs.existsSync(themeBrandBrikPath)) {
   console.log('  ✓ Including Brik brand theme');
 }
 
+// Non-color mode overrides (currently borderWidth; future: spacing, radius, elevation, motion)
+const modesBorderWidthPath = path.join(TOKENS_DIR, 'modes-borderwidth.css');
+let modesBorderWidth = '';
+if (fs.existsSync(modesBorderWidthPath)) {
+  modesBorderWidth = '\n\n' + fs.readFileSync(modesBorderWidthPath, 'utf8');
+  console.log('  ✓ Including borderWidth mode overrides');
+}
+
 // Shared keyframe library — required for any component using bds-spin, bds-pulse, bds-pop, etc.
 const animations = fs.readFileSync(path.join(TOKENS_DIR, 'animations.css'), 'utf8');
 
 fs.writeFileSync(
   path.join(DIST_DIR, 'tokens.css'),
-  header + figmaTokens + darkTokens + darkCorrections + themeBrandBrik + '\n\n' + gapFills + '\n\n' + animations,
+  header + figmaTokens + darkTokens + darkCorrections + themeBrandBrik + modesBorderWidth + '\n\n' + gapFills + '\n\n' + animations,
 );
 console.log('  ✓ dist/tokens.css');
 

--- a/tokens/CASCADE.md
+++ b/tokens/CASCADE.md
@@ -13,8 +13,9 @@ renew-pms, brikdesigns) via `@brikdesigns/bds/tokens.css`. Built by
 2. `figma-tokens-dark.css` — auto-generated dark-mode tokens (`:root[data-theme="dark"]`)
 3. `figma-dark-corrections.css` — manual overrides for known-wrong Figma dark values
 4. `theme-brand-brik.css` — Brik brand overrides (scoped to `.theme-brand-brik` class)
-5. `gap-fills.css` — manual tokens not yet in Figma
-6. `animations.css` — shared keyframe library (`bds-spin`, `bds-pulse`, `bds-pop`, etc.) — required by any component CSS that references these names
+5. `modes-borderwidth.css` — borderWidth mode overrides (`[data-mode-borderwidth="thin|bold"]`)
+6. `gap-fills.css` — manual tokens not yet in Figma
+7. `animations.css` — shared keyframe library (`bds-spin`, `bds-pulse`, `bds-pop`, etc.) — required by any component CSS that references these names
 
 **Not bundled:** `bridge.css` (opt-in via separate export), `font-audit.css`
 (Storybook-only), `motion-classes.css` (opt-in utility classes — consumers import
@@ -39,6 +40,7 @@ No consumer should toggle a `.dark` class — the attribute is the only switch.
 | Fix a value that came out of Figma wrong | `figma-dark-corrections.css` (dark) or a new `figma-corrections.css` (light — doesn't exist yet, add when needed) |
 | Add a semantic token Figma doesn't export | `gap-fills.css` |
 | Adjust Brik's brand colors / fonts | `theme-brand-brik.css` — consumers get these automatically when they apply `.theme-brand-brik` to `<body>` |
+| Wire a non-color mode pick (Thin/Bold/Compact/Round/etc.) into CSS overrides | `modes-{category}.css` (only `modes-borderwidth.css` exists today; add `modes-spacing.css`, `modes-radius.css`, etc. as each mode is wired) |
 | Add a Webflow-facing alias | `bridge.css` (deprecated layer) |
 | Touch an auto-generated file | Don't. Fix in Figma and re-pull, or add an override in a manual file. |
 
@@ -54,6 +56,7 @@ place for a correction is a manual file bundled AFTER the auto-generated ones.
 
 - `figma-dark-corrections.css` — known-wrong dark values
 - `theme-brand-brik.css` — Brik brand overrides (class-scoped, bundled into dist)
+- `modes-borderwidth.css` — borderWidth mode overrides (`[data-mode-borderwidth]`-scoped, bundled into dist)
 - `gap-fills.css` — tokens Figma doesn't export yet
 - `bridge.css` — legacy Webflow aliases (deprecated, opt-in only)
 - `font-audit.css`, `animations.css`, `motion-classes.css` — Storybook/component-level

--- a/tokens/modes-borderwidth.css
+++ b/tokens/modes-borderwidth.css
@@ -1,0 +1,54 @@
+/**
+ * BDS borderWidth Mode Overrides
+ *
+ * Loaded by: bundled into dist/tokens.css after theme-brand-brik.css,
+ * before gap-fills.css. See tokens/CASCADE.md for the full load order.
+ *
+ * Wires the "Thin" and "Bold" picks from brand-kit-modes.json's borderWidth
+ * mode catalog. Without this file, every consumer gets Figma's Standard
+ * values regardless of mode pick — clients fill out the manifest and
+ * nothing happens visually. See brik-bds#313 (this PR) and brik-llm#52
+ * (data-quality drift surfaced by the gap).
+ *
+ * Selector contract: `[data-mode-borderwidth="thin|bold"]` on :root (html).
+ * Parallels the existing `[data-theme="dark"]` mechanism so consumers have
+ * one mode-switch convention. Standard is the default — no override needed
+ * (Figma's --border-width-* values stand).
+ *
+ * Values per websites/shared/MODE-ARCHITECTURE.md (in brik-llm). The fixed
+ * semantic aliases --border-width-{thin,standard,bold} (gap-fills.css)
+ * intentionally stay invariant — those are reference points; the modulation
+ * lives here on --border-width-{sm,md,lg}.
+ *
+ * Note: Figma currently exports Standard sm/md/lg = 0.5px/1px/2px, while
+ * MODE-ARCHITECTURE.md prescribes 1px/2px/3px. Reconciling Figma's Standard
+ * to match the spec table is tracked separately. Once Figma is updated and
+ * re-pulled, the Thin/Bold steps below will read as one tier of difference
+ * from Standard at every size, as the spec intends.
+ */
+
+/* ─── Thin ─────────────────────────────────────────────────────
+   One step thinner than Standard at md and lg; sm matches because
+   sub-pixel rendering below 1px is unreliable across browsers. */
+[data-mode-borderwidth="thin"] {
+  --border-width-sm: 1px;
+  --border-width-md: 1px;
+  --border-width-lg: 2px;
+}
+
+/* ─── Bold ─────────────────────────────────────────────────────
+   One step bolder than Standard at every size. */
+[data-mode-borderwidth="bold"] {
+  --border-width-sm: 2px;
+  --border-width-md: 3px;
+  --border-width-lg: 4px;
+}
+
+/* ─── Dark-mode parity ─────────────────────────────────────────
+   Borders don't change weight in dark mode by themselves — but if a
+   downstream consumer sets [data-theme="dark"] AND [data-mode-borderwidth]
+   together, both selectors apply at the same specificity. The mode picks
+   above already use border-width units that are theme-agnostic, so no
+   dark-mode override block is needed. If border-width semantics ever
+   diverge by theme, add a `:root[data-theme="dark"][data-mode-borderwidth=…]`
+   block here following the figma-tokens-dark.css convention. */


### PR DESCRIPTION
## Summary
- feat(tokens): wire borderWidth mode CSS overrides (#313)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)