### PR TITLE
chore(release): 0.57.3 — PageHeader tunable spacing variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.57.2",
+      "version": "0.57.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.57.2",
+  "version": "0.57.3",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Patch release for the PageHeader internal-spacing tunability work merged in [#419](https://github.com/brikdesigns/brik-bds/pull/419).

Adds four component-scoped CSS variables on \`.bds-page-header\`:

- \`--page-header-section-gap\` (default \`var(--gap-lg)\`)
- \`--page-header-content-gap\` (default \`var(--gap-sm)\`)
- \`--page-header-actions-gap\` (default \`var(--gap-sm)\`)
- \`--page-header-padding-bottom\` (default \`0\`)

**Defaults preserve 0.57.2 behavior pixel-for-pixel.** Additive, no API change.

## Release flow

1. Merge this PR.
2. Tag from main: \`git tag v0.57.3 && git push origin v0.57.3\`.
3. \`release.yml\` workflow validates \`package.json === tag\` and publishes \`@brikdesigns/bds@0.57.3\` to GitHub Packages.

## Downstream

renew-pms will bump to 0.57.3 and add a 2-line override in \`globals.css\` to set \`--page-header-content-gap\` and \`--page-header-padding-bottom\` to renew's preferred clinical-density rhythm — closes the original "page-header gaps look tight" feedback at the root, via tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)