### PR TITLE
bds: docs site build fix

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "description": "Fumadocs-powered guidance site for the Brik Design System.",
   "scripts": {
+    "predev": "node ./scripts/ensure-bds-dist.mjs",
     "dev": "next dev -p 3001",
+    "prebuild": "node ./scripts/ensure-bds-dist.mjs",
     "build": "next build",
     "start": "next start -p 3001",
     "postinstall": "fumadocs-mdx"

--- a/docs-site/scripts/ensure-bds-dist.mjs
+++ b/docs-site/scripts/ensure-bds-dist.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bdsRoot = resolve(here, '..', '..');
+const sentinel = resolve(bdsRoot, 'dist', 'content-system', 'index.js');
+
+if (existsSync(sentinel)) {
+  process.exit(0);
+}
+
+console.log('[ensure-bds-dist] dist/content-system/index.js not found — building parent BDS lib once.');
+const result = spawnSync('npm', ['run', 'build:lib'], {
+  cwd: bdsRoot,
+  stdio: 'inherit',
+  shell: false,
+});
+
+if (result.status !== 0) {
+  console.error('[ensure-bds-dist] npm run build:lib failed in parent.');
+  process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
## Summary
- fix(docs-site): auto-build parent BDS lib before next build/dev

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)