### PR TITLE
fix(scripts): repair figma-pull-tokens.sh paths — _vendor location + worktree compat

### DIFF
--- a/scripts/figma-pull-tokens.sh
+++ b/scripts/figma-pull-tokens.sh
@@ -25,8 +25,21 @@ set -euo pipefail
 # ── Paths ────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BDS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-TOOLS_DIR="/Users/nickstanerson/Documents/GitHub/brik/_tools/claude-talk-to-figma-mcp"
-PULL_SCRIPT="$TOOLS_DIR/scripts/pull-variables.js"
+# _vendor/ lives at the brik/ root: parent of brik-bds (primary) or grandparent of
+# brik-bds-worktrees/{slug} (task worktree). Resolve both cases. Override with
+# BRIK_TOOLS_DIR if running from a non-standard layout.
+if [[ -n "${BRIK_TOOLS_DIR:-}" ]]; then
+  TOOLS_DIR="$BRIK_TOOLS_DIR"
+elif [[ -d "$BDS_ROOT/../_vendor/claude-talk-to-figma-mcp" ]]; then
+  TOOLS_DIR="$(cd "$BDS_ROOT/../_vendor/claude-talk-to-figma-mcp" && pwd)"
+elif [[ -d "$BDS_ROOT/../../_vendor/claude-talk-to-figma-mcp" ]]; then
+  TOOLS_DIR="$(cd "$BDS_ROOT/../../_vendor/claude-talk-to-figma-mcp" && pwd)"
+else
+  echo "ERROR: cannot locate _vendor/claude-talk-to-figma-mcp from $BDS_ROOT" >&2
+  echo "       set BRIK_TOOLS_DIR to the absolute path explicitly" >&2
+  exit 1
+fi
+PULL_SCRIPT="$BDS_ROOT/scripts/pull-variables.js"
 SYNC_SCRIPT="$BDS_ROOT/scripts/sync-figma-mcp.js"
 RELAY_SCRIPT="$TOOLS_DIR/src/socket.ts"
 CHANNEL_FILE="$HOME/.figma-channel"


### PR DESCRIPTION
## Summary

Repairs three path bugs in `scripts/figma-pull-tokens.sh` that made the documented happy-path wrapper fail silently. Closes #339.

## What was broken

1. **`TOOLS_DIR` hardcoded a stale path.** Pointed at `/Users/nickstanerson/Documents/GitHub/brik/_tools/claude-talk-to-figma-mcp` — but the vendored relay+plugin lives at `brik/_vendor/`, not `_tools/`, and the path was username-pinned + case-pinned (`GitHub` vs the actual lowercase `github` on disk).

2. **`PULL_SCRIPT` pointed at the wrong repo.** Resolved to `$TOOLS_DIR/scripts/pull-variables.js`, but that file doesn't exist in the vendored repo — only `configure-claude.js`, `launcher.js`, `setup.sh`, `test-integration.js` ship in `_vendor/.../scripts/`. The actual `pull-variables.js` lives in BDS's own `scripts/`.

3. **Worktree depth mismatch.** Even after fixing `_tools` → `_vendor`, the relative path `\$BDS_ROOT/../_vendor/...` resolves correctly from the primary worktree (`brik/brik-bds/`) but **not** from a task worktree (`brik/brik-bds-worktrees/{slug}/`) — the depths differ by one. The wrapper has to handle both.

## What this PR does

```bash
# Old:
TOOLS_DIR="/Users/nickstanerson/Documents/GitHub/brik/_tools/claude-talk-to-figma-mcp"
PULL_SCRIPT="$TOOLS_DIR/scripts/pull-variables.js"

# New:
if [[ -n "${BRIK_TOOLS_DIR:-}" ]]; then
  TOOLS_DIR="$BRIK_TOOLS_DIR"
elif [[ -d "$BDS_ROOT/../_vendor/claude-talk-to-figma-mcp" ]]; then
  TOOLS_DIR="$(cd "$BDS_ROOT/../_vendor/claude-talk-to-figma-mcp" && pwd)"
elif [[ -d "$BDS_ROOT/../../_vendor/claude-talk-to-figma-mcp" ]]; then
  TOOLS_DIR="$(cd "$BDS_ROOT/../../_vendor/claude-talk-to-figma-mcp" && pwd)"
else
  echo "ERROR: cannot locate _vendor/claude-talk-to-figma-mcp from $BDS_ROOT" >&2
  echo "       set BRIK_TOOLS_DIR to the absolute path explicitly" >&2
  exit 1
fi

PULL_SCRIPT="$BDS_ROOT/scripts/pull-variables.js"
SYNC_SCRIPT="$BDS_ROOT/scripts/sync-figma-mcp.js"   # already correct
RELAY_SCRIPT="$TOOLS_DIR/src/socket.ts"             # already correct
```

`BRIK_TOOLS_DIR` env var lets non-standard layouts (e.g. CI runners) override the auto-detection without further script changes.

## Verified

End-to-end path resolution:

```
$ # From primary (brik/brik-bds/)
PULL  YES  /…/brik/brik-bds/scripts/pull-variables.js
SYNC  YES  /…/brik/brik-bds/scripts/sync-figma-mcp.js
RELAY YES  /…/brik/_vendor/claude-talk-to-figma-mcp/src/socket.ts

$ # From task worktree (brik/brik-bds-worktrees/<slug>/)
PULL  YES  /…/brik/brik-bds-worktrees/<slug>/scripts/pull-variables.js
SYNC  YES  /…/brik/brik-bds-worktrees/<slug>/scripts/sync-figma-mcp.js
RELAY YES  /…/brik/_vendor/claude-talk-to-figma-mcp/src/socket.ts
```

`bash -n scripts/figma-pull-tokens.sh` clean.

## Why this matters

The wrapper is the documented happy path for "pull latest tokens from Figma" per [BDS CLAUDE.md → Figma Variables Sync](../tree/main/CLAUDE.md#figma-variables-sync). With it broken, every token-sync session has been falling back to invoking the underlying scripts (`bun scripts/pull-variables.js` + `node scripts/sync-figma-mcp.js`) directly. PR #336's work today did exactly that.

## Surfaced by

PR #336 — needed the wrapper for the dev-plugin pull pipeline; it errored on the missing path and the workaround was the manual two-script invocation.

## Test plan

- [ ] CI: build-tokens, drift-alarm pass (no consumer impact — wrapper-only change)
- [ ] Manual: `./scripts/figma-pull-tokens.sh <channel-id>` runs end-to-end on Nick's machine from primary worktree
- [ ] Manual: same from a task worktree under `brik-bds-worktrees/<slug>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)