### PR TITLE
chore(release): 0.53.0 — sync main to match published artifact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## What this PR does

Bumps `package.json` from 0.52.0 → 0.53.0 on `main` to match the already-published [v0.53.0](https://github.com/brikdesigns/brik-bds/pkgs/npm/bds) artifact.

**No code change** — only `package.json` + `package-lock.json` version fields. Diff stat: `2 files, +3/-3`.

## Why this is needed

[#376](https://github.com/brikdesigns/brik-bds/pull/376) merged with the Meter feature. The release flow that followed:

1. ✅ Ran `npm version minor` locally → bumped to 0.53.0, created commit + tag
2. ❌ `git push origin main` → rejected (main is branch-protected — \"Changes must be made through a pull request\")
3. ✅ `git push origin v0.53.0` → tag landed
4. ✅ Release workflow validated + published 0.53.0 to GitHub Packages

The published artifact is correct (the tag points to a commit with `package.json` 0.53.0). But `main` itself still shows 0.52.0 because step 2 was rejected. Without this PR, the next `npm version` run on main would try to bump 0.52.0 → 0.53.0 and conflict with the existing tag.

## Doc fix follow-up (not in this PR)

[`docs/RELEASE.md`](https://github.com/brikdesigns/brik-bds/blob/main/docs/RELEASE.md) currently documents:

```bash
npm version minor -m 'chore(release): %s'
git push && git push --tags
```

That doesn't work with branch protection on `main`. The actual flow is:

1. Open release PR with `package.json` bump (this PR pattern)
2. Merge to main
3. Tag the merged commit
4. Push tag → workflow publishes

Worth a small docs PR after this lands.

## Test plan

- [ ] After merge: `git pull --ff-only && cat package.json | jq -r .version` → `0.53.0`
- [ ] No re-publish: GitHub Packages already has 0.53.0 from the original tag-push run.
- [ ] Next `npm version` on main works without tag conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)