### PR TITLE
feat(storybook): ADR-007 Phase 3 batch 9 — 4 pages migrated with new Patterns stories

### DIFF
--- a/components/ui/AddableEntryList/AddableEntryList.mdx
+++ b/components/ui/AddableEntryList/AddableEntryList.mdx
@@ -1,94 +1,54 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './AddableEntryList.stories';
 
 <Meta of={Stories} />
 
-# Addable entry list
+# AddableEntryList
 
-The text + textarea sibling of [`AddableTextList`](?path=/docs/components-form-addable-text-list--overview). Use for lists where each row needs a headline value + context: competitor URL + notes, reference site + why, line item + description, team member + role.
+<ComponentLinks slug="addable-entry-list" />
 
-The entry shape is intentionally generic (`{ primary, secondary }`) so a single BDS component serves all of these — map your domain shape at the boundary.
+User-managed list of `{ primary, description }` entries. The primary field type (`text` or `url`) controls value rendering — text shows raw, URL renders as a link in read mode.
 
----
-
-## Modes
-
-**Plain mode** (no `primarySuggestions`). Each entry is inline-editable: a primary input + secondary textarea + "Remove" button per row. The Add button appends a new empty row. This is the default and the right choice for free-form lists (competitors, reference sites, line items).
-
-**Suggestion mode** (with `primarySuggestions`). Preserves the reveal-form flow — existing entries render as read-only cards with an x-icon remove, and the Add button reveals a staging combobox. Use for vocabulary-locked lists (services from a catalog, etc.) where the primary is picked from a known set.
-
-**Read mode** (`disabled`). Both plain and suggestion modes collapse to token-backed typography: primary uses `--label-md`, secondary uses `--body-md`. When `primaryInputType="url"`, the primary renders as a clickable anchor.
-
-## Primary input type
-
-Set `primaryInputType` to match the data:
-
-- `'text'` (default) — plain text input; read mode renders as static text.
-- `'url'` — `type="url"` input with URL autocomplete; read mode renders as a clickable anchor with brand color and underline.
-
----
-
-## Playground (edit mode — URL primary)
+## Playground
 
 <Canvas of={Stories.Playground} />
 
-## Read mode — URL primary
-
-<Canvas of={Stories.ReadModeUrl} />
-
-## Read mode — text primary
-
-<Canvas of={Stories.ReadModeText} />
-
-## Inline edit — text primary
-
-<Canvas of={Stories.InlineEditText} />
-
-## Empty state
-
-<Canvas of={Stories.Empty} />
-
-## Empty description fallback (read mode)
-
-<Canvas of={Stories.WithEmptyDescriptionLabel} />
-
 ## Variants
 
-Modes, sizes, and states.
+All-modes view — read mode and edit mode side by side, with both URL-primary and text-primary configurations.
 
 <Canvas of={Stories.Variants} />
 
----
+### Read mode (URL primary)
 
-## Behavior
+URL primary renders each entry's URL as an anchor in read mode.
 
-### Plain mode
+<Canvas of={Stories.ReadModeUrl} />
 
-- **Add** appends an empty `{ primary: '', secondary: '' }` row; onChange fires with the appended entry.
-- Typing into any field patches that row's primary or secondary via onChange.
-- **Remove** drops the row immediately.
-- When `maxItems` is reached, the Add button is hidden.
+### Read mode (text primary)
 
-### Suggestion mode
+Text primary shows the value as plain text.
 
-- **Add** reveals a staging form with a combobox-backed primary (filtered by typed query).
-- Arrow + Enter commits a highlighted suggestion, moves focus to the secondary textarea.
-- **Save** commits the staged entry and keeps the form open for rapid entry.
-- **Escape** cancels the staging form.
-- Duplicates are blocked case-insensitively unless `allowDuplicates` is set.
-- With `primaryStrict`, free-form entries outside the suggestion list are rejected.
+<Canvas of={Stories.ReadModeText} />
 
-## When to use which Addable\* list
+### Inline edit (text primary)
 
-Three siblings cover the full add/remove spectrum. Pick by row shape and vocabulary:
+Edit mode with inline text inputs for each row.
 
-| Pick | When | Render |
-| ---- | ---- | ------ |
-| [`AddableTextList`](?path=/docs/components-form-addable-text-list--overview) | Each row is **one short, unstructured value**, no fixed vocabulary. | Removable tag per value. |
-| [`AddableComboList`](?path=/docs/components-form-addable-combo-list--overview) | Each row is **one value from a known vocabulary** with optional free-form fallback. | Removable tag per value + combobox input. |
-| `AddableEntryList` | Each row needs a **primary value and a secondary note** (competitor URL + notes, service + description, reference site + why). | Inline-editable rows in plain mode; read-only cards in suggestion mode. |
+<Canvas of={Stories.InlineEditText} />
 
-If the row needs **three or more structured fields** (e.g. competitor / gap / copy implication), none of these fit — build a local "frame card" pattern; promote to BDS only after a second consumer appears.
+### Empty state
+
+The list renders an empty-state row when no entries exist.
+
+<Canvas of={Stories.Empty} />
+
+## Patterns
+
+Catalog-backed services list — primary field tied to an industry catalog with suggestions, free-text fallback, and full edit-flow.
+
+<Canvas of={Stories.Patterns} />
 
 ## Props
 

--- a/components/ui/AddableEntryList/AddableEntryList.stories.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.stories.tsx
@@ -208,9 +208,9 @@ export const InlineEditText: Story = {
  * Suggestion mode preserves the reveal-form flow (existing entries render as
  * read-only cards; Add opens a staging form).
  *
- * @summary Primary with suggestions
+ * @summary Common usage patterns
  */
-export const PrimaryWithSuggestions: Story = {
+export const Patterns: Story = {
   name: 'Primary With Suggestions',
   args: {
     label: 'Services',

--- a/components/ui/BadgeGroup/BadgeGroup.mdx
+++ b/components/ui/BadgeGroup/BadgeGroup.mdx
@@ -1,62 +1,43 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './BadgeGroup.stories';
 
 <Meta of={Stories} />
 
 # BadgeGroup
 
-Horizontal cluster of `<Badge>` elements with locked spacing. The indicator-family sibling of `TagGroup` — same API shape, different child.
+<ComponentLinks slug="badge-group" />
 
-Use when you need to display multiple status indicators side by side — integration health rows, payment state summaries, tag-like badges on an entity row.
-
----
+Horizontal cluster of `<Badge>` elements with locked spacing. Use as a `Field` value, inside a table cell, or standalone inside a `SheetSection`.
 
 ## Playground
 
 <Canvas of={Stories.Playground} />
 
-## Gaps
+## Variants
+
+`solid` and `subtle` appearance values from Badge composed in the same group.
+
+<Canvas of={Stories.Variants} />
+
+### Gaps
 
 Three locked gap sizes — `xs` for tight clusters, `sm` for standard lists, `md` for roomy displays.
 
 <Canvas of={Stories.Gaps} />
 
-## Inside a Field
+### Inside a Field
 
-Badge clusters work well as `Field` values when multiple statuses need to be shown at once — e.g. the health of several integrations on one line.
+The canonical use: a `Field` value expressed as multiple status badges.
 
 <Canvas of={Stories.InsideField} />
 
-## Appearance mix
+## Patterns
 
-Compare `solid` and `subtle` Badge appearances inside the same group container. Pick one appearance per cluster for visual consistency — BadgeGroup does not enforce this at the API level.
+Account status, notification counts, and tag sets — recurring badge cluster usage across the portal.
 
-<Canvas of={Stories.VariantMix} />
-
----
+<Canvas of={Stories.Patterns} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-
----
-
-## Usage
-
-```tsx
-import { BadgeGroup, Badge, Field } from '@brikdesigns/bds';
-
-<Field label="Integrations health">
-  <BadgeGroup>
-    <Badge status="positive" size="sm">Helicone</Badge>
-    <Badge status="positive" size="sm">Supabase</Badge>
-    <Badge status="warning" size="sm">Stripe</Badge>
-  </BadgeGroup>
-</Field>
-```
-
-## Rules
-
-- **Don't wrap a single Badge.** If there's only one, just use `<Badge>` directly inside the Field.
-- **Use `Badge` children, not arbitrary nodes.** BadgeGroup locks spacing for Badge's specific footprint; other content will misalign.
-- **Pair with `TagGroup`, not against it.** Use `TagGroup` for labels (category, filter, attribute). Use `BadgeGroup` for status indicators (live/active/paid). Both share the same API.

--- a/components/ui/BadgeGroup/BadgeGroup.stories.tsx
+++ b/components/ui/BadgeGroup/BadgeGroup.stories.tsx
@@ -90,10 +90,10 @@ export const InsideField: Story = {
   ),
 };
 
-/* ─── 4. Appearance mix ──────────────────────────────────────── */
+/* ─── 4. Variants — appearance mix ───────────────────────────── */
 
-/** @summary Variant mix */
-export const VariantMix: Story = {
+/** @summary All variants side by side */
+export const Variants: Story = {
   name: 'Appearance mix',
   render: () => (
     <Frame width="480px">
@@ -113,6 +113,42 @@ export const VariantMix: Story = {
             <Badge status="warning" size="sm" appearance="subtle">Overdue</Badge>
             <Badge status="error" size="sm" appearance="subtle">Failed</Badge>
             <Badge status="info" size="sm" appearance="subtle">Scheduled</Badge>
+          </BadgeGroup>
+        </Field>
+      </div>
+    </Frame>
+  ),
+};
+
+/* ─── 5. Patterns ────────────────────────────────────────────── */
+
+/** @summary Common usage patterns */
+export const Patterns: Story = {
+  render: () => (
+    <Frame width="480px">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
+        <Field label="Account status">
+          <BadgeGroup gap="sm">
+            <Badge status="positive" size="sm" appearance="subtle">Active</Badge>
+            <Badge status="info" size="sm" appearance="subtle">Verified</Badge>
+            <Badge status="warning" size="sm" appearance="subtle">Trial</Badge>
+          </BadgeGroup>
+        </Field>
+
+        <Field label="Notifications">
+          <BadgeGroup gap="xs">
+            <Badge status="error" size="sm">3 alerts</Badge>
+            <Badge status="warning" size="sm">5 pending</Badge>
+            <Badge status="info" size="sm">12 messages</Badge>
+          </BadgeGroup>
+        </Field>
+
+        <Field label="Tags">
+          <BadgeGroup gap="sm" wrap>
+            <Badge status="brand" size="sm" appearance="subtle">Engineering</Badge>
+            <Badge status="brand" size="sm" appearance="subtle">Design</Badge>
+            <Badge status="brand" size="sm" appearance="subtle">Product</Badge>
+            <Badge status="brand" size="sm" appearance="subtle">Marketing</Badge>
           </BadgeGroup>
         </Field>
       </div>

--- a/components/ui/CardList/CardList.mdx
+++ b/components/ui/CardList/CardList.mdx
@@ -1,65 +1,51 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './CardList.stories';
 
 <Meta of={Stories} />
 
 # CardList
 
-Layout wrapper that stacks any card component (`Card`, `CardTestimonial`, `PricingCard`, `CollapsibleCard`, etc.) in a vertical column or horizontal row. Handles gap, equal column distribution, and wrapping so the card components themselves stay layout-agnostic.
+<ComponentLinks slug="card-list" />
 
----
+Layout primitive for arrays of `Card`. Locks orientation, gap, and width-distribution rules so consumers don't reach for raw `display: grid`.
 
 ## Playground
 
 <Canvas of={Stories.Playground} />
 
-## Vertical
+## Variants
 
-Stacks cards top-to-bottom at full width. Use for feeds, settings lists, or any full-width content column.
+### Vertical
+
+Stacked layout — full-width cards in a column. Use for sidebars, news lists, and compact card stacks.
 
 <Canvas of={Stories.Vertical} />
 
-## Horizontal
+### Horizontal
 
-Lays cards out in a row with equal-width columns by default. Wraps to a new line on narrow viewports.
+Equal-column layout — each card stretches to fill its share of the row. Use for service grids, feature lists, and testimonial rows.
 
 <Canvas of={Stories.Horizontal} />
 
-## Horizontal — fit content
+### Horizontal — fit content
 
-Set `fitContent` when each card declares its own width (e.g. a scrollable product carousel). Items won't stretch to fill the row.
+`fitContent` lets cards size to their own intrinsic width instead of stretching equally.
 
 <Canvas of={Stories.HorizontalFitContent} />
 
-## Gap scale
+### Gap scale
+
+Four locked gap sizes — `sm`, `md`, `lg`, `xl`.
 
 <Canvas of={Stories.GapScale} />
 
----
+## Patterns
+
+Service grid and vertical news stack — recurring CardList compositions.
+
+<Canvas of={Stories.Patterns} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-
----
-
-## Usage
-
-```tsx
-import { CardList, Card, CardTitle, CardDescription } from '@brik/bds';
-
-<CardList orientation="horizontal" gap="lg">
-  <Card variant="outlined" padding="lg">
-    <CardTitle>Design</CardTitle>
-    <CardDescription>Brand and identity.</CardDescription>
-  </Card>
-  <Card variant="outlined" padding="lg">
-    <CardTitle>Development</CardTitle>
-    <CardDescription>Product engineering.</CardDescription>
-  </Card>
-</CardList>
-```
-
-- `orientation` — `'vertical'` (default) or `'horizontal'`
-- `gap` — `'sm' | 'md' | 'lg' | 'xl'` (default `'md'`)
-- `fitContent` — horizontal only; when `true`, items size to their children instead of filling equal columns

--- a/components/ui/CardList/CardList.stories.tsx
+++ b/components/ui/CardList/CardList.stories.tsx
@@ -187,6 +187,61 @@ export const HorizontalFitContent: Story = {
   ),
 };
 
+/* ─── Patterns ───────────────────────────────────────────────── */
+
+/** @summary Common usage patterns */
+export const Patterns: Story = {
+  render: () => (
+    <Stack>
+      <SectionLabel>Service grid (3-column horizontal)</SectionLabel>
+      <CardList orientation="horizontal" gap="lg">
+        <Card variant="outlined" padding="lg">
+          <Badge>Design</Badge>
+          <CardTitle>Brand identity</CardTitle>
+          <CardDescription>Logo, type, and tone — the foundation every campaign builds on.</CardDescription>
+          <CardFooter>
+            <Button variant="outline" size="sm">Learn more</Button>
+          </CardFooter>
+        </Card>
+        <Card variant="outlined" padding="lg">
+          <Badge>Build</Badge>
+          <CardTitle>Web development</CardTitle>
+          <CardDescription>Production sites built on the components your designers already know.</CardDescription>
+          <CardFooter>
+            <Button variant="outline" size="sm">Learn more</Button>
+          </CardFooter>
+        </Card>
+        <Card variant="outlined" padding="lg">
+          <Badge>Run</Badge>
+          <CardTitle>Ongoing partnership</CardTitle>
+          <CardDescription>Iterate after launch with a team that already knows your stack.</CardDescription>
+          <CardFooter>
+            <Button variant="outline" size="sm">Learn more</Button>
+          </CardFooter>
+        </Card>
+      </CardList>
+
+      <SectionLabel>Vertical news stack (in a sidebar)</SectionLabel>
+      <div style={{ width: 360 }}>
+        <CardList orientation="vertical" gap="md">
+          <Card variant="outlined" padding="md">
+            <CardTitle as="h4">Q1 review</CardTitle>
+            <CardDescription>What shipped, what slipped, and what's queued for Q2.</CardDescription>
+          </Card>
+          <Card variant="outlined" padding="md">
+            <CardTitle as="h4">New hires</CardTitle>
+            <CardDescription>Three engineers and a designer joined this month.</CardDescription>
+          </Card>
+          <Card variant="outlined" padding="md">
+            <CardTitle as="h4">Roadmap update</CardTitle>
+            <CardDescription>Two features promoted from Next to Now after customer feedback.</CardDescription>
+          </Card>
+        </CardList>
+      </div>
+    </Stack>
+  ),
+};
+
 /* ─── Gap scale ──────────────────────────────────────────────── */
 
 /** @summary Gap scale */

--- a/components/ui/ProgressStepper/ProgressStepper.mdx
+++ b/components/ui/ProgressStepper/ProgressStepper.mdx
@@ -1,105 +1,61 @@
 import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
 import * as Stories from './ProgressStepper.stories';
 
 <Meta of={Stories} />
 
 # Progress stepper
 
-Step indicator with two visual variants — `steps` (vertical, labeled) and `dots` (horizontal, compact). Both share the same `activeStep`, `linear`, and `onStepClick` model. Use for checkout flows, setup wizards, and multi-page forms.
+<ComponentLinks slug="progress-stepper" />
 
-The `dots` variant replaces the previous standalone `ProgressDots` component (deleted per [ADR-004 §3](../../docs/adrs/ADR-004-component-bloat-guardrails.md) — same shape, same logic, different layout = one component with a variant prop, not two components).
+Multi-step progress indicator. Shows the current position in a wizard, onboarding flow, or checkout sequence. Two variants — labeled `steps` and unlabeled `dots` — plus optional linear-mode constraint.
 
----
+## Playground
 
-## Overview
+<Canvas of={Stories.Playground} />
 
-<Canvas of={Stories.Default} />
+## Variants
 
-## With descriptions
+### With descriptions
 
-Add description text to each step for additional context.
+Steps can include descriptions for richer context.
 
 <Canvas of={Stories.WithDescriptions} />
 
-## Step positions
+### Step positions
 
-### First step
+First, middle, and last-step states render distinct connector treatments.
+
 <Canvas of={Stories.FirstStep} />
 
-### Last step
 <Canvas of={Stories.LastStep} />
 
-### All complete
 <Canvas of={Stories.AllComplete} />
 
-## Sizes
+### Sizes
 
-### Small
-Compact stepper for constrained layouts.
+`size="sm"` for compact toolbars and constrained layouts.
 
 <Canvas of={Stories.SmallSize} />
 
-## Dots variant
+### Dots variant
 
-Compact horizontal dot indicator. The active dot stretches wider; completed dots are dimmed; upcoming dots are muted. No label text — pair with a page heading or step counter.
+`variant="dots"` swaps the labeled circles for dots — use for mobile carousels and minimal flows.
 
 <Canvas of={Stories.DotsVariant} />
 
-### Dots with linear mode
+### Linear mode
 
-<Canvas of={Stories.DotsLinear} />
-
-## Linear mode
-
-Interactive stepper restricted to sequential navigation.
+`linear` constrains navigation to forward-only progression.
 
 <Canvas of={Stories.LinearMode} />
 
-## Interactive
+## Patterns
 
-Click steps to navigate between them.
+Interactive multi-step flow with state-driven navigation.
 
-<Canvas of={Stories.Interactive} />
-
----
+<Canvas of={Stories.Patterns} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-
----
-
-## Usage
-
-```tsx
-import { ProgressStepper } from '@brik/bds';
-
-// Basic stepper
-<ProgressStepper
-  steps={[
-    { label: 'Account' },
-    { label: 'Profile' },
-    { label: 'Review' },
-  ]}
-  activeStep={1}
-/>
-
-// With descriptions
-<ProgressStepper
-  steps={[
-    { label: 'Details', description: 'Enter your information' },
-    { label: 'Payment', description: 'Add billing details' },
-    { label: 'Confirm', description: 'Review and submit' },
-  ]}
-  activeStep={0}
-  onStepClick={(step) => setStep(step)}
-/>
-
-// Dots variant — compact horizontal indicator
-<ProgressStepper
-  variant="dots"
-  count={5}
-  activeStep={2}
-  onStepClick={(step) => setStep(step)}
-/>
-```

--- a/components/ui/ProgressStepper/ProgressStepper.stories.tsx
+++ b/components/ui/ProgressStepper/ProgressStepper.stories.tsx
@@ -27,8 +27,8 @@ const onboardingSteps: ProgressStep[] = [
   { label: 'Review & confirm', description: 'Review your selections' },
 ];
 
-/** @summary Default rendering */
-export const Default: Story = {
+/** @summary Interactive playground for prop tweaking */
+export const Playground: Story = {
   args: {
     steps: proposalSteps,
     activeStep: 1,
@@ -159,9 +159,11 @@ export const DotsLinear = () => {
 };
 
 /**
+ * @summary Common usage patterns
+ *
  * Non-linear mode (default) allows free navigation to any step.
  */
-export const Interactive = () => {
+export const Patterns = () => {
   const [active, setActive] = useState(0);
 
   return (


### PR DESCRIPTION
## Summary
- feat(displays): tighten read-mode page rhythm — PageHeader / TabBar / DataSection (#439)
- feat(storybook): ADR-007 Phase 3 batch 9 — 4 pages migrated, 2 new Patterns stories authored
- Merge remote-tracking branch 'origin/main' into task/storybook-recipe-phase-3-batch-9

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)