### PR TITLE
ci(storybook): enforce ADR-007 page recipe in pre-commit + CI

### DIFF
--- a/.github/workflows/storybook-recipe-check.yml
+++ b/.github/workflows/storybook-recipe-check.yml
@@ -1,0 +1,43 @@
+name: Storybook Recipe Check
+
+# Enforces ADR-007 (Storybook component page recipe) on every PR and on every
+# push to main. Fails the build if any `components/ui/*/*.mdx` file deviates
+# from the canonical Title → ComponentLinks → description → Playground →
+# Variants → Patterns → Props shape.
+#
+# Why this is a CI gate (not just pre-commit):
+#   - Pre-commit only runs when an MDX file is staged. CI catches regressions
+#     introduced by surrounding edits (story exports renamed, component dirs
+#     moved) that wouldn't trip the staged-file filter.
+#   - Cloud-agent commits (OpenClaw, scheduled routines) bypass local hooks.
+#   - PRs from forks or fresh clones may not have husky installed.
+#
+# Source of truth: docs/adrs/ADR-007-storybook-page-recipe.md
+# Lint script: scripts/lint-storybook-recipe.js
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  storybook-recipe-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Storybook recipe check
+        run: node scripts/lint-storybook-recipe.js --enforce

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -64,6 +64,15 @@ else
   echo "No staged component files — skipping token + JSDoc lint."
 fi
 
+# ── Storybook page recipe (ADR-007) ──
+# Whole-repo scan; fires only when a component MDX file is staged so
+# token-only or test-only commits don't pay the cost.
+STAGED_MDX=$(git diff --cached --name-only --diff-filter=ACM -- 'components/ui/**/*.mdx')
+if [ -n "$STAGED_MDX" ]; then
+  echo "Linting Storybook page recipe (ADR-007)..."
+  node scripts/lint-storybook-recipe.js --enforce
+fi
+
 # Typecheck always runs (fast, catches real errors)
 npm run typecheck
 


### PR DESCRIPTION
## Summary
- ci(storybook): enforce ADR-007 page recipe in pre-commit + CI

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)