### PR TITLE
bds: page header tab bar double border

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -9,6 +9,15 @@
   justify-content: center;
   padding: var(--padding-xl) 80px; /* bds-lint-ignore — Figma page header spec */
   width: 100%;
+  /* Single 1px divider hands the page header off to the body. When the `tabs`
+     slot is filled, TabBar's own baseline takes over (suppressed below) so we
+     don't stack two borders. */
+  border-bottom: var(--border-width-sm) solid var(--border-secondary);
+}
+
+/* Suppress root divider when tabs are present — TabBar provides its baseline. */
+.bds-page-header:has(.bds-page-header__tabs) {
+  border-bottom: none;
 }
 
 .bds-page-header--flush {
@@ -140,15 +149,15 @@
   width: 100%;
 }
 
-/* ─── Tabs ───────────────────────────────────────────────────── */
+/* ─── Tabs ─────────────────────────────────────────────────────
+   The `tabs` slot is a passive container. The bottom divider when tabs are
+   present comes from TabBar's own `tab` variant baseline (`TabBar.css`).
+   The PageHeader root border above is suppressed via `:has()` to avoid the
+   double-border that the previous `__tabs { border-bottom }` declaration
+   created against TabBar's inline border (brik-bds#400).
+*/
 
 .bds-page-header__tabs {
   width: 100%;
-  border-bottom: var(--border-width-sm) solid var(--border-secondary);
-}
-
-.bds-page-header__tabs .bds-tab-bar--tab .bds-tab-bar-item {
-  border-bottom-width: var(--border-width-sm);
-  margin-bottom: calc(-1 * var(--border-width-sm));
 }
 }

--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -98,11 +98,11 @@
   align-items: flex-start;
   justify-content: center;
   width: 100%;
-  border-top: var(--border-width-sm) solid var(--border-secondary);
-}
-
-.bds-page-header__metadata--no-divider {
-  border-top: none;
+  /* No internal divider — the page header has a single bottom border that
+     hands off to the body. Internal separators were creating a visual
+     "multiple borders at different widths" effect (the metadata row sits
+     inside the header's 80px horizontal padding, while the root border
+     spans the outer box). brik-bds#400. */
 }
 
 .bds-page-header__metadata-inner {
@@ -111,10 +111,6 @@
   align-items: flex-start;
   padding-top: var(--padding-xl);
   width: 100%;
-}
-
-.bds-page-header__metadata--no-divider .bds-page-header__metadata-inner {
-  padding-top: 0;
 }
 
 .bds-page-header__metadata-item {

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -24,8 +24,6 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
   metadata?: MetadataItem[];
   /** Summary content (e.g. stat cards) rendered between metadata and tabs. */
   stats?: ReactNode;
-  /** Show divider and top padding above metadata. Default: true */
-  showDivider?: boolean;
   /** Remove horizontal padding (for layouts that provide their own). Default: false */
   flush?: boolean;
   /** Title scale. Default: 'lg' */
@@ -46,7 +44,6 @@ export function PageHeader({
   tabs,
   metadata,
   stats,
-  showDivider = true,
   flush = false,
   size = 'lg',
   className,
@@ -73,7 +70,7 @@ export function PageHeader({
       </div>
 
       {metadata && metadata.length > 0 && (
-        <div className={bdsClass('bds-page-header__metadata', !showDivider && 'bds-page-header__metadata--no-divider')}>
+        <div className="bds-page-header__metadata">
           <div className="bds-page-header__metadata-inner">
             {metadata.map((item) => (
               <div key={item.label} className="bds-page-header__metadata-item">

--- a/components/ui/TabBar/TabBar.css
+++ b/components/ui/TabBar/TabBar.css
@@ -44,11 +44,27 @@
   opacity: 0.5;
 }
 
-/* ── Tab variant ── */
+/* ── Tab variant ──
+   Bar baseline + per-tab indicator both live here (not inline) so that:
+   1. PageHeader can suppress its own root border when tabs are present via
+      `:has(.bds-page-header__tabs)` without inline-style specificity fights.
+   2. Width is consistent at `--border-width-sm` (1px) — chrome divider scale,
+      not the chunky xl scale this used to render at.
+*/
 
-/* Tabs overlap the container's baseline border so active indicator replaces it */
+.bds-tab-bar--tab {
+  border-bottom: var(--border-width-sm) solid var(--border-secondary);
+}
+
 .bds-tab-bar--tab .bds-tab-bar-item {
-  margin-bottom: calc(-1 * var(--border-width-xl));
+  border-bottom: var(--border-width-sm) solid transparent;
+  /* Negative margin overlays the item border onto the bar baseline so the
+     active indicator replaces (not stacks under) the divider segment. */
+  margin-bottom: calc(-1 * var(--border-width-sm));
+}
+
+.bds-tab-bar--tab .bds-tab-bar-item[aria-selected="true"] {
+  border-bottom-color: var(--border-brand-primary);
 }
 
 .bds-tab-bar--tab .bds-tab-bar-item:hover:not(:disabled):not([aria-selected="true"]) {
@@ -61,6 +77,14 @@
 }
 
 /* ── Tab variant on-color ── */
+
+.bds-tab-bar--tab.bds-tab-bar--on-color {
+  border-bottom-color: var(--border-on-color-dark);
+}
+
+.bds-tab-bar--tab.bds-tab-bar--on-color .bds-tab-bar-item[aria-selected="true"] {
+  border-bottom-color: var(--border-on-color-dark);
+}
 
 .bds-tab-bar--tab.bds-tab-bar--on-color .bds-tab-bar-item:hover:not(:disabled):not([aria-selected="true"]) {
   opacity: 0.8;

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -48,7 +48,10 @@ const barBase: CSSProperties = {
 const barVariantStyles: Record<TabBarVariant, CSSProperties> = {
   text: { ...barBase, gap: 'var(--gap-xl)' },
   'text-underline': { ...barBase, gap: 'var(--gap-xl)' },
-  tab: { ...barBase, gap: 0, borderBottom: 'var(--border-width-xl) solid var(--border-secondary)' },
+  // `tab` variant baseline border lives in TabBar.css so external CSS
+  // (e.g. PageHeader's `:has(.bds-page-header__tabs)` rule) can suppress
+  // it without fighting inline-style specificity.
+  tab: { ...barBase, gap: 0 },
   box: { ...barBase, gap: 0 },
 };
 
@@ -110,13 +113,10 @@ function getTextUnderlineStyles(active: boolean, onColor: boolean): CSSPropertie
 }
 
 function getTabStyles(active: boolean, onColor: boolean): CSSProperties {
-  /* All tabs use border-width-xl (3px) for a consistent baseline.
-     Active tabs use brand color; inactive tabs use transparent so the container's
-     xl baseline border shows through unchanged. Prevents thickness mismatch. */
-  const borderColor = onColor
-    ? active ? 'var(--border-on-color-dark)' : 'transparent'
-    : active ? 'var(--border-brand-primary)' : 'transparent';
-
+  /* Color + opacity stay inline (per-state). The active/inactive border-bottom
+     and the negative-margin overlap onto the bar baseline live in TabBar.css
+     so external rules (e.g. PageHeader's tabs slot) can override widths via
+     normal CSS specificity instead of fighting inline shorthand. */
   const textColor = onColor
     ? 'var(--text-on-color-dark)'
     : active
@@ -128,7 +128,6 @@ function getTabStyles(active: boolean, onColor: boolean): CSSProperties {
     color: textColor,
     backgroundColor: 'transparent',
     padding: 'var(--padding-lg)',
-    borderBottom: `var(--border-width-xl) solid ${borderColor}`,
     opacity: onColor && !active ? 0.6 : 1,
   };
 }


### PR DESCRIPTION
## Summary
- fix(PageHeader,TabBar): single 1px bottom-border, no double-stack with tabs (closes #400)
- fix(PageHeader)!: drop redundant metadata internal divider + showDivider prop

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)