### PR TITLE
feat(canonical-class-check): CSS-class canon enforcement engine

### DIFF
--- a/.github/workflows/canonical-class-check.yml
+++ b/.github/workflows/canonical-class-check.yml
@@ -1,0 +1,60 @@
+name: Canonical Class Check
+
+# Enforces BDS's canonical CSS-class layer on every PR and push to main.
+# Sibling of canonical-check.yml — that gate covers `--*` token names; this
+# one covers the component-class layer (`bds-button`, `bds-avatar`, etc.).
+#
+# Fails the build when:
+#   - A `bds-*` class is referenced that isn't published in dist/styles.css
+#     (invented variant)
+#   - A non-prefixed class root collides with a canonical primitive
+#     (e.g. `.button--primary` while BDS publishes `bds-button`)
+#   - A shorthand alias collides with canon (e.g. `.btn` aliases `bds-button`)
+#
+# Project-namespaced BEM blocks (`.team-card__portrait`, `.hero-section__inner`)
+# are NOT flagged — layout CSS stays project-local. The audit is precise about
+# the boundary between component primitives (BDS-owned) and layout (project).
+#
+# Why this is a CI gate (not just pre-push):
+#   - Pre-push runs `validate:full` locally but does not include the class
+#     check.
+#   - Cloud-agent commits (OpenClaw, scheduled routines) bypass local hooks
+#     entirely.
+#   - PRs from forks or fresh clones may not have husky installed.
+#
+# Source of truth: BDS dist/styles.css (component class layer).
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  canonical-class-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # canonical-class-check parses the allowlist from `dist/styles.css`,
+      # which is gitignored. Unlike the token-side allowlist (cheap to
+      # regenerate via `build:dist-tokens`), the component CSS only exists
+      # after the full lib build (Vite extracts each component's *.css).
+      # `build:lib` is the only path that emits dist/styles.css.
+      - name: Build dist (canonical class allowlist source)
+        run: npm run build:lib
+
+      - name: Canonical class check
+        run: npm run canonical-class-check

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
       "types": "./scripts/canonical-check.d.ts",
       "import": "./scripts/canonical-check.mjs",
       "default": "./scripts/canonical-check.mjs"
+    },
+    "./canonical-class-check": {
+      "types": "./scripts/canonical-class-check.d.ts",
+      "import": "./scripts/canonical-class-check.mjs",
+      "default": "./scripts/canonical-class-check.mjs"
     }
   },
   "files": [
@@ -54,11 +59,14 @@
     "content-system/blueprints/astro/index.ts",
     "scripts/bds-find.mjs",
     "scripts/canonical-check.mjs",
-    "scripts/canonical-check.d.ts"
+    "scripts/canonical-check.d.ts",
+    "scripts/canonical-class-check.mjs",
+    "scripts/canonical-class-check.d.ts"
   ],
   "bin": {
     "bds-find": "scripts/bds-find.mjs",
-    "canonical-check": "scripts/canonical-check.mjs"
+    "canonical-check": "scripts/canonical-check.mjs",
+    "canonical-class-check": "scripts/canonical-class-check.mjs"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
@@ -128,6 +136,8 @@
     "bds:find": "node scripts/bds-find.mjs",
     "canonical-check": "node scripts/canonical-check.mjs --allowlist dist/tokens.css components content-system/blueprints content-system/atmospheres content-system/industries",
     "canonical-check:report": "node scripts/canonical-check.mjs --allowlist dist/tokens.css --format md components content-system stories || true",
+    "canonical-class-check": "node scripts/canonical-class-check.mjs --allowlist dist/styles.css content-system/blueprints",
+    "canonical-class-check:report": "node scripts/canonical-class-check.mjs --allowlist dist/styles.css --format md content-system/blueprints stories || true",
     "build:types": "tsc --project tsconfig.build.json",
     "build:dist-tokens": "node scripts/build-dist-tokens.js",
     "chromatic": "npx chromatic --project-token=${CHROMATIC_PROJECT_TOKEN:?CHROMATIC_PROJECT_TOKEN env var required — see .env.example}",

--- a/scripts/__tests__/canonical-class-check.test.mjs
+++ b/scripts/__tests__/canonical-class-check.test.mjs
@@ -1,0 +1,413 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  parseClassAllowlist,
+  canonicalRoots,
+  classRoot,
+  extractClassReferences,
+  extractClassDefinitions,
+  classifyClass,
+  classSourceScan,
+  classRuntimeScan,
+  assertCanonicalClasses,
+  DEFAULT_CLASS_ALIASES,
+  DEFAULT_CLASS_EXEMPT_PATTERNS,
+} from '../canonical-class-check.mjs';
+
+// Miniature canonical class fixture — distilled from dist/styles.css.
+// Stays deterministic across BDS releases. Includes the canonical roots
+// the violation classifier needs to check against (`bds-button`,
+// `bds-avatar`, `bds-badge`, `bds-card`, `bds-accordion-item`).
+const STYLES_CSS_FIXTURE = `
+/**
+ * Canonical fixture — distilled from dist/styles.css.
+ */
+.bds-button { padding: 0; }
+.bds-button--primary { background: var(--background-brand-primary); }
+.bds-button--secondary { background: transparent; }
+.bds-button--ghost { padding-left: 0; }
+.bds-button--md { font-size: 14px; }
+.bds-button__content { display: inline-flex; }
+.bds-button-group { display: flex; gap: 8px; }
+
+.bds-avatar { width: 40px; }
+.bds-avatar--sm { width: 24px; }
+.bds-avatar--lg { width: 64px; }
+.bds-avatar__image { object-fit: cover; }
+.bds-avatar__status--online { background: var(--background-positive); }
+
+.bds-badge { display: inline-flex; }
+.bds-badge--brand { color: var(--text-brand); }
+
+.bds-card { padding: 16px; }
+.bds-card__header { padding-bottom: 8px; }
+
+.bds-accordion-item { border-top: 1px solid var(--border-primary); }
+.bds-accordion-item__icon { transition: transform 0.2s; }
+
+/* enough roots to clear the 20-token sanity floor in the CLI */
+.bds-tag { padding: 2px 6px; }
+.bds-tag--info { background: var(--background-info); }
+.bds-chip { display: inline-flex; }
+.bds-divider { height: 1px; }
+.bds-dialog { position: fixed; }
+.bds-tabs { display: flex; }
+.bds-tabs__tab { padding: 8px; }
+.bds-field { display: flex; flex-direction: column; }
+.bds-field__label { font-size: 14px; }
+.bds-checkbox { width: 16px; }
+.bds-radio { width: 16px; }
+.bds-switch { width: 32px; }
+.bds-tooltip { position: absolute; }
+`;
+
+describe('parseClassAllowlist', () => {
+  it('captures every .bds-* class declaration', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    expect(allowlist.has('bds-button')).toBe(true);
+    expect(allowlist.has('bds-button--primary')).toBe(true);
+    expect(allowlist.has('bds-button__content')).toBe(true);
+    expect(allowlist.has('bds-avatar__status--online')).toBe(true);
+    expect(allowlist.has('bds-accordion-item')).toBe(true);
+  });
+
+  it('ignores classes not prefixed with bds-', () => {
+    const allowlist = parseClassAllowlist(`.foo { color: red; } .btn { padding: 0; }`);
+    expect(allowlist.size).toBe(0);
+  });
+
+  it('skips bds- classes inside block comments', () => {
+    const allowlist = parseClassAllowlist('/* example: .bds-fake-button */');
+    expect(allowlist.has('bds-fake-button')).toBe(false);
+  });
+
+  it('returns an empty Set for empty input', () => {
+    expect(parseClassAllowlist('').size).toBe(0);
+  });
+});
+
+describe('classRoot', () => {
+  it('returns the bare block for plain classes', () => {
+    expect(classRoot('bds-button')).toBe('bds-button');
+    expect(classRoot('btn')).toBe('btn');
+  });
+
+  it('strips BEM modifiers (--)', () => {
+    expect(classRoot('bds-button--primary')).toBe('bds-button');
+    expect(classRoot('btn--primary')).toBe('btn');
+  });
+
+  it('strips BEM elements (__)', () => {
+    expect(classRoot('bds-button__content')).toBe('bds-button');
+    expect(classRoot('tp-card__bio-btn')).toBe('tp-card');
+  });
+
+  it('uses the FIRST separator when both __ and -- appear', () => {
+    expect(classRoot('bds-avatar__status--online')).toBe('bds-avatar');
+    expect(classRoot('bds-button--primary__inner')).toBe('bds-button');
+  });
+
+  it('preserves hyphens INSIDE the root (no separator)', () => {
+    expect(classRoot('bds-accordion-item')).toBe('bds-accordion-item');
+    expect(classRoot('bds-accordion-item__icon')).toBe('bds-accordion-item');
+  });
+});
+
+describe('canonicalRoots', () => {
+  it('reduces an allowlist to distinct bds-* block roots', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    const roots = canonicalRoots(allowlist);
+    expect(roots.has('bds-button')).toBe(true);
+    expect(roots.has('bds-avatar')).toBe(true);
+    expect(roots.has('bds-accordion-item')).toBe(true);
+    // Modifier/element entries do NOT become separate roots
+    expect(roots.has('bds-button--primary')).toBe(false);
+    expect(roots.has('bds-button__content')).toBe(false);
+  });
+
+  it('ignores entries that lack the bds- prefix', () => {
+    const roots = canonicalRoots(new Set(['bds-button', 'foo', 'btn']));
+    expect(roots).toEqual(new Set(['bds-button']));
+  });
+});
+
+describe('extractClassReferences', () => {
+  it('finds CSS class selectors', () => {
+    const refs = extractClassReferences(`.btn--primary { color: red; } .tp-card__name { font-weight: 700; }`);
+    expect(refs.has('btn--primary')).toBe(true);
+    expect(refs.has('tp-card__name')).toBe(true);
+  });
+
+  it('finds class= and className= attributes', () => {
+    const refs = extractClassReferences(`<a class="btn btn--primary nav-cta">x</a> <Foo className="card card--lg" />`);
+    expect(refs.has('btn')).toBe(true);
+    expect(refs.has('btn--primary')).toBe(true);
+    expect(refs.has('nav-cta')).toBe(true);
+    expect(refs.has('card')).toBe(true);
+    expect(refs.has('card--lg')).toBe(true);
+  });
+
+  it('honors bds-lint-ignore line comments', () => {
+    const refs = extractClassReferences([
+      '.btn { padding: 0; } /* bds-lint-ignore — legacy primitive */',
+      '.card { padding: 0; }',
+    ].join('\n'));
+    expect(refs.has('btn')).toBe(false);
+    expect(refs.has('card')).toBe(true);
+  });
+
+  it('skips classes inside block comments', () => {
+    const refs = extractClassReferences('/* example: .btn--primary */ .real-class { color: red; }');
+    expect(refs.has('btn--primary')).toBe(false);
+    expect(refs.has('real-class')).toBe(true);
+  });
+
+  it('captures classes adjacent to selector combinators', () => {
+    const refs = extractClassReferences('.parent > .child:hover { color: red; }');
+    expect(refs.has('parent')).toBe(true);
+    expect(refs.has('child')).toBe(true);
+  });
+});
+
+describe('extractClassDefinitions', () => {
+  it('captures rule-head class selectors', () => {
+    const css = `.btn { padding: 0; } .btn--primary { color: red; } .btn:hover { color: blue; }`;
+    const defs = extractClassDefinitions(css);
+    expect(defs.has('btn')).toBe(true);
+    expect(defs.has('btn--primary')).toBe(true);
+  });
+});
+
+describe('classifyClass', () => {
+  function setup() {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    const roots = canonicalRoots(allowlist);
+    return {
+      allowlist,
+      roots,
+      aliases: DEFAULT_CLASS_ALIASES,
+      exemptPatterns: DEFAULT_CLASS_EXEMPT_PATTERNS,
+    };
+  }
+
+  it('passes canonical bds-* classes that exist in the allowlist', () => {
+    const opts = setup();
+    expect(classifyClass('bds-button', opts).kind).toBe('ok');
+    expect(classifyClass('bds-button--primary', opts).kind).toBe('ok');
+    expect(classifyClass('bds-button__content', opts).kind).toBe('ok');
+    expect(classifyClass('bds-accordion-item__icon', opts).kind).toBe('ok');
+  });
+
+  it('flags invented bds-* names not in the allowlist', () => {
+    const opts = setup();
+    const v = classifyClass('bds-button--cta', opts);
+    expect(v.kind).toBe('invented-bds');
+    expect(v.class).toBe('bds-button--cta');
+  });
+
+  it('flags invented bds-* roots that do not exist in canon', () => {
+    const opts = setup();
+    expect(classifyClass('bds-fake-thing', opts).kind).toBe('invented-bds');
+  });
+
+  it('flags non-prefixed class roots that shadow a canonical root', () => {
+    const opts = setup();
+    const v = classifyClass('button', opts);
+    expect(v.kind).toBe('shadow-root');
+    expect(v.canonical).toBe('bds-button');
+  });
+
+  it('flags BEM modifiers on shadowing roots', () => {
+    const opts = setup();
+    const v = classifyClass('button--primary', opts);
+    expect(v.kind).toBe('shadow-root');
+    expect(v.canonical).toBe('bds-button');
+  });
+
+  it('flags shorthand aliases (btn → bds-button)', () => {
+    const opts = setup();
+    const v = classifyClass('btn', opts);
+    expect(v.kind).toBe('shadow-alias');
+    expect(v.alias).toBe('btn');
+    expect(v.canonical).toBe('bds-button');
+  });
+
+  it('flags BEM modifiers on alias shorthand', () => {
+    const opts = setup();
+    const v = classifyClass('btn--primary', opts);
+    expect(v.kind).toBe('shadow-alias');
+    expect(v.canonical).toBe('bds-button');
+  });
+
+  it('passes project-namespaced BEM blocks (the layout escape hatch)', () => {
+    const opts = setup();
+    expect(classifyClass('tp-card', opts).kind).toBe('ok');
+    expect(classifyClass('tp-card__portrait', opts).kind).toBe('ok');
+    expect(classifyClass('team-card__name', opts).kind).toBe('ok');
+    expect(classifyClass('hero-section__inner', opts).kind).toBe('ok');
+  });
+
+  it('passes utility-style classes that do not collide', () => {
+    const opts = setup();
+    expect(classifyClass('flex', opts).kind).toBe('ok');
+    expect(classifyClass('container', opts).kind).toBe('ok');
+    expect(classifyClass('sr-only', opts).kind).toBe('ok');
+  });
+
+  it('respects exempt-pattern overrides (default exempts `card`)', () => {
+    const opts = setup();
+    // `card` shadows `bds-card` in raw allowlist terms, but the default
+    // exempts the bare `card` root because of legitimate project-local
+    // collisions (e.g. `.team-card`, `.feature-card` are too common to
+    // ban via this rule).
+    expect(classifyClass('card', opts).kind).toBe('ok');
+    expect(classifyClass('card--lg', opts).kind).toBe('ok');
+  });
+
+  it('still flags `card` when exemptPatterns is overridden to empty', () => {
+    const opts = { ...setup(), exemptPatterns: [] };
+    expect(classifyClass('card', opts).kind).toBe('shadow-root');
+  });
+});
+
+describe('classSourceScan', () => {
+  function withTempDir(fn) {
+    const dir = mkdtempSync(join(tmpdir(), 'canonical-class-check-'));
+    try {
+      return fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('reports zero violations for a canonical fixture', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'a.astro'), `<a class="bds-button bds-button--primary">x</a>`);
+      writeFileSync(join(dir, 'b.tsx'), `<Foo className="bds-avatar bds-avatar--lg" />`);
+      const result = classSourceScan({ paths: [dir], allowlist });
+      expect(result.violations).toEqual([]);
+      expect(result.scannedFiles).toBe(2);
+    });
+  });
+
+  it('flags shadow-root violations with file paths', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'drift.astro'), `<a class="button button--primary">x</a>`);
+      const result = classSourceScan({ paths: [dir], allowlist });
+      const buttonViolation = result.violations.find((v) => v.class === 'button');
+      expect(buttonViolation).toBeDefined();
+      expect(buttonViolation.kind).toBe('shadow-root');
+      expect(buttonViolation.canonical).toBe('bds-button');
+      expect(buttonViolation.files[0]).toContain('drift.astro');
+    });
+  });
+
+  it('flags shadow-alias violations (the Vale `btn--primary` case)', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    withTempDir((dir) => {
+      writeFileSync(
+        join(dir, 'global.css'),
+        `.btn { padding: 0; } .btn--primary { color: red; } .btn--secondary { color: blue; }`,
+      );
+      const result = classSourceScan({ paths: [dir], allowlist });
+      const btn = result.violations.find((v) => v.class === 'btn');
+      expect(btn?.kind).toBe('shadow-alias');
+      expect(btn?.alias).toBe('btn');
+      expect(btn?.canonical).toBe('bds-button');
+    });
+  });
+
+  it('flags invented bds-* names', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'a.astro'), `<a class="bds-button bds-button--cta">x</a>`);
+      const result = classSourceScan({ paths: [dir], allowlist });
+      const v = result.violations.find((x) => x.class === 'bds-button--cta');
+      expect(v?.kind).toBe('invented-bds');
+    });
+  });
+
+  it('passes project-namespaced BEM blocks (layout CSS stays project-local)', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    withTempDir((dir) => {
+      writeFileSync(
+        join(dir, 'TeamPreview.astro'),
+        `<li class="tp-card"><div class="tp-card__portrait" /><h3 class="tp-card__name">x</h3></li>`,
+      );
+      const result = classSourceScan({ paths: [dir], allowlist });
+      expect(result.violations).toEqual([]);
+    });
+  });
+
+  it('skips test files and __tests__ dirs by default', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    withTempDir((dir) => {
+      mkdirSync(join(dir, '__tests__'));
+      writeFileSync(join(dir, '__tests__', 'fixture.astro'), `<a class="btn btn--primary" />`);
+      const result = classSourceScan({ paths: [dir], allowlist });
+      expect(result.violations).toEqual([]);
+      expect(result.scannedFiles).toBe(0);
+    });
+  });
+
+  it('aggregates the same violation across multiple files', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'a.astro'), `<a class="btn btn--primary" />`);
+      writeFileSync(join(dir, 'b.astro'), `<a class="btn" />`);
+      const result = classSourceScan({ paths: [dir], allowlist });
+      const btn = result.violations.find((v) => v.class === 'btn');
+      expect(btn?.files.length).toBe(2);
+    });
+  });
+
+  it('throws on empty allowlist (caller error, not silent pass)', () => {
+    expect(() =>
+      classSourceScan({ paths: ['nonexistent'], allowlist: new Set() }),
+    ).toThrowError(/allowlist is empty/);
+  });
+});
+
+describe('classRuntimeScan', () => {
+  it('flags definitions that shadow canonical roots', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    const css = `.btn { padding: 0; } .btn--primary { color: red; } .tp-card { display: grid; }`;
+    const result = classRuntimeScan({ css, allowlist });
+    const classes = result.violations.map((v) => v.class).sort();
+    expect(classes).toEqual(['btn', 'btn--primary']);
+  });
+
+  it('does not flag canonical bds-* definitions', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    const css = `.bds-button { padding: 0; } .bds-button--primary { color: red; }`;
+    const result = classRuntimeScan({ css, allowlist });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('throws on empty allowlist', () => {
+    expect(() =>
+      classRuntimeScan({ css: '.foo {}', allowlist: new Set() }),
+    ).toThrowError(/allowlist is empty/);
+  });
+});
+
+describe('assertCanonicalClasses', () => {
+  it('does not throw on canonical CSS', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    expect(() =>
+      assertCanonicalClasses(`.bds-button { padding: 0; }`, { allowlist }),
+    ).not.toThrow();
+  });
+
+  it('throws with a descriptive message on violations', () => {
+    const allowlist = parseClassAllowlist(STYLES_CSS_FIXTURE);
+    expect(() =>
+      assertCanonicalClasses(`.btn--primary { padding: 0; }`, { allowlist }),
+    ).toThrowError(/canonical-class-check.*btn--primary/s);
+  });
+});

--- a/scripts/canonical-class-check.d.ts
+++ b/scripts/canonical-class-check.d.ts
@@ -1,0 +1,125 @@
+/**
+ * Type definitions for @brikdesigns/bds/canonical-class-check.
+ *
+ * Source: scripts/canonical-class-check.mjs (hand-authored ESM with named
+ * exports + CLI entry). These types are hand-written to keep the .mjs file
+ * portable and avoid pulling the canonical-class-check tooling into the BDS
+ * lib build — same separation as canonical-check.d.ts.
+ */
+
+export type ExemptPattern = string | RegExp;
+
+/** Map of shorthand class root → canonical BDS root (without `bds-` prefix). */
+export type AliasMap = Readonly<Record<string, string>>;
+
+export interface ClassSourceScanOptions {
+  /** Filesystem paths to scan (files or directories). */
+  paths: string[];
+  /** Canonical class allowlist parsed from BDS dist/styles.css. */
+  allowlist: Set<string>;
+  /** Shorthand → canonical aliases. Default: `{ btn: 'button' }`. */
+  aliases?: AliasMap;
+  /** Class roots to skip (string or RegExp). Default exempts `card`. */
+  exemptPatterns?: ExemptPattern[];
+  /** File extensions to include. Default: ['.css', '.astro', '.tsx', '.jsx', '.html']. */
+  extensions?: string[];
+  /** Path patterns to exclude. Default skips __tests__, *.test.*, node_modules, dist, .git, storybook-static. */
+  excludePathPatterns?: ExemptPattern[];
+}
+
+export type ClassViolationKind = 'invented-bds' | 'shadow-root' | 'shadow-alias';
+
+export interface ClassViolation {
+  /** The offending class name as written in source. */
+  class: string;
+  /** Why it was flagged. */
+  kind: ClassViolationKind;
+  /** Canonical BDS root the violation shadows (for `shadow-*` kinds). */
+  canonical?: string;
+  /** Shorthand alias root (only for `shadow-alias`). */
+  alias?: string;
+  /** Files where the class was referenced (sourceScan only). */
+  files?: string[];
+}
+
+export interface ClassSourceScanResult {
+  violations: ClassViolation[];
+  scannedFiles: number;
+  canonicalCount: number;
+  canonicalRootCount: number;
+}
+
+export interface ClassRuntimeScanOptions {
+  /** CSS string to inspect (typically generator output). */
+  css: string;
+  /** Canonical class allowlist parsed from BDS dist/styles.css. */
+  allowlist: Set<string>;
+  /** Shorthand → canonical aliases. */
+  aliases?: AliasMap;
+  /** Class roots to skip. */
+  exemptPatterns?: ExemptPattern[];
+}
+
+export interface ClassRuntimeScanResult {
+  violations: ClassViolation[];
+  emittedCount: number;
+  canonicalRootCount: number;
+}
+
+export interface AssertCanonicalClassesOptions
+  extends Omit<ClassRuntimeScanOptions, 'css' | 'allowlist'> {
+  /** Pre-parsed allowlist. If omitted, the allowlist is read from `allowlistPath`. */
+  allowlist?: Set<string>;
+  /** Path to a styles.css file. Defaults to node_modules/@brikdesigns/bds/dist/styles.css. */
+  allowlistPath?: string;
+}
+
+export const DEFAULT_CLASS_ALIASES: AliasMap;
+export const DEFAULT_CLASS_EXEMPT_PATTERNS: readonly RegExp[];
+export const DEFAULT_SCAN_EXTENSIONS: readonly string[];
+export const DEFAULT_EXCLUDE_PATH_PATTERNS: readonly RegExp[];
+
+/** Parse a styles.css string into a Set of canonical `bds-*` class names. */
+export function parseClassAllowlist(cssText: string): Set<string>;
+
+/** Read a styles.css file from disk and parse it. Throws on missing file. */
+export function parseClassAllowlistFromFile(path: string): Set<string>;
+
+/** Resolve the default styles.css path (consumer node_modules first, then BDS-self). */
+export function resolveDefaultClassAllowlistPath(cwd?: string): string;
+
+/** Reduce a class allowlist to its set of distinct BEM block roots. */
+export function canonicalRoots(allowlist: Set<string>): Set<string>;
+
+/** Split a BEM class name into its block root (everything before the first `__` or `--`). */
+export function classRoot(className: string): string;
+
+/** Extract every class name referenced in markup attributes and CSS selectors. */
+export function extractClassReferences(text: string): Set<string>;
+
+/** Extract every class definition (CSS rule selector head) from a CSS string. */
+export function extractClassDefinitions(css: string): Set<string>;
+
+/** Decide whether a single class name is canonical, project-local, or violating. */
+export function classifyClass(
+  className: string,
+  opts: {
+    allowlist: Set<string>;
+    roots: Set<string>;
+    aliases: AliasMap;
+    exemptPatterns: ExemptPattern[];
+  },
+):
+  | { kind: 'ok' }
+  | { kind: 'invented-bds'; class: string }
+  | { kind: 'shadow-root'; class: string; canonical: string }
+  | { kind: 'shadow-alias'; class: string; alias: string; canonical: string };
+
+/** Scan filesystem paths for class-name violations. Does not throw. */
+export function classSourceScan(opts: ClassSourceScanOptions): ClassSourceScanResult;
+
+/** Scan a CSS string for violating class definitions. Does not throw. */
+export function classRuntimeScan(opts: ClassRuntimeScanOptions): ClassRuntimeScanResult;
+
+/** Vitest-friendly: throw on the first non-canonical class definition in `css`. */
+export function assertCanonicalClasses(css: string, opts?: AssertCanonicalClassesOptions): void;

--- a/scripts/canonical-class-check.mjs
+++ b/scripts/canonical-class-check.mjs
@@ -1,0 +1,628 @@
+#!/usr/bin/env node
+/**
+ * canonical-class-check — Canonical CSS-class enforcement for the Brik
+ * Design System.
+ *
+ * Validates that component-tier class names referenced in source code (or
+ * defined in consumer CSS) either consume the canonical `bds-*` allowlist
+ * parsed from `dist/styles.css`, or do not collide with a canonical
+ * primitive vocabulary.
+ *
+ * Why this exists. The canonical token registry has a sibling problem at
+ * the component-class layer: client repos invent parallel taxonomies
+ * (`.btn--primary`, `.card`, `.tp-card__bio-btn`) that re-implement
+ * primitives BDS already publishes (`bds-button`, `bds-card`). This is the
+ * same drift mode that produced portal #512/#553 at the token layer.
+ *
+ * What gets flagged.
+ *   1. Class definitions in CSS / scoped Astro <style> that match a known
+ *      canonical root with the `bds-` prefix stripped — e.g. `.button` or
+ *      `.button--primary` while BDS publishes `bds-button`.
+ *   2. Class definitions matching a known shorthand alias (`btn` → `button`).
+ *   3. Class references in `class="..."` / `className="..."` markup that
+ *      contain those same forbidden roots.
+ *   4. Invented `bds-*` names not in the allowlist (e.g. `.bds-button-cta`
+ *      where the canonical scale is only `--tiny|sm|md|lg|xl`).
+ *
+ * What is intentionally NOT flagged.
+ *   - Project-namespaced BEM blocks like `.tp-card__portrait` — `tp-card`
+ *     is a project-local block name, not a primitive collision. Layout CSS
+ *     stays project-local.
+ *   - Utility classes (`.flex`, `.grid`, `.container`) that don't collide
+ *     with BDS primitive vocabulary.
+ *
+ * ── CLI ────────────────────────────────────────────────────────────────────
+ *   canonical-class-check <path...>           Scan paths for class violations
+ *   canonical-class-check --css <file>        Scan a CSS file for violating
+ *                                             definitions (runtime mode — strict)
+ *   canonical-class-check --allowlist <file>  Override allowlist source
+ *                                             (default: dist/styles.css)
+ *   canonical-class-check --aliases <list>    Comma-separated alias=canonical
+ *                                             pairs (e.g. 'btn=button')
+ *   canonical-class-check --exempt <patterns> Comma-separated regex of class
+ *                                             roots to skip
+ *   canonical-class-check --format md|json    Output format (default: md for
+ *                                             TTY, json otherwise)
+ *   canonical-class-check --help              Show this message
+ *
+ * ── Library ────────────────────────────────────────────────────────────────
+ *   import {
+ *     parseClassAllowlist,
+ *     parseClassAllowlistFromFile,
+ *     classSourceScan,
+ *     classRuntimeScan,
+ *     assertCanonicalClasses,
+ *   } from '@brikdesigns/bds/canonical-class-check';
+ *
+ * ── Exit codes ─────────────────────────────────────────────────────────────
+ *   0  Clean — no parallel-taxonomy class names detected
+ *   1  Violations found
+ *   2  Bad invocation (missing args, unreadable allowlist, etc.)
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, dirname, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { stripCssComments } from './canonical-check.mjs';
+
+// ── Defaults ─────────────────────────────────────────────────────────────
+
+/**
+ * Shorthand → canonical aliases. Keys are class-root names that are
+ * unambiguously shorthand for a BDS canonical root. The check treats them
+ * as forbidden whenever the corresponding `bds-<value>` exists in the
+ * allowlist. Extend cautiously — every entry forbids real client code.
+ */
+export const DEFAULT_CLASS_ALIASES = Object.freeze({
+  btn: 'button',
+});
+
+/**
+ * Class roots that are exempt from the "matches a canonical root" rule.
+ * Use sparingly — every entry is a primitive that BDS would otherwise own.
+ *
+ * `card` is exempted because it's a generic noun that frequently appears in
+ * project-local section blocks (e.g. `.team-card__name` vs `bds-card`).
+ * Distinguishing requires more context than a regex can provide; we rely
+ * on review for `card` and only enforce the pure-`btn`/`button` collision
+ * + invented `bds-*` cases by default. Consumers can drop the exemption.
+ */
+export const DEFAULT_CLASS_EXEMPT_PATTERNS = Object.freeze([
+  /^card$/,
+]);
+
+export const DEFAULT_SCAN_EXTENSIONS = Object.freeze([
+  '.css',
+  '.astro',
+  '.tsx',
+  '.jsx',
+  '.html',
+]);
+
+export const DEFAULT_EXCLUDE_PATH_PATTERNS = Object.freeze([
+  /(^|\/)__tests__(\/|$)/,
+  /\.test\.(ts|tsx|mjs|js)$/,
+  /(^|\/)node_modules(\/|$)/,
+  /(^|\/)dist(\/|$)/,
+  /(^|\/)\.git(\/|$)/,
+  /(^|\/)storybook-static(\/|$)/,
+]);
+
+// ── Allowlist parsing ────────────────────────────────────────────────────
+
+/**
+ * Parse a styles.css string into a Set of canonical `bds-*` class names.
+ * Captures every class selector — handles compound selectors, pseudo-class
+ * suffixes, attribute selectors, and BEM modifiers.
+ *
+ * The parser is intentionally permissive: it captures `.bds-foo`,
+ * `.bds-foo--bar`, `.bds-foo__bar`. It strips a trailing colon (pseudo)
+ * or `[` (attribute) or whitespace boundary.
+ */
+export function parseClassAllowlist(cssText) {
+  const allowlist = new Set();
+  const stripped = stripCssComments(cssText);
+  // Match `.bds-<name>` where <name> is BEM-conformant: lowercase letters,
+  // digits, hyphens, double-hyphen modifiers, double-underscore elements.
+  // Anchor on a non-class character (start, whitespace, or selector
+  // combinator) so we don't accept `.foo.bds-fake` as a separate token —
+  // wait, we DO want that, because `.foo.bds-fake` is two classes joined.
+  // The boundary is `.` — every class starts with one.
+  const re = /\.(bds-[a-z][a-z0-9_-]*)/g;
+  let match;
+  while ((match = re.exec(stripped)) !== null) {
+    allowlist.add(match[1]);
+  }
+  return allowlist;
+}
+
+export function parseClassAllowlistFromFile(path) {
+  if (!existsSync(path)) {
+    throw new Error(
+      `canonical-class-check: allowlist source not found at ${path}\n` +
+      `  Expected BDS dist/styles.css. Run \`npm install\` (consumers) or ` +
+      `\`npm run build:lib\` (BDS itself) to populate.`,
+    );
+  }
+  return parseClassAllowlist(readFileSync(path, 'utf8'));
+}
+
+/**
+ * Locate the canonical dist/styles.css. Resolution order mirrors
+ * canonical-check.mjs:
+ *   1. Explicit CLI / opts argument
+ *   2. node_modules/@brikdesigns/bds/dist/styles.css (consumers)
+ *   3. dist/styles.css next to this script (BDS itself)
+ */
+export function resolveDefaultClassAllowlistPath(cwd = process.cwd()) {
+  const consumerPath = resolve(cwd, 'node_modules/@brikdesigns/bds/dist/styles.css');
+  if (existsSync(consumerPath)) return consumerPath;
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const selfPath = resolve(__dirname, '..', 'dist', 'styles.css');
+  if (existsSync(selfPath)) return selfPath;
+  return consumerPath;
+}
+
+// ── Root extraction ──────────────────────────────────────────────────────
+
+/**
+ * Split a BEM-conformant class name into its block root.
+ * `bds-avatar`            → `bds-avatar`
+ * `bds-avatar--lg`        → `bds-avatar`
+ * `bds-avatar__image`     → `bds-avatar`
+ * `bds-accordion-item`    → `bds-accordion-item`     (no separator)
+ * `bds-accordion-item__icon` → `bds-accordion-item`
+ * `tp-card__bio-btn`      → `tp-card`
+ * `btn--primary`          → `btn`
+ */
+export function classRoot(className) {
+  const dunder = className.indexOf('__');
+  const ddash = className.indexOf('--');
+  let cut = className.length;
+  if (dunder !== -1 && dunder < cut) cut = dunder;
+  if (ddash !== -1 && ddash < cut) cut = ddash;
+  return className.slice(0, cut);
+}
+
+/**
+ * Reduce a full class allowlist to its set of distinct block roots.
+ * `Set('bds-button', 'bds-button--primary', 'bds-button__content')`
+ *   → `Set('bds-button')`
+ */
+export function canonicalRoots(allowlist) {
+  const roots = new Set();
+  for (const cls of allowlist) {
+    if (!cls.startsWith('bds-')) continue;
+    roots.add(classRoot(cls));
+  }
+  return roots;
+}
+
+// ── Class extraction from source ─────────────────────────────────────────
+
+/**
+ * Extract every class token referenced in markup attributes
+ * (`class="..."`, `className="..."`) and CSS class selectors (`.foo`,
+ * `.foo--bar { … }`) within a body of text. Returns a Set of distinct
+ * class names.
+ *
+ * Honors `bds-lint-ignore` line comments — same convention as the rest of
+ * BDS lint scripts. A line containing the literal string is skipped.
+ *
+ * Only top-level class definitions and markup attributes are captured.
+ * Embedded class fragments inside JS template literals are not parsed
+ * (they appear in `className={\`...\`}` use cases, but flat-string capture
+ * via the `class=` regex covers the common shape).
+ */
+export function extractClassReferences(text) {
+  const filtered = text
+    .split(/\r?\n/)
+    .filter((line) => !line.includes('bds-lint-ignore'))
+    .join('\n');
+  const stripped = stripCssComments(filtered);
+
+  const classes = new Set();
+
+  // 1. CSS class selectors: `.<name>` followed by a selector boundary
+  //    (`{`, `,`, ` `, `:`, `[`, `.`, `>`, `+`, `~`, end-of-line).
+  const cssRe = /\.([a-z][a-z0-9_-]*)(?=[\s{,.:[>+~]|$)/gm;
+  let m;
+  while ((m = cssRe.exec(stripped)) !== null) {
+    classes.add(m[1]);
+  }
+
+  // 2. Markup attributes: `class="..."`, `className="..."` (and
+  //    `:class="..."`, `class:list={...}` for Vue/Astro). Capture the
+  //    quoted value, then split on whitespace.
+  const attrRe = /\b(?:class|className)\s*=\s*["']([^"']+)["']/g;
+  while ((m = attrRe.exec(stripped)) !== null) {
+    for (const piece of m[1].split(/\s+/)) {
+      if (piece) classes.add(piece);
+    }
+  }
+
+  return classes;
+}
+
+/**
+ * Extract every class *definition* (a CSS rule selector) from a CSS
+ * string. Used by `classRuntimeScan` to enforce that emitted CSS does
+ * not redefine canonical primitives under non-canonical names.
+ */
+export function extractClassDefinitions(css) {
+  const stripped = stripCssComments(css);
+  const re = /\.([a-z][a-z0-9_-]*)(?=[\s{,.:[>+~]|$)/gm;
+  const found = new Set();
+  let match;
+  while ((match = re.exec(stripped)) !== null) {
+    found.add(match[1]);
+  }
+  return found;
+}
+
+// ── Violation classification ─────────────────────────────────────────────
+
+function isExemptRoot(root, exemptPatterns) {
+  for (const pat of exemptPatterns) {
+    if (typeof pat === 'string' && root === pat) return true;
+    if (pat instanceof RegExp && pat.test(root)) return true;
+  }
+  return false;
+}
+
+/**
+ * Decide whether a single class name is a violation.
+ *
+ * Returns one of:
+ *   { kind: 'ok' }                    — class is canonical or project-local
+ *   { kind: 'invented-bds', class }   — `bds-*` name not in allowlist
+ *   { kind: 'shadow-root', class, canonical } — non-prefixed root collides
+ *                                       with `bds-<root>` canon
+ *   { kind: 'shadow-alias', class, alias, canonical } — shorthand alias
+ *                                       (e.g. `btn` → `button`) collides
+ */
+export function classifyClass(className, opts) {
+  const { allowlist, roots, aliases, exemptPatterns } = opts;
+  const root = classRoot(className);
+
+  if (root.startsWith('bds-')) {
+    // Canonical-shaped. Must appear verbatim in the allowlist (any of:
+    // root, root--*, root__*).
+    if (allowlist.has(className)) return { kind: 'ok' };
+    if (roots.has(root)) {
+      // Root is canonical, but this BEM modifier/element isn't published.
+      // That's an invented variant — flag it.
+      return { kind: 'invented-bds', class: className };
+    }
+    return { kind: 'invented-bds', class: className };
+  }
+
+  if (isExemptRoot(root, exemptPatterns)) return { kind: 'ok' };
+
+  // Direct shadow: project class root matches a canonical root with the
+  // `bds-` prefix stripped (`button` shadows `bds-button`).
+  if (roots.has(`bds-${root}`)) {
+    return { kind: 'shadow-root', class: className, canonical: `bds-${root}` };
+  }
+
+  // Alias shadow: project class root is a shorthand for a canonical root
+  // (`btn` shadows `bds-button` via aliases.btn = 'button').
+  const aliasTarget = aliases[root];
+  if (aliasTarget && roots.has(`bds-${aliasTarget}`)) {
+    return {
+      kind: 'shadow-alias',
+      class: className,
+      alias: root,
+      canonical: `bds-${aliasTarget}`,
+    };
+  }
+
+  return { kind: 'ok' };
+}
+
+// ── Path walking (mirror of canonical-check) ─────────────────────────────
+
+function isPathExempted(path, excludePathPatterns) {
+  for (const pat of excludePathPatterns) {
+    if (typeof pat === 'string' && path.includes(pat)) return true;
+    if (pat instanceof RegExp && pat.test(path)) return true;
+  }
+  return false;
+}
+
+function walkPath(root, opts, acc = []) {
+  const {
+    extensions = DEFAULT_SCAN_EXTENSIONS,
+    excludePathPatterns = DEFAULT_EXCLUDE_PATH_PATTERNS,
+  } = opts;
+
+  let stat;
+  try {
+    stat = statSync(root);
+  } catch {
+    return acc;
+  }
+
+  if (stat.isFile()) {
+    if (isPathExempted(root, excludePathPatterns)) return acc;
+    if (extensions.some((e) => root.endsWith(e))) acc.push(root);
+    return acc;
+  }
+  if (!stat.isDirectory()) return acc;
+
+  for (const entry of readdirSync(root)) {
+    const child = join(root, entry);
+    if (isPathExempted(child, excludePathPatterns)) continue;
+    walkPath(child, opts, acc);
+  }
+  return acc;
+}
+
+// ── Public scan APIs ─────────────────────────────────────────────────────
+
+/**
+ * Scan filesystem paths for class-name violations. Mirrors
+ * canonical-check.sourceScan in shape: returns the violation list, the
+ * source files each violation appeared in, and counts. Does NOT throw.
+ */
+export function classSourceScan(opts) {
+  const {
+    paths,
+    allowlist,
+    aliases = DEFAULT_CLASS_ALIASES,
+    exemptPatterns = DEFAULT_CLASS_EXEMPT_PATTERNS,
+    extensions = DEFAULT_SCAN_EXTENSIONS,
+    excludePathPatterns = DEFAULT_EXCLUDE_PATH_PATTERNS,
+  } = opts;
+
+  if (!allowlist || allowlist.size === 0) {
+    throw new Error('canonical-class-check.classSourceScan: allowlist is empty');
+  }
+
+  const roots = canonicalRoots(allowlist);
+  const files = [];
+  for (const p of paths) walkPath(p, { extensions, excludePathPatterns }, files);
+
+  // Map<className, { kind, files, canonical?, alias? }>
+  const violations = new Map();
+  for (const file of files) {
+    const text = readFileSync(file, 'utf8');
+    const refs = extractClassReferences(text);
+    for (const cls of refs) {
+      const verdict = classifyClass(cls, { allowlist, roots, aliases, exemptPatterns });
+      if (verdict.kind === 'ok') continue;
+      const existing = violations.get(cls);
+      if (existing) {
+        existing.files.push(file);
+      } else {
+        violations.set(cls, { ...verdict, files: [file] });
+      }
+    }
+  }
+
+  const list = [...violations.values()]
+    .map((v) => ({ ...v, files: [...new Set(v.files)].sort() }))
+    .sort((a, b) => a.class.localeCompare(b.class));
+
+  return {
+    violations: list,
+    scannedFiles: files.length,
+    canonicalCount: allowlist.size,
+    canonicalRootCount: roots.size,
+  };
+}
+
+/**
+ * Scan a CSS string for class *definitions* that violate canon.
+ * Stricter than classSourceScan — only inspects `.foo { … }` selector
+ * starts, not class-attribute references. The parallel of runtimeScan.
+ */
+export function classRuntimeScan(opts) {
+  const {
+    css,
+    allowlist,
+    aliases = DEFAULT_CLASS_ALIASES,
+    exemptPatterns = DEFAULT_CLASS_EXEMPT_PATTERNS,
+  } = opts;
+
+  if (!allowlist || allowlist.size === 0) {
+    throw new Error('canonical-class-check.classRuntimeScan: allowlist is empty');
+  }
+
+  const roots = canonicalRoots(allowlist);
+  const defs = extractClassDefinitions(css);
+  const violations = [];
+  for (const cls of defs) {
+    const verdict = classifyClass(cls, { allowlist, roots, aliases, exemptPatterns });
+    if (verdict.kind === 'ok') continue;
+    violations.push(verdict);
+  }
+  violations.sort((a, b) => a.class.localeCompare(b.class));
+  return {
+    violations,
+    emittedCount: defs.size,
+    canonicalRootCount: roots.size,
+  };
+}
+
+/**
+ * Vitest-friendly assertion. Throws on the first violation with a message
+ * naming the offending classes. Convenience wrapper around classRuntimeScan
+ * for emitted-CSS tests.
+ */
+export function assertCanonicalClasses(css, opts = {}) {
+  const allowlist = opts.allowlist
+    ?? parseClassAllowlistFromFile(opts.allowlistPath ?? resolveDefaultClassAllowlistPath());
+  const result = classRuntimeScan({ ...opts, css, allowlist });
+  if (result.violations.length > 0) {
+    const summary = result.violations
+      .map((v) => {
+        if (v.kind === 'shadow-root') return `${v.class}  (shadows ${v.canonical})`;
+        if (v.kind === 'shadow-alias') return `${v.class}  (alias '${v.alias}' shadows ${v.canonical})`;
+        return `${v.class}  (invented bds-* — not in allowlist)`;
+      })
+      .join('\n  ');
+    throw new Error(
+      `canonical-class-check: emitted CSS contains ${result.violations.length} class violation(s):\n  ` +
+      summary +
+      `\n\nSource of truth: BDS dist/styles.css. Use bds-* classes or project-namespaced BEM blocks.`,
+    );
+  }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────
+
+const USAGE = `canonical-class-check — Canonical CSS-class enforcement for @brikdesigns/bds
+
+Usage:
+  canonical-class-check <path...>           Scan paths for class violations
+  canonical-class-check --css <file>        Scan a CSS file for violating
+                                            definitions (runtime mode — strict)
+  canonical-class-check --allowlist <file>  Override allowlist source
+                                            (default: node_modules/@brikdesigns/bds/dist/styles.css)
+  canonical-class-check --aliases <list>    Comma-separated alias=canonical
+                                            pairs (default: btn=button)
+  canonical-class-check --exempt <patterns> Comma-separated regex of class
+                                            roots to skip
+  canonical-class-check --format md|json    Output format (default: md for TTY, json otherwise)
+  canonical-class-check --help              Show this message
+
+Exit codes:
+  0  Clean — no parallel-taxonomy class names detected
+  1  Violations found
+  2  Bad invocation (missing args, unreadable allowlist)
+
+Source of truth: BDS dist/styles.css (component class layer).
+`;
+
+function parseCliArgs(argv) {
+  const opts = {
+    paths: [],
+    cssFile: null,
+    allowlistPath: null,
+    aliases: null,
+    exemptPatterns: null,
+    format: null,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') opts.help = true;
+    else if (a === '--css') opts.cssFile = argv[++i];
+    else if (a === '--allowlist') opts.allowlistPath = argv[++i];
+    else if (a === '--aliases') {
+      opts.aliases = {};
+      for (const pair of argv[++i].split(',')) {
+        const [k, v] = pair.split('=').map((s) => s.trim());
+        if (k && v) opts.aliases[k] = v;
+      }
+    }
+    else if (a === '--exempt') opts.exemptPatterns = argv[++i].split(',').map((s) => new RegExp(s));
+    else if (a.startsWith('--format=')) opts.format = a.slice('--format='.length);
+    else if (a === '--format') opts.format = argv[++i];
+    else if (a.startsWith('-')) {
+      process.stderr.write(`canonical-class-check: unknown flag ${a}\n`);
+      process.exit(2);
+    }
+    else opts.paths.push(a);
+  }
+  if (!opts.format) opts.format = process.stdout.isTTY ? 'md' : 'json';
+  return opts;
+}
+
+function describeViolation(v) {
+  if (v.kind === 'shadow-root') return `${v.class}  (shadows ${v.canonical})`;
+  if (v.kind === 'shadow-alias') return `${v.class}  (alias '${v.alias}' shadows ${v.canonical})`;
+  return `${v.class}  (invented bds-* — not in allowlist)`;
+}
+
+function renderMarkdown(result, mode) {
+  if (result.violations.length === 0) {
+    return `canonical-class-check: clean — ${mode === 'runtime' ? result.emittedCount + ' definitions' : result.scannedFiles + ' files'} scanned, 0 class violations against ${result.canonicalRootCount} canonical roots\n`;
+  }
+  const lines = [];
+  lines.push(`canonical-class-check: ${result.violations.length} class violation(s) — parallel taxonomy drift`);
+  lines.push(`  Source of truth: BDS dist/styles.css`);
+  if (mode === 'source') {
+    lines.push(`  Scanned ${result.scannedFiles} files against ${result.canonicalRootCount} canonical roots`);
+    lines.push('');
+    for (const v of result.violations) {
+      const where = (v.files || []).slice(0, 3).map((f) => f.split(sep).slice(-3).join('/')).join(', ');
+      const more = (v.files || []).length > 3 ? `, +${v.files.length - 3} more` : '';
+      lines.push(`  ${describeViolation(v)}   (${where}${more})`);
+    }
+  } else {
+    lines.push(`  Inspected ${result.emittedCount} emitted definitions`);
+    lines.push('');
+    for (const v of result.violations) lines.push(`  ${describeViolation(v)}`);
+  }
+  lines.push('');
+  lines.push('  Use bds-* classes from @brikdesigns/bds, or project-namespaced BEM');
+  lines.push('  for layout (e.g. .team-card__portrait). Inline aliases are not accepted.');
+  return lines.join('\n') + '\n';
+}
+
+function renderJson(result, mode) {
+  return JSON.stringify({ mode, ...result }, null, 2) + '\n';
+}
+
+function main() {
+  const opts = parseCliArgs(process.argv.slice(2));
+
+  if (opts.help) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+
+  const allowlistPath = opts.allowlistPath ?? resolveDefaultClassAllowlistPath();
+  let allowlist;
+  try {
+    allowlist = parseClassAllowlistFromFile(allowlistPath);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(2);
+  }
+
+  if (allowlist.size < 20) {
+    process.stderr.write(
+      `canonical-class-check: allowlist parse returned only ${allowlist.size} class names from ${allowlistPath}\n` +
+      `  Expected 100+ canonical entries. Verify dist/styles.css is built.\n`,
+    );
+    process.exit(2);
+  }
+
+  const aliases = opts.aliases ?? DEFAULT_CLASS_ALIASES;
+  const exemptPatterns = opts.exemptPatterns ?? DEFAULT_CLASS_EXEMPT_PATTERNS;
+
+  if (opts.cssFile) {
+    if (!existsSync(opts.cssFile)) {
+      process.stderr.write(`canonical-class-check: --css file not found: ${opts.cssFile}\n`);
+      process.exit(2);
+    }
+    const css = readFileSync(opts.cssFile, 'utf8');
+    const result = classRuntimeScan({ css, allowlist, aliases, exemptPatterns });
+    process.stdout.write(opts.format === 'json' ? renderJson(result, 'runtime') : renderMarkdown(result, 'runtime'));
+    process.exit(result.violations.length > 0 ? 1 : 0);
+  }
+
+  if (opts.paths.length === 0) {
+    process.stderr.write(USAGE);
+    process.exit(2);
+  }
+
+  const result = classSourceScan({ paths: opts.paths, allowlist, aliases, exemptPatterns });
+  process.stdout.write(opts.format === 'json' ? renderJson(result, 'source') : renderMarkdown(result, 'source'));
+  process.exit(result.violations.length > 0 ? 1 : 0);
+}
+
+const isCliEntry = (() => {
+  try {
+    return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] ?? '');
+  } catch (err) {
+    process.stderr.write(`canonical-class-check: could not determine CLI entry — ${err.message}\n`);
+    return false;
+  }
+})();
+
+if (isCliEntry) main();


### PR DESCRIPTION
## Summary
- feat(canonical-class-check): CSS-class canon enforcement engine

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)