### PR TITLE
feat(Meter): configurable valueSuffix + fillColor escape hatch (closes #375)

### DIFF
--- a/components/ui/Meter/Meter.mdx
+++ b/components/ui/Meter/Meter.mdx
@@ -64,6 +64,26 @@ Three sizes for different layout contexts.
 Format the displayed value with a custom function.
 <Canvas of={Stories.CustomFormatter} />
 
+### Suffix
+
+The value defaults to a `" Score"` suffix to fit score-gauge contexts. Pass `valueSuffix=""` to drop it (e.g. completion counters), or any custom string (e.g. `" pts"`, `" mins"`).
+
+#### No suffix
+<Canvas of={Stories.NoSuffix} />
+
+#### Custom suffix
+<Canvas of={Stories.CustomSuffix} />
+
+### Custom fill color
+
+Pass `fillColor` to override the status-driven bar color. Useful for category-driven progress where the color comes from domain data (e.g. per-department palette colors) rather than a status semantic. Mirrors `ProgressBar`'s `fillColor` escape hatch. `status` is still used for ARIA semantics when set.
+
+#### Single custom color
+<Canvas of={Stories.CustomFillColor} />
+
+#### Category-driven fills
+<Canvas of={Stories.CategoryFills} />
+
 ---
 
 ## Props
@@ -91,4 +111,10 @@ import { Meter } from '@brik/bds';
 
 // Small size, label below
 <Meter value={45} max={100} size="sm" labelPosition="below" />
+
+// Plain X/Y counter — no suffix
+<Meter value={4} max={10} valueSuffix="" label="Modules complete" />
+
+// Category-driven fill (e.g. per-department palette)
+<Meter value={3} max={8} valueSuffix="" fillColor={departmentColor.base} />
 ```

--- a/components/ui/Meter/Meter.stories.tsx
+++ b/components/ui/Meter/Meter.stories.tsx
@@ -36,6 +36,14 @@ const meta: Meta<typeof Meter> = {
       options: ['above', 'below'],
       description: 'Position label/value above or below the bar',
     },
+    valueSuffix: {
+      control: 'text',
+      description: 'Suffix after the value (default: " Score"). Pass "" to suppress.',
+    },
+    fillColor: {
+      control: 'color',
+      description: 'Override fill color. When set, `status` stops driving the bar color.',
+    },
   },
   decorators: [
     (Story) => (
@@ -186,6 +194,53 @@ export const AllStatuses: Story = {
       <Meter value={4} max={10} status="warning" label="Fair" />
       <Meter value={1} max={5} status="error" label="Fail" />
       <Meter value={0} max={7} status="neutral" label="Pending" />
+    </div>
+  ),
+};
+
+// Custom suffix
+/** @summary No suffix — plain X/Y for completion counters */
+export const NoSuffix: Story = {
+  args: {
+    value: 4,
+    max: 10,
+    status: 'warning',
+    label: 'Modules complete',
+    valueSuffix: '',
+  },
+};
+
+/** @summary Custom suffix */
+export const CustomSuffix: Story = {
+  args: {
+    value: 87,
+    max: 100,
+    status: 'positive',
+    label: 'Quiz',
+    valueSuffix: ' pts',
+  },
+};
+
+// Custom fill color (escape hatch)
+/** @summary Custom fill color */
+export const CustomFillColor: Story = {
+  args: {
+    value: 3,
+    max: 8,
+    label: 'Department A',
+    valueSuffix: '',
+    fillColor: '#7c5cff',
+  },
+};
+
+/** @summary Category-driven fills — multiple custom colors */
+export const CategoryFills: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, width: 300 }}>
+      <Meter value={2} max={4} label="Management" valueSuffix="" fillColor="#7c5cff" />
+      <Meter value={5} max={6} label="Operations" valueSuffix="" fillColor="#22c55e" />
+      <Meter value={1} max={9} label="Finance" valueSuffix="" fillColor="#f59e0b" />
+      <Meter value={0} max={3} label="HR" valueSuffix="" fillColor="#06b6d4" />
     </div>
   ),
 };

--- a/components/ui/Meter/Meter.tsx
+++ b/components/ui/Meter/Meter.tsx
@@ -39,6 +39,10 @@ export interface MeterProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childr
   valueFormatter?: (value: number, max: number) => string;
   /** Position label/value above or below the bar (default: "below") */
   labelPosition?: MeterLabelPosition;
+  /** Suffix rendered after the value (default: " Score"). Pass "" to suppress. */
+  valueSuffix?: string;
+  /** Override the fill color. When set, `status` no longer drives the bar color (status is still used for ARIA semantics). Mirrors ProgressBar's `fillColor` escape hatch. */
+  fillColor?: string;
 }
 
 function defaultFormatter(value: number, max: number): string {
@@ -55,6 +59,12 @@ function defaultFormatter(value: number, max: number): string {
  * <Meter value={6} max={7} status="positive" label="Pass" />
  * <Meter value={3} max={10} status="warning" label="Fair" size="lg" />
  * <Meter value={1} max={5} status="error" label="Fail" showValue={false} />
+ *
+ * // Plain "X/Y" with no suffix (e.g. completion counters):
+ * <Meter value={4} max={10} valueSuffix="" />
+ *
+ * // Category-driven fill (e.g. per-department palette colors):
+ * <Meter value={3} max={8} valueSuffix="" fillColor={departmentColor.base} />
  * ```
  *
  * @summary Horizontal gauge bar for scores and ratings
@@ -68,6 +78,8 @@ export function Meter({
   showValue = true,
   valueFormatter = defaultFormatter,
   labelPosition = 'below',
+  valueSuffix = ' Score',
+  fillColor,
   className,
   style,
   ...rest
@@ -84,7 +96,9 @@ export function Meter({
       {showValue && (
         <div>
           <span className="bds-meter__value">{valueFormatter(value, max)}</span>
-          <span className="bds-meter__value-suffix"> Score</span>
+          {valueSuffix && (
+            <span className="bds-meter__value-suffix">{valueSuffix}</span>
+          )}
         </div>
       )}
     </>
@@ -93,8 +107,15 @@ export function Meter({
   const track = (
     <div className={bdsClass('bds-meter__track', `bds-meter__track--${size}`)}>
       <div
-        className={bdsClass('bds-meter__fill', `bds-meter__fill--${size}`, `bds-meter__fill--${status}`)}
-        style={{ width: `${percentage}%` }}
+        className={bdsClass(
+          'bds-meter__fill',
+          `bds-meter__fill--${size}`,
+          !fillColor && `bds-meter__fill--${status}`,
+        )}
+        style={{
+          width: `${percentage}%`,
+          ...(fillColor ? { backgroundColor: fillColor } : {}),
+        }}
       />
     </div>
   );


### PR DESCRIPTION
Closes #375.

## Summary

Two additive, backward-compatible props on `<Meter>`:

- **`valueSuffix?: string`** — defaults to `" Score"` (preserves existing rendering). Pass `""` to suppress for plain `X/Y` counters, or any custom string (`" pts"`, `" mins"`, etc.).
- **`fillColor?: string`** — overrides the status-driven fill, mirroring `<ProgressBar>`'s precedent. When set, `status` no longer drives the bar color but is still used for ARIA semantics. Enables category-driven progress where color comes from domain data (per-department palette colors, brand customization) rather than a status enum.

## Why

The hardcoded `" Score"` suffix was a known wart that forced consumers to bail on Meter entirely:
- `renew-pms` [PR #115](https://github.com/brikdesigns/renew-pms/pull/115) explicitly chose `<ProgressBar> + <SheetHelperText>` over `<Meter>` for sheet progress bars because of it.
- `renew-pms` `DashboardClient.DeptBar` ([screenshot context](https://github.com/brikdesigns/renew-pms/issues/101)) hand-rolls a labeled progress bar today — needs both the suffix drop **and** an arbitrary fill (per-department palette) to use Meter.

`fillColor` mirrors the existing `<ProgressBar>` API so the two primitives stay symmetrical (and consumers don't have to learn two different escape-hatch shapes).

## Backward compatibility

- `valueSuffix` defaults to `" Score"` → existing consumers see no change in rendering.
- `fillColor` undefined → falls through to status-driven `.bds-meter__fill--{status}` class. No change.

Verified by leaving the existing `Pass` / `Fair` / `Fail` / `Neutral` / `Small` / `Large` / `NoValue` / `CustomFormatter` / `LabelAbove` / `LabelBelow` / `LabelPositionComparison` / `AllStatuses` stories untouched — they still render the same DOM.

## Stories added

- `NoSuffix` — `valueSuffix=""` (completion counter)
- `CustomSuffix` — `valueSuffix=" pts"`
- `CustomFillColor` — single `fillColor` override
- `CategoryFills` — 4 category-colored bars in a stack (mirrors the renew DeptBar use case)

## MDX added

- "Suffix" section (No suffix + Custom suffix subsections)
- "Custom fill color" section (Single + Category-driven subsections)
- Usage code samples updated with both new props

## Validation

- `npm run typecheck` — clean
- `npm test` — 95 files / 550 tests pass (550 vs prior 546 = the 4 new stories detected as smoke tests)
- `npm run lint-tokens` — 0 errors, 6 pre-existing warnings (none in Meter)
- `npm run lint-jsdoc` — clean
- `npm run build:lib` — clean
- Pre-push hook 8/8 checks passed

## Hex colors in `CategoryFills`

The story uses raw hex (`#7c5cff`, `#22c55e`, etc.) intentionally — the whole point of `fillColor` is that consumers pass non-BDS-token colors (domain data: department palettes, client brand colors). Using `var(--*)` would mislead the API surface. Token-lint passes the file (story-data hex isn't flagged).

## Test plan

- [ ] Storybook: existing Meter stories render identically to current main.
- [ ] Storybook: `NoSuffix`, `CustomSuffix`, `CustomFillColor`, `CategoryFills` render correctly.
- [ ] DevTools inspect on `CustomFillColor` story: fill div has `style="background-color: #7c5cff"` and **no** `bds-meter__fill--neutral` class.
- [ ] DevTools inspect on `Pass` story (untouched): fill div has `bds-meter__fill--positive` class and **no** inline `background-color`.

## Consumer follow-ups

After this lands and BDS publishes a new minor:

- `renew-pms`: bump `@brikdesigns/bds` (tiny PR), then swap `DashboardClient.DeptBar` to `<Meter valueSuffix="" fillColor={departmentColor(key).base} />`. Tracked in [`renew-pms inline-style-cleanup-audit.md`](https://github.com/brikdesigns/renew-pms/blob/staging/docs/qa/inline-style-cleanup-audit.md) Deferred Item #3.
- `renew-pms`: optionally revisit PR #115 sheet progress bars — could collapse `<ProgressBar> + <SheetHelperText>` back into `<Meter valueSuffix="">` if visual matches.
- No portal / brikdesigns.com consumer impact (verified by grep — `<Meter>` not yet adopted in those repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)