### PR TITLE
feat(DevFeedbackWidget): explicit variant prop — auto / slot / fab (closes #383)

### DIFF
--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.stories.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.stories.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { BrikDevBar } from '../BrikDevBar';
+import { DevFeedbackWidget } from './DevFeedbackWidget';
+
+/* ─── Layout helpers (story-only) ─────────────────────── */
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      minHeight: 360,
+      padding: 'var(--padding-xl)',
+      fontFamily: 'var(--font-family-body)',
+      color: 'var(--text-primary)',
+    }}
+  >
+    {children}
+  </div>
+);
+
+/* ─── Meta ────────────────────────────────────────────── */
+
+const meta: Meta<typeof DevFeedbackWidget> = {
+  title: 'Dev Tools/DevFeedbackWidget',
+  component: DevFeedbackWidget,
+  tags: ['surface-product', 'surface-shared'],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    variant: {
+      control: { type: 'inline-radio' },
+      options: ['auto', 'slot', 'fab'],
+    },
+    endpoint: { control: 'text' },
+    contextLabel: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DevFeedbackWidget>;
+
+/* ═══════════════════════════════════════════════════════════════
+   1. PLAYGROUND — explore all three variants via Controls panel
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Interactive playground for prop tweaking */
+export const Playground: Story = {
+  args: {
+    variant: 'fab',
+    endpoint: '/api/feedback',
+    contextLabel: 'Story',
+  },
+  render: (args) => (
+    <Frame>
+      <p style={{ marginBottom: 'var(--gap-md)' }}>
+        Toggle the <code>variant</code> control: <strong>fab</strong> renders the floating
+        button standalone; <strong>slot</strong> registers with the DevBar shell (and warns
+        if the shell never appears); <strong>auto</strong> runtime-detects.
+      </p>
+      <DevFeedbackWidget {...args} />
+    </Frame>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   2. FAB — standalone, no DevBar shell
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Standalone floating button — explicit `variant="fab"` skips the DevBar lookup */
+export const FabStandalone: Story = {
+  render: () => (
+    <Frame>
+      <p>Standalone FAB, no DevBar present. Use this in product apps that ship customer feedback collection without the dev shell.</p>
+      <DevFeedbackWidget variant="fab" endpoint="/api/feedback" contextLabel="Page" />
+    </Frame>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   3. SLOT — explicit slot mode (no FAB flicker)
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Slot-only — registers with BrikDevBar; never renders the FAB even pre-load */
+export const SlotWithDevBar: Story = {
+  render: () => (
+    <Frame>
+      <p>Explicit <code>variant=&quot;slot&quot;</code>. The widget seeds <code>devBarPresent=true</code> from the start so the FAB never flashes during the bar&apos;s load. Logs a warning if no DevBar appears within 2s.</p>
+      <BrikDevBar />
+      <DevFeedbackWidget variant="slot" endpoint="/api/feedback" contextLabel="Story" />
+    </Frame>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   4. AUTO — runtime detect (current default behavior)
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Auto detect with DevBar present — registers slot; FAB is hidden once detected */
+export const AutoWithDevBar: Story = {
+  render: () => (
+    <Frame>
+      <p>Default <code>variant=&quot;auto&quot;</code>. Polls <code>window.BrikDevBar</code> every 100ms for 2s. With the shell mounted, the widget settles into slot mode.</p>
+      <BrikDevBar />
+      <DevFeedbackWidget endpoint="/api/feedback" contextLabel="Story" />
+    </Frame>
+  ),
+};
+
+/** @summary Auto detect without DevBar — falls back to FAB after the 2s detection window */
+export const AutoWithoutDevBar: Story = {
+  render: () => (
+    <Frame>
+      <p>Default <code>variant=&quot;auto&quot;</code> with no DevBar shell. After the 2s lookup window, falls back to FAB rendering. Note: until detection times out, you may briefly see no widget — the trade-off the explicit <code>fab</code>/<code>slot</code> variants resolve.</p>
+      <DevFeedbackWidget endpoint="/api/feedback" contextLabel="Page" />
+    </Frame>
+  ),
+};

--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
@@ -22,7 +22,10 @@ import { createPortal } from 'react-dom';
  * renders identically regardless of the host's light/dark theme.
  *
  * Integrates with the Brik DevBar (`window.BrikDevBar`) when present,
- * falling back to a standalone FAB otherwise.
+ * falling back to a standalone FAB otherwise. Set the `variant` prop to
+ * `'slot'` or `'fab'` to assert the mode explicitly and skip the runtime
+ * detect — useful for product apps that want to swap modes via env gate
+ * without the FAB-flicker that 'auto' mode permits during DevBar load.
  *
  * @token-exempt — the inlined BDS object below holds raw hex values on
  * purpose: this widget is a dev overlay that must render consistently even
@@ -56,6 +59,18 @@ const FEEDBACK_TYPES = [
 // Types live in BrikDevBar — imported here to avoid duplicate declarations.
 import type { DevBarSlotDef } from '../BrikDevBar';
 
+/**
+ * Rendering variant.
+ * - `'auto'` (default) — runtime-detect `window.BrikDevBar`; render as a
+ *   slot when present, fall back to a standalone FAB. Backwards-compatible.
+ * - `'slot'` — assert slot mode. Register with BrikDevBar (queues if the
+ *   bar hasn't loaded yet) and never render the FAB. Logs a warning if no
+ *   DevBar appears within 2s.
+ * - `'fab'` — assert FAB mode. Skip the DevBar lookup entirely; render the
+ *   standalone floating button immediately.
+ */
+export type DevFeedbackVariant = 'auto' | 'slot' | 'fab';
+
 // ── Public props ────────────────────────────────────────────────────────
 export interface DevFeedbackWidgetProps {
   /** POST endpoint for feedback submissions. */
@@ -68,6 +83,8 @@ export interface DevFeedbackWidgetProps {
   fabPosition?: { bottom?: string; left?: string; right?: string };
   /** Additional payload fields sent with every submission. */
   extraPayload?: Record<string, unknown>;
+  /** Rendering variant — controls slot vs FAB explicitly. Defaults to `'auto'` (back-compat). */
+  variant?: DevFeedbackVariant;
 }
 
 // ── Component ───────────────────────────────────────────────────────────
@@ -80,6 +97,7 @@ export function DevFeedbackWidget({
   getContextValue,
   fabPosition = { bottom: '16px', left: '72px' },
   extraPayload,
+  variant = 'auto',
 }: DevFeedbackWidgetProps = {}) {
   const [open, setOpen] = useState(false);
   const [type, setType] = useState<string>('bug');
@@ -87,7 +105,11 @@ export function DevFeedbackWidget({
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [contextValue, setContextValue] = useState('');
-  const [devBarPresent, setDevBarPresent] = useState(false);
+  // For variant='slot' we treat the DevBar as present from the start so
+  // the FAB never flashes while the bar is registering. For variant='fab'
+  // we keep it false (no DevBar lookup runs). Auto seeds false and lets
+  // runtime detection update it.
+  const [devBarPresent, setDevBarPresent] = useState(variant === 'slot');
   const panelRef = useRef<HTMLDivElement>(null);
   const fabRef = useRef<HTMLDivElement>(null);
 
@@ -141,8 +163,10 @@ export function DevFeedbackWidget({
     };
   }, [open]);
 
-  // Detect DevBar so we can hide the standalone FAB.
+  // Detect DevBar so we can hide the standalone FAB. Only runs in 'auto'
+  // mode — explicit variants short-circuit the polling.
   useEffect(() => {
+    if (variant !== 'auto') return;
     const check = () => {
       if (typeof window !== 'undefined' && window.BrikDevBar) {
         setDevBarPresent(true);
@@ -155,7 +179,7 @@ export function DevFeedbackWidget({
       clearInterval(iv);
       clearTimeout(stop);
     };
-  }, []);
+  }, [variant]);
 
   // Register the DevBar slot (queues if DevBar hasn't loaded yet).
   const slotDef = useMemo<DevBarSlotDef>(
@@ -172,6 +196,7 @@ export function DevFeedbackWidget({
   );
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (variant === 'fab') return;
     const tryRegister = () => {
       if (window.BrikDevBar) {
         window.BrikDevBar.register(slotDef);
@@ -189,13 +214,21 @@ export function DevFeedbackWidget({
     const iv = setInterval(() => {
       if (tryRegister()) clearInterval(iv);
     }, 100);
-    const stop = setTimeout(() => clearInterval(iv), 2000);
+    const stop = setTimeout(() => {
+      clearInterval(iv);
+      if (variant === 'slot' && !window.BrikDevBar) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[DevFeedbackWidget] variant="slot" but BrikDevBar did not appear within 2s — widget will not be reachable.',
+        );
+      }
+    }, 2000);
     return () => {
       clearInterval(iv);
       clearTimeout(stop);
       window.BrikDevBar?.unregister(slotDef.id);
     };
-  }, [slotDef]);
+  }, [slotDef, variant]);
 
   // Sync DevBar active state with our open state.
   useEffect(() => {

--- a/components/ui/DevFeedbackWidget/index.ts
+++ b/components/ui/DevFeedbackWidget/index.ts
@@ -1,3 +1,3 @@
 export { DevFeedbackWidget } from './DevFeedbackWidget';
-export type { DevFeedbackWidgetProps } from './DevFeedbackWidget';
+export type { DevFeedbackWidgetProps, DevFeedbackVariant } from './DevFeedbackWidget';
 // DevBarSlotDef + DevBarApi now live in BrikDevBar — re-exported from there.


### PR DESCRIPTION
## Summary

Adds `variant?: 'auto' | 'slot' | 'fab'` prop with default `'auto'`. Explicit variants short-circuit the 2-second `window.BrikDevBar` polling that today's runtime-detect mode requires — eliminating the FAB-flicker that consumers (renew-pms, brik-client-portal) currently work around with their own `barReady` polling effects.

## API

| Variant | Behavior |
|---------|----------|
| `'auto'` (default) | Current behavior. Polls `window.BrikDevBar` every 100ms for 2s; renders FAB until detected, then settles into slot mode. **Backwards compatible.** |
| `'slot'` | Asserts slot mode. Seeds `devBarPresent=true` from the start so the FAB never flashes during shell load. Console-warns if no DevBar appears within 2s. |
| `'fab'` | Asserts FAB mode. Skips DevBar lookup entirely. No slot registration, no polling, no flash. |

## Renew consumer simplification (follow-up)

Renew's [`src/components/DevFeedbackWidget.tsx`](https://github.com/brikdesigns/renew-pms/blob/staging/src/components/DevFeedbackWidget.tsx) currently runs its own `barReady` polling effect (~15 lines) to avoid the flicker:

```tsx
// Today
const [barReady, setBarReady] = useState(false);
useEffect(() => {
  const check = () => { if (window.BrikDevBar) setBarReady(true); };
  // ...100ms polling loop...
}, []);
if (SLOT_MODE && !barReady) return null;

// After this lands + new release
<DevFeedbackWidget variant={SLOT_MODE ? 'slot' : 'fab'} ... />
```

That cleanup is a separate post-publish PR on renew-pms.

## Acceptance criteria (from #383)

- [x] `variant` prop with `'auto'` / `'slot'` / `'fab'` values; default `'auto'`
- [x] Storybook stories cover all four scenarios — slot, fab, auto-with-bar, auto-without-bar
- [x] `surface-product` + `surface-shared` tags applied
- [ ] **Follow-up PR on renew-pms:** swap to `variant=\"slot\"` / `variant=\"fab\"`, drop `barReady` polling
- [ ] **Follow-up PR on brik-client-portal:** same simplification (if applicable)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint-tokens` clean (no new warnings on DevFeedbackWidget files)
- [x] All 8 validation gates green via `pr-task.sh`
- [x] Storybook builds; 5 stories registered under `Dev Tools/DevFeedbackWidget`
- [ ] **Reviewer:** spot-check Storybook → Dev Tools/DevFeedbackWidget. Verify each variant renders as documented.

## Backwards compatibility

`variant` is optional, defaults to `'auto'` = existing behavior. No breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)