### PR TITLE
feat(footer): marketing-site slots — newsletter, contact, badged links, bottom links

### DIFF
--- a/components/ui/Footer/Footer.css
+++ b/components/ui/Footer/Footer.css
@@ -21,6 +21,14 @@
   box-sizing: border-box;
 }
 
+/* ─── Above-top slot (newsletter, announcement, etc.) ─────────── */
+
+.bds-footer__above-top {
+  width: 100%;
+  padding-bottom: var(--padding-lg);
+  border-bottom: var(--border-width-sm) solid var(--border-secondary);
+}
+
 /* ─── Variants ────────────────────────────────────────────────── */
 
 .bds-footer--default {
@@ -58,6 +66,12 @@
   max-width: 280px;
 }
 
+.bds-footer__brand-extra {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+
 /* ─── Columns ─────────────────────────────────────────────────── */
 
 .bds-footer__columns {
@@ -90,10 +104,19 @@
   line-height: var(--font-line-height-normal);
   text-decoration: none;
   transition: opacity var(--duration-fast) var(--ease-out);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-sm);
 }
 
 .bds-footer__link:hover {
   opacity: 0.7;
+}
+
+.bds-footer__link-adornment {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 /* ─── Bottom bar ──────────────────────────────────────────────── */
@@ -108,6 +131,13 @@
   border-top: var(--border-width-sm) solid var(--border-secondary);
 }
 
+.bds-footer__bottom-left {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--gap-sm);
+}
+
 .bds-footer__copyright {
   font-family: var(--font-family-body);
   font-size: var(--body-xs);
@@ -115,10 +145,40 @@
   margin: 0;
 }
 
+.bds-footer__bottom-links {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--gap-sm);
+  padding: 0;
+  margin: 0;
+}
+
+.bds-footer__bottom-link {
+  font-family: var(--font-family-body);
+  font-size: var(--body-xs);
+  font-weight: var(--font-weight-regular);
+  text-decoration: none;
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+
+.bds-footer__bottom-link:hover {
+  opacity: 0.7;
+}
+
+.bds-footer__bottom-sep {
+  font-family: var(--font-family-body);
+  font-size: var(--body-xs);
+  user-select: none;
+}
+
 .bds-footer__social {
   display: flex;
   align-items: center;
   gap: var(--gap-md);
+  font-family: var(--font-family-body);
+  font-size: var(--body-xs);
 }
 
 /* ─── Variant color overrides ─────────────────────────────────── */
@@ -126,10 +186,18 @@
 .bds-footer--default .bds-footer__heading { color: var(--text-primary); }
 .bds-footer--default .bds-footer__link { color: var(--text-secondary); }
 .bds-footer--default .bds-footer__tagline { color: var(--text-secondary); }
+.bds-footer--default .bds-footer__brand-extra { color: var(--text-secondary); }
 .bds-footer--default .bds-footer__copyright { color: var(--text-muted); }
+.bds-footer--default .bds-footer__bottom-link { color: var(--text-muted); }
+.bds-footer--default .bds-footer__bottom-sep { color: var(--text-muted); }
+.bds-footer--default .bds-footer__social { color: var(--text-muted); }
 
 .bds-footer--brand .bds-footer__heading { color: var(--text-inverse); }
 .bds-footer--brand .bds-footer__link { color: var(--text-inverse); }
 .bds-footer--brand .bds-footer__tagline { color: var(--text-inverse); }
+.bds-footer--brand .bds-footer__brand-extra { color: var(--text-inverse); }
 .bds-footer--brand .bds-footer__copyright { color: var(--text-inverse); }
+.bds-footer--brand .bds-footer__bottom-link { color: var(--text-inverse); }
+.bds-footer--brand .bds-footer__bottom-sep { color: var(--text-inverse); }
+.bds-footer--brand .bds-footer__social { color: var(--text-inverse); }
 }

--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -151,12 +151,92 @@ export const Variants: Story = {
    3. PATTERNS — Full marketing page footer
    ═══════════════════════════════════════════════════════════════ */
 
+/* \u2500\u2500\u2500 Marketing-pattern helpers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 */
+
+const NewsletterSection = () => (
+  <div style={{
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 'var(--gap-md)',
+    textAlign: 'center',
+    padding: 'var(--padding-md) 0',
+  }}>
+    <h3 style={{
+      fontFamily: 'var(--font-family-heading)',
+      fontSize: 'var(--heading-md)',
+      fontWeight: 'var(--font-weight-bold)' as unknown as number,
+      margin: 0,
+      color: 'inherit',
+    }}>
+      Join our newsletter
+    </h3>
+    <p style={{
+      fontFamily: 'var(--font-family-body)',
+      fontSize: 'var(--body-sm)',
+      margin: 0,
+      opacity: 0.8,
+    }}>
+      Subscribe for updates, design tips, and case studies.
+    </p>
+    <input
+      type="email"
+      placeholder="you@example.com"
+      style={{
+        width: '320px',
+        maxWidth: '100%',
+        padding: 'var(--padding-sm)',
+        fontFamily: 'var(--font-family-body)',
+        fontSize: 'var(--body-sm)',
+        border: 'var(--border-width-sm) solid var(--border-secondary)',
+        borderRadius: 'var(--border-radius-sm)',
+      }}
+    />
+  </div>
+);
+
+const ContactBlock = () => (
+  <>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)', fontSize: 'var(--body-sm)' }}>
+      <span style={{ opacity: 0.6 }}>{'\u260E'}</span>
+      <span>(555) 123-4567</span>
+    </div>
+    <a
+      href="mailto:hello@example.com"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--gap-sm)',
+        fontSize: 'var(--body-sm)',
+        color: 'inherit',
+        textDecoration: 'none',
+      }}
+    >
+      <span style={{ opacity: 0.6 }}>{'\u2709'}</span>
+      <span>hello@example.com</span>
+    </a>
+  </>
+);
+
+const ServiceDot = ({ color }: { color: string }) => (
+  <span
+    aria-hidden="true"
+    style={{
+      display: 'inline-block',
+      width: 10,
+      height: 10,
+      borderRadius: '50%',
+      backgroundColor: color,
+    }}
+  />
+);
+
 /** @summary Common usage patterns */
 export const Patterns: Story = {
   render: () => (
     <Stack>
       <div>
-        <SectionLabel>Marketing site footer</SectionLabel>
+        <SectionLabel>Minimal marketing footer (legacy shape \u2014 no marketing slots)</SectionLabel>
         <Footer
           logo={<LogoPlaceholder />}
           tagline="Modern websites and digital systems for growing businesses."
@@ -188,6 +268,50 @@ export const Patterns: Story = {
           ]}
           copyright={'\u00A9 2026 Brik Designs LLC. All rights reserved.'}
           socialLinks={socialLinks}
+        />
+      </div>
+
+      <div>
+        <SectionLabel>Full marketing footer \u2014 newsletter + contact + badged columns + bottom links</SectionLabel>
+        <Footer
+          aboveTop={<NewsletterSection />}
+          logo={<LogoPlaceholder />}
+          tagline="We're a digital marketing and design agency."
+          brandExtra={<ContactBlock />}
+          columns={[
+            {
+              heading: 'Services',
+              links: [
+                { label: 'Brand Design', href: '#', adornment: <ServiceDot color="var(--services--yellow)" /> },
+                { label: 'Marketing Design', href: '#', adornment: <ServiceDot color="var(--services--green)" /> },
+                { label: 'Information Design', href: '#', adornment: <ServiceDot color="var(--services--blue)" /> },
+                { label: 'Product Design', href: '#', adornment: <ServiceDot color="var(--services--purple)" /> },
+                { label: 'Back Office Design', href: '#', adornment: <ServiceDot color="var(--services--orange)" /> },
+              ],
+            },
+            {
+              heading: 'About',
+              links: [
+                { label: 'Who We Are', href: '#' },
+                { label: 'What We Do', href: '#' },
+                { label: 'Customer Stories', href: '#' },
+              ],
+            },
+            {
+              heading: 'Follow Us',
+              links: [
+                { label: 'LinkedIn', href: '#' },
+                { label: 'Instagram', href: '#' },
+                { label: 'Facebook', href: '#' },
+              ],
+            },
+          ]}
+          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
+          bottomLinks={[
+            { label: 'Terms', href: '#' },
+            { label: 'Privacy policy', href: '#' },
+          ]}
+          socialLinks={<span>Made with {'\u2764\uFE0F'} in Palm Beach, FL</span>}
         />
       </div>
     </Stack>

--- a/components/ui/Footer/Footer.tsx
+++ b/components/ui/Footer/Footer.tsx
@@ -1,6 +1,19 @@
-import { type HTMLAttributes, type ReactNode } from 'react';
+import { type HTMLAttributes, type ReactNode, Fragment } from 'react';
 import { bdsClass } from '../../utils';
 import './Footer.css';
+
+/**
+ * Footer link (used in column lists)
+ */
+export interface FooterColumnLink {
+  /** Visible label */
+  label: string;
+  /** Destination URL */
+  href: string;
+  /** Optional inline content rendered before the label — typically a colored
+   * badge dot, icon, or other small adornment that signals link category */
+  adornment?: ReactNode;
+}
 
 /**
  * Footer link column
@@ -9,7 +22,18 @@ export interface FooterColumn {
   /** Column heading */
   heading: string;
   /** Links in this column */
-  links: { label: string; href: string }[];
+  links: FooterColumnLink[];
+}
+
+/**
+ * Inline link rendered next to the copyright in the bottom bar
+ * (separated by a bullet)
+ */
+export interface FooterBottomLink {
+  /** Visible label */
+  label: string;
+  /** Destination URL */
+  href: string;
 }
 
 /**
@@ -20,12 +44,23 @@ export interface FooterProps extends HTMLAttributes<HTMLElement> {
   logo?: ReactNode;
   /** Optional tagline or description below the logo */
   tagline?: string;
+  /** Optional content rendered inside the logo area, below the tagline.
+   * Typical use: a contact block with phone / email / address. The slot is
+   * a generic ReactNode so consumers can compose any structure. */
+  brandExtra?: ReactNode;
   /** Link columns */
   columns?: FooterColumn[];
   /** Copyright text */
   copyright?: string;
-  /** Social icons or links in the bottom bar */
+  /** Optional inline links rendered next to the copyright, separated by a
+   * bullet. Typical use: Terms / Privacy. */
+  bottomLinks?: FooterBottomLink[];
+  /** Right-aligned content in the bottom bar. Typically social icons or a
+   * small marketing tagline (e.g. "Made with ❤️ in Palm Beach, FL"). */
   socialLinks?: ReactNode;
+  /** Optional content rendered above the standard top section, full-width.
+   * Typical use: newsletter signup, announcement banner, secondary CTA. */
+  aboveTop?: ReactNode;
   /** Footer variant */
   variant?: FooterVariant;
 }
@@ -41,15 +76,38 @@ export type FooterVariant = 'default' | 'brand';
  * A responsive footer with logo, link columns, copyright, and social links.
  * Matches the Webflow footer structure with BDS tokens.
  *
- * @example
+ * @example Minimal
  * ```tsx
  * <Footer
  *   logo={<img src="/logo.svg" alt="Logo" height={24} />}
  *   columns={[
  *     { heading: 'Product', links: [{ label: 'Features', href: '/features' }] },
- *     { heading: 'Company', links: [{ label: 'About', href: '/about' }] },
  *   ]}
  *   copyright="2026 Brik Designs. All rights reserved."
+ * />
+ * ```
+ *
+ * @example Marketing site (newsletter + contact + badges + extra links)
+ * ```tsx
+ * <Footer
+ *   logo={<Logo />}
+ *   tagline="We're a digital marketing and design agency."
+ *   aboveTop={<NewsletterSection />}
+ *   brandExtra={<ContactBlock phone="..." email="..." />}
+ *   columns={[
+ *     {
+ *       heading: 'Services',
+ *       links: [
+ *         { label: 'Brand Design', href: '/brand', adornment: <ServiceDot color="yellow" /> },
+ *       ],
+ *     },
+ *   ]}
+ *   copyright="© 2026 Brik Designs. All rights reserved."
+ *   bottomLinks={[
+ *     { label: 'Terms', href: '/terms' },
+ *     { label: 'Privacy', href: '/privacy' },
+ *   ]}
+ *   socialLinks={<span>Made with ❤️ in Palm Beach, FL</span>}
  * />
  * ```
  *
@@ -58,26 +116,40 @@ export type FooterVariant = 'default' | 'brand';
 export function Footer({
   logo,
   tagline,
+  brandExtra,
   columns = [],
   copyright,
+  bottomLinks,
   socialLinks,
+  aboveTop,
   variant = 'default',
   className = '',
   style,
   ...props
 }: FooterProps) {
+  const hasBottom =
+    copyright || (bottomLinks && bottomLinks.length > 0) || socialLinks;
+  const hasBottomLeft =
+    copyright || (bottomLinks && bottomLinks.length > 0);
+
   return (
     <footer
       className={bdsClass('bds-footer', `bds-footer--${variant}`, className)}
       style={style}
       {...props}
     >
+      {/* Above-top slot: newsletter, announcement, secondary CTA */}
+      {aboveTop && <div className="bds-footer__above-top">{aboveTop}</div>}
+
       {/* Top section: logo + columns */}
       <div className="bds-footer__top">
-        {(logo || tagline) && (
+        {(logo || tagline || brandExtra) && (
           <div className="bds-footer__logo-area">
             {logo}
             {tagline && <p className="bds-footer__tagline">{tagline}</p>}
+            {brandExtra && (
+              <div className="bds-footer__brand-extra">{brandExtra}</div>
+            )}
           </div>
         )}
         {columns.length > 0 && (
@@ -91,6 +163,11 @@ export function Footer({
                     href={link.href}
                     className="bds-footer__link"
                   >
+                    {link.adornment && (
+                      <span className="bds-footer__link-adornment">
+                        {link.adornment}
+                      </span>
+                    )}
                     {link.label}
                   </a>
                 ))}
@@ -101,10 +178,42 @@ export function Footer({
       </div>
 
       {/* Bottom bar */}
-      {(copyright || socialLinks) && (
+      {hasBottom && (
         <div className="bds-footer__bottom">
-          {copyright && <p className="bds-footer__copyright">{copyright}</p>}
-          {socialLinks && <div className="bds-footer__social">{socialLinks}</div>}
+          {hasBottomLeft && (
+            <div className="bds-footer__bottom-left">
+              {copyright && (
+                <p className="bds-footer__copyright">{copyright}</p>
+              )}
+              {bottomLinks && bottomLinks.length > 0 && (
+                <ul className="bds-footer__bottom-links">
+                  {bottomLinks.map((link, i) => (
+                    <Fragment key={link.href + link.label}>
+                      {(i > 0 || copyright) && (
+                        <li
+                          aria-hidden="true"
+                          className="bds-footer__bottom-sep"
+                        >
+                          •
+                        </li>
+                      )}
+                      <li>
+                        <a
+                          href={link.href}
+                          className="bds-footer__bottom-link"
+                        >
+                          {link.label}
+                        </a>
+                      </li>
+                    </Fragment>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+          {socialLinks && (
+            <div className="bds-footer__social">{socialLinks}</div>
+          )}
         </div>
       )}
     </footer>


### PR DESCRIPTION
## Summary

Adds four additive slots to the `Footer` component so consumers can render the full marketing-footer shape without rebuilding the component. All four are additive and non-breaking — the existing minimal usage (logo + tagline + columns + copyright) renders identically.

| Slot | Type | Typical use |
|---|---|---|
| \`aboveTop\` | \`ReactNode\` | Newsletter signup, announcement banner, secondary CTA — full-width above the top row |
| \`brandExtra\` | \`ReactNode\` | Contact block (phone / email / address) — inside logo area, after tagline |
| \`bottomLinks\` | \`{ label, href }[]\` | Terms / Privacy — inline next to copyright with bullet separators |
| \`FooterColumnLink.adornment\` | \`ReactNode\` | Colored category dots, icons — per-link JSX prefix |

Right-side bottom-bar content keeps the existing \`socialLinks\` slot (implementation is generic ReactNode, so consumers can pass non-social content like "Made with ❤️ in Palm Beach, FL" without API churn).

## Motivation

Consumed by [brikdesigns/brikdesigns#39](https://github.com/brikdesigns/brikdesigns/issues/39) Finding #2 (Footer migration). The current bespoke \`Footer.tsx\` in that repo had ~60% of its content with no home in the BDS Footer — newsletter section, brand-column contact items, badge-decorated service-line links, and extra copyright-bar links.

Rather than ship a partial migration that drops features, this PR extends BDS so the swap can be clean. Same shape will benefit any future Brik marketing site that needs a richer footer (vale-partners, birdwell-mutlak, memphis-dental, future clients).

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint-tokens\` clean on Footer files (pre-existing warnings in unrelated files, not caused by this PR)
- [x] \`npm run lint-jsdoc\` clean
- [x] \`npm run lint-storybook-recipe\` clean (73/73 conforming)
- [x] \`./scripts/pr-checklist.sh\` — automated checks pass
- [x] \`npm run build-storybook\` builds successfully
- [ ] Reviewer: open \`Navigation/Primary/footer\` → \`Patterns\` story; verify both "minimal legacy" and "full marketing" footers render correctly in both default and brand variants
- [ ] Reviewer: scope rule — single concern (Footer component only; no token, theme, or other component changes)

## Follow-up

- Separate release PR will bump to 0.60.0 once this lands (per recent precedent: feat → release PR)
- brikdesigns repo will then bump \`@brikdesigns/bds\` and complete its Footer migration in a third PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)