### PR TITLE
chore(release): 0.59.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.58.0",
+      "version": "0.59.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",
@@ -14,7 +14,9 @@
         "@radix-ui/react-popover": "^1.1.15"
       },
       "bin": {
-        "bds-find": "scripts/bds-find.mjs"
+        "bds-find": "scripts/bds-find.mjs",
+        "canonical-check": "scripts/canonical-check.mjs",
+        "canonical-class-check": "scripts/canonical-class-check.mjs"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- chore(release): 0.59.0

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)