### PR TITLE
chore(release): 0.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.59.0",
+      "version": "0.60.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Cuts \`@brikdesigns/bds\` 0.60.0 to release the marketing-site Footer slot additions from [#459](https://github.com/brikdesigns/brik-bds/pull/459).

## Released changes

- \`aboveTop\` slot — newsletter / announcement / secondary CTA above the top row
- \`brandExtra\` slot — contact block (phone / email / address) inside logo area, after tagline
- \`bottomLinks\` — Terms / Privacy / etc. as inline links next to the copyright with bullet separators
- \`FooterColumnLink.adornment\` — per-link JSX prefix (e.g. colored service-category dots)

All four are additive and non-breaking. Existing minimal usage (logo + tagline + columns + copyright) renders identically.

## Release procedure

1. Merge this PR (squash).
2. On main: \`git tag v0.60.0 && git push origin v0.60.0\`
3. The \`Release\` workflow validates package.json matches the tag, runs \`npm run validate\`, publishes to GitHub Packages.

## Consumer follow-ups

- **brikdesigns** — bumps \`@brikdesigns/bds\` to 0.60.0 and completes the Footer migration ([brikdesigns#39](https://github.com/brikdesigns/brikdesigns/issues/39) Finding #2). Already queued.
- **portal / renew-pms / freedom / future client sites** — non-breaking; pick up on next routine bump. No action required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)