### PR TITLE
fix(storybook): single setConfig + themes.light/dark base — manager chrome fragments less

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,9 +1,11 @@
 <!--
   Manager Head — Immersive Storybook Theming
 
-  Two mechanisms work together:
-  1. manager.tsx sets --sb-* CSS custom properties on <body> (instant)
-  2. This CSS references those variables to style the full chrome
+  Single source of truth at runtime: --sb-* CSS custom properties on <body>,
+  written by manager.tsx on every globalsUpdated event. Storybook's emotion
+  theme is set ONCE at startup (also in manager.tsx, with themes.light or
+  themes.dark spread as the base) so chrome surfaces we don't override here
+  inherit sensible defaults instead of being fought.
 
   Fonts are loaded here because the manager frame is separate from preview.
 -->
@@ -48,9 +50,9 @@
     color: var(--sb-text-muted, #828282) !important;
   }
 
-  /* Sidebar group headings */
-  [class*="sidebar"] [class*="GroupHeading"],
-  [class*="sidebar"] [class*="heading"] {
+  /* Sidebar group headings — scope to the GroupHeading class only.
+     [class*="heading"] alone is too broad and matched unrelated elements. */
+  [class*="sidebar"] [class*="GroupHeading"] {
     color: var(--sb-text-muted, #828282) !important;
     font-family: var(--sb-font-base, sans-serif) !important;
   }
@@ -117,20 +119,15 @@
   }
 
   /* ============================================
-     DARK THEME — Additional overrides
-     Storybook's emotion CSS fights harder on dark,
-     so we use the data attribute for specificity.
+     DARK THEME — color-scheme + scrollbar
+     Borders are already on the --sb-border-color var, so the duplicate
+     border override is gone. Native form controls (focus rings, scrollbar
+     defaults) need color-scheme to render correctly in dark.
      ============================================ */
   body[data-bds-dark="true"] {
     color-scheme: dark;
   }
 
-  body[data-bds-dark="true"] [class*="sidebar"],
-  body[data-bds-dark="true"] .sb-bar {
-    border-color: var(--sb-border-color, #444) !important;
-  }
-
-  /* Dark mode scrollbar */
   body[data-bds-dark="true"] ::-webkit-scrollbar-track {
     background: var(--sb-app-bg, black);
   }

--- a/.storybook/manager.tsx
+++ b/.storybook/manager.tsx
@@ -1,19 +1,24 @@
 import { addons } from 'storybook/manager-api';
-import { create } from 'storybook/theming';
+import { create, themes } from 'storybook/theming';
 import { storybookThemes, type StorybookThemeConfig } from '../tokens/storybook-themes';
 import type { ThemeNumber } from '../tokens';
 
 /**
  * Brik Design System — Manager Theming
  *
- * CSS custom properties on <body> handle all visual updates instantly.
- * manager-head.html references --sb-* variables to style sidebar,
- * toolbar, search inputs, and chrome elements.
+ * `addons.setConfig({ theme })` is called ONCE at startup (its intended
+ * use per the Storybook 10 docs and Theming 2.0 RFC). We do NOT re-call
+ * it on toolbar switches because that triggers a manager remount, which
+ * has shown up as transient "page failed to load" errors.
  *
- * addons.setConfig({ theme }) is called ONCE at startup (its intended
- * use). It is NOT called on theme switches — it triggers expensive
- * React re-renders of the entire manager UI (Storybook Theming 2.0
- * RFC confirms this is a startup-time API, not a runtime API).
+ * Runtime theme changes happen entirely via `--sb-*` CSS custom
+ * properties on `<body>` (see manager-head.html). Storybook's built-in
+ * `themes.light` / `themes.dark` are spread as the base of `create()`
+ * so chrome surfaces we don't override get sensible defaults instead
+ * of fighting emotion-injected styles.
+ *
+ * The brand logo is swapped on theme change by mutating the rendered
+ * <img> src directly — no setConfig needed.
  */
 
 const sharedBrand = {
@@ -24,11 +29,10 @@ const sharedBrand = {
   inputBorderRadius: 4,
 };
 
-/**
- * Apply CSS custom properties to the manager <body>.
- * manager-head.html references these --sb-* variables to style
- * sidebar, toolbar, and other chrome elements instantly.
- */
+function brandImageFor(base: 'light' | 'dark'): string {
+  return base === 'dark' ? '/brik-logo-white.svg' : '/brik-logo.svg';
+}
+
 function applyThemeVars(config: StorybookThemeConfig) {
   const s = document.body.style;
   s.setProperty('--sb-app-bg', config.appBg);
@@ -47,76 +51,54 @@ function applyThemeVars(config: StorybookThemeConfig) {
   s.setProperty('--sb-color-primary', config.colorPrimary);
   s.setProperty('--sb-color-secondary', config.colorSecondary);
   s.setProperty('--sb-font-base', config.fontBase);
-  // Dark mode flag for CSS selectors that need light/dark branching
   document.body.setAttribute('data-bds-dark', String(config.base === 'dark'));
+  document.body.setAttribute('data-bds-theme', config.base);
 }
 
-// Set initial theme — setConfig() at startup (its intended use)
-const initialConfig = storybookThemes['brik'];
-applyThemeVars(initialConfig);
+function swapBrandImage(base: 'light' | 'dark') {
+  const next = brandImageFor(base);
+  const img = document.querySelector<HTMLImageElement>(
+    `img[alt="${sharedBrand.brandTitle}"]`,
+  );
+  if (img && !img.src.endsWith(next)) img.src = next;
+}
+
+const initial = storybookThemes['brik'];
+applyThemeVars(initial);
+
 addons.setConfig({
   theme: create({
+    ...themes[initial.base],
     ...sharedBrand,
-    brandImage: '/brik-logo.svg',
-    base: initialConfig.base,
-    colorPrimary: initialConfig.colorPrimary,
-    colorSecondary: initialConfig.colorSecondary,
-    appBg: initialConfig.appBg,
-    appContentBg: initialConfig.appContentBg,
-    appPreviewBg: initialConfig.appPreviewBg,
-    appBorderColor: initialConfig.appBorderColor,
-    textColor: initialConfig.textColor,
-    textInverseColor: initialConfig.textInverseColor,
-    textMutedColor: initialConfig.textMutedColor,
-    barTextColor: initialConfig.barTextColor,
-    barSelectedColor: initialConfig.barSelectedColor,
-    barHoverColor: initialConfig.barHoverColor,
-    barBg: initialConfig.barBg,
-    inputBg: initialConfig.inputBg,
-    inputBorder: initialConfig.inputBorder,
-    inputTextColor: initialConfig.inputTextColor,
-    fontBase: initialConfig.fontBase,
+    brandImage: brandImageFor(initial.base),
+    base: initial.base,
+    colorPrimary: initial.colorPrimary,
+    colorSecondary: initial.colorSecondary,
+    appBg: initial.appBg,
+    appContentBg: initial.appContentBg,
+    appPreviewBg: initial.appPreviewBg,
+    appBorderColor: initial.appBorderColor,
+    textColor: initial.textColor,
+    textInverseColor: initial.textInverseColor,
+    textMutedColor: initial.textMutedColor,
+    barTextColor: initial.barTextColor,
+    barSelectedColor: initial.barSelectedColor,
+    barHoverColor: initial.barHoverColor,
+    barBg: initial.barBg,
+    inputBg: initial.inputBg,
+    inputBorder: initial.inputBorder,
+    inputTextColor: initial.inputTextColor,
+    fontBase: initial.fontBase,
   }),
 });
 
-// Listen for theme changes — update both CSS vars (instant visual) and
-// manager emotion theme (api.setOptions). This is the standard approach
-// used by storybook-dark-mode addon and major design systems.
 if (typeof window !== 'undefined') {
   const channel = addons.getChannel();
   channel.on('globalsUpdated', ({ globals }: { globals: Record<string, unknown> }) => {
     const themeNum = globals.themeNumber as string;
     const config = storybookThemes[themeNum as ThemeNumber];
-    if (config) {
-      // 1. CSS vars — instant visual update for sidebar/toolbar
-      applyThemeVars(config);
-
-      // 2. Emotion theme — updates all emotion-styled manager components
-      //    (tabs, panels, borders, etc. that CSS vars don't reach)
-      addons.setConfig({
-        theme: create({
-          ...sharedBrand,
-          brandImage: config.base === 'dark' ? '/brik-logo-white.svg' : '/brik-logo.svg',
-          base: config.base,
-          colorPrimary: config.colorPrimary,
-          colorSecondary: config.colorSecondary,
-          appBg: config.appBg,
-          appContentBg: config.appContentBg,
-          appPreviewBg: config.appPreviewBg,
-          appBorderColor: config.appBorderColor,
-          textColor: config.textColor,
-          textInverseColor: config.textInverseColor,
-          textMutedColor: config.textMutedColor,
-          barTextColor: config.barTextColor,
-          barSelectedColor: config.barSelectedColor,
-          barHoverColor: config.barHoverColor,
-          barBg: config.barBg,
-          inputBg: config.inputBg,
-          inputBorder: config.inputBorder,
-          inputTextColor: config.inputTextColor,
-          fontBase: config.fontBase,
-        }),
-      });
-    }
+    if (!config) return;
+    applyThemeVars(config);
+    swapBrandImage(config.base);
   });
 }


### PR DESCRIPTION
## Summary
- bds: page header tab bar double border (#401)
- chore(release): 0.56.0 (#402)
- feat(PageHeader)!: drop padding + flush prop; lean structural container (0.57.0) (#403)
- fix(TabBar): active-tab indicator was 0px — UA border reset moved to CSS (0.57.1) (#405)
- fix(Board,Chip): board column overflow + chip box-model parity (brik-bds#411, #414) (#416)
- fix(DevFeedbackWidget): panel anchors to fabPosition (closes brik-bds#415) (#417)
- chore(release): 0.57.2 (#418)
- feat(PageHeader): tunable internal spacing via component-scoped CSS variables (#419)
- chore(release): 0.57.3 (#420)
- feat(TabBar): tab variant — drop horizontal padding, brand-color active (#421)
- chore(release): 0.57.4 (#422)
- fix(TabBar): tab + box variants — gap-md between items (was 0px) (#423)
- chore(release): 0.57.5 (#424)
- fix(storybook): single setConfig + themes.light/dark base — chrome no longer fragments on theme switch

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)