### PR TITLE
feat(storybook): ADR-007 Phase 3 batch 4 — 9 more pages migrated, broader banned-section strip

### DIFF
--- a/components/ui/Badge/Badge.mdx
+++ b/components/ui/Badge/Badge.mdx
@@ -1,32 +1,16 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './Badge.stories';
 
 <Meta of={Stories} />
 
 # Badge
 
+<ComponentLinks slug="badge" />
+
 Status indicators and labels for displaying contextual information. Badges use semantic system colors to communicate status at a glance, with `solid` (saturated bg) and `subtle` (pastel bg) appearance values.
 
----
-
-## Indicators vs Actions
-
-Badge is an **indicator** — non-interactive. It reflects state (published, in review, archived). Never wire `onClick`, never wrap in a link, never use Badge to trigger behavior.
-
-| Family | Components | When to use |
-|---|---|---|
-| **Indicator** (display state) | `Badge`, `Tag`, `Dot`, `AlertBanner` | Labeling a record's status, category, or metadata. Read-only. |
-| **Action** (user-initiated) | `Button`, `LinkButton`, `IconButton`, `FilterButton`, `Chip` | Triggering navigation, mutation, filtering, or selection. |
-
-**Badge vs Tag:** Badge carries a semantic status color (positive/warning/error/info/progress/brand). Tag is categorical — no status meaning, neutral styling. Use Badge when the state has a value judgment (good/bad/waiting); use Tag when it doesn't (industry, size, owner).
-
-**Badge vs Chip:** If it's clickable, it's a Chip, not a Badge. "Status: Active" with a dismiss X on an active-filter row is a Chip (user can remove it). "Status: Active" in a read-only table cell is a Badge (just reflecting state).
-
----
-
 ## Playground
-
-Use the Controls panel to explore all props interactively.
 
 <Canvas of={Stories.Playground} />
 
@@ -61,43 +45,7 @@ Real-world compositions for common badge use cases.
 
 <Canvas of={Stories.Patterns} />
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
 
----
-
-## Usage
-
-```tsx
-import { Badge } from '@brik/bds';
-
-// Solid appearance (default)
-<Badge status="positive">Done</Badge>
-<Badge status="warning">Needs Attention</Badge>
-<Badge status="error">Canceled</Badge>
-
-// Subtle appearance (pastel fill)
-<Badge status="positive" appearance="subtle">Done</Badge>
-<Badge status="progress" appearance="subtle">In Progress</Badge>
-
-// With icon
-<Badge status="positive" icon={<Icon icon="ph:check" />}>
-  Done
-</Badge>
-
-// Icon-only (xs)
-<Badge size="xs" status="error" icon={<Icon icon="ph:x-circle" />} />
-```
-
----
-
-## Tokens
-
-- `--color-system-green` / `--color-system-green-light` — Positive status
-- `--color-system-red` / `--color-system-red-light` — Error status
-- `--color-system-yellow` / `--color-system-yellow-light` — Warning status
-- `--color-system-blue` / `--color-system-blue-light` — Progress status
-- `--color-system-neutral` / `--color-system-neutral-light` — Info status

--- a/components/ui/ChecklistItem/ChecklistItem.mdx
+++ b/components/ui/ChecklistItem/ChecklistItem.mdx
@@ -1,9 +1,12 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './ChecklistItem.stories';
 
 <Meta of={Stories} />
 
 # ChecklistItem
+
+<ComponentLinks slug="checklist-item" />
 
 Row-style completion control. Combines `CompletionToggle`'s circular visual with a native `<label>` + `<input type="checkbox">`, so the **entire row is the click target**. Native `Space` / `Enter` toggle for free; no manual `onKeyDown` needed.
 
@@ -12,8 +15,6 @@ When checked, the label gets `text-decoration: line-through` and a muted color, 
 **Distinct from `Checkbox`.** Same shape (label + box + click handler), different visual + semantics. Use `ChecklistItem` for completion-state on units of work — task checklists, clinical procedures, compliance checks. Use `Checkbox` for form selections — multi-select filters, "I agree to terms," settings toggles. The visual difference (circle vs. square) matches the semantic difference.
 
 For card chrome where the toggle stands alone (the rest of the card is a different click target), use `CompletionToggle` instead — `ChecklistItem` is specifically the row composition.
-
----
 
 ## Playground
 
@@ -33,44 +34,7 @@ For card chrome where the toggle stands alone (the rest of the card is a differe
 
 A daily-maintenance checklist inside a task sheet — the canonical use case in a clinical PMS. The completion bg + strikethrough makes done vs. not-done glanceable at the row level; the running `n of N completed` counter sits above the list.
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
 
----
-
-## Usage
-
-```tsx
-import { ChecklistItem } from '@brikdesigns/bds';
-
-// Controlled
-<ChecklistItem
-  label="Restock surgical gloves"
-  checked={item.completed}
-  onCheckedChange={(next) => save(item.id, next)}
-/>
-
-// Disabled while save is in flight
-<ChecklistItem
-  label={item.label}
-  checked={item.completed}
-  onCheckedChange={...}
-  disabled={saving}
-/>
-```
-
-## When to use
-
-- Task checklist items inside a task sheet
-- Clinical procedure steps that staff complete in order
-- Compliance checks (regulatory + safety) that need to be marked done
-- Anywhere a discrete unit of work has a "done / not done" state and the entire row should be the click target
-
-## When not to use
-
-- Form selections / multi-select / "I agree to terms" → use `Checkbox`
-- Card-chrome toggle (e.g. mark-complete on a board card) → use `CompletionToggle`
-- Clinical attestation / sign-off requiring initials + timestamp → wait for the dedicated attestation primitive

--- a/components/ui/Chip/Chip.mdx
+++ b/components/ui/Chip/Chip.mdx
@@ -1,36 +1,16 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './Chip.stories';
 
 <Meta of={Stories} />
 
 # Chip
 
+<ComponentLinks slug="chip" />
+
 Compact interactive pill for filtering, selection, and removable tokens. Use for filter dropdown triggers, active-filter chips, and multi-select state.
 
----
-
-## Indicators vs Actions
-
-Chip is an **action** — always interactive. Render a Chip only when `onChipClick`, `onRemove`, or `showDropdown` is wired up. A Chip with no handler is a bug — use `Badge` (status) or `Tag` (category) instead.
-
-| Family | Components | When to use |
-|---|---|---|
-| **Indicator** (display state) | `Badge`, `Tag`, `Dot`, `AlertBanner` | Labeling a record's status, category, or metadata. Read-only. |
-| **Action** (user-initiated) | `Button`, `LinkButton`, `IconButton`, `FilterButton`, `Chip` | Triggering navigation, mutation, filtering, or selection. |
-
-**Chip vs FilterButton vs Button:**
-
-- `Button` — primary CTAs, form submits, primary workflows. Rectangular.
-- `FilterButton` — dropdown trigger inside a `FilterBar`. Encapsulates the dropdown state machine.
-- `Chip` — compact pill for filter selections *after* a choice is made ("Status: Active" with X), multi-select tokens, or secondary toggle pills. Pair with FilterButton, don't duplicate it.
-
-**Chip vs Badge / Tag:** If the pill is read-only — rendered from data, not clickable — use `Badge` (status) or `Tag` (category). "Published" in a read-only table cell is a Badge. "Published" as a toggleable filter in a facet sidebar is a Chip.
-
----
-
 ## Playground
-
-Use the Controls panel to explore all props interactively.
 
 <Canvas of={Stories.Playground} />
 
@@ -53,13 +33,9 @@ Real-world compositions for filtering and selection.
 
 <Canvas of={Stories.Patterns} />
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
-
----
 
 ## CSS Override API
 
@@ -78,25 +54,3 @@ Component-scoped CSS variables exposed on `.bds-chip`. Set on a wrapping element
 }
 ```
 
----
-
-## Usage
-
-```tsx
-import { Chip } from '@brik/bds';
-
-// Basic chip
-<Chip label="Design" />
-
-// Filter dropdown trigger
-<Chip label="All statuses" icon={<FilterIcon />} showDropdown onChipClick={() => openMenu()} />
-
-// Removable chip (active filter)
-<Chip label="Status: Active" onRemove={() => removeFilter('status')} />
-
-// Size, variant, and appearance
-<Chip label="Active" size="sm" variant="primary" appearance="outline" />
-
-// Disabled
-<Chip label="Archived" disabled />
-```

--- a/components/ui/CompletionToggle/CompletionToggle.mdx
+++ b/components/ui/CompletionToggle/CompletionToggle.mdx
@@ -1,17 +1,18 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './CompletionToggle.stories';
 
 <Meta of={Stories} />
 
 # CompletionToggle
 
+<ComponentLinks slug="completion-toggle" />
+
 Circular completion control. The atomic primitive for representing the **complete / not complete** state on a discrete unit of work — a task, a checklist item, a clinical step. Renders as a `<button>` so it can stand alone as a click target in card chrome.
 
 **Distinct from `Checkbox`.** Checkbox is rectangular and intended for form selections (multi-select filter, "I agree to terms"). CompletionToggle is circular and intended for completion-state on units of work. The visual difference matches the semantic difference; reach for the right one based on what the box represents — a *selection* (square) vs. a *completion* (circle).
 
 For row-style use where the entire row is the click target (label + circle, like a sub-task row inside a sheet), use `ChecklistItem` — it pairs this control's visual with a native `<label>` + `<input>` for proper form semantics and full-row click target.
-
----
 
 ## Playground
 
@@ -32,41 +33,7 @@ For row-style use where the entire row is the click target (label + circle, like
 - **Card chrome** — Used as a self-contained toggle on a task card. The toggle is the click target; the rest of the card is something else (e.g. opens the task sheet).
 - **Inline list** — Stand-alone toggles next to label text. For full-row click targets, use `ChecklistItem` instead of composing manually.
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
 
----
-
-## Usage
-
-```tsx
-import { CompletionToggle } from '@brikdesigns/bds';
-
-// Controlled
-<CompletionToggle
-  checked={task.completed}
-  onCheckedChange={(next) => mark(task.id, next)}
-/>
-
-// Disabled (e.g. while save is in flight)
-<CompletionToggle
-  checked={task.completed}
-  onCheckedChange={...}
-  disabled={saving}
-/>
-```
-
-## When to use
-
-- Task cards with a "mark complete" affordance
-- Standalone "is this done" toggles outside a list context
-- Anywhere `<input type="checkbox">` would be semantically wrong because the value isn't a *selection* but a *completion*
-
-## When not to use
-
-- Form selections / multi-select / "I agree to terms" → use `Checkbox`
-- Clinical attestation / sign-off with initials + timestamp → wait for the dedicated attestation primitive
-- Full-row click target with label inside a list → use `ChecklistItem`

--- a/components/ui/InteractiveListItem/InteractiveListItem.mdx
+++ b/components/ui/InteractiveListItem/InteractiveListItem.mdx
@@ -1,17 +1,18 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './InteractiveListItem.stories';
 
 <Meta of={Stories} />
 
 # InteractiveListItem
 
+<ComponentLinks slug="interactive-list-item" />
+
 Clickable horizontal row composed of leading + (title + subtitle) + trailing slots. The whole row is the click target — single `<button>` for native a11y (focus ring, `Space` / `Enter` activation, `disabled`).
 
 Use when a list row drills into something — clicking a member opens their profile, clicking an activity item opens the related task, clicking a persona switches the dev session.
 
 **Distinct from `CardControl`.** `CardControl` is a settings card whose **trailing action** (Switch / Button / link) is the click target — the card itself is *not* interactive. `InteractiveListItem` is the inverse — the **whole row** is interactive, the trailing slot is decorative (a Tag, Badge, progress block, or caret indicator). If you need both — a row that drills in AND a switch in the trailing — you have a UX conflict; pick one click target.
-
----
 
 ## Playground
 
@@ -32,62 +33,7 @@ Use when a list row drills into something — clicking a member opens their prof
 
 An activity feed inside a sheet. Each row drills into the related request. The subtitle slot here is a `ReactNode` carrying multi-line metadata: the first line is text (submitter · timestamp), the second line is a row of inline `<Badge>`s. The trailing slot shows a caret indicator.
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
 
----
-
-## Usage
-
-```tsx
-import { InteractiveListItem } from '@brikdesigns/bds';
-
-<InteractiveListItem
-  leading={<UserAvatar name={member.name} size="md" />}
-  title={member.name}
-  subtitle={`${member.role} · ${member.department}`}
-  trailing={<Badge status="info">New hire</Badge>}
-  onClick={() => openProfile(member.id)}
-/>
-```
-
-### Multi-line subtitle with badges
-
-When the subtitle needs structured content (timestamps, status badges, multiple lines), pass a `ReactNode`:
-
-```tsx
-<InteractiveListItem
-  leading={<StatusIcon resolved={req.resolved} />}
-  title={req.title}
-  subtitle={
-    <>
-      <span>{req.submitter} · {timeAgo(req.created_at)}</span>
-      <span style={{ display: 'flex', gap: 'var(--gap-sm)' }}>
-        <StatusBadge status={req.status} size="xs" />
-        <PriorityBadge priority={req.urgency} size="xs" />
-      </span>
-    </>
-  }
-  trailing={<Icon icon="ph:caret-right" />}
-  onClick={() => openRequest(req.id)}
-/>
-```
-
-The component applies muted body-text styling to the subtitle wrapper but consumer elements (`<StatusBadge>`, `<PriorityBadge>`) preserve their own visual identity.
-
-## When to use
-
-- "Drill into" rows — clicking a member opens their profile sheet
-- Activity feeds — clicking an item opens the related task / request
-- Persona / mode switchers — clicking a persona swaps the dev session
-- Any row pattern with a leading visual + primary text + optional secondary + optional trailing badge/indicator
-
-## When not to use
-
-- Settings cards with a Switch / Button as the action target → use `CardControl` (or `Card preset="control"`)
-- Form selections / multi-select → use `Checkbox` or `MenuItem`
-- Completion-state toggle rows → use `ChecklistItem`
-- Two-cell key-value rows in a read-mode field list → use `ReadOnlyField` (in renew-pms)

--- a/components/ui/SegmentedControl/SegmentedControl.mdx
+++ b/components/ui/SegmentedControl/SegmentedControl.mdx
@@ -1,17 +1,16 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './SegmentedControl.stories';
 
 <Meta of={Stories} />
 
 # Segmented control
 
+<ComponentLinks slug="segmented-control" />
+
 Pill-shaped toggle for switching between mutually exclusive views or modes. Unlike `TabBar` (page navigation), `SegmentedControl` switches content in-place.
 
----
-
 ## Playground
-
-Use the Controls panel to explore all props interactively.
 
 <Canvas of={Stories.Playground} />
 
@@ -31,49 +30,7 @@ Real-world usage: view switcher, pricing toggle, and date range selector.
 
 <Canvas of={Stories.Patterns} />
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
 
----
-
-## Usage
-
-```tsx
-import { SegmentedControl } from '@brik/bds';
-import { useState } from 'react';
-
-const [view, setView] = useState('grid');
-
-<SegmentedControl
-  value={view}
-  onChange={setView}
-  items={[
-    { label: 'Grid', value: 'grid' },
-    { label: 'List', value: 'list' },
-  ]}
-/>
-
-// Full width with size
-<SegmentedControl
-  value={period}
-  onChange={setPeriod}
-  size="lg"
-  fullWidth
-  items={[
-    { label: 'Monthly', value: 'monthly' },
-    { label: 'Yearly', value: 'yearly' },
-  ]}
-/>
-```
-
----
-
-## When to use
-
-- **Toggle between 2-5 views in the same panel** — `SegmentedControl`
-- **Navigate between pages or sections** — `TabBar`
-- **Binary on/off toggle** — `Switch`
-- **Select from a long list** — `Select`

--- a/components/ui/Slider/Slider.mdx
+++ b/components/ui/Slider/Slider.mdx
@@ -1,17 +1,16 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './Slider.stories';
 
 <Meta of={Stories} />
 
 # Slider
 
+<ComponentLinks slug="slider" />
+
 Range input for selecting a numeric value by dragging. Use for volume controls, price filters, and any setting where approximate selection is acceptable.
 
----
-
 ## Playground
-
-Use the Controls panel to explore all props interactively.
 
 <Canvas of={Stories.Playground} />
 
@@ -31,13 +30,9 @@ Real-world usage: audio settings panel and budget filter.
 
 <Canvas of={Stories.Patterns} />
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
-
----
 
 ## CSS Override API
 
@@ -54,28 +49,3 @@ Component-scoped CSS variables exposed on `.bds-slider`. Set on a wrapping eleme
 }
 ```
 
----
-
-## Usage
-
-```tsx
-import { Slider } from '@brik/bds';
-import { useState } from 'react';
-
-const [value, setValue] = useState(50);
-
-// Basic slider
-<Slider label="Volume" value={value} onChange={setValue} showValue />
-
-// Custom range with step
-<Slider
-  label="Price"
-  value={value}
-  onChange={setValue}
-  min={0}
-  max={1000}
-  step={50}
-  size="lg"
-  showValue
-/>
-```

--- a/components/ui/Tag/Tag.mdx
+++ b/components/ui/Tag/Tag.mdx
@@ -1,32 +1,16 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './Tag.stories';
 
 <Meta of={Stories} />
 
 # Tag
 
+<ComponentLinks slug="tag" />
+
 Categorization labels for classifying records — industry, segment, owner, size. Available in three sizes (`sm`, `md`, `lg`) plus `xs` icon-only.
 
----
-
-## Indicators vs Actions
-
-Tag is an **indicator** — non-interactive. It labels *what a record is*, not *what a user can do*. Never wire `onClick`, never wrap in a link.
-
-| Family | Components | When to use |
-|---|---|---|
-| **Indicator** (display state) | `Badge`, `Tag`, `Dot`, `AlertBanner` | Labeling a record's status, category, or metadata. Read-only. |
-| **Action** (user-initiated) | `Button`, `LinkButton`, `IconButton`, `FilterButton`, `Chip` | Triggering navigation, mutation, filtering, or selection. |
-
-**Tag vs Badge:** Tag is neutral categorization (no status meaning). Badge carries a semantic status color (positive/warning/error/info/progress/brand). Industry=`Dental` → Tag. Status=`Active` → Badge.
-
-**Tag vs Chip:** If the pill is clickable — toggling a filter, dismissing an active filter, opening a dropdown — it's a Chip, not a Tag. Tag's `onRemove` prop is **deprecated** (see Props below) because it contradicts the indicator contract; migrate removable pills to Chip.
-
----
-
 ## Playground
-
-Use the Controls panel to explore all props interactively.
 
 <Canvas of={Stories.Playground} />
 
@@ -47,38 +31,7 @@ Real-world compositions for categorization and filtering.
 
 <Canvas of={Stories.Patterns} />
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
 
----
-
-## Usage
-
-```tsx
-import { Tag } from '@brik/bds';
-import { Icon } from '@iconify/react';
-
-// Basic tag
-<Tag>Category</Tag>
-
-// Sizes
-<Tag size="sm">Small</Tag>
-<Tag size="md">Medium</Tag>
-<Tag size="lg">Large</Tag>
-
-// Left icon
-<Tag icon={<Icon icon="ph:certificate" />}>Featured</Tag>
-
-// Right icon
-<Tag trailingIcon={<Icon icon="ph:x-circle" />}>Dismiss</Tag>
-
-// Removable tag — DEPRECATED (see "Indicators vs Actions" above).
-// Use Chip with onRemove for removable/interactive pills.
-<Tag onRemove={() => console.log('Removed')}>Filter</Tag>
-
-// Disabled tag
-<Tag disabled>Archived</Tag>
-```

--- a/components/ui/TextInput/TextInput.mdx
+++ b/components/ui/TextInput/TextInput.mdx
@@ -1,17 +1,16 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './TextInput.stories';
 
 <Meta of={Stories} />
 
 # Text input
 
+<ComponentLinks slug="text-input" />
+
 Text input field for collecting user data. Supports labels, helper text, error states, icons, size variants, and multiple input types.
 
----
-
 ## Playground
-
-Use the Controls panel to explore all props interactively.
 
 <Canvas of={Stories.Playground} />
 
@@ -31,13 +30,9 @@ Real-world usage: contact form and login form layouts.
 
 <Canvas of={Stories.Patterns} />
 
----
-
 ## Props
 
 <ArgTypes of={Stories} />
-
----
 
 ## CSS Override API
 
@@ -54,62 +49,3 @@ Component-scoped CSS variables exposed on `.bds-text-input-field`. Set on a wrap
 }
 ```
 
----
-
-## Usage
-
-```tsx
-import { TextInput } from '@brik/bds';
-
-// Basic input
-<TextInput placeholder="Enter text..." />
-
-// With label and helper
-<TextInput
-  label="Password"
-  type="password"
-  helperText="Must be at least 8 characters"
-/>
-
-// Error state
-<TextInput
-  label="Email"
-  error="Please enter a valid email address"
-  type="email"
-/>
-
-// With icon
-<TextInput
-  label="Email"
-  placeholder="you@example.com"
-  iconBefore={<Icon icon="ph:envelope" />}
-/>
-```
-
-## Email, search, URL — use `type=` + `iconBefore`
-
-The previous `EmailInput` and `SearchInput` components have been removed (see [ADR-004](../docs/adrs/ADR-004-component-bloat-guardrails.md)). They were 5–10 line wrappers that set a `type=` and rendered a leading icon. Use TextInput directly:
-
-```tsx
-import { Envelope, MagnifyingGlass } from '@brik/bds/icons';
-
-// Email — replaces <EmailInput />
-<TextInput
-  label="Email"
-  type="email"
-  autoComplete="email"
-  iconBefore={<Icon icon={Envelope} />}
-  placeholder="you@example.com"
-/>
-
-// Search — replaces <SearchInput />
-// `type="search"` automatically renders the native clear button
-// (styled to match BDS via TextInput.css).
-<TextInput
-  type="search"
-  iconBefore={<Icon icon={MagnifyingGlass} />}
-  placeholder="Search..."
-/>
-```
-
-For password inputs with show/hide toggle behavior, use the dedicated [`PasswordInput`](?path=/docs/components-form-password-input--docs) — that component carries real load-bearing UX (toggle state, eye icons, password-manager hooks) and isn't a wrapper.


### PR DESCRIPTION
## Summary
- feat(storybook): ADR-007 Phase 3 batch 4 — 9 more pages migrated, broader strip

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)