### PR TITLE
ci(actions): bump checkout + setup-node v4 → v6

### DIFF
--- a/.github/workflows/canonical-check.yml
+++ b/.github/workflows/canonical-check.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/drift-alarm.yml
+++ b/.github/workflows/drift-alarm.yml
@@ -25,12 +25,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout brik-bds
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history — needed to count commits from older submodule SHAs
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js (with GitHub Packages registry)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/sync-staging.yml
+++ b/.github/workflows/sync-staging.yml
@@ -32,7 +32,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` and `actions/setup-node` from **v4 → v6** in 5 workflow files. Surfaces the GitHub Node 24 deadline before it bites:

- **June 2, 2026** — Node 24 becomes the default for JS-based GitHub Actions
- **September 16, 2026** — Node 20 removed from runners

The release workflow run for v0.51.1 (#357) surfaced the deprecation warning explicitly, naming `actions/checkout@v4` and `actions/setup-node@v4` as affected.

## Why v6

Both actions shipped a v6 major in late 2025 (checkout v6.0.0 in Nov, setup-node v6.0.0 in Oct) that runs on Node 24. The `with:` inputs we use (fetch-depth, node-version, registry-url, scope, cache) are stable across v4 → v5 → v6 — confirmed no input-shape change.

## Files touched

| Workflow | Was | Now |
|---|---|---|
| `canonical-check.yml` | checkout@v4, setup-node@v4 | @v6, @v6 |
| `chromatic.yml` | checkout@v4, setup-node@v4 | @v6, @v6 |
| `drift-alarm.yml` | checkout@v4, setup-node@v4 | @v6, @v6 |
| `release.yml` | checkout@v4, setup-node@v4 | @v6, @v6 |
| `sync-staging.yml` | checkout@v4 | @v6 |

`build-tokens.yml` and `sync-figma-variables.yml` were already on v6 — no change.

## Live test

`canonical-check.yml` runs on every PR to main. This PR will execute it on the bumped action versions — green CI on this PR is the verification that the bump works.

## Cross-repo follow-ups

Same v4 pinning likely exists across other Brik repos: portal, renew-pms, freedom, brikdesigns, brik-llm, plus client repos (vale-partners, birdwell-mutlak, memphis-dental). Per the "one concern per PR" rule each gets its own bump PR — mechanical replication of this one. Will do those as separate PRs after this lands and the canonical-check workflow proves green on v6.

## Test plan

- [x] Local pre-push validation suite (8 checks) passed before pushing the branch
- [ ] `canonical-check.yml` runs on this PR (green = v6 verified end-to-end)
- [ ] After merge to main: `release.yml` will run on the next tag push using v6 actions