### PR TITLE
bds: tab bar active indicator fix

### DIFF
--- a/components/ui/TabBar/TabBar.css
+++ b/components/ui/TabBar/TabBar.css
@@ -3,9 +3,14 @@
    Inline CSSProperties can't handle :hover/:active/:disabled,
    so these live in CSS. */
 
-/* ── Shared cursor + transition ── */
+/* ── Shared cursor + transition + UA reset ──
+   `border: 0` resets the user-agent <button> border (used to live inline in
+   `tabBase`, but inline `border: none` beats external CSS via specificity
+   and was killing the `tab` variant's active-state indicator). Per-variant
+   border rules below add what they need on top of this baseline. */
 
 .bds-tab-bar-item {
+  border: 0;
   transition: opacity var(--duration-fast) var(--ease-out),
     background-color var(--duration-fast) var(--ease-out),
     color var(--duration-fast) var(--ease-out),

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -55,7 +55,10 @@ const barVariantStyles: Record<TabBarVariant, CSSProperties> = {
   box: { ...barBase, gap: 0 },
 };
 
-/* ── Shared tab base ── */
+/* ── Shared tab base ──
+   Note: UA button border reset lives in `.bds-tab-bar-item` (CSS), NOT here.
+   Inline `border: 'none'` would beat any external `border-bottom` rule via
+   specificity — killing the `tab` variant's per-state active indicator. */
 
 const tabBase: CSSProperties = {
   fontFamily: 'var(--font-family-label)',
@@ -66,7 +69,6 @@ const tabBase: CSSProperties = {
   whiteSpace: 'nowrap',
   cursor: 'pointer',
   background: 'none',
-  border: 'none',
   padding: 0,
   minWidth: 0,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.57.0",
+      "version": "0.57.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- fix(TabBar): active-tab indicator was 0px — UA border reset moved to CSS (0.57.1)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)