### PR TITLE
chore(release): 0.57.2 — Board overflow + Chip parity + Feedback panel position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.57.1",
+      "version": "0.57.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.57.1",
+  "version": "0.57.2",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Patch release bundling three bug fixes already merged to main:

- **#416 / closes #411 + #414** — `fix(Board,Chip)`: Board column overflow + Chip box-model parity
- **#417 / closes #415** — `fix(DevFeedbackWidget)`: panel anchors to fabPosition

No API changes; consumer behavior with default props is unchanged. Patch bump per BDS release convention (bug fix only → patch).

## Release flow

1. Merge this PR to main (squash).
2. Tag from main: `git tag v0.57.2 && git push origin v0.57.2`
3. The `release.yml` workflow validates `package.json === tag` and publishes `@brikdesigns/bds@0.57.2` to GitHub Packages.

## Downstream

Once published, renew-pms will bump and:
- Delete 4 consumer overrides retired by #416 (3 Board column rules in `globals.css`, 1 Chip rule in `calendar.css`)
- Lower `BDS_SELECTOR_BASELINE` from 32 → 28 in `scripts/token-audit.sh`
- Visually verify the Feedback panel now anchors to the right edge alongside the FAB

🤖 Generated with [Claude Code](https://claude.com/claude-code)