### PR TITLE
fix(TabBar): gap-md between tab + box items

### DIFF
--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -51,8 +51,8 @@ const barVariantStyles: Record<TabBarVariant, CSSProperties> = {
   // `tab` variant baseline border lives in TabBar.css so external CSS
   // (e.g. PageHeader's `:has(.bds-page-header__tabs)` rule) can suppress
   // it without fighting inline-style specificity.
-  tab: { ...barBase, gap: 0 },
-  box: { ...barBase, gap: 0 },
+  tab: { ...barBase, gap: 'var(--gap-md)' },
+  box: { ...barBase, gap: 'var(--gap-md)' },
 };
 
 /* ── Shared tab base ──


### PR DESCRIPTION
## Summary

The `tab` and `box` variants set `gap: 0` on the bar container, leaving sibling tab labels visually crammed together. The `text` and `text-underline` variants already use `gap-xl`; `tab` and `box` were the inconsistency.

Surfaced 2026-05-03 on the renew-pms Tasks page (`<TabBar variant=\"tab\">` inside a `<PageHeader tabs={…}>` slot). Tabs rendered as a single string (`All TasksMy TasksOpen Tasks`) with the active brand underline running under just the first label. Fix is global to BDS — every PageHeader hosting a `tab`-variant TabBar gets corrected automatically on consumer bump.

## Change

`components/ui/TabBar/TabBar.tsx` — two lines:

```diff
-  tab: { ...barBase, gap: 0 },
-  box: { ...barBase, gap: 0 },
+  tab: { ...barBase, gap: 'var(--gap-md)' },
+  box: { ...barBase, gap: 'var(--gap-md)' },
```

`--gap-md` resolves to 8px, the smallest gap in the scale that produces clear visual separation. Active indicator placement is unchanged — gap is between siblings, the indicator lives on each item's `border-bottom`.

## Test plan

- [x] Visual verification in Storybook (`Navigation/Secondary/tab-bar` → `Variants` story): tab + box now show clear inter-tab spacing, active indicator unchanged
- [x] `npm run validate:full` — all 8 checks pass (token lint, JSDoc, grid, theme, blueprint, canonical, TS, storybook build)
- [x] `text` and `text-underline` variants visually unaffected (still `gap-xl`)

## Consumer sync plan

- [ ] **renew-pms**: bump `@brikdesigns/bds` post-publish — the surface that surfaced this bug
- [ ] **brik-client-portal**: `npm update @brikdesigns/bds` post-publish
- [ ] **brikdesigns.com**: `./scripts/bds-sync.sh` post-publish

## Release impact

`fix(TabBar)` → patch release via release-please (0.57.4 → 0.57.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)