### PR TITLE
bds: page header lean padding

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -7,8 +7,9 @@
   gap: var(--gap-lg);
   align-items: flex-start;
   justify-content: center;
-  padding: var(--padding-xl) 80px; /* bds-lint-ignore — Figma page header spec */
   width: 100%;
+  /* No internal padding — the page header is a structural container.
+     Consumers control surrounding spacing via their own layout. */
   /* Single 1px divider hands the page header off to the body. When the `tabs`
      slot is filled, TabBar's own baseline takes over (suppressed below) so we
      don't stack two borders. */
@@ -18,11 +19,6 @@
 /* Suppress root divider when tabs are present — TabBar provides its baseline. */
 .bds-page-header:has(.bds-page-header__tabs) {
   border-bottom: none;
-}
-
-.bds-page-header--flush {
-  padding-left: 0;
-  padding-right: 0;
 }
 
 /* ─── Title row ──────────────────────────────────────────────── */

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -24,8 +24,6 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
   metadata?: MetadataItem[];
   /** Summary content (e.g. stat cards) rendered between metadata and tabs. */
   stats?: ReactNode;
-  /** Remove horizontal padding (for layouts that provide their own). Default: false */
-  flush?: boolean;
   /** Title scale. Default: 'lg' */
   size?: 'sm' | 'md' | 'lg';
 }
@@ -44,7 +42,6 @@ export function PageHeader({
   tabs,
   metadata,
   stats,
-  flush = false,
   size = 'lg',
   className,
   style,
@@ -52,7 +49,7 @@ export function PageHeader({
 }: PageHeaderProps) {
   return (
     <div
-      className={bdsClass('bds-page-header', flush && 'bds-page-header--flush', size !== 'lg' && `bds-page-header--${size}`, className)}
+      className={bdsClass('bds-page-header', size !== 'lg' && `bds-page-header--${size}`, className)}
       style={style}
       {...props}
     >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.56.0",
+      "version": "0.57.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(PageHeader)!: drop padding + flush prop; lean structural container (0.57.0)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)