### PR TITLE
bds: canonical check tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",
@@ -38,7 +38,12 @@
     "./atmospheres/none.css": "./content-system/atmospheres/none.css",
     "./styles.css": "./dist/styles.css",
     "./tokens.css": "./dist/tokens.css",
-    "./bridge.css": "./dist/bridge.css"
+    "./bridge.css": "./dist/bridge.css",
+    "./canonical-check": {
+      "types": "./scripts/canonical-check.d.ts",
+      "import": "./scripts/canonical-check.mjs",
+      "default": "./scripts/canonical-check.mjs"
+    }
   },
   "files": [
     "dist",
@@ -47,10 +52,13 @@
     "content-system/atmospheres/*.css",
     "content-system/blueprints/astro/**/*.astro",
     "content-system/blueprints/astro/index.ts",
-    "scripts/bds-find.mjs"
+    "scripts/bds-find.mjs",
+    "scripts/canonical-check.mjs",
+    "scripts/canonical-check.d.ts"
   ],
   "bin": {
-    "bds-find": "scripts/bds-find.mjs"
+    "bds-find": "scripts/bds-find.mjs",
+    "canonical-check": "scripts/canonical-check.mjs"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
@@ -117,6 +125,8 @@
     "build:content-system": "tsc --project tsconfig.content-system.json",
     "build:inspector-manifest": "node scripts/build-inspector-manifest.mjs",
     "bds:find": "node scripts/bds-find.mjs",
+    "canonical-check": "node scripts/canonical-check.mjs --allowlist dist/tokens.css components",
+    "canonical-check:report": "node scripts/canonical-check.mjs --allowlist dist/tokens.css --format md components content-system stories || true",
     "build:types": "tsc --project tsconfig.build.json",
     "build:dist-tokens": "node scripts/build-dist-tokens.js",
     "chromatic": "npx chromatic --project-token=chpt_c16ee79525f408c",

--- a/scripts/__tests__/canonical-check.test.mjs
+++ b/scripts/__tests__/canonical-check.test.mjs
@@ -1,0 +1,356 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  parseAllowlist,
+  parseAllowlistFromFile,
+  stripCssComments,
+  extractTokenReferences,
+  extractTokenDefinitions,
+  sourceScan,
+  runtimeScan,
+  assertCanonicalCss,
+  DEFAULT_EXEMPT_PATTERNS,
+} from '../canonical-check.mjs';
+
+// A miniature canonical registry — covers each prefix the scanner cares about
+// without depending on the live dist/tokens.css. Tests stay deterministic
+// across BDS releases.
+const TOKENS_CSS_FIXTURE = `
+/**
+ * Canonical fixture — distilled from dist/tokens.css.
+ */
+:root {
+  /* Text family */
+  --text-primary: #111;
+  --text-on-color-dark: #fff;
+  --text-on-color-light: #111;
+  --text-link: var(--background-brand-primary);
+
+  /* Surface family */
+  --surface-primary: #fff;
+  --surface-secondary: #f8f8f8;
+  --surface-brand-primary: var(--background-brand-primary);
+
+  /* Background family */
+  --background-primary: #fff;
+  --background-brand-primary: #2a55b4;
+  --background-brand-primary-hover: #1f3f8a;
+
+  /* Border family — semantic + sizing tiers */
+  --border-primary: #e0e0e0;
+  --border-radius-100: 4px;
+  --border-width-100: 1px;
+
+  /* Color primitives */
+  --color-grayscale-100: #f5f5f5;
+  --color-blue-500: #2a55b4;
+
+  /* Sentinel non-prefix token — must NOT appear in allowlist */
+  --space-100: 4px;
+  --font-size-md: 16px;
+
+  /* extra padding to clear the 20-token sanity floor in the CLI */
+  --text-secondary: #555;
+  --text-muted: #888;
+  --text-inverse: #fff;
+  --text-disabled: #aaa;
+  --surface-muted: #f0f0f0;
+  --surface-inverse: #111;
+  --background-secondary: #f5f5f5;
+  --background-muted: #f0f0f0;
+  --background-disabled: #eee;
+  --border-secondary: #ccc;
+  --border-disabled: #ddd;
+  --color-grayscale-200: #eee;
+  --color-grayscale-300: #ddd;
+  --color-blue-400: #4a75d4;
+}
+`;
+
+describe('parseAllowlist', () => {
+  it('captures every --token-name declaration', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    expect(allowlist.has('--text-primary')).toBe(true);
+    expect(allowlist.has('--surface-primary')).toBe(true);
+    expect(allowlist.has('--background-brand-primary')).toBe(true);
+    expect(allowlist.has('--border-primary')).toBe(true);
+    expect(allowlist.has('--color-grayscale-100')).toBe(true);
+  });
+
+  it('captures sizing-tier border tokens (separate semantic, still canonical)', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    expect(allowlist.has('--border-radius-100')).toBe(true);
+    expect(allowlist.has('--border-width-100')).toBe(true);
+  });
+
+  it('captures non-prefix tokens too (the parser is prefix-agnostic; filtering happens in the scanner)', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    expect(allowlist.has('--space-100')).toBe(true);
+    expect(allowlist.has('--font-size-md')).toBe(true);
+  });
+
+  it('returns an empty Set for empty input', () => {
+    expect(parseAllowlist('').size).toBe(0);
+  });
+
+  it('skips declarations that appear inside a /* … */ block on the same line', () => {
+    // The parser anchors on line-start / `{` / `;` boundaries. `/*` is none
+    // of those, so a same-line commented declaration is correctly ignored
+    // even though parseAllowlist itself doesn't run stripCssComments. Real
+    // dist/tokens.css never has this shape — it's defensive.
+    const allowlist = parseAllowlist('/* --surface-fake: red; */');
+    expect(allowlist.has('--surface-fake')).toBe(false);
+  });
+});
+
+describe('stripCssComments', () => {
+  it('removes single-line block comments', () => {
+    const out = stripCssComments('a /* ignore */ b');
+    expect(out).toContain('a');
+    expect(out).toContain('b');
+    expect(out).not.toContain('ignore');
+  });
+
+  it('removes multi-line block comments with continuation lines', () => {
+    const input = [
+      '/* note: --color-grayscale-* primitives are referenced',
+      '   directly in BDS components — that is intentional and',
+      '   should not surface as a violation */',
+      '--surface-primary: #fff;',
+    ].join('\n');
+    const out = stripCssComments(input);
+    expect(out).not.toContain('--color-grayscale-');
+    expect(out).toContain('--surface-primary');
+  });
+
+  it('removes leading-line // comments (TS / JS)', () => {
+    const out = stripCssComments(['// banned token: --surface-paper', '--surface-primary: #fff;'].join('\n'));
+    expect(out).not.toContain('--surface-paper');
+    expect(out).toContain('--surface-primary');
+  });
+
+  it('preserves URLs that contain `//`', () => {
+    // Line-leading // is what we strip; mid-line `//` (URLs etc) survives.
+    const input = "background: url('https://example.com/img.png');";
+    expect(stripCssComments(input)).toContain("https://example.com/img.png");
+  });
+});
+
+describe('extractTokenReferences', () => {
+  it('finds every reference in the configured prefix family', () => {
+    const css = `
+      .foo { color: var(--text-primary); background: var(--background-primary); }
+      .bar { border-color: var(--border-primary); }
+    `;
+    const refs = extractTokenReferences(css);
+    expect(refs).toContain('--text-primary');
+    expect(refs).toContain('--background-primary');
+    expect(refs).toContain('--border-primary');
+  });
+
+  it('skips tokens outside the configured prefixes', () => {
+    const css = `.foo { padding: var(--space-100); font-size: var(--font-size-md); }`;
+    const refs = extractTokenReferences(css);
+    expect(refs.has('--space-100')).toBe(false);
+    expect(refs.has('--font-size-md')).toBe(false);
+  });
+
+  it('honors a custom prefix list', () => {
+    const css = `.foo { color: var(--text-primary); padding: var(--space-100); }`;
+    const refs = extractTokenReferences(css, ['space']);
+    expect(refs.has('--space-100')).toBe(true);
+    expect(refs.has('--text-primary')).toBe(false);
+  });
+
+  it('skips lines annotated with `bds-lint-ignore` (consistent with other BDS lint scripts)', () => {
+    const css = [
+      '--text-input-focus-ring-width: 1px; /* bds-lint-ignore — component-scoped */',
+      '--surface-paper: #fff; /* not annotated */',
+    ].join('\n');
+    const refs = extractTokenReferences(css);
+    expect(refs.has('--text-input-focus-ring-width')).toBe(false);
+    expect(refs.has('--surface-paper')).toBe(true);
+  });
+
+  it('does not collapse `-*` glob suffixes inside block comments', () => {
+    // Regression: the block-comment stripper must remove the entire comment
+    // BEFORE token extraction. Otherwise the regex grabs `--color-grayscale`
+    // from "--color-grayscale-*" and emits a false positive.
+    const input = '/* references --color-grayscale-* primitives */\n--surface-primary: #fff;';
+    const refs = extractTokenReferences(input);
+    expect(refs.has('--color-grayscale')).toBe(false);
+    expect(refs.has('--surface-primary')).toBe(true);
+  });
+});
+
+describe('extractTokenDefinitions', () => {
+  it('finds LHS declarations only — not var() references', () => {
+    const css = `.foo { --surface-primary: #fff; color: var(--text-primary); }`;
+    const defs = extractTokenDefinitions(css);
+    expect(defs.has('--surface-primary')).toBe(true);
+    expect(defs.has('--text-primary')).toBe(false);
+  });
+
+  it('honors prefix filtering', () => {
+    const css = `:root { --surface-primary: #fff; --space-100: 4px; }`;
+    const defs = extractTokenDefinitions(css, ['surface']);
+    expect(defs.has('--surface-primary')).toBe(true);
+    expect(defs.has('--space-100')).toBe(false);
+  });
+});
+
+describe('sourceScan', () => {
+  function withTempDir(fn) {
+    const dir = mkdtempSync(join(tmpdir(), 'canonical-check-'));
+    try {
+      return fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('reports zero violations for a canonical fixture', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'a.css'), '.foo { color: var(--text-primary); }');
+      writeFileSync(join(dir, 'b.tsx'), `const x = 'var(--background-primary)';`);
+      const result = sourceScan({ paths: [dir], allowlist });
+      expect(result.violations).toEqual([]);
+      expect(result.scannedFiles).toBe(2);
+      expect(result.canonicalCount).toBe(allowlist.size);
+    });
+  });
+
+  it('flags non-canonical names with file paths', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'drift.css'), '.foo { color: var(--surface-paper); }');
+      const result = sourceScan({ paths: [dir], allowlist });
+      expect(result.violations.length).toBe(1);
+      expect(result.violations[0].token).toBe('--surface-paper');
+      expect(result.violations[0].files[0]).toContain('drift.css');
+    });
+  });
+
+  it('exempts --border-(radius|width)-* by default', () => {
+    const allowlist = parseAllowlist('--surface-primary: #fff;');
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'a.css'), '.foo { border-radius: var(--border-radius-99); }');
+      const result = sourceScan({ paths: [dir], allowlist });
+      expect(result.violations).toEqual([]);
+    });
+  });
+
+  it('skips test files and __tests__ dirs by default', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    withTempDir((dir) => {
+      mkdirSync(join(dir, '__tests__'));
+      writeFileSync(join(dir, '__tests__', 'fake.test.ts'), `'var(--surface-paper)'`);
+      const result = sourceScan({ paths: [dir], allowlist });
+      expect(result.violations).toEqual([]);
+      expect(result.scannedFiles).toBe(0);
+    });
+  });
+
+  it('honors custom exemptTokens (string match + regex)', () => {
+    const allowlist = parseAllowlist('--surface-primary: #fff;');
+    withTempDir((dir) => {
+      writeFileSync(
+        join(dir, 'a.css'),
+        '.a { color: var(--color-fd-foo); } .b { color: var(--surface-allowed); }',
+      );
+      const result = sourceScan({
+        paths: [dir],
+        allowlist,
+        exemptTokens: [...DEFAULT_EXEMPT_PATTERNS, '--surface-allowed'],
+      });
+      expect(result.violations).toEqual([]);
+    });
+  });
+
+  it('throws on empty allowlist (caller error, not silent pass)', () => {
+    expect(() =>
+      sourceScan({ paths: ['nonexistent'], allowlist: new Set() }),
+    ).toThrowError(/allowlist is empty/);
+  });
+});
+
+describe('runtimeScan', () => {
+  it('flags non-canonical generator output', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    const css = `:root {
+      --text-primary: #111;
+      --text-on-brand: #fff;          /* non-canonical */
+      --surface-paper: #faf7f2;       /* non-canonical */
+      --border-radius-200: 8px;       /* exempt — sizing tier */
+    }`;
+    const result = runtimeScan({ css, allowlist });
+    expect(result.violations).toContain('--text-on-brand');
+    expect(result.violations).toContain('--surface-paper');
+    expect(result.violations).not.toContain('--text-primary');
+    expect(result.violations).not.toContain('--border-radius-200');
+  });
+
+  it('omits --color-* from default prefixes (those are primitives, not semantic)', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    const css = `:root { --color-bespoke: #ff0000; }`;
+    const result = runtimeScan({ css, allowlist });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('counts emitted definitions accurately', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    const css = `:root { --text-primary: #111; --surface-primary: #fff; }`;
+    const result = runtimeScan({ css, allowlist });
+    expect(result.emittedCount).toBe(2);
+  });
+});
+
+describe('assertCanonicalCss', () => {
+  it('returns silently for canonical CSS', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    expect(() =>
+      assertCanonicalCss(`:root { --text-primary: #111; }`, { allowlist }),
+    ).not.toThrow();
+  });
+
+  it('throws with the offending tokens listed in the message', () => {
+    const allowlist = parseAllowlist(TOKENS_CSS_FIXTURE);
+    let captured;
+    try {
+      assertCanonicalCss(
+        `:root { --text-on-brand: #fff; --surface-paper: #faf; }`,
+        { allowlist },
+      );
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured, 'expected assertCanonicalCss to throw').toBeDefined();
+    expect(captured.message).toContain('--text-on-brand');
+    expect(captured.message).toContain('--surface-paper');
+    expect(captured.message).toMatch(/2 non-canonical token name\(s\)/);
+  });
+});
+
+describe('parseAllowlistFromFile', () => {
+  it('throws a descriptive error when the file is missing', () => {
+    expect(() => parseAllowlistFromFile('/no/such/path/tokens.css')).toThrowError(
+      /allowlist source not found/,
+    );
+  });
+
+  it('reads and parses an existing tokens.css', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'canonical-check-'));
+    try {
+      const path = join(dir, 'tokens.css');
+      writeFileSync(path, TOKENS_CSS_FIXTURE);
+      const allowlist = parseAllowlistFromFile(path);
+      expect(allowlist.has('--text-primary')).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/canonical-check.d.ts
+++ b/scripts/canonical-check.d.ts
@@ -1,0 +1,92 @@
+/**
+ * Type definitions for @brikdesigns/bds/canonical-check.
+ *
+ * Source: scripts/canonical-check.mjs (hand-authored ESM with named exports
+ * + CLI entry). These types are hand-written to keep the .mjs file portable
+ * and avoid pulling the canonical-check tooling into the BDS lib build.
+ */
+
+export type ExemptPattern = string | RegExp;
+
+export interface SourceScanOptions {
+  /** Filesystem paths to scan (files or directories). */
+  paths: string[];
+  /** Canonical token allowlist parsed from BDS tokens.css. */
+  allowlist: Set<string>;
+  /** Prefixes to scan. Default: ['text', 'surface', 'background', 'border', 'color']. */
+  prefixes?: string[];
+  /** File extensions to include. Default: ['.css', '.ts', '.tsx', '.astro', '.mjs', '.js']. */
+  extensions?: string[];
+  /** Path patterns to exclude (string or RegExp). Default skips __tests__, *.test.*, node_modules, dist, .git. */
+  excludePathPatterns?: ExemptPattern[];
+  /** Token names or RegExps to skip. Default exempts --border-(radius|width)-* and --color-fd-*. */
+  exemptTokens?: ExemptPattern[];
+}
+
+export interface SourceScanViolation {
+  /** Non-canonical token name (e.g. `--surface-paper`). */
+  token: string;
+  /** Files where the token was referenced. */
+  files: string[];
+}
+
+export interface SourceScanResult {
+  violations: SourceScanViolation[];
+  scannedFiles: number;
+  canonicalCount: number;
+}
+
+export interface RuntimeScanOptions {
+  /** CSS string to inspect (typically generator output). */
+  css: string;
+  /** Canonical token allowlist parsed from BDS tokens.css. */
+  allowlist: Set<string>;
+  /** Prefixes to validate. Default: ['text', 'surface', 'background', 'border'] (omits --color-* — primitives). */
+  prefixes?: string[];
+  /** Token names or RegExps to skip. */
+  exemptTokens?: ExemptPattern[];
+}
+
+export interface RuntimeScanResult {
+  violations: string[];
+  emittedCount: number;
+}
+
+export interface AssertCanonicalCssOptions extends Omit<RuntimeScanOptions, 'css' | 'allowlist'> {
+  /** Pre-parsed allowlist. If omitted, the allowlist is read from `allowlistPath`. */
+  allowlist?: Set<string>;
+  /** Path to a tokens.css file. Defaults to node_modules/@brikdesigns/bds/dist/tokens.css. */
+  allowlistPath?: string;
+}
+
+export const DEFAULT_PREFIXES: readonly string[];
+export const DEFAULT_EXEMPT_PATTERNS: readonly RegExp[];
+export const DEFAULT_SCAN_EXTENSIONS: readonly string[];
+export const DEFAULT_EXCLUDE_PATH_PATTERNS: readonly RegExp[];
+
+/** Parse a tokens.css string into a Set of canonical `--token-name`s. */
+export function parseAllowlist(cssText: string): Set<string>;
+
+/** Read a tokens.css file from disk and parse it. Throws on missing file. */
+export function parseAllowlistFromFile(path: string): Set<string>;
+
+/** Resolve the default tokens.css path (consumer node_modules first, then BDS-self). */
+export function resolveDefaultAllowlistPath(cwd?: string): string;
+
+/** Strip CSS / JS block comments and leading-line `//` comments from text. */
+export function stripCssComments(input: string): string;
+
+/** Extract every token reference (matching prefixes) from text — names only. */
+export function extractTokenReferences(text: string, prefixes?: string[]): Set<string>;
+
+/** Extract every CSS custom-property *declaration* (LHS) from a CSS string. */
+export function extractTokenDefinitions(css: string, prefixes?: string[]): Set<string>;
+
+/** Scan filesystem paths for non-canonical token references. Does not throw. */
+export function sourceScan(opts: SourceScanOptions): SourceScanResult;
+
+/** Scan a CSS string for non-canonical token *definitions*. Does not throw. */
+export function runtimeScan(opts: RuntimeScanOptions): RuntimeScanResult;
+
+/** Vitest-friendly: throw on the first non-canonical definition in `css`. */
+export function assertCanonicalCss(css: string, opts?: AssertCanonicalCssOptions): void;

--- a/scripts/canonical-check.mjs
+++ b/scripts/canonical-check.mjs
@@ -1,0 +1,505 @@
+#!/usr/bin/env node
+/**
+ * canonical-check — Canonical token-name enforcement for the Brik Design System.
+ *
+ * Validates that `--text-*`, `--surface-*`, `--background-*`, semantic
+ * `--border-*`, and `--color-*` token names referenced in source code (or
+ * emitted at runtime by a generator) exist in the canonical BDS allowlist
+ * parsed from `dist/tokens.css`.
+ *
+ * Source of truth: https://design.brikdesigns.com/docs/primitives/color
+ *
+ * Why this lives in @brikdesigns/bds (not a separate package): the validator's
+ * sole job is reading BDS's own `dist/tokens.css`. Coupling at the package
+ * level means version skew is impossible — `bds@x.y` ships with the
+ * canonical-check that matches `bds@x.y`'s registry.
+ *
+ * ── CLI ────────────────────────────────────────────────────────────────────
+ *   canonical-check <path...>           Scan paths for non-canonical names
+ *   canonical-check --css <file>        Scan a CSS file for non-canonical
+ *                                       definitions (runtime mode — strict)
+ *   canonical-check --allowlist <file>  Override allowlist source
+ *                                       (default: dist/tokens.css)
+ *   canonical-check --prefixes <list>   Comma-separated prefixes to scan
+ *                                       (default: text,surface,background,border,color)
+ *   canonical-check --exempt <patterns> Comma-separated regex of tokens to
+ *                                       skip (e.g. '^--border-(radius|width)')
+ *   canonical-check --format md|json    Output format (default: md for TTY,
+ *                                       json otherwise)
+ *   canonical-check --help              Show this message
+ *
+ * ── Library ────────────────────────────────────────────────────────────────
+ *   import {
+ *     parseAllowlist,
+ *     parseAllowlistFromFile,
+ *     sourceScan,
+ *     runtimeScan,
+ *     assertCanonicalCss,
+ *   } from '@brikdesigns/bds/canonical-check';
+ *
+ * ── Exit codes ─────────────────────────────────────────────────────────────
+ *   0  Clean — no non-canonical names detected
+ *   1  Violations found
+ *   2  Bad invocation (missing args, unreadable allowlist, etc.)
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, dirname, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ── Defaults ─────────────────────────────────────────────────────────────
+
+export const DEFAULT_PREFIXES = ['text', 'surface', 'background', 'border', 'color'];
+
+export const DEFAULT_EXEMPT_PATTERNS = [
+  // Sizing-tier border tokens — spacing primitives, not surface borders.
+  // Defined under their own canonical entries (--border-radius-*, --border-width-*).
+  /^--border-(radius|width)(-|$)/,
+  // fumadocs vendor prefix — design-token namespace consumed by docs sites
+  // that override fumadocs internals. Not BDS-canonical by design.
+  /^--color-fd-/,
+];
+
+export const DEFAULT_SCAN_EXTENSIONS = ['.css', '.ts', '.tsx', '.astro', '.mjs', '.js'];
+
+export const DEFAULT_EXCLUDE_PATH_PATTERNS = [
+  /(^|\/)__tests__(\/|$)/,
+  /\.test\.(ts|tsx|mjs|js)$/,
+  /(^|\/)node_modules(\/|$)/,
+  /(^|\/)dist(\/|$)/,
+  /(^|\/)\.git(\/|$)/,
+];
+
+// ── Allowlist ────────────────────────────────────────────────────────────
+
+/**
+ * Parse a tokens.css string into the canonical Set of `--token-name`s.
+ * Captures every CSS custom property *declaration* — handles both expanded
+ * (one decl per line) and compact (`.foo { --x: y; --z: w }`) forms by
+ * anchoring on line-start, `{`, or `;` boundaries. Skips declarations that
+ * are merely `var(--name)` references — `(` is not a declaration boundary.
+ */
+export function parseAllowlist(cssText) {
+  const allowlist = new Set();
+  const re = /(?:^|[{;])\s*(--[a-z][a-z0-9-]*)\s*:/gm;
+  let match;
+  while ((match = re.exec(cssText)) !== null) {
+    allowlist.add(match[1]);
+  }
+  return allowlist;
+}
+
+/** Read a file and parse its allowlist. Throws with a useful message if missing. */
+export function parseAllowlistFromFile(path) {
+  if (!existsSync(path)) {
+    throw new Error(
+      `canonical-check: allowlist source not found at ${path}\n` +
+      `  Expected BDS tokens.css. Run \`npm install\` (consumers) or ` +
+      `\`npm run build:lib\` (BDS itself) to populate.`,
+    );
+  }
+  return parseAllowlist(readFileSync(path, 'utf8'));
+}
+
+/**
+ * Locate the canonical tokens.css. Resolution order:
+ *   1. Explicit CLI / opts argument
+ *   2. node_modules/@brikdesigns/bds/dist/tokens.css (consumers)
+ *   3. dist/tokens.css next to this script (BDS itself)
+ */
+export function resolveDefaultAllowlistPath(cwd = process.cwd()) {
+  const consumerPath = resolve(cwd, 'node_modules/@brikdesigns/bds/dist/tokens.css');
+  if (existsSync(consumerPath)) return consumerPath;
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const selfPath = resolve(__dirname, '..', 'dist', 'tokens.css');
+  if (existsSync(selfPath)) return selfPath;
+  return consumerPath; // return canonical-shaped path even if missing — error message is clearer
+}
+
+// ── CSS comment stripping ────────────────────────────────────────────────
+
+/**
+ * Strip `/* … *​/` block comments and `// …` line comments from CSS / JS / TS
+ * content. Block-comment support handles continuation lines that don't start
+ * with `*` (e.g. an inline reference to `--color-grayscale-*` inside a
+ * /​*  *​/ block was producing a false positive `--color-grayscale` because
+ * the regex grabbed the prefix up to the last alphanumeric).
+ *
+ * Line-comment stripping is content-aware: the `//` must not be preceded by
+ * `:` (URL prefix) or be inside a string. We approximate by only stripping
+ * `//` when it appears at the start of a trimmed line — which is the common
+ * "//-prefixed annotation" case that motivated the original token-audit
+ * exemption.
+ */
+export function stripCssComments(input) {
+  const lines = input.split(/\r?\n/);
+  const out = [];
+  let inBlock = false;
+
+  for (let raw of lines) {
+    let line = raw;
+    while (line.length > 0) {
+      if (inBlock) {
+        const e = line.indexOf('*/');
+        if (e === -1) { line = ''; break; }
+        line = line.slice(e + 2);
+        inBlock = false;
+      }
+      const s = line.indexOf('/*');
+      if (s === -1) break;
+      const rest = line.slice(s + 2);
+      const e = rest.indexOf('*/');
+      if (e === -1) {
+        line = line.slice(0, s);
+        inBlock = true;
+        break;
+      }
+      line = line.slice(0, s) + ' ' + rest.slice(e + 2);
+    }
+    if (/^[ \t]*\/\//.test(line)) continue;
+    if (line !== '') out.push(line);
+  }
+  return out.join('\n');
+}
+
+// ── Token extraction ─────────────────────────────────────────────────────
+
+/**
+ * Extract every token name in the allowed prefixes from a body of text.
+ * Returns a Set for stable diff semantics.
+ *
+ * Honors the `bds-lint-ignore` comment directive used elsewhere in BDS
+ * (see scripts/lint-tokens.js, scripts/token-coverage.js): any line
+ * containing the literal `bds-lint-ignore` is skipped before extraction,
+ * matching the rest of the BDS lint toolchain. The TextInput component-
+ * scoped `--text-input-focus-ring-width` CSS variable is the canonical
+ * example of an intentionally non-canonical name annotated this way.
+ */
+export function extractTokenReferences(text, prefixes = DEFAULT_PREFIXES) {
+  const filtered = text
+    .split(/\r?\n/)
+    .filter((line) => !line.includes('bds-lint-ignore'))
+    .join('\n');
+  const stripped = stripCssComments(filtered);
+  const prefixGroup = prefixes.join('|');
+  const re = new RegExp(`--(?:${prefixGroup})-[a-z0-9-]*[a-z0-9]`, 'g');
+  const found = new Set();
+  let match;
+  while ((match = re.exec(stripped)) !== null) {
+    found.add(match[0]);
+  }
+  return found;
+}
+
+/**
+ * Extract every CSS custom property *declaration* (LHS of `--name:`) from a
+ * CSS string, restricted to the configured prefixes. Used by `runtimeScan`
+ * to validate generator output where every emitted definition must be
+ * canonical.
+ */
+export function extractTokenDefinitions(css, prefixes = DEFAULT_PREFIXES) {
+  const stripped = stripCssComments(css);
+  const prefixGroup = prefixes.join('|');
+  // Match on line-start, `{`, or `;` boundaries — handles both expanded
+  // (one decl per line) and compact (`.foo { --x: y; }`) forms. Skips
+  // `var(--x)` uses since `(` is not a declaration boundary.
+  const re = new RegExp(`(?:^|[{;])\\s*(--(?:${prefixGroup})-[a-z0-9-]*[a-z0-9])\\s*:`, 'gm');
+  const found = new Set();
+  let match;
+  while ((match = re.exec(stripped)) !== null) {
+    found.add(match[1]);
+  }
+  return found;
+}
+
+// ── Path walking ─────────────────────────────────────────────────────────
+
+function isExempted(path, excludePathPatterns) {
+  for (const pat of excludePathPatterns) {
+    if (typeof pat === 'string' && path.includes(pat)) return true;
+    if (pat instanceof RegExp && pat.test(path)) return true;
+  }
+  return false;
+}
+
+function walkPath(root, opts, acc = []) {
+  const {
+    extensions = DEFAULT_SCAN_EXTENSIONS,
+    excludePathPatterns = DEFAULT_EXCLUDE_PATH_PATTERNS,
+  } = opts;
+
+  let stat;
+  try {
+    stat = statSync(root);
+  } catch {
+    return acc; // path doesn't exist — caller is responsible for surfacing
+  }
+
+  if (stat.isFile()) {
+    if (isExempted(root, excludePathPatterns)) return acc;
+    if (extensions.some((e) => root.endsWith(e))) acc.push(root);
+    return acc;
+  }
+  if (!stat.isDirectory()) return acc;
+
+  for (const entry of readdirSync(root)) {
+    const child = join(root, entry);
+    if (isExempted(child, excludePathPatterns)) continue;
+    walkPath(child, opts, acc);
+  }
+  return acc;
+}
+
+function isTokenExempt(token, exemptPatterns) {
+  for (const pat of exemptPatterns) {
+    if (typeof pat === 'string' && token === pat) return true;
+    if (pat instanceof RegExp && pat.test(token)) return true;
+  }
+  return false;
+}
+
+// ── Public scan APIs ─────────────────────────────────────────────────────
+
+/**
+ * Scan filesystem paths for non-canonical token references.
+ *
+ * Returns a result object with the violation list, the source files each
+ * violation appeared in, and counts. Does NOT throw — call sites decide how
+ * to surface (CLI exits non-zero, vitest can use `assertCanonicalCss`).
+ */
+export function sourceScan(opts) {
+  const {
+    paths,
+    allowlist,
+    prefixes = DEFAULT_PREFIXES,
+    extensions = DEFAULT_SCAN_EXTENSIONS,
+    excludePathPatterns = DEFAULT_EXCLUDE_PATH_PATTERNS,
+    exemptTokens = DEFAULT_EXEMPT_PATTERNS,
+  } = opts;
+
+  if (!allowlist || allowlist.size === 0) {
+    throw new Error('canonical-check.sourceScan: allowlist is empty');
+  }
+
+  const files = [];
+  for (const p of paths) {
+    walkPath(p, { extensions, excludePathPatterns }, files);
+  }
+
+  const tokenToFiles = new Map();
+  for (const file of files) {
+    const text = readFileSync(file, 'utf8');
+    const refs = extractTokenReferences(text, prefixes);
+    for (const token of refs) {
+      if (isTokenExempt(token, exemptTokens)) continue;
+      if (allowlist.has(token)) continue;
+      if (!tokenToFiles.has(token)) tokenToFiles.set(token, []);
+      tokenToFiles.get(token).push(file);
+    }
+  }
+
+  const violations = [...tokenToFiles.entries()]
+    .map(([token, files]) => ({ token, files: [...new Set(files)].sort() }))
+    .sort((a, b) => a.token.localeCompare(b.token));
+
+  return {
+    violations,
+    scannedFiles: files.length,
+    canonicalCount: allowlist.size,
+  };
+}
+
+/**
+ * Scan a CSS string (typically generator output) for non-canonical token
+ * *definitions*. Stricter than `sourceScan` — every emitted `--name:` must
+ * be in the allowlist (or exempt), regardless of whether the same name is
+ * also defined in the allowlist source. This is the runtime gate for
+ * theme-CSS generators.
+ */
+export function runtimeScan(opts) {
+  const {
+    css,
+    allowlist,
+    prefixes = ['text', 'surface', 'background', 'border'],
+    exemptTokens = DEFAULT_EXEMPT_PATTERNS,
+  } = opts;
+
+  if (!allowlist || allowlist.size === 0) {
+    throw new Error('canonical-check.runtimeScan: allowlist is empty');
+  }
+
+  const defs = extractTokenDefinitions(css, prefixes);
+  const violations = [];
+  for (const token of defs) {
+    if (isTokenExempt(token, exemptTokens)) continue;
+    if (!allowlist.has(token)) violations.push(token);
+  }
+  violations.sort();
+
+  return { violations, emittedCount: defs.size };
+}
+
+/**
+ * Vitest-friendly assertion. Throws on the first violation with a message
+ * naming the offending tokens. Convenience wrapper around `runtimeScan` for
+ * generator-output tests.
+ */
+export function assertCanonicalCss(css, opts = {}) {
+  const allowlist = opts.allowlist
+    ?? parseAllowlistFromFile(opts.allowlistPath ?? resolveDefaultAllowlistPath());
+  const result = runtimeScan({ ...opts, css, allowlist });
+  if (result.violations.length > 0) {
+    throw new Error(
+      `canonical-check: emitted CSS contains ${result.violations.length} non-canonical token name(s):\n  ` +
+      result.violations.join('\n  ') +
+      `\n\nSource of truth: https://design.brikdesigns.com/docs/primitives/color`,
+    );
+  }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────
+
+const USAGE = `canonical-check — Canonical token-name enforcement for @brikdesigns/bds
+
+Usage:
+  canonical-check <path...>           Scan paths for non-canonical names
+  canonical-check --css <file>        Scan a CSS file for non-canonical
+                                      definitions (runtime mode — strict)
+  canonical-check --allowlist <file>  Override allowlist source
+                                      (default: node_modules/@brikdesigns/bds/dist/tokens.css)
+  canonical-check --prefixes <list>   Comma-separated prefixes to scan
+                                      (default: text,surface,background,border,color)
+  canonical-check --exempt <patterns> Comma-separated regex of tokens to skip
+  canonical-check --format md|json    Output format (default: md for TTY, json otherwise)
+  canonical-check --help              Show this message
+
+Exit codes:
+  0  Clean — no non-canonical names detected
+  1  Violations found
+  2  Bad invocation (missing args, unreadable allowlist)
+
+Source of truth: https://design.brikdesigns.com/docs/primitives/color
+`;
+
+function parseCliArgs(argv) {
+  const opts = {
+    paths: [],
+    cssFile: null,
+    allowlistPath: null,
+    prefixes: null,
+    exemptPatterns: null,
+    format: null,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') opts.help = true;
+    else if (a === '--css') opts.cssFile = argv[++i];
+    else if (a === '--allowlist') opts.allowlistPath = argv[++i];
+    else if (a === '--prefixes') opts.prefixes = argv[++i].split(',').map((s) => s.trim()).filter(Boolean);
+    else if (a === '--exempt') opts.exemptPatterns = argv[++i].split(',').map((s) => new RegExp(s));
+    else if (a.startsWith('--format=')) opts.format = a.slice('--format='.length);
+    else if (a === '--format') opts.format = argv[++i];
+    else if (a.startsWith('-')) {
+      process.stderr.write(`canonical-check: unknown flag ${a}\n`);
+      process.exit(2);
+    }
+    else opts.paths.push(a);
+  }
+  if (!opts.format) opts.format = process.stdout.isTTY ? 'md' : 'json';
+  return opts;
+}
+
+function renderMarkdown(result, mode) {
+  if (result.violations.length === 0) {
+    return `canonical-check: clean — ${mode === 'runtime' ? result.emittedCount + ' definitions' : result.scannedFiles + ' files'} scanned, 0 non-canonical names\n`;
+  }
+  const lines = [];
+  lines.push(`canonical-check: ${result.violations.length} non-canonical token name(s) — parallel taxonomy drift`);
+  lines.push(`  Source of truth: https://design.brikdesigns.com/docs/primitives/color`);
+  if (mode === 'source') {
+    lines.push(`  Scanned ${result.scannedFiles} files against ${result.canonicalCount} canonical tokens`);
+    lines.push('');
+    for (const { token, files } of result.violations) {
+      const where = files.slice(0, 3).map((f) => f.split(sep).slice(-3).join('/')).join(', ');
+      lines.push(`  ${token}   (${where}${files.length > 3 ? `, +${files.length - 3} more` : ''})`);
+    }
+  } else {
+    lines.push(`  Inspected ${result.emittedCount} emitted definitions`);
+    lines.push('');
+    for (const token of result.violations) lines.push(`  ${token}`);
+  }
+  lines.push('');
+  lines.push('  If a name is canonical, add it to BDS dist/tokens.css first.');
+  lines.push('  Inline aliases for non-canonical names are not accepted.');
+  return lines.join('\n') + '\n';
+}
+
+function renderJson(result, mode) {
+  return JSON.stringify({ mode, ...result }, null, 2) + '\n';
+}
+
+function main() {
+  const opts = parseCliArgs(process.argv.slice(2));
+
+  if (opts.help) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+
+  const allowlistPath = opts.allowlistPath ?? resolveDefaultAllowlistPath();
+  let allowlist;
+  try {
+    allowlist = parseAllowlistFromFile(allowlistPath);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(2);
+  }
+
+  if (allowlist.size < 20) {
+    process.stderr.write(
+      `canonical-check: allowlist parse returned only ${allowlist.size} names from ${allowlistPath}\n` +
+      `  Expected 50+ canonical entries. Verify the file format.\n`,
+    );
+    process.exit(2);
+  }
+
+  const exemptTokens = opts.exemptPatterns ?? DEFAULT_EXEMPT_PATTERNS;
+  const prefixes = opts.prefixes ?? DEFAULT_PREFIXES;
+
+  if (opts.cssFile) {
+    if (!existsSync(opts.cssFile)) {
+      process.stderr.write(`canonical-check: --css file not found: ${opts.cssFile}\n`);
+      process.exit(2);
+    }
+    const css = readFileSync(opts.cssFile, 'utf8');
+    const result = runtimeScan({ css, allowlist, prefixes, exemptTokens });
+    process.stdout.write(opts.format === 'json' ? renderJson(result, 'runtime') : renderMarkdown(result, 'runtime'));
+    process.exit(result.violations.length > 0 ? 1 : 0);
+  }
+
+  if (opts.paths.length === 0) {
+    process.stderr.write(USAGE);
+    process.exit(2);
+  }
+
+  const result = sourceScan({ paths: opts.paths, allowlist, prefixes, exemptTokens });
+  process.stdout.write(opts.format === 'json' ? renderJson(result, 'source') : renderMarkdown(result, 'source'));
+  process.exit(result.violations.length > 0 ? 1 : 0);
+}
+
+// Entry-point detection — ESM doesn't have `require.main === module`. Compare
+// the resolved file path of this module against argv[1]. Wrapped because exotic
+// loaders (http imports, REPL) can make `fileURLToPath` throw on a non-file
+// URL; if that happens, surface it on stderr rather than swallowing — silent
+// "failed to detect entry" would mean main() never runs and the CLI looks dead.
+const isCliEntry = (() => {
+  try {
+    return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] ?? '');
+  } catch (err) {
+    process.stderr.write(`canonical-check: could not determine CLI entry — ${err.message}\n`);
+    return false;
+  }
+})();
+
+if (isCliEntry) main();

--- a/scripts/validate-all.js
+++ b/scripts/validate-all.js
@@ -25,6 +25,9 @@ const steps = [
   { name: 'Grid Audit', cmd: 'node scripts/audit-grid.js --summary' },
   { name: 'Theme Compliance', cmd: 'node scripts/validate-themes.js' },
   { name: 'Blueprint Library', cmd: 'node scripts/validate-blueprints.mjs' },
+  // Canonical-check requires dist/tokens.css. Ensure it's built before scanning.
+  // The build is fast (~1s) and idempotent, so re-running has near-zero cost.
+  { name: 'Canonical Tokens', cmd: 'npm run build:dist-tokens >/dev/null && npm run canonical-check' },
   { name: 'TypeScript', cmd: 'npm run typecheck' },
   { name: 'Storybook Build', cmd: 'npm run build-storybook' },
 ];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,14 @@ export default defineConfig({
           },
         },
       },
+      {
+        extends: true,
+        test: {
+          name: 'scripts',
+          environment: 'node',
+          include: ['scripts/**/*.test.{ts,mjs,js}'],
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
## Summary
- feat(canonical-check): bds-canonical-check tooling on @brikdesigns/bds

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)