### PR TITLE
docs(content-system): adoption status table for healthcare-ada (closes brik-llm#148)

### DIFF
--- a/content-system/compliance/healthcare-ada.md
+++ b/content-system/compliance/healthcare-ada.md
@@ -21,6 +21,16 @@
 
 **Consumer integration:** A short "Compliance Profile" section in each consumer repo's `CLAUDE.md` points to this document. Project-specific overrides go in the project's CLAUDE.md; the canonical rules stay here.
 
+| Consumer repo | Compliance Profile section | a11y CI gate |
+|---|---|---|
+| [`brik-client-portal`](https://github.com/brikdesigns/brik-client-portal) | ✅ added 2026-05-05 | ✅ axe-core/playwright pilot on public routes |
+| [`renew-pms`](https://github.com/brikdesigns/renew-pms) | ✅ added 2026-05-05 | ⏭️ pending — adopt portal pattern per [brik-llm#130](https://github.com/brikdesigns/brik-llm/issues/130) phase 4.4 |
+| [`memphis-dental`](https://github.com/brikdesigns/memphis-dental) | ✅ added 2026-05-05 | ✅ on the gate ([brik-llm#190](https://github.com/brikdesigns/brik-llm/issues/190)) |
+| [`tncld`](https://github.com/brikdesigns/tncld) | ✅ pre-existing (updated to point at canonical) | n/a — Webflow not Astro |
+| [`birdwell-mutlak`](https://github.com/brikdesigns/birdwell-mutlak) | ⏭️ no CLAUDE.md yet | ✅ canonical reference impl |
+| [`vale-partners`](https://github.com/brikdesigns/vale-partners) | ⏭️ pending | ✅ on the gate |
+| [`freedom-client-portal`](https://github.com/brikdesigns/freedom-client-portal) | n/a | n/a — inactive product |
+
 **Companion policy — accessibility overlays:** Brik does not install UserWay, AccessiBe, EqualWeb, or any other accessibility overlay widget on client sites. The full position and the first-party alternative path (Accessibility Preferences panel, dated Accessibility Statement, axe-core CI) are documented in [`accessibility-overlays.md`](./accessibility-overlays.md) and formalized in [ADR-002](../../docs/adrs/ADR-002-accessibility-overlays.md). Read that doc before entertaining any client ask for a widget-based compliance signal.
 
 ---


### PR DESCRIPTION
Adds a consumer-integration status table to `content-system/compliance/healthcare-ada.md`. Closes the loop on [brik-llm#148](https://github.com/brikdesigns/brik-llm/issues/148) — the doc was promoted to canonical 2026-04-21; this just makes adoption state visible at the canonical doc itself instead of requiring agents to grep each consumer.

Status as of 2026-05-05:
- portal, renew, memphis: Compliance Profile added (companion PRs in flight)
- tncld: pre-existing profile updated to point at canonical
- birdwell, vale: gate adopted; profile pending
- freedom: inactive

Closes [brik-llm#148](https://github.com/brikdesigns/brik-llm/issues/148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)