### PR TITLE
chore(release): 0.55.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Batches all 5 PRs landed since v0.53.0 into a single publish:

| PR | Type | Summary |
|----|------|---------|
| #382 | feat(content-system) | Brik voice & tone substrate |
| #385 | feat(ProgressCircle) | New circular progress primitive (closes #384) |
| #386 | feat(Menu) | Header slot prop (closes #381) |
| #387 | docs(claude) | Phase 4 markdown-IA cleanup (closes #371) |
| #389 | feat(DevFeedbackWidget) | Explicit variant prop — auto/slot/fab (closes #383) |

The earlier `chore(release): 0.54.0` commit (#388) bumped package.json but the v0.54.0 tag was never pushed. This PR bumps 0.54.0 → 0.55.0 so a single tag push ships everything cleanly.

## Publish gesture (after merge)

```bash
git pull --ff-only
git tag v0.55.0
git push origin v0.55.0
```

The Release workflow validates (`lint-tokens --errors-only`, `lint-jsdoc`, `validate:blueprints`, `typecheck`) then runs `npm publish` to GitHub Packages.

## Unblocks

- **[renew#175](https://github.com/brikdesigns/renew-pms/issues/175)** — swap dashboard SVG donut for `<ProgressCircle>` (queued, ready the moment publish lands)
- **renew DevFeedbackWidget cleanup** — drop `barReady` polling effect, switch to `variant=\"slot\"` / `variant=\"fab\"` (follow-up PR after publish)

## Consumer bump targets (post-publish)

- [ ] **brik-client-portal:** `npm install @brikdesigns/bds@0.55.0`
- [ ] **renew-pms:** submodule bump
- [ ] **brikdesigns:** `./scripts/bds-sync.sh`

## Test plan

- [x] `npm run typecheck` clean
- [x] All validation gates green via `pr-task.sh`
- [ ] **Reviewer:** sanity-check that #382/#385/#386/#387/#389 are all on `main` ahead of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)