### PR TITLE
feat(PageHeader): tunable internal spacing via component-scoped CSS variables

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -2,14 +2,22 @@
 /* ─── PageHeader ─────────────────────────────────────────────── */
 
 .bds-page-header {
+  /* ─── Component-scoped override surface ──────────────────────────
+     Consumers can tune these via cascade (theme file, globals.css, or
+     a per-instance style prop) to dial in the right rhythm without
+     forking the component. Defaults preserve the lean 0.57.0 shape. */
+  --page-header-section-gap: var(--gap-lg);     /* between root sections (inner/metadata/stats/tabs) */
+  --page-header-content-gap: var(--gap-sm);     /* between title-row and subtitle */
+  --page-header-actions-gap: var(--gap-sm);     /* between content column and actions column */
+  --page-header-padding-bottom: 0;              /* breathing room before the bottom divider */
+
   display: flex;
   flex-direction: column;
-  gap: var(--gap-lg);
+  gap: var(--page-header-section-gap); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   align-items: flex-start;
   justify-content: center;
   width: 100%;
-  /* No internal padding — the page header is a structural container.
-     Consumers control surrounding spacing via their own layout. */
+  padding-bottom: var(--page-header-padding-bottom); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   /* Single 1px divider hands the page header off to the body. When the `tabs`
      slot is filled, TabBar's own baseline takes over (suppressed below) so we
      don't stack two borders. */
@@ -25,7 +33,7 @@
 
 .bds-page-header__inner {
   display: flex;
-  gap: var(--gap-sm);
+  gap: var(--page-header-actions-gap); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   align-items: flex-start;
   width: 100%;
 }
@@ -36,7 +44,7 @@
   display: flex;
   flex: 1 0 0;
   flex-direction: column;
-  gap: var(--gap-sm);
+  gap: var(--page-header-content-gap); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   align-items: flex-start;
   justify-content: center;
   min-width: 0;

--- a/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/components/ui/PageHeader/PageHeader.stories.tsx
@@ -274,3 +274,65 @@ export const Patterns: Story = {
     );
   },
 };
+
+/* ═══════════════════════════════════════════════════════════════
+   4. TUNABLE SPACING — component-scoped CSS variables
+   ═══════════════════════════════════════════════════════════════ */
+
+/**
+ * @summary Demonstrates the four CSS variables that tune internal rhythm —
+ * defaults vs a roomier override (matching renew-pms's tuning).
+ */
+export const TunableSpacing: Story = {
+  render: () => {
+    return (
+      <Stack gap="var(--gap-huge)">
+        {/* Defaults */}
+        <div>
+          <SectionLabel>Defaults — gap-sm content gap, 0 divider padding</SectionLabel>
+          <PageHeader
+            title="Default Header"
+            subtitle="Title↔subtitle gap = 6px (gap-sm). Subtitle sits flush above the divider."
+            actions={<Button variant="primary" size="sm">Action</Button>}
+          />
+        </div>
+
+        {/* Tuned for clinical density (renew-pms) */}
+        <div>
+          <SectionLabel>Tuned — wider content gap + divider breathing room</SectionLabel>
+          <PageHeader
+            title="Tuned Header"
+            subtitle="Title↔subtitle gap bumped to 12px; 16px breathing room before the divider."
+            actions={<Button variant="primary" size="sm">Action</Button>}
+            style={{
+              // bds-lint-ignore — component-scoped CSS variables, not design tokens
+              ['--page-header-content-gap' as string]: 'var(--padding-sm)',
+              ['--page-header-padding-bottom' as string]: 'var(--padding-md)',
+            }}
+          />
+        </div>
+
+        {/* Even roomier — shows the full knob set */}
+        <div>
+          <SectionLabel>Roomy — all four knobs at the higher end</SectionLabel>
+          <PageHeader
+            title="Roomy Header"
+            subtitle="Each gap stepped up one tier — useful for marketing-shaped pages with breathing room."
+            tabs={<TabBar variant="tab" items={[
+              { label: 'Overview', active: true, onClick: () => {} },
+              { label: 'Settings', active: false, onClick: () => {} },
+            ]} />}
+            actions={<Button variant="primary" size="sm">Action</Button>}
+            style={{
+              // bds-lint-ignore — component-scoped CSS variables, not design tokens
+              ['--page-header-section-gap' as string]: 'var(--gap-xl)',
+              ['--page-header-content-gap' as string]: 'var(--gap-md)',
+              ['--page-header-actions-gap' as string]: 'var(--gap-md)',
+              ['--page-header-padding-bottom' as string]: 'var(--padding-md)',
+            }}
+          />
+        </div>
+      </Stack>
+    );
+  },
+};

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -31,6 +31,22 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
 /**
  * PageHeader — composable page-level header with breadcrumbs, badge, actions, metadata, stats, and tabs.
  *
+ * ## Tunable spacing
+ *
+ * Four component-scoped CSS variables on `.bds-page-header` let consumers
+ * adjust the internal rhythm without forking the component. Override at any
+ * cascade level (theme file, `globals.css`, `style` prop). Defaults preserve
+ * the lean 0.57.0 shape:
+ *
+ * - `--page-header-section-gap` (default `var(--gap-lg)` = 16px) — between
+ *   root sections (inner / metadata / stats / tabs).
+ * - `--page-header-content-gap` (default `var(--gap-sm)` = 6px) — between
+ *   the title-row and the subtitle.
+ * - `--page-header-actions-gap` (default `var(--gap-sm)` = 6px) — between
+ *   the content column (title + subtitle) and the actions column.
+ * - `--page-header-padding-bottom` (default `0`) — breathing room before the
+ *   bottom divider, useful when the divider sits flush against the title.
+ *
  * @summary Page-level header — title, breadcrumbs, actions, tabs
  */
 export function PageHeader({


### PR DESCRIPTION
## Summary

Surfaced from renew-pms user feedback that PageHeader's title↔subtitle and content↔divider gaps read as too tight (live-measured: 6px and 0px on dashboard). The fix isn't to change BDS defaults — different consumers want different rhythms — but to make the rhythm tunable without forking the component.

Adds four component-scoped CSS variables on `.bds-page-header`, following the existing BDS pattern (`Select` uses `--select-chevron-color` the same way). **Defaults preserve the lean 0.57.0 shape exactly — zero breaking change for any consumer.**

## API

| Variable | Default | Controls |
|---|---|---|
| `--page-header-section-gap` | `var(--gap-lg)` | Between root sections (inner / metadata / stats / tabs) |
| `--page-header-content-gap` | `var(--gap-sm)` | Between title-row and subtitle |
| `--page-header-actions-gap` | `var(--gap-sm)` | Between content column and actions column |
| `--page-header-padding-bottom` | `0` | Breathing room before the bottom divider |

Override at any cascade level — theme file, `globals.css`, or per-instance via `style`. Example renew-pms planned tuning:

\`\`\`css
.bds-page-header {
  --page-header-content-gap: var(--padding-sm);   /* 12px instead of 6px */
  --page-header-padding-bottom: var(--padding-md); /* 16px before divider */
}
\`\`\`

## What's NOT in this PR

- **No default changes.** Defaults match the current 0.57.2 behavior pixel-for-pixel.
- **No new props.** Tunability lives in CSS via cascade — same model as `Select`'s chevron color.
- **No consumer changes.** Renew-pms will tune in a follow-up via `globals.css`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run components/ui/PageHeader` — 4/4 passing
- [x] BDS token-lint + JSDoc lint clean
- [x] Story added — `TunableSpacing` shows defaults vs renew's planned tuning vs an even roomier preset

## Release

Patch bump (0.57.3) appropriate when this lands — additive only, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)