### PR TITLE
feat(footer): add inverse variant for dark-surface marketing footers

### DIFF
--- a/components/ui/Footer/Footer.css
+++ b/components/ui/Footer/Footer.css
@@ -40,6 +40,10 @@
   background-color: var(--surface-brand-primary);
 }
 
+.bds-footer--inverse {
+  background-color: var(--surface-inverse);
+}
+
 /* ─── Top section: logo + columns ─────────────────────────────── */
 
 .bds-footer__top {
@@ -200,4 +204,13 @@
 .bds-footer--brand .bds-footer__bottom-link { color: var(--text-inverse); }
 .bds-footer--brand .bds-footer__bottom-sep { color: var(--text-inverse); }
 .bds-footer--brand .bds-footer__social { color: var(--text-inverse); }
+
+.bds-footer--inverse .bds-footer__heading { color: var(--text-on-color-dark); }
+.bds-footer--inverse .bds-footer__link { color: var(--text-on-color-dark); }
+.bds-footer--inverse .bds-footer__tagline { color: var(--text-on-color-dark); }
+.bds-footer--inverse .bds-footer__brand-extra { color: var(--text-on-color-dark); }
+.bds-footer--inverse .bds-footer__copyright { color: var(--text-on-color-dark); }
+.bds-footer--inverse .bds-footer__bottom-link { color: var(--text-on-color-dark); }
+.bds-footer--inverse .bds-footer__bottom-sep { color: var(--text-on-color-dark); }
+.bds-footer--inverse .bds-footer__social { color: var(--text-on-color-dark); }
 }

--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -78,7 +78,7 @@ const meta: Meta<typeof Footer> = {
   tags: ['surface-web'],
   parameters: { layout: 'fullscreen' },
   argTypes: {
-    variant: { control: 'select', options: ['default', 'brand'] },
+    variant: { control: 'select', options: ['default', 'brand', 'inverse'] },
   },
 } satisfies Meta<typeof Footer>;
 
@@ -126,6 +126,17 @@ export const Variants: Story = {
           columns={sampleColumns}
           copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
           variant="brand"
+        />
+      </div>
+
+      <div>
+        <SectionLabel>Inverse (dark surface \u2014 meets WCAG AA on body-sm)</SectionLabel>
+        <Footer
+          logo={<LogoPlaceholder />}
+          tagline="Building better digital experiences for small businesses."
+          columns={sampleColumns}
+          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
+          variant="inverse"
         />
       </div>
 

--- a/components/ui/Footer/Footer.tsx
+++ b/components/ui/Footer/Footer.tsx
@@ -68,7 +68,7 @@ export interface FooterProps extends HTMLAttributes<HTMLElement> {
 /**
  * Footer variant
  */
-export type FooterVariant = 'default' | 'brand';
+export type FooterVariant = 'default' | 'brand' | 'inverse';
 
 /**
  * Footer - BDS page footer with link columns


### PR DESCRIPTION
## Summary

Adds \`variant='inverse'\` to BDS Footer using \`--surface-inverse\` (near-black) + \`--text-on-color-dark\` (white). Both canonical tokens — no new parallel taxonomy.

## Why

Existing variants are insufficient for marketing sites that want a dark footer (the universal Brik marketing pattern). Contrast math today:

| Variant | Surface | Text | Body-sm contrast | AA? |
|---|---|---|---|---|
| \`default\` | \`--surface-primary\` (white) | \`--text-secondary\` (#828282) | 3.84:1 | ❌ fails normal |
| \`brand\` | \`--surface-brand-primary\` (poppy #E35335) | \`--text-inverse\` (white) | 4.34:1 | ❌ fails normal |
| \`inverse\` (new) | \`--surface-inverse\` (near-black) | \`--text-on-color-dark\` (white) | >12:1 | ✅ passes |

Both \`default\` and \`brand\` fail WCAG 2.1 AA at small body sizes — surfaced in [brikdesigns/brikdesigns#42](https://github.com/brikdesigns/brikdesigns/pull/42) CI when its Footer migration produced 6 new \`color-contrast\` violations × 16 routes.

## Implementation

Three changes:

1. \`FooterVariant\` union: \`'default' | 'brand'\` → \`'default' | 'brand' | 'inverse'\`
2. \`Footer.css\`: new \`.bds-footer--inverse\` block with surface + 8 child color overrides (heading / link / tagline / brand-extra / copyright / bottom-link / bottom-sep / social)
3. \`Footer.stories.tsx\`: added \"Inverse (dark surface — meets WCAG AA on body-sm)\" entry in the Variants gallery, between \"Brand\" and \"With social links\"

Additive — no behavior change for existing \`default\` / \`brand\` consumers.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`node scripts/lint-tokens.js components/ui/Footer/\` clean (no new warnings)
- [x] \`npm run lint-jsdoc\` clean
- [x] \`npm run build-storybook\` builds successfully
- [ ] Reviewer: \`Navigation/Primary/footer\` → \`Variants\` story; verify \"Inverse\" renders dark with white text, all six section labels readable

## Follow-up

- After merge: release PR to bump 0.60.0 → 0.61.0 (separate, per recent precedent)
- After publish: [brikdesigns/brikdesigns#42](https://github.com/brikdesigns/brikdesigns/pull/42) bumps submodule + flips \`variant='inverse'\`, baseline regressions disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)