### PR TITLE
bds: docs postcss override

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -28,7 +28,7 @@
     },
     "..": {
       "name": "@brikdesigns/bds",
-      "version": "0.42.0",
+      "version": "0.52.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",
@@ -36,16 +36,17 @@
         "@radix-ui/react-popover": "^1.1.15"
       },
       "bin": {
-        "bds-find": "scripts/bds-find.mjs"
+        "bds-find": "scripts/bds-find.mjs",
+        "canonical-check": "scripts/canonical-check.mjs"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",
         "@notionhq/client": "^3.1.3",
-        "@storybook/addon-a11y": "10.2.19",
-        "@storybook/addon-docs": "10.2.19",
+        "@storybook/addon-a11y": "10.3.6",
+        "@storybook/addon-docs": "10.3.6",
         "@storybook/addon-mcp": "^0.4.1",
-        "@storybook/addon-vitest": "^10.2.19",
-        "@storybook/react-vite": "10.2.19",
+        "@storybook/addon-vitest": "10.3.6",
+        "@storybook/react-vite": "10.3.6",
         "@tokens-studio/sd-transforms": "^2.0.3",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
@@ -60,7 +61,7 @@
         "playwright": "^1.59.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
-        "storybook": "10.2.19",
+        "storybook": "10.3.6",
         "style-dictionary": "^5.3.1",
         "typescript": "^5.5.0",
         "vite": "^6.4.2",
@@ -5070,34 +5071,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
@@ -5171,10 +5144,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -27,5 +27,8 @@
     "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.5.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary
- fix(docs-site): override postcss to ^8.5.10 — patches GHSA-qx2v-qp2m-jg93

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)