### PR TITLE
fix(canonical-check): migrate astro blueprints to canonical tokens + widen gate

### DIFF
--- a/content-system/blueprints/astro/CtaDarkCentered.astro
+++ b/content-system/blueprints/astro/CtaDarkCentered.astro
@@ -15,10 +15,10 @@
  * CSS custom properties:
  *   --bp-cta-dark-centered-padding-y
  *   --bp-cta-dark-centered-bg              (default: var(--surface-inverse))
- *   --bp-cta-dark-centered-heading-color   (default: var(--text-on-inverse))
- *   --bp-cta-dark-centered-body-color      (default: var(--text-muted-on-inverse))
+ *   --bp-cta-dark-centered-heading-color   (default: var(--text-inverse))
+ *   --bp-cta-dark-centered-body-color      (default: var(--text-inverse))
  *   --bp-cta-dark-centered-cta-bg          (default: var(--background-brand-primary))
- *   --bp-cta-dark-centered-cta-color       (default: var(--text-on-brand-primary))
+ *   --bp-cta-dark-centered-cta-color       (default: var(--text-on-color-dark))
  *
  * a11y: h2 + aria-labelledby. Center-aligned but reading order is
  * natural (heading → body → CTA). CTA uses :focus-visible ring with
@@ -50,7 +50,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
 
 <style>
   .bp-cta-dark-centered {
-    background: var(--bp-cta-dark-centered-bg, var(--surface-inverse, var(--color-black)));
+    background: var(--bp-cta-dark-centered-bg, var(--surface-inverse, var(--color-grayscale-black)));
     padding-block: var(
       --bp-cta-dark-centered-padding-y,
       clamp(var(--space-3xl), 8vw, var(--space-5xl))
@@ -74,7 +74,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
     font-size: clamp(var(--font-size-700), 4vw, var(--font-size-1000));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
-    color: var(--bp-cta-dark-centered-heading-color, var(--text-on-inverse, var(--color-white)));
+    color: var(--bp-cta-dark-centered-heading-color, var(--text-inverse, var(--color-grayscale-white)));
   }
 
   .bp-cta-dark-centered__body {
@@ -82,7 +82,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
     font-family: var(--font-family-body);
     font-size: var(--font-size-400);
     line-height: var(--line-height-relaxed);
-    color: var(--bp-cta-dark-centered-body-color, var(--text-muted-on-inverse, var(--color-gray-light)));
+    color: var(--bp-cta-dark-centered-body-color, var(--text-inverse, var(--color-grayscale-lightest)));
     max-width: 55ch;
   }
 
@@ -92,7 +92,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
     margin-top: var(--space-md);
     padding: var(--space-sm) var(--space-xl);
     background: var(--bp-cta-dark-centered-cta-bg, var(--background-brand-primary));
-    color: var(--bp-cta-dark-centered-cta-color, var(--text-on-brand-primary, var(--text-inverse)));
+    color: var(--bp-cta-dark-centered-cta-color, var(--text-on-color-dark, var(--text-inverse)));
     font-family: var(--font-family-label);
     font-size: var(--font-size-300);
     font-weight: var(--font-weight-semibold);
@@ -106,7 +106,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
   }
 
   .bp-cta-dark-centered__cta:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 2px;
   }
 </style>

--- a/content-system/blueprints/astro/CtaSplitContact.astro
+++ b/content-system/blueprints/astro/CtaSplitContact.astro
@@ -139,7 +139,7 @@ const email = clientFacts.email;
     margin-top: var(--space-md);
     padding: var(--space-sm) var(--space-lg);
     background: var(--background-brand-primary);
-    color: var(--text-on-brand-primary, var(--text-inverse));
+    color: var(--text-on-color-dark, var(--text-inverse));
     font-family: var(--font-family-label);
     font-size: var(--font-size-300);
     font-weight: var(--font-weight-semibold);
@@ -154,7 +154,7 @@ const email = clientFacts.email;
   }
 
   .bp-cta-split-contact__cta:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 2px;
   }
 
@@ -190,7 +190,7 @@ const email = clientFacts.email;
   }
 
   a.bp-cta-split-contact__method:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 2px;
   }
 

--- a/content-system/blueprints/astro/HeroInteriorMinimal.astro
+++ b/content-system/blueprints/astro/HeroInteriorMinimal.astro
@@ -103,7 +103,7 @@ const cta = section.cta;
     margin-top: var(--space-md);
     padding: var(--space-sm) var(--space-lg);
     background: var(--background-brand-primary);
-    color: var(--text-on-brand-primary, var(--text-inverse));
+    color: var(--text-on-color-dark, var(--text-inverse));
     font-family: var(--font-family-label);
     font-size: var(--font-size-300);
     font-weight: var(--font-weight-semibold);
@@ -118,7 +118,7 @@ const cta = section.cta;
   }
 
   .bp-hero-interior-minimal__cta:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 2px;
   }
 </style>

--- a/content-system/blueprints/astro/HeroSplit6040.astro
+++ b/content-system/blueprints/astro/HeroSplit6040.astro
@@ -42,7 +42,7 @@
  * - Eyebrow is prose, not a heading — avoids double-h2 shadowing.
  * - Image alt: empty-string decorative default per Birdwell intel #40.
  * - Keyboard: CTA is an anchor with :focus-visible ring via
- *   --color-focus-ring gap-fill token.
+ *   the canonical --border-focus token.
  * - Reduced motion: no animations declared — this blueprint is static.
  */
 import type { BlueprintProps } from './types';
@@ -205,7 +205,7 @@ const imageAlt = '';
     margin-top: var(--space-lg);
     padding: var(--space-sm) var(--space-lg);
     background: var(--background-brand-primary);
-    color: var(--text-on-brand-primary, var(--text-inverse));
+    color: var(--text-on-color-dark, var(--text-inverse));
     font-family: var(--font-family-label);
     font-size: var(--font-size-300);
     font-weight: var(--font-weight-semibold);
@@ -223,7 +223,7 @@ const imageAlt = '';
   }
 
   .bp-hero-split-60-40__cta:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 2px;
   }
 
@@ -250,8 +250,8 @@ const imageAlt = '';
     align-items: center;
     justify-content: center;
     padding: var(--space-xl);
-    background: var(--surface-secondary, var(--color-gray-light));
-    border: 2px dashed var(--border-secondary, var(--color-gray-medium));
+    background: var(--surface-secondary, var(--color-grayscale-lightest));
+    border: 2px dashed var(--border-secondary, var(--color-grayscale-lighter));
     border-radius: var(--bp-hero-split-image-radius, var(--border-radius-lg));
   }
 
@@ -259,7 +259,7 @@ const imageAlt = '';
     margin: 0;
     font-family: var(--font-family-body);
     font-size: var(--font-size-300);
-    color: var(--text-muted, var(--color-gray-dark));
+    color: var(--text-muted, var(--color-grayscale-dark));
     text-align: center;
   }
 </style>

--- a/content-system/blueprints/astro/SiteHeader.astro
+++ b/content-system/blueprints/astro/SiteHeader.astro
@@ -198,7 +198,7 @@ function isCurrent(href: string): boolean {
     --bp-site-header-bg: var(--surface-navigation, transparent);
     --bp-site-header-text-color: var(--text-primary);
     --bp-site-header-cta-bg: var(--background-brand-primary);
-    --bp-site-header-cta-color: var(--text-on-brand-primary, var(--text-inverse));
+    --bp-site-header-cta-color: var(--text-on-color-dark, var(--text-inverse));
 
     position: sticky;
     top: 0;
@@ -227,7 +227,7 @@ function isCurrent(href: string): boolean {
   }
 
   .bp-site-header__brand:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 4px;
   }
 
@@ -273,7 +273,7 @@ function isCurrent(href: string): boolean {
   }
 
   .bp-site-header__nav-link:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 4px;
   }
 
@@ -302,7 +302,7 @@ function isCurrent(href: string): boolean {
   }
 
   .bp-site-header__phone:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 2px;
   }
 
@@ -323,7 +323,7 @@ function isCurrent(href: string): boolean {
   }
 
   .bp-site-header__cta:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 2px;
   }
 
@@ -348,7 +348,7 @@ function isCurrent(href: string): boolean {
   }
 
   .bp-site-header__hamburger:focus-visible {
-    outline: 2px solid var(--color-focus-ring, var(--background-brand-primary));
+    outline: 2px solid var(--border-focus, var(--background-brand-primary));
     outline-offset: 2px;
   }
 

--- a/content-system/blueprints/astro/StatsDarkBar.astro
+++ b/content-system/blueprints/astro/StatsDarkBar.astro
@@ -19,8 +19,8 @@
  * CSS custom properties:
  *   --bp-stats-dark-bar-padding-y
  *   --bp-stats-dark-bar-bg        (default: var(--surface-inverse))
- *   --bp-stats-dark-bar-value-color   (default: var(--text-on-inverse))
- *   --bp-stats-dark-bar-label-color   (default: var(--text-muted-on-inverse))
+ *   --bp-stats-dark-bar-value-color   (default: var(--text-inverse))
+ *   --bp-stats-dark-bar-label-color   (default: var(--text-inverse))
  *   --bp-stats-dark-bar-divider       (default: var(--border-secondary))
  *
  * a11y: semantic list (ul/li). If section.heading present, wired via
@@ -61,7 +61,7 @@ const items = section.items;
 
 <style>
   .bp-stats-dark-bar {
-    background: var(--bp-stats-dark-bar-bg, var(--surface-inverse, var(--color-black)));
+    background: var(--bp-stats-dark-bar-bg, var(--surface-inverse, var(--color-grayscale-black)));
     padding-block: var(
       --bp-stats-dark-bar-padding-y,
       clamp(var(--space-xl), 5vw, var(--space-3xl))
@@ -128,7 +128,7 @@ const items = section.items;
     font-size: clamp(var(--font-size-700), 4vw, var(--font-size-900));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
-    color: var(--bp-stats-dark-bar-value-color, var(--text-on-inverse, var(--color-white)));
+    color: var(--bp-stats-dark-bar-value-color, var(--text-inverse, var(--color-grayscale-white)));
   }
 
   .bp-stats-dark-bar__label {
@@ -136,6 +136,6 @@ const items = section.items;
     font-size: var(--font-size-200);
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: var(--bp-stats-dark-bar-label-color, var(--text-muted-on-inverse, var(--color-gray-light)));
+    color: var(--bp-stats-dark-bar-label-color, var(--text-inverse, var(--color-grayscale-lightest)));
   }
 </style>

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "build:content-system": "tsc --project tsconfig.content-system.json",
     "build:inspector-manifest": "node scripts/build-inspector-manifest.mjs",
     "bds:find": "node scripts/bds-find.mjs",
-    "canonical-check": "node scripts/canonical-check.mjs --allowlist dist/tokens.css components",
+    "canonical-check": "node scripts/canonical-check.mjs --allowlist dist/tokens.css components content-system/blueprints",
     "canonical-check:report": "node scripts/canonical-check.mjs --allowlist dist/tokens.css --format md components content-system stories || true",
     "build:types": "tsc --project tsconfig.build.json",
     "build:dist-tokens": "node scripts/build-dist-tokens.js",


### PR DESCRIPTION
## Summary

Migrates **9 non-canonical token references** across all 5 Astro blueprints in `content-system/blueprints/astro/` (the surface that ships verbatim to client sites via the npm package's `files` array, per #349), then **widens the `canonical-check` package script** to scan `content-system/blueprints` alongside `components` — locking the surface so no new non-canonical names can drift in.

Closes #349.

## Migration map

| Non-canonical | → Canonical | Files |
|---|---|---|
| `--text-on-brand-primary` | `--text-on-color-dark` | 5 |
| `--text-on-inverse` | `--text-inverse` | 2 |
| `--text-muted-on-inverse` | `--text-inverse` | 2 (loses muted distinction — see #353) |
| `--color-focus-ring` | `--border-focus` | 5 |
| `--color-black` | `--color-grayscale-black` | 2 |
| `--color-white` | `--color-grayscale-white` | 2 |
| `--color-gray-light` | `--color-grayscale-lightest` | 3 |
| `--color-gray-medium` | `--color-grayscale-lighter` | 1 |
| `--color-gray-dark` | `--color-grayscale-dark` | 1 |

## Side effects

- **Latent bug fix on the brand-primary CTA.** The prior fallback chain `var(--text-on-brand-primary, var(--text-inverse))` resolved to *black* text on the always-orange `--background-brand-primary` surface in dark mode, because `--text-inverse` flips with theme while the brand-primary surface does not. The new `--text-on-color-dark` is white in both modes — correct.
- **Heading and body share a color on dark CTA sections.** `CtaDarkCentered` and `StatsDarkBar` no longer differentiate body copy from headings on `--surface-inverse`. The pre-migration `--text-muted-on-inverse` was non-canonical; restoring the muted tier requires a new canonical token (tracked in #353).

## Why this is bigger than the original issue text

The widened scan surfaced 9 violations across 5 blueprint files, not the 2 names #349 originally listed. Rather than fix only what was named and leave latent debt the gate would still flag, this PR cleans the entire blueprint surface so the widening gate is meaningful.

## Out of scope (separate issues filed)

- **#353** — Token gap: muted text on `--surface-inverse`. Adds canonical replacement for `--text-muted-on-inverse`, restores hierarchy on dark CTAs.
- **#354** — Atmosphere CSS files (`content-system/atmospheres/*.css`) re-define banned canonical-prefix names (parallel taxonomy — same failure mode as portal #512/#553). 6 files. Intersects #218.
- **#355** — Industry pack palette refs (`real-estate-commercial.ts`) use non-canonical color names. Architectural decision needed on whether content-pack data should embed canonical-prefix CSS vars at all.

## Test plan

Pre-push validation gate passed all 8 checks, including:
- [x] **Canonical Tokens** — runs `npm run canonical-check` against the widened scope (`components content-system/blueprints`); zero violations
- [x] **Token Lint** / **JSDoc Lint** / **Grid Audit** / **Theme Compliance** / **Blueprint Library**
- [x] **TypeScript** typecheck
- [x] **Storybook Build**

No React components or component CSS touched — Storybook visual verification N/A.

## Consumer sync

Astro blueprints are consumed by the marketing/client-site builds (Astro), not the React product portals. Changes propagate on next `npm install @brikdesigns/bds` + tag-driven release. No portal/renew-pms/freedom impact.