### PR TITLE
feat(displays): tighten read-mode rhythm — PageHeader / TabBar / DataSection

### DIFF
--- a/components/ui/DataSection/DataSection.css
+++ b/components/ui/DataSection/DataSection.css
@@ -42,7 +42,7 @@
    `titleAs` prop). The BEM class names the role; the HTML tag is semantic. */
 .bds-data-section__title {
   font-family: var(--font-family-heading);
-  font-size: var(--heading-md);
+  font-size: var(--heading-sm);
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--text-primary);

--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -6,7 +6,7 @@
      Consumers can tune these via cascade (theme file, globals.css, or
      a per-instance style prop) to dial in the right rhythm without
      forking the component. Defaults preserve the lean 0.57.0 shape. */
-  --page-header-section-gap: var(--gap-lg);     /* between root sections (inner/metadata/stats/tabs) */
+  --page-header-section-gap: var(--gap-xl);     /* between root sections (inner/metadata/stats/tabs) */
   --page-header-content-gap: var(--gap-sm);     /* between title-row and subtitle */
   --page-header-actions-gap: var(--gap-sm);     /* between content column and actions column */
   --page-header-padding-bottom: 0;              /* breathing room before the bottom divider */
@@ -78,7 +78,7 @@
 
 .bds-page-header__subtitle {
   font-family: var(--font-family-body);
-  font-size: var(--body-lg);
+  font-size: var(--body-md);
   font-weight: var(--font-weight-regular);
   line-height: var(--font-line-height-normal);
   margin: 0;

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -38,7 +38,7 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
  * cascade level (theme file, `globals.css`, `style` prop). Defaults preserve
  * the lean 0.57.0 shape:
  *
- * - `--page-header-section-gap` (default `var(--gap-lg)` = 16px) — between
+ * - `--page-header-section-gap` (default `var(--gap-xl)` = 24px) — between
  *   root sections (inner / metadata / stats / tabs).
  * - `--page-header-content-gap` (default `var(--gap-sm)` = 6px) — between
  *   the title-row and the subtitle.

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -51,7 +51,12 @@ const barVariantStyles: Record<TabBarVariant, CSSProperties> = {
   // `tab` variant baseline border lives in TabBar.css so external CSS
   // (e.g. PageHeader's `:has(.bds-page-header__tabs)` rule) can suppress
   // it without fighting inline-style specificity.
-  tab: { ...barBase, gap: 'var(--gap-md)' },
+  // align-items is flex-end so each item's bottom edge coincides with the
+  // bar's content-box bottom — required for the negative-margin overlap on
+  // `.bds-tab-bar-item` to actually cap the bar baseline. With the default
+  // `center` alignment items float mid-bar and the active indicator renders
+  // in a separate band below the baseline.
+  tab: { ...barBase, alignItems: 'flex-end', gap: 'var(--gap-xl)' },
   box: { ...barBase, gap: 'var(--gap-md)' },
 };
 


### PR DESCRIPTION
## Summary
- fix(storybook): single setConfig + themes.light/dark base — chrome no longer fragments on theme switch (#425)
- docs(theming): document drawer patterns + fullscreen-overlay contract (#426)
- docs(adr): ADR-007 — Storybook component page recipe (#427)
- feat(storybook): ADR-007 Phase 1 — ComponentLinks block, tokenized code colors, recipe lint (#428)
- feat(tooltip): ADR-007 Phase 2 — Tooltip migrated as gold-standard reference (#429)
- feat(storybook): ADR-007 Phase 3 batch 1 — 12 component MDX pages migrated to recipe (#430)
- fix(storybook): Carbon-style ActionBar — attached footer, right-aligned buttons (#431)
- feat(storybook): ADR-007 Phase 3 batch 2 — 12 more component MDX pages migrated (#432)
- feat(storybook): ADR-007 Phase 3 batch 3 — 12 more component MDX pages migrated (#433)
- feat(storybook): ADR-007 Phase 3 batch 4 — 9 more pages migrated, broader strip (#434)
- feat(storybook): ADR-007 Phase 3 batch 5 — 6 narrative-cycle pages migrated via H3 demotion (#435)
- feat(storybook): ADR-007 Phase 3 batch 6 — 4 deeper-narrative pages migrated (#436)
- feat(storybook): ADR-007 Phase 3 batch 7 — 6 pages needing rename + H3 demotion (#437)
- feat(storybook): ADR-007 Phase 3 batch 8 — 3 pages migrated via story rename + MDX rewrite (#438)
- feat(displays): tighten read-mode page rhythm — PageHeader / TabBar / DataSection

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)