### PR TITLE
feat(content-system): export COLOR_PRIMITIVE_TIERS as BDS-side contract (closes #298)

### DIFF
--- a/content-system/vocabularies/color-primitive-tier.ts
+++ b/content-system/vocabularies/color-primitive-tier.ts
@@ -1,0 +1,62 @@
+/**
+ * Color Primitive Tier — the canonical brand-tier vocabulary that decides
+ * which canonical BDS token slots a profile's color primitive resolves into.
+ *
+ * Single source of truth shared by the portal theme generator
+ * (`generate-theme-css.ts` → `findPrimitiveByTier`), `resolve-theme.ts`
+ * (which previously declared the type locally), and any future per-client
+ * repo that reads primitives by tier. Drift here breaks brand-color
+ * resolution silently — pinning the vocabulary to a BDS contract makes
+ * speculative tier additions impossible without a definition step here
+ * first.
+ *
+ * Tier values are scoped to BRAND-TIER decisions only — they never
+ * override canonical neutral slots (`--text-primary` / `--surface-primary` /
+ * etc.). Per the BDS canonical token registry, neutral slots resolve from
+ * the white / black / gray primitives exclusively. To shift a brand's body
+ * surface or body text to a warm-tinted neutral (e.g. Vale's cream +
+ * moss-deepest), redefine that brand's `white` or `black` primitive hex
+ * value rather than introducing a parallel "paper" / "ink" tier. Same root
+ * cause as the canonical-token-rollback runbook (2026-04-27) which retired
+ * the parallel surface/text alias taxonomy at the CSS-var layer.
+ *
+ * Source of truth:
+ *   https://design.brikdesigns.com/docs/primitives/color
+ *   node_modules/@brikdesigns/bds/dist/tokens.css
+ *
+ * Tier semantics:
+ *   - primary    — chromatic brand identity. Drives `--text-brand-primary`,
+ *                  accents, `--text-link`.
+ *   - secondary  — supporting brand color. Tag-only today; no automatic
+ *                  mapping.
+ *   - tertiary   — third-tier brand color. Tag-only today.
+ *   - accent     — non-primary chromatic colors. Tag-only today.
+ *   - neutral    — gray ramp source. Drives gray-ramp neutral resolution.
+ *   - brand-fill — AA-safe variant of primary used for filled brand
+ *                  surfaces (`--background-brand-primary`) and brand-
+ *                  colored text (`--text-brand-primary`). Specify when
+ *                  primary fails AA contrast against the paper/white
+ *                  surface (Vale's olive #698339 is 3.4:1 on white;
+ *                  olive-deep #3d4c23 is 9.0:1).
+ *
+ * Why no separate body-surface / body-text brand-tier: those tier values
+ * (named "paper" and "ink" in portal PR #576) were reverted in #577
+ * because they pushed brand-tinted values into canonical neutral token
+ * slots, violating the BDS taxonomy where neutral tokens must resolve
+ * from neutral primitives. To shift body neutrals brand-side, redefine
+ * the brand's white/black primitive hex values; do not introduce
+ * parallel tier vocabulary.
+ */
+export const COLOR_PRIMITIVE_TIERS = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'accent',
+  'neutral',
+  'brand-fill',
+] as const;
+
+export type ColorPrimitiveTier = (typeof COLOR_PRIMITIVE_TIERS)[number];
+
+export const isColorPrimitiveTier = (value: string): value is ColorPrimitiveTier =>
+  (COLOR_PRIMITIVE_TIERS as readonly string[]).includes(value);

--- a/content-system/vocabularies/index.ts
+++ b/content-system/vocabularies/index.ts
@@ -82,3 +82,9 @@ export {
   type ThemeMode,
   ATMOSPHERE_THEME_MODE,
 } from './atmosphere';
+
+export {
+  COLOR_PRIMITIVE_TIERS,
+  isColorPrimitiveTier,
+  type ColorPrimitiveTier,
+} from './color-primitive-tier';


### PR DESCRIPTION
## Summary

Exports `COLOR_PRIMITIVE_TIERS` (literal-tuple `as const`), the companion `ColorPrimitiveTier` type, and an `isColorPrimitiveTier` type-guard from `@brikdesigns/bds/content-system`. Pins the brand-tier vocabulary to a BDS contract so consumers (portal `resolve-theme.ts`, theme generator, future per-client repos) validate against a single source of truth instead of declaring it locally — making speculative tier additions (the failure mode that produced the `paper`/`ink` tiers in portal #576, reverted in #577) impossible without landing here first.

JSDoc carries the rationale forward — including the explicit "no body-surface / body-text brand tier" guardrail tied to the canonical-token-rollback runbook (2026-04-27).

## Decisions

- **Home:** `content-system/vocabularies/` next to `animation-tier`, `payment-method`, etc. The issue body said `@brikdesigns/bds/content-system` or similar — that entry point already auto-re-exports vocabularies, so no new entry point.
- **Name:** kept `COLOR_PRIMITIVE_TIERS` (issue spec + matches what portal already uses) over the BCS `*_VALUES` convention. `INDUSTRY_SLUGS` already establishes that category enums can drop `_VALUES`.

## Acceptance (#298)

- [x] BDS exports `COLOR_PRIMITIVE_TIERS` as `readonly [...]` tuple
- [x] Companion `type ColorPrimitiveTier = typeof COLOR_PRIMITIVE_TIERS[number]`
- [ ] Storybook tier-vocabulary docs page → companion issue #301 (separate scope)
- [ ] Portal PR migrates `resolve-theme.ts` to import from BDS → separate portal-repo PR

## Test plan

- [x] `npm run build:content-system` — `dist/content-system/vocabularies/color-primitive-tier.d.ts` emits the readonly literal tuple correctly
- [x] `npm run validate:full` — all 7 checks (token lint, JSDoc lint, grid audit, theme compliance, blueprint library, typecheck, Storybook build) pass
- [ ] After merge + publish: portal PR migrates `resolve-theme.ts` to import the contract

Closes #298