### PR TITLE
feat(Menu): add header slot for non-interactive titles (closes #381)

### DIFF
--- a/components/ui/Menu/Menu.css
+++ b/components/ui/Menu/Menu.css
@@ -29,6 +29,24 @@
   transform-origin: top center;
 }
 
+/* ─── Header (non-interactive label slot) ─────────────── */
+
+.bds-menu__header {
+  display: flex;
+  flex-direction: column;
+  padding: var(--padding-tiny) var(--padding-tiny) var(--padding-md);
+  border-bottom: 1px solid var(--border-muted);
+  margin-bottom: var(--gap-tiny);
+  font-family: var(--font-family-label);
+  font-size: var(--body-xs);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  user-select: none;
+}
+
 /* ─── Menu item ───────────────────────────────────────── */
 
 .bds-menu__item {

--- a/components/ui/Menu/Menu.mdx
+++ b/components/ui/Menu/Menu.mdx
@@ -27,6 +27,24 @@ Real-world usage: `FilterButton` trigger, `Button` trigger with action menu, and
 
 <Canvas of={Stories.Patterns} />
 
+### Header slot
+
+Pass `header?: ReactNode` to render a non-interactive label above the items inside the menu panel — practice name, user identity block, filter group label, etc. The header sits inside Menu's outside-click ref so pressing it does not close the menu.
+
+```tsx
+<Menu
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  header="Northstar Dental"
+  items={[
+    { id: 'settings', label: 'Account settings', onClick: ... },
+    { id: 'signout', label: 'Sign out', onClick: ... },
+  ]}
+/>
+```
+
+Default styling (`bds-menu__header` class) is uppercase label-style on `--text-secondary` with a subtle bottom border. Pass any `ReactNode` (multiple lines, mixed typography) to fully override the visual treatment.
+
 ### Items with description
 
 Pass `description?: string` on a `MenuItemData` to render a second-line description below the label. Used for "what does this option do?" affordance — common in "Add new ___" menus where each option is a different kind of thing (e.g. *Checklist — Recurring to-do lists*, *Procedure — Step-by-step workflows*).

--- a/components/ui/Menu/Menu.stories.tsx
+++ b/components/ui/Menu/Menu.stories.tsx
@@ -119,6 +119,44 @@ export const Variants: Story = {
           style={{ position: 'relative' }}
         />
       </div>
+
+      <div>
+        <SectionLabel>With header (string)</SectionLabel>
+        <Menu
+          isOpen
+          onClose={() => {}}
+          header="Northstar Dental"
+          items={[
+            { id: '1', label: 'Account settings', icon: <Icon icon="ph:gear" />, onClick: () => {} },
+            { id: '2', label: 'Switch practice', icon: <Icon icon="ph:swap" />, onClick: () => {} },
+            { id: '3', label: 'Sign out', icon: <Icon icon="ph:sign-out" />, onClick: () => {} },
+          ]}
+          style={{ position: 'relative' }}
+        />
+      </div>
+
+      <div>
+        <SectionLabel>With header (custom node)</SectionLabel>
+        <Menu
+          isOpen
+          onClose={() => {}}
+          header={
+            <>
+              <span style={{ fontFamily: 'var(--font-family-heading)', fontSize: 'var(--body-md)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--text-primary)', textTransform: 'none', letterSpacing: 0 }}>
+                Dr. Sara Patel
+              </span>
+              <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-xs)', fontWeight: 'var(--font-weight-regular)', color: 'var(--text-secondary)', textTransform: 'none', letterSpacing: 0 }}>
+                sara@northstardental.com
+              </span>
+            </>
+          }
+          items={[
+            { id: '1', label: 'Profile', icon: <Icon icon="ph:user" />, onClick: () => {} },
+            { id: '2', label: 'Sign out', icon: <Icon icon="ph:sign-out" />, onClick: () => {} },
+          ]}
+          style={{ position: 'relative' }}
+        />
+      </div>
     </Stack>
   ),
 };

--- a/components/ui/Menu/Menu.tsx
+++ b/components/ui/Menu/Menu.tsx
@@ -41,6 +41,13 @@ export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childre
   onClose: () => void;
   /** Currently active/selected item ID */
   activeId?: string;
+  /**
+   * Optional non-interactive header rendered above the items inside the menu
+   * panel — e.g. a practice name, user email, or filter group label. Sits
+   * inside the menu's outside-click ref so it does not close on press.
+   * Default styling applies via `bds-menu__header`; pass any node to override.
+   */
+  header?: ReactNode;
 }
 
 /**
@@ -114,6 +121,7 @@ export function Menu({
   isOpen,
   onClose,
   activeId,
+  header,
   className = '',
   style,
   ...props
@@ -159,6 +167,11 @@ export function Menu({
       style={style}
       {...props}
     >
+      {header != null && (
+        <div className="bds-menu__header" role="presentation">
+          {header}
+        </div>
+      )}
       {items.map((item) => (
         <MenuItem
           key={item.id}


### PR DESCRIPTION
## Summary

Optional `header?: ReactNode` prop on `<Menu>`. Renders a non-interactive label inside the menu panel, above items, using `bds-menu__header` styling. Sits inside Menu's outside-click ref — clicking the header does not close the menu.

Replaces the renew-pms stopgap (absolutely-positioned wrapper + sibling header + `onMouseDown.stopPropagation` + `position: static / boxShadow: none / borderRadius: 0` override on `<Menu>`) with a first-class slot.

## API

```tsx
// String header — default uppercase-label styling
<Menu
  isOpen={open}
  onClose={() => setOpen(false)}
  header="Northstar Dental"
  items={[...]}
/>

// Custom ReactNode header — full visual override
<Menu
  header={
    <>
      <span style={{ font.family.heading, fontWeight: semibold }}>Dr. Sara Patel</span>
      <span style={{ font.size.body.xs, color: text.secondary }}>sara@northstardental.com</span>
    </>
  }
  items={[...]}
/>
```

## Acceptance criteria (from #381)

- [x] `header?: ReactNode` prop on `<Menu>` (TypeScript signature + JSDoc)
- [x] Default styling for the header slot via `bds-menu__header` class using canonical tokens
- [x] Outside-click handler treats header as inside-menu (header sits inside `menuRef`)
- [x] Storybook stories with and without header — string + custom node variants
- [ ] **Follow-up:** renew-pms `AppSidebar.tsx` migrates from local stopgap to BDS prop (separate PR, post-publish)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint-tokens` clean (no warnings on Menu files)
- [x] Full validation suite (8/8) green via `pr-task.sh`
- [ ] **Reviewer:** spot-check Storybook → Navigation/Menu/menu → Variants story. The bottom two rows are the new "With header (string)" and "With header (custom node)" examples. I built and validated structurally but could not visually verify rendering.

## Backwards compatibility

`header` is optional. All existing call sites unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)