### PR TITLE
feat(ProgressCircle): add circular progress primitive (closes #384)

### DIFF
--- a/components/ui/ProgressCircle/ProgressCircle.css
+++ b/components/ui/ProgressCircle/ProgressCircle.css
@@ -1,0 +1,96 @@
+@layer bds-components {
+/* ProgressCircle — circular progress indicator */
+
+/* ─── Container ───────────────────────────────────────── */
+
+.bds-progress-circle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* ─── SVG (rotated so progress starts at 12 o'clock) ──── */
+
+.bds-progress-circle__svg {
+  transform: rotate(-90deg);
+}
+
+/* ─── Track ───────────────────────────────────────────── */
+
+.bds-progress-circle__track {
+  stroke: var(--background-muted);
+}
+
+/* ─── Fill ────────────────────────────────────────────── */
+
+.bds-progress-circle__fill {
+  stroke: var(--background-brand-primary);
+  transition:
+    stroke-dashoffset var(--duration-500) var(--ease-out),
+    stroke var(--duration-200) var(--ease-out);
+}
+
+.bds-progress-circle--positive .bds-progress-circle__fill {
+  stroke: var(--background-positive);
+}
+
+.bds-progress-circle--warning .bds-progress-circle__fill {
+  stroke: var(--background-warning);
+}
+
+.bds-progress-circle--negative .bds-progress-circle__fill {
+  stroke: var(--background-negative);
+}
+
+/* ─── Indeterminate spin ──────────────────────────────── */
+
+.bds-progress-circle--indeterminate .bds-progress-circle__svg {
+  animation: bds-progress-circle-spin var(--duration-600) linear infinite;
+}
+
+.bds-progress-circle--indeterminate .bds-progress-circle__fill {
+  transition: none;
+}
+
+@keyframes bds-progress-circle-spin {
+  from { transform: rotate(-90deg); }
+  to   { transform: rotate(270deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bds-progress-circle--indeterminate .bds-progress-circle__svg {
+    animation: none;
+  }
+  .bds-progress-circle__fill {
+    transition: none;
+  }
+}
+
+/* ─── Centered slot ───────────────────────────────────── */
+
+.bds-progress-circle__center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-family-heading);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  pointer-events: none;
+}
+
+.bds-progress-circle__center--sm {
+  font-size: var(--body-md);
+}
+
+.bds-progress-circle__center--md {
+  font-size: var(--heading-tiny);
+}
+
+.bds-progress-circle__center--lg {
+  font-size: var(--heading-sm);
+}
+}

--- a/components/ui/ProgressCircle/ProgressCircle.mdx
+++ b/components/ui/ProgressCircle/ProgressCircle.mdx
@@ -1,0 +1,103 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as Stories from './ProgressCircle.stories';
+
+<Meta of={Stories} />
+
+# Progress circle
+
+Circular progress indicator. Third primitive in the Progress family alongside [`<ProgressBar>`](?path=/docs/components-feedback-progress-bar--docs) (linear) and [`<ProgressStepper>`](?path=/docs/components-feedback-progress-stepper--docs) (multi-step). Use for compact dashboards, completion meters, and any single-value progress display where a circle reads better than a bar.
+
+---
+
+## Playground
+
+Use the Controls panel to explore all props interactively.
+
+<Canvas of={Stories.Playground} />
+
+## Sizes
+
+Three diameter presets — `sm` 64px, `md` 96px, `lg` 128px. All snap to the 4-point grid.
+
+<Canvas of={Stories.Sizes} />
+
+## Statuses
+
+The `status` prop maps to canonical Brik status tokens — `default` brand fill, `positive`, `warning`, `negative`.
+
+<Canvas of={Stories.Statuses} />
+
+## Matrix
+
+Every `size × status` combination.
+
+<Canvas of={Stories.Matrix} />
+
+## Custom center
+
+The `showValue` prop accepts a `ReactNode` for arbitrary centered content — pair a percentage with a sub-label, or render a streak counter.
+
+<Canvas of={Stories.CustomCenter} />
+
+## Indeterminate
+
+Set `indeterminate` for continuous spin when progress is unknown. Honors `prefers-reduced-motion` — spin halts when the user opts out.
+
+<Canvas of={Stories.Indeterminate} />
+
+## Patterns
+
+Animated determinate fill plus a dashboard widget composing the percentage with a sub-label.
+
+<Canvas of={Stories.Patterns} />
+
+---
+
+## Props
+
+<ArgTypes of={Stories} />
+
+---
+
+## Usage
+
+```tsx
+import { ProgressCircle } from '@brikdesigns/bds';
+
+// Basic — percentage centered
+<ProgressCircle value={72} showValue label="Onboarding completion" />
+
+// Status fill
+<ProgressCircle value={100} status="positive" showValue />
+
+// Custom centered slot
+<ProgressCircle
+  value={68}
+  size="lg"
+  showValue={<div>...</div>}
+  label="Quarter progress"
+/>
+
+// Indeterminate spinner
+<ProgressCircle value={0} indeterminate label="Loading" />
+```
+
+---
+
+## Accessibility
+
+- Renders `role="progressbar"` with `aria-valuenow` (omitted when `indeterminate`), `aria-valuemin=0`, `aria-valuemax=100`.
+- Pass a `label` prop — required for screen-reader context. The visual `showValue` content is `aria-hidden` via the inner SVG.
+- `aria-busy` is set on the indeterminate variant.
+- The continuous-spin animation respects `prefers-reduced-motion: reduce`.
+
+---
+
+## When to use which Progress primitive
+
+| Need | Component |
+|------|-----------|
+| Single value, horizontal layout, narrow track | `<ProgressBar>` |
+| Single value, compact circular widget | `<ProgressCircle>` |
+| Multiple discrete steps with labels | `<ProgressStepper variant="steps">` |
+| Multiple steps, no labels (carousel, mobile) | `<ProgressStepper variant="dots">` |

--- a/components/ui/ProgressCircle/ProgressCircle.stories.tsx
+++ b/components/ui/ProgressCircle/ProgressCircle.stories.tsx
@@ -1,0 +1,253 @@
+import React, { useState, useEffect } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ProgressCircle } from './ProgressCircle';
+
+/* ─── Layout helpers (story-only) ─────────────────────── */
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <div style={{
+    fontFamily: 'var(--font-family-label)',
+    fontSize: 'var(--body-xs)', // bds-lint-ignore
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginBottom: 'var(--gap-md)',
+    color: 'var(--text-muted)',
+  }}>
+    {children}
+  </div>
+);
+
+const Row = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap, flexWrap: 'wrap' as const }}>
+    {children}
+  </div>
+);
+
+const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
+);
+
+/* ─── Meta ────────────────────────────────────────────── */
+
+const meta: Meta<typeof ProgressCircle> = {
+  title: 'Components/Feedback/progress-circle',
+  component: ProgressCircle,
+  tags: ['surface-shared'],
+  parameters: { layout: 'padded' },
+  argTypes: {
+    value: { control: { type: 'range', min: 0, max: 100, step: 1 } },
+    size: { control: { type: 'inline-radio' }, options: ['sm', 'md', 'lg'] },
+    status: { control: { type: 'inline-radio' }, options: ['default', 'positive', 'warning', 'negative'] },
+    label: { control: 'text' },
+    showValue: { control: 'boolean' },
+    indeterminate: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProgressCircle>;
+
+/* ═══════════════════════════════════════════════════════════════
+   1. PLAYGROUND — Args-based, use Controls panel to explore
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Interactive playground for prop tweaking */
+export const Playground: Story = {
+  args: {
+    value: 72,
+    size: 'md',
+    status: 'default',
+    showValue: true,
+    label: 'Onboarding completion',
+    indeterminate: false,
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   2. SIZES — sm / md / lg side by side
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary All three diameter presets */
+export const Sizes: Story = {
+  render: () => (
+    <Row>
+      <div>
+        <SectionLabel>sm — 64px</SectionLabel>
+        <ProgressCircle value={50} size="sm" showValue label="Small" />
+      </div>
+      <div>
+        <SectionLabel>md — 96px</SectionLabel>
+        <ProgressCircle value={50} size="md" showValue label="Medium" />
+      </div>
+      <div>
+        <SectionLabel>lg — 128px</SectionLabel>
+        <ProgressCircle value={50} size="lg" showValue label="Large" />
+      </div>
+    </Row>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   3. STATUSES — default / positive / warning / negative
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Each canonical status token applied as fill */
+export const Statuses: Story = {
+  render: () => (
+    <Row>
+      <div>
+        <SectionLabel>default (brand)</SectionLabel>
+        <ProgressCircle value={72} status="default" showValue label="Default" />
+      </div>
+      <div>
+        <SectionLabel>positive</SectionLabel>
+        <ProgressCircle value={100} status="positive" showValue label="Complete" />
+      </div>
+      <div>
+        <SectionLabel>warning</SectionLabel>
+        <ProgressCircle value={45} status="warning" showValue label="At risk" />
+      </div>
+      <div>
+        <SectionLabel>negative</SectionLabel>
+        <ProgressCircle value={15} status="negative" showValue label="Failing" />
+      </div>
+    </Row>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   4. MATRIX — every size × status combination
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Full size × status matrix */
+export const Matrix: Story = {
+  render: () => {
+    const statuses = ['default', 'positive', 'warning', 'negative'] as const;
+    const sizes = ['sm', 'md', 'lg'] as const;
+    return (
+      <Stack>
+        {statuses.map((status) => (
+          <div key={status}>
+            <SectionLabel>{status}</SectionLabel>
+            <Row>
+              {sizes.map((size) => (
+                <ProgressCircle
+                  key={size}
+                  value={62}
+                  size={size}
+                  status={status}
+                  showValue
+                  label={`${status} ${size}`}
+                />
+              ))}
+            </Row>
+          </div>
+        ))}
+      </Stack>
+    );
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   5. CUSTOM CENTER — arbitrary node content
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Centered slot accepts any ReactNode for custom labels */
+export const CustomCenter: Story = {
+  render: () => (
+    <Row>
+      <ProgressCircle
+        value={70}
+        size="lg"
+        showValue={
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontSize: 'var(--heading-md)', fontWeight: 'var(--font-weight-bold)', color: 'var(--text-primary)' }}>
+              70%
+            </div>
+            <div style={{ fontSize: 'var(--body-sm)', color: 'var(--text-secondary)' }}>
+              of 200
+            </div>
+          </div>
+        }
+        label="Tasks complete"
+      />
+      <ProgressCircle
+        value={3}
+        size="lg"
+        showValue={
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontSize: 'var(--heading-md)', fontWeight: 'var(--font-weight-bold)', color: 'var(--text-primary)' }}>
+              3
+            </div>
+            <div style={{ fontSize: 'var(--body-sm)', color: 'var(--text-secondary)' }}>
+              of 7 days
+            </div>
+          </div>
+        }
+        label="Streak"
+      />
+    </Row>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   6. INDETERMINATE — animated continuous spin
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Continuous spin for unknown-duration progress */
+export const Indeterminate: Story = {
+  render: () => (
+    <Row>
+      <ProgressCircle value={0} size="sm" indeterminate label="Loading small" />
+      <ProgressCircle value={0} size="md" indeterminate label="Loading medium" />
+      <ProgressCircle value={0} size="lg" indeterminate label="Loading large" />
+    </Row>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   7. PATTERNS — animated determinate fill, dashboard widget
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Common usage patterns */
+export const Patterns: Story = {
+  render: () => {
+    function Animated() {
+      const [progress, setProgress] = useState(0);
+      useEffect(() => {
+        const t = setInterval(() => {
+          setProgress((p) => (p >= 100 ? 0 : p + 1));
+        }, 60);
+        return () => clearInterval(t);
+      }, []);
+      return (
+        <Stack>
+          <div>
+            <SectionLabel>Animated determinate</SectionLabel>
+            <ProgressCircle value={progress} size="lg" showValue label="Loading" />
+          </div>
+          <div>
+            <SectionLabel>Dashboard widget</SectionLabel>
+            <ProgressCircle
+              value={68}
+              size="lg"
+              status="positive"
+              showValue={
+                <div style={{ textAlign: 'center' }}>
+                  <div style={{ fontSize: 'var(--heading-md)', fontWeight: 'var(--font-weight-bold)', color: 'var(--text-primary)' }}>
+                    68%
+                  </div>
+                  <div style={{ fontSize: 'var(--body-sm)', color: 'var(--text-secondary)' }}>
+                    on track
+                  </div>
+                </div>
+              }
+              label="Quarter progress"
+            />
+          </div>
+        </Stack>
+      );
+    }
+    return <Animated />;
+  },
+};

--- a/components/ui/ProgressCircle/ProgressCircle.tsx
+++ b/components/ui/ProgressCircle/ProgressCircle.tsx
@@ -1,0 +1,144 @@
+import { type CSSProperties, type HTMLAttributes, type ReactNode } from 'react';
+import { bdsClass } from '../../utils';
+import './ProgressCircle.css';
+
+export type ProgressCircleSize = 'sm' | 'md' | 'lg';
+export type ProgressCircleStatus = 'default' | 'positive' | 'warning' | 'negative';
+
+export interface ProgressCircleProps extends Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'children'> {
+  /** Progress value from 0 to 100. Ignored when `indeterminate` is true. */
+  value: number;
+  /** Diameter preset — `sm` 64px, `md` 96px, `lg` 128px */
+  size?: ProgressCircleSize;
+  /** Fill color semantic — uses canonical status tokens */
+  status?: ProgressCircleStatus;
+  /** Accessible label for screen readers */
+  label?: string;
+  /** Centered slot — typically a percentage. Pass `true` to render `${value}%`, a node to render arbitrary content, or omit to render nothing. */
+  showValue?: boolean | ReactNode;
+  /** Animated continuous spin for unknown duration progress */
+  indeterminate?: boolean;
+  /** Override fill stroke color (escape hatch — defaults to status token) */
+  fillColor?: string;
+}
+
+// bds-lint-ignore — geometry constants on the 4-pt grid; exposed as CSS-driven dimensions
+const SIZE_CONFIG: Record<ProgressCircleSize, { diameter: number; stroke: number }> = {
+  sm: { diameter: 64,  stroke: 6 },
+  md: { diameter: 96,  stroke: 8 },
+  lg: { diameter: 128, stroke: 10 },
+};
+
+/**
+ * ProgressCircle — circular progress indicator.
+ *
+ * Third primitive in the Progress family alongside `<ProgressBar>` (linear) and
+ * `<ProgressStepper>` (multi-step). Use for compact dashboards, completion
+ * meters, and any single-value progress display where a circle reads better
+ * than a bar.
+ *
+ * The centered slot accepts either a `value`-derived percentage (`showValue`)
+ * or arbitrary node content for custom labels.
+ *
+ * @example Basic
+ * ```tsx
+ * <ProgressCircle value={72} showValue label="Onboarding completion" />
+ * ```
+ *
+ * @example Status
+ * ```tsx
+ * <ProgressCircle value={100} status="positive" showValue />
+ * ```
+ *
+ * @example Indeterminate
+ * ```tsx
+ * <ProgressCircle value={0} indeterminate label="Loading" />
+ * ```
+ *
+ * @summary Themed circular progress indicator
+ */
+export function ProgressCircle({
+  value,
+  size = 'md',
+  status = 'default',
+  label,
+  showValue,
+  indeterminate = false,
+  fillColor,
+  className,
+  style,
+  ...props
+}: ProgressCircleProps) {
+  const { diameter, stroke } = SIZE_CONFIG[size];
+  const radius = (diameter - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  const clampedValue = Math.min(100, Math.max(0, value));
+  const dashOffset = indeterminate
+    ? circumference * 0.75
+    : circumference - (clampedValue / 100) * circumference;
+
+  // Runtime-calculated SVG geometry — must stay inline
+  const fillStyle: CSSProperties = {
+    strokeDasharray: circumference,
+    strokeDashoffset: dashOffset,
+    ...(fillColor ? { stroke: fillColor } : {}),
+  };
+
+  const centerContent =
+    showValue === true ? `${Math.round(clampedValue)}%` : showValue;
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={indeterminate ? undefined : clampedValue}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={label}
+      aria-busy={indeterminate || undefined}
+      className={bdsClass(
+        'bds-progress-circle',
+        `bds-progress-circle--${size}`,
+        `bds-progress-circle--${status}`,
+        indeterminate && 'bds-progress-circle--indeterminate',
+        className,
+      )}
+      style={{ width: diameter, height: diameter, ...style }}
+      {...props}
+    >
+      <svg
+        className="bds-progress-circle__svg"
+        width={diameter}
+        height={diameter}
+        viewBox={`0 0 ${diameter} ${diameter}`}
+        aria-hidden="true"
+      >
+        <circle
+          className="bds-progress-circle__track"
+          cx={diameter / 2}
+          cy={diameter / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={stroke}
+        />
+        <circle
+          className="bds-progress-circle__fill"
+          cx={diameter / 2}
+          cy={diameter / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          style={fillStyle}
+        />
+      </svg>
+      {centerContent != null && centerContent !== false && (
+        <div className={bdsClass('bds-progress-circle__center', `bds-progress-circle__center--${size}`)}>
+          {centerContent}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ProgressCircle;

--- a/components/ui/ProgressCircle/index.ts
+++ b/components/ui/ProgressCircle/index.ts
@@ -1,0 +1,6 @@
+export {
+  ProgressCircle,
+  type ProgressCircleProps,
+  type ProgressCircleSize,
+  type ProgressCircleStatus,
+} from './ProgressCircle';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -59,6 +59,7 @@ export * from './PasswordInput';
 export * from './Popover';
 export * from './PricingCard';
 export * from './ProgressBar';
+export * from './ProgressCircle';
 export * from './ProgressStepper';
 export * from './Radio';
 export * from './SegmentedControl';


### PR DESCRIPTION
## Summary

Third primitive in the Progress family alongside `<ProgressBar>` (linear) and `<ProgressStepper>` (multi-step). Replaces hand-rolled SVG donuts in consumer dashboards (renew-pms#173, [DashboardClient.tsx:154-177](https://github.com/brikdesigns/renew-pms/blob/main/src/app/(auth)/dashboard/DashboardClient.tsx#L154-L177)).

## API

| Prop | Values | Notes |
|------|--------|-------|
| `value` | `0–100` | Clamped; ignored when `indeterminate` |
| `size` | `sm` (64) · `md` (96) · `lg` (128) | All on 4-pt grid |
| `status` | `default` · `positive` · `warning` · `negative` | Canonical status tokens |
| `showValue` | `boolean \| ReactNode` | `true` → auto-percentage; node → custom centered slot |
| `indeterminate` | `boolean` | Continuous spin; honors `prefers-reduced-motion` |
| `label` | `string` | Required for screen readers |
| `fillColor` | `string` | Escape hatch override |

## Acceptance criteria (from #384)

- [x] `<ProgressCircle>` shipped under `components/ui/ProgressCircle/` with stories + MDX
- [x] API consistent with ProgressBar family (`value` 0–100, `size`, `status`, label slot)
- [x] Track + fill via canonical semantic tokens — themeable
- [x] Story matrix: each size × status, custom center slot, indeterminate state
- [ ] Published in a versioned BDS release (follow-up `chore(release)` PR)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint-tokens` clean
- [x] `npm run build:lib` clean — manifest 85 → 86 components
- [x] Full validation suite (8/8 checks) green via `pr-task.sh`
- [x] Storybook index registers all 7 stories + MDX docs page
- [ ] **Reviewer:** spot-check Storybook locally — `npm run storybook` → Components/Feedback/progress-circle. I built and validated structurally but could not visually verify rendering in a browser.

## Consumer sync plan

- [ ] After merge + `chore(release)` publish: renew-pms swaps `ProgressRing` (DashboardClient.tsx:156) → `<ProgressCircle>` from `@brikdesigns/bds`
- [ ] Portal: opportunistic — no current consumer
- [ ] brikdesigns: `./scripts/bds-sync.sh` if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)