### PR TITLE
chore(release): 0.51.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Patch release **v0.51.1**, covering all work merged since v0.51.0:

| Type | PR | What |
|---|---|---|
| fix | #356 | astro blueprints migrated to canonical token names; `canonical-check` gate widened to `content-system/blueprints` |
| fix | #346 / #352 | `AddableEntryList` — drop rAF wrapper around secondary focus shift |
| ci | #348 | gate PRs to main on canonical token registry |
| docs | #350 / #351 | motion: sync image-mood vocabulary to canonical code |

## Semver call: patch

Per `docs/RELEASE.md`:
> patch (0.45.0 → 0.45.1) — bug fix, no API change

This release contains two component-level fixes plus one BDS-internal CI gate plus one docs sync. No new components, no new props, no breaking API or token-name changes.

## Latent bug fix for consumers

The pre-#356 fallback chain `var(--text-on-brand-primary, var(--text-inverse))` resolved to **black text on the always-orange `--background-brand-primary` surface in dark mode**, because `--text-inverse` flips with theme while the brand surface does not. After this release, the canonical `--text-on-color-dark` (always white) is used — correct in both modes.

## Known regression — no live-site impact at this release

`CtaDarkCentered` and `StatsDarkBar` no longer differentiate body copy from headings on `--surface-inverse`. The pre-migration `--text-muted-on-inverse` was non-canonical and dropped. Tracking restoration in **#353** once the canonical muted-on-inverse token lands.

No current Astro client site consumes these blueprints, so this regression doesn't ship to anyone live. Confirmed via `grep -rln "blueprints/astro"` across the workspace — only BDS-internal references.

## Post-merge

After merge:
1. `git pull --ff-only` on primary `main`
2. `git tag v0.51.1 && git push origin v0.51.1`
3. The `Release` workflow at `.github/workflows/release.yml` validates the version match, runs lint + typecheck + blueprint validation, then `npm publish` to GitHub Packages
4. Consumers (`portal`, `renew-pms`, `brikdesigns`) can `npm install @brikdesigns/bds@0.51.1` in follow-up PRs

## Test plan

Pre-push gate ran the standard validate suite (typecheck passed; component lint skipped — version bump only).