### PR TITLE
bds: industry pack audience roles

### DIFF
--- a/content-system/industries/getters.test.ts
+++ b/content-system/industries/getters.test.ts
@@ -543,12 +543,16 @@ describe('real-estate-commercial pack', () => {
     expect(megaMenu?.categories).toHaveLength(3);
   });
 
-  it('navigationIA has audienceAccents and audienceIcons arrays parallel to columns', () => {
-    const ia = realEstateCommercial.navigationIA;
-    expect(ia?.audienceAccents).toBeDefined();
-    expect(ia?.audienceIcons).toBeDefined();
-    expect(ia?.audienceAccents).toHaveLength(3);
-    expect(ia?.audienceIcons).toHaveLength(3);
+  it('mega-menu categories carry audienceId + icon for per-column theming', () => {
+    const categories = realEstateCommercial.navigationIA?.servicesMegaMenu?.categories;
+    expect(categories).toBeDefined();
+    expect(categories).toHaveLength(3);
+    expect(categories?.[0].audienceId).toBe('healthcare');
+    expect(categories?.[0].icon).toBe('ph:stethoscope');
+    expect(categories?.[1].audienceId).toBe('land');
+    expect(categories?.[1].icon).toBe('ph:tree');
+    expect(categories?.[2].audienceId).toBe('commercial');
+    expect(categories?.[2].icon).toBe('ph:storefront');
   });
 
   it('parent industry is real-estate', () => {

--- a/content-system/industries/real-estate-commercial.mdx
+++ b/content-system/industries/real-estate-commercial.mdx
@@ -71,11 +71,21 @@ This is **not** an investor audience. The pack explicitly excludes capital-marke
   <NavigationIASpec ia={realEstateCommercial.navigationIA} />
 )}
 
-The `audienceAccents` and `audienceIcons` arrays on the `navigationIA` field power per-column visual differentiation in the `nav_mega_audience_pathways` blueprint:
+Each category carries an `audienceId` and `icon` slug. The `nav_mega_audience_pathways` blueprint binds `audienceId` to a `[data-audience=X]` attribute on each rendered column so the consumer site's theme can re-bind canonical brand tokens (`--background-brand-primary`, `--text-brand-primary`, `--border-brand-primary`) per audience. BCS pack data carries no color decisions; visual binding is a client-theme concern.
 
-- Column 0 (Healthcare): accent `var(--color-moss-dark)`, icon `ph:stethoscope`
-- Column 1 (Land): accent `var(--color-olive-light)`, icon `ph:tree`
-- Column 2 (Commercial): accent `var(--color-gold-light)`, icon `ph:storefront`
+- Column 0: `audienceId: 'healthcare'`, icon `ph:stethoscope`
+- Column 1: `audienceId: 'land'`, icon `ph:tree`
+- Column 2: `audienceId: 'commercial'`, icon `ph:storefront`
+
+A consumer theme (e.g. Vale Partners) provides the visual differentiation:
+
+```css
+[data-audience=healthcare] { --background-brand-primary: var(--vale-partners-olive); }
+[data-audience=land]       { --background-brand-primary: var(--vale-partners-gold); }
+[data-audience=commercial] { --background-brand-primary: var(--vale-partners-navy-darker); }
+```
+
+Sites without per-audience theming render every column in the same canonical brand color — content structure intact, no visual loss.
 
 ## 5. Blueprint Stubs
 

--- a/content-system/industries/real-estate-commercial.ts
+++ b/content-system/industries/real-estate-commercial.ts
@@ -463,10 +463,12 @@ export const realEstateCommercial: IndustryPack = {
   // Commercial) requires a structured audience-pathway mega-menu. The small-
   // business pack explicitly notes this pattern as a graduation condition.
   //
-  // Each column represents one audience. `audienceAccents` and `audienceIcons`
-  // are parallel to `servicesMegaMenu.categories` and enable the
-  // `nav_mega_audience_pathways` blueprint to render distinct color cues per
-  // column. Values map to Vale's palette primitives.
+  // Each column represents one audience. The `audienceId` on each category
+  // is the semantic role; consumer themes bind it to brand-color tokens via
+  // `[data-audience=X]` (or equivalent) scoped re-binding of canonical
+  // `--background-brand-primary` / `--text-brand-primary` / `--border-brand-primary`.
+  // BCS pack data carries no color decisions — visual binding is the client
+  // theme's responsibility.
   //
   // Archetype: `editorial-transparent` — the brokerage brand leads at first
   // load; the header solidifies on scroll. Primary link count is tight at 4
@@ -486,7 +488,9 @@ export const realEstateCommercial: IndustryPack = {
       columns: 3,
       categories: [
         {
+          audienceId: 'healthcare',
           heading: 'Healthcare',
+          icon: 'ph:stethoscope',
           items: [
             { label: 'Practice site selection', href: '/services/healthcare/site-selection', note: 'Demographic + patient-flow analysis' },
             { label: 'Lease negotiation', href: '/services/healthcare/lease-negotiation', note: 'TI allowance + favorable terms' },
@@ -495,7 +499,9 @@ export const realEstateCommercial: IndustryPack = {
           ],
         },
         {
+          audienceId: 'land',
           heading: 'Land',
+          icon: 'ph:tree',
           items: [
             { label: 'Residential land', href: '/services/land/residential', note: 'Middle Tennessee homesites' },
             { label: 'Agricultural land', href: '/services/land/agricultural', note: 'Farm + row-crop tracts' },
@@ -504,7 +510,9 @@ export const realEstateCommercial: IndustryPack = {
           ],
         },
         {
+          audienceId: 'commercial',
           heading: 'Commercial',
+          icon: 'ph:storefront',
           items: [
             { label: 'Tenant representation', href: '/services/commercial/tenant-rep', note: 'Find the right space for the business' },
             { label: 'Retail & restaurant site selection', href: '/services/commercial/site-selection', note: 'Foot traffic + trade-area analysis' },
@@ -527,13 +535,6 @@ export const realEstateCommercial: IndustryPack = {
     },
     scrollBehavior: 'transparent-top-frosted-past-80',
     mobileDrawer: 'slide-left-panel',
-    // Per-column audience accent colors — parallel to servicesMegaMenu.categories.
-    // Index 0 = Healthcare, 1 = Land, 2 = Commercial.
-    // Values reference Vale's palette primitives; consumer theme resolves these.
-    audienceAccents: ['var(--color-moss-dark)', 'var(--color-olive-light)', 'var(--color-gold-light)'],
-    // Per-column icon slugs — parallel to servicesMegaMenu.categories.
-    // Icons pulled from BDS icon vocabulary (Phosphor icon set).
-    audienceIcons: ['ph:stethoscope', 'ph:tree', 'ph:storefront'],
   },
 
   footerArchetype: 'four_col_directory',

--- a/content-system/schema/industry-pack.ts
+++ b/content-system/schema/industry-pack.ts
@@ -379,20 +379,6 @@ export interface NavigationIA {
   scrollBehavior: ScrollBehavior;
   /** Mobile drawer shape. */
   mobileDrawer: DrawerPattern;
-  /**
-   * Optional per-column accent color slot — lets audience pathways in a
-   * mega-menu render with distinct color cues. Array is parallel to
-   * `servicesMegaMenu.categories` (index i = column i). Token names or
-   * raw hex; consumers should resolve against the client theme.
-   * Present on packs that use a multi-audience pathway mega-menu pattern.
-   */
-  audienceAccents?: string[];
-  /**
-   * Optional per-column icon slot (icon id / slug) for audience pathways
-   * in a mega-menu. Array parallel to `servicesMegaMenu.categories`
-   * (index i = column i). Icon slugs should map to the BDS icon vocabulary.
-   */
-  audienceIcons?: string[];
 }
 
 export interface NavigationLink {
@@ -412,7 +398,28 @@ export interface ServicesMegaMenu {
 }
 
 export interface ServicesMegaMenuCategory {
+  /**
+   * Optional audience scope ID — when present, components should bind
+   * this value to a `[data-audience=X]` (or equivalent) attribute on
+   * the rendered column so the client theme can re-bind canonical
+   * brand tokens (`--background-brand-primary`, `--text-brand-primary`,
+   * `--border-brand-primary`) per audience.
+   *
+   * BCS packs only express the semantic ID; visual binding is a
+   * client-theme concern. Sites without per-audience theming render
+   * all columns in the same canonical brand color (no visual loss,
+   * content structure preserved).
+   *
+   * Lowercase, hyphenated. Examples: 'healthcare', 'land', 'commercial'.
+   */
+  audienceId?: string;
+  /** Column heading text. */
   heading: string;
+  /**
+   * Optional icon slug (Phosphor or other supported set) shown in the
+   * column header. Format: `{set}:{name}` — e.g. `ph:stethoscope`.
+   */
+  icon?: string;
   items: readonly ServicesMegaMenuItem[];
 }
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "build:content-system": "tsc --project tsconfig.content-system.json",
     "build:inspector-manifest": "node scripts/build-inspector-manifest.mjs",
     "bds:find": "node scripts/bds-find.mjs",
-    "canonical-check": "node scripts/canonical-check.mjs --allowlist dist/tokens.css components content-system/blueprints content-system/atmospheres",
+    "canonical-check": "node scripts/canonical-check.mjs --allowlist dist/tokens.css components content-system/blueprints content-system/atmospheres content-system/industries",
     "canonical-check:report": "node scripts/canonical-check.mjs --allowlist dist/tokens.css --format md components content-system stories || true",
     "build:types": "tsc --project tsconfig.build.json",
     "build:dist-tokens": "node scripts/build-dist-tokens.js",


### PR DESCRIPTION
## Summary
- refactor(bcs): industry-pack audience scopes use semantic IDs (closes #355)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)