### PR TITLE
chore(release): 0.61.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.60.0",
+      "version": "0.61.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Releases the Footer inverse variant from [#463](https://github.com/brikdesigns/brik-bds/pull/463).

## Released changes

- \`Footer\` \`variant='inverse'\` — uses canonical \`--surface-inverse\` + \`--text-on-color-dark\`. Passes WCAG 2.1 AA at all body sizes; gives marketing sites a dark-footer option that doesn't introduce contrast debt.

## Release procedure

1. Merge this PR (squash).
2. On main: \`git tag v0.61.0 && git push origin v0.61.0\`
3. Release workflow validates package.json matches the tag, runs validate, publishes to GitHub Packages.

## Consumer follow-ups

- **brikdesigns** ([brikdesigns#42](https://github.com/brikdesigns/brikdesigns/pull/42)) — bumps submodule + flips \`variant=\"inverse\"\`. Closes 6 axe contrast violations × 16 routes that this enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)