### PR TITLE
feat(TabBar): tab variant — drop horizontal padding, brand-color active

### DIFF
--- a/components/ui/TabBar/TabBar.css
+++ b/components/ui/TabBar/TabBar.css
@@ -61,11 +61,13 @@
   border-bottom: var(--border-width-sm) solid var(--border-secondary);
 }
 
+/* Items reserve the active-indicator's width (--border-width-lg = 4px) as a
+   transparent border on every item — so toggling active doesn't shift layout.
+   Negative margin overlays the item border onto the bar baseline so the
+   active indicator replaces (not stacks under) the divider segment. */
 .bds-tab-bar--tab .bds-tab-bar-item {
-  border-bottom: var(--border-width-sm) solid transparent;
-  /* Negative margin overlays the item border onto the bar baseline so the
-     active indicator replaces (not stacks under) the divider segment. */
-  margin-bottom: calc(-1 * var(--border-width-sm));
+  border-bottom: var(--border-width-lg) solid transparent;
+  margin-bottom: calc(-1 * var(--border-width-lg));
 }
 
 .bds-tab-bar--tab .bds-tab-bar-item[aria-selected="true"] {

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -118,18 +118,25 @@ function getTabStyles(active: boolean, onColor: boolean): CSSProperties {
   /* Color + opacity stay inline (per-state). The active/inactive border-bottom
      and the negative-margin overlap onto the bar baseline live in TabBar.css
      so external rules (e.g. PageHeader's tabs slot) can override widths via
-     normal CSS specificity instead of fighting inline shorthand. */
+     normal CSS specificity instead of fighting inline shorthand.
+
+     Padding shape: items have no horizontal padding (chunky 24px-each-side
+     was breaking the page-header rhythm); padding-bottom holds the breathing
+     room between text and the active indicator. Active text uses
+     `--text-brand-primary` so the active state reads as a brand affordance,
+     matching the brand-color underline. */
   const textColor = onColor
     ? 'var(--text-on-color-dark)'
     : active
-      ? 'var(--text-primary)'
+      ? 'var(--text-brand-primary)'
       : 'var(--text-secondary)';
 
   return {
     ...tabBase,
     color: textColor,
     backgroundColor: 'transparent',
-    padding: 'var(--padding-lg)',
+    padding: 0,
+    paddingBottom: 'var(--padding-sm)',
     opacity: onColor && !active ? 0.6 : 1,
   };
 }


### PR DESCRIPTION
## Summary

Surfaced from renew-pms feedback that the `tab` variant's chunky 24px-each-side padding was breaking page-header rhythm, and the 1px active-state indicator wasn't reading as a strong-enough affordance.

## Changes (tab variant only)

| Property | Before | After |
|---|---|---|
| Item padding | `var(--padding-lg)` (24px all sides) | `0` horizontal, `var(--padding-sm)` (12px) bottom |
| Active text color | `var(--text-primary)` | `var(--text-brand-primary)` |
| Active indicator | `var(--border-width-sm)` (1px) | `var(--border-width-lg)` (4px) |

Items reserve a 4px transparent `border-bottom` on **every** state, so toggling active never causes layout shift. The active state simply paints the brand color into that 4px slot. Bar baseline (1px gray border-bottom on the container) stays unchanged — inactive tabs still hand off cleanly to body content.

The 12px `padding-bottom` matches the existing `text-underline` variant's pattern: text-on-top, indicator-on-bottom, breathing room in between.

## Out of scope

- `text` / `text-underline` / `box` variants are unchanged — this PR tunes only the `tab` variant.
- No new props or API changes — same `<TabBar variant="tab">` consumers automatically get the refreshed visual.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run components/ui/TabBar` — 3/3 passing
- [x] BDS token-lint + JSDoc lint clean

## Release

Patch bump (0.57.4) appropriate when this lands — visual refinement, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)