### PR TITLE
fix(AddableEntryList): drop rAF wrapper around secondary focus shift (#346)

### DIFF
--- a/components/ui/AddableEntryList/AddableEntryList.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.tsx
@@ -444,7 +444,10 @@ function SuggestionModeEdit({
     strict: primaryStrict,
     onCommit: (value) => {
       setPrimaryDraft(value);
-      requestAnimationFrame(() => focusSecondary());
+      // Sync focus is safe here: the secondary textarea is unconditionally
+      // mounted while isEditing is true, so the ref is already populated.
+      // Deferring via rAF makes interaction-test focus assertions racy.
+      focusSecondary();
     },
     onCancel: cancel,
   });


### PR DESCRIPTION
## Summary
- docs(motion): sync image-mood vocabulary to canonical code (#350) (#351)
- fix(AddableEntryList): drop rAF wrapper around secondary focus shift (#346)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)