### PR TITLE
chore(release): 0.54.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Releases 4 PRs merged since 0.53.0:

| PR | Type | Summary |
|----|------|---------|
| #382 | feat(content-system) | Brik voice & tone substrate — first first-party content pack |
| #385 | feat(ProgressCircle) | New circular progress primitive (closes #384) |
| #386 | feat(Menu) | Header slot prop (closes #381) |
| #387 | docs(claude) | Phase 4 markdown-IA cleanup (closes #371) |

Two new components, one new BCS pack, and consumer-facing docs tightening — minor bump per [`docs/RELEASE.md`](docs/RELEASE.md).

## Publish gesture (after merge)

The `Release` workflow runs on tag push. From `main` after this merges:

```bash
git pull --ff-only
git tag v0.54.0
git push origin v0.54.0
```

The workflow validates (`lint-tokens --errors-only`, `lint-jsdoc`, `validate:blueprints`, `typecheck`), then runs `npm publish` to GitHub Packages.

## Consumer bump targets (post-publish)

- [ ] **brik-client-portal:** `npm install @brikdesigns/bds@0.54.0`
- [ ] **renew-pms:** submodule bump (then can adopt ProgressCircle for [renew#175](https://github.com/brikdesigns/renew-pms/issues/175))
- [ ] **brikdesigns:** `./scripts/bds-sync.sh`

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build:lib` clean — manifest 86 components
- [x] All validation gates green via `pr-task.sh`
- [ ] **Reviewer:** sanity-check that #382 / #385 / #386 / #387 are all on `main` ahead of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)