### PR TITLE
chore(release): 0.58.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.57.5",
+  "version": "0.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.57.5",
+      "version": "0.58.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.57.5",
+  "version": "0.58.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- fix(storybook): single setConfig + themes.light/dark base — chrome no longer fragments on theme switch (#425)
- docs(theming): document drawer patterns + fullscreen-overlay contract (#426)
- docs(adr): ADR-007 — Storybook component page recipe (#427)
- feat(storybook): ADR-007 Phase 1 — ComponentLinks block, tokenized code colors, recipe lint (#428)
- feat(tooltip): ADR-007 Phase 2 — Tooltip migrated as gold-standard reference (#429)
- feat(storybook): ADR-007 Phase 3 batch 1 — 12 component MDX pages migrated to recipe (#430)
- fix(storybook): Carbon-style ActionBar — attached footer, right-aligned buttons (#431)
- feat(storybook): ADR-007 Phase 3 batch 2 — 12 more component MDX pages migrated (#432)
- feat(storybook): ADR-007 Phase 3 batch 3 — 12 more component MDX pages migrated (#433)
- feat(storybook): ADR-007 Phase 3 batch 4 — 9 more pages migrated, broader strip (#434)
- feat(storybook): ADR-007 Phase 3 batch 5 — 6 narrative-cycle pages migrated via H3 demotion (#435)
- feat(storybook): ADR-007 Phase 3 batch 6 — 4 deeper-narrative pages migrated (#436)
- feat(storybook): ADR-007 Phase 3 batch 7 — 6 pages needing rename + H3 demotion (#437)
- feat(storybook): ADR-007 Phase 3 batch 8 — 3 pages migrated via story rename + MDX rewrite (#438)
- feat(displays): tighten read-mode page rhythm — PageHeader / TabBar / DataSection (#439)
- feat(storybook): ADR-007 Phase 3 batch 9 — 4 pages migrated, 2 new Patterns stories authored (#440)
- feat(storybook): ADR-007 Phase 3 batch 10 — 4 authoring-track pages migrated (#441)
- feat(storybook): ADR-007 Phase 3 close-out — delete 3 non-component-page MDX files, hit 100% recipe conformance (#444)
- ci(storybook): enforce ADR-007 page recipe in pre-commit + CI (#445)
- chore(release): 0.58.0
- Merge remote-tracking branch 'origin/main' into task/bds-release-0-58-0

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)