### PR TITLE
devbar: widgets canonical

### DIFF
--- a/components/ui/BrikDevBar/BrikDevBar.tsx
+++ b/components/ui/BrikDevBar/BrikDevBar.tsx
@@ -12,7 +12,7 @@ import { useEffect, useRef } from 'react';
  * Brik Client Portal, and Renew PMS — that's the point: one visual source of
  * truth, identical across all Brik surfaces.
  *
- * Source: brik-llm/scripts/brik-dev-tool/widgets/devbar.js (synced via sync-downstream.sh)
+ * Source: ./widgets/devbar.js (canonical; synced via scripts/sync-devbar-widgets.sh)
  *
  * Promoted from brik-client-portal/src/components/BrikDevBar.tsx on 2026-04-25.
  * DevBarSlotDef + DevBarApi types moved here from DevFeedbackWidget.tsx
@@ -61,7 +61,7 @@ declare global {
  *
  * Render this once in your DevTools layout (or any high-level layout component).
  * Both scripts must be present in the app's public/ directory — see the sync
- * script at brik-llm/scripts/brik-dev-tool/sync-downstream.sh.
+ * script at brik-bds/scripts/sync-devbar-widgets.sh.
  *
  * @summary Dev-only inspection bar (loads devbar/inspect scripts)
  */

--- a/components/ui/BrikDevBar/widgets/EventsWidget.stories.tsx
+++ b/components/ui/BrikDevBar/widgets/EventsWidget.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import { BrikDevBar } from '../BrikDevBar';
+
+/**
+ * Brik DevBar — Events slot.
+ *
+ * Source: components/ui/BrikDevBar/widgets/events-widget.js (canonical).
+ *
+ * Subscribes to the `@brikdesigns/events` MemoryTransport buffer (window
+ * global `__brikEventsMemory`) and renders a live-tail panel of recent
+ * events. If the SDK isn't initialized on the page, the slot still
+ * registers and shows a "no events yet" placeholder.
+ *
+ * Self-bootstrapping: no data-attrs required. Polls every 500ms for a
+ * late-arriving MemoryTransport.
+ *
+ * The story below seeds a fake MemoryTransport on `window` so the panel
+ * has something to display.
+ */
+const meta: Meta = {
+  title: 'Dev Tools/widgets/Events',
+  tags: ['surface-product'],
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj;
+
+interface FakeEvent {
+  name: string;
+  ts: number;
+  payload?: Record<string, unknown>;
+}
+
+interface FakeMemoryTransport {
+  buffer: FakeEvent[];
+  push: (e: FakeEvent) => void;
+  list: () => FakeEvent[];
+}
+
+declare global {
+  interface Window {
+    __brikEventsMemory?: FakeMemoryTransport;
+    __brikEventsWidgetInitialized?: boolean;
+  }
+}
+
+function loadEventsScript() {
+  const MARKER = 'data-brik-events-loader';
+  if (document.querySelector(`script[${MARKER}]`)) return;
+  const s = document.createElement('script');
+  s.src = '/brik-events-widget.js';
+  s.async = false;
+  s.setAttribute(MARKER, '');
+  document.head.appendChild(s);
+}
+
+function EventsDemo({ seed }: { seed: boolean }) {
+  useEffect(() => {
+    if (seed && !window.__brikEventsMemory) {
+      const buf: FakeEvent[] = [
+        { name: 'page.viewed', ts: Date.now() - 4000, payload: { path: '/' } },
+        { name: 'cta.clicked', ts: Date.now() - 2500, payload: { id: 'hero-primary' } },
+        { name: 'form.submitted', ts: Date.now() - 1000, payload: { form: 'contact' } },
+      ];
+      window.__brikEventsMemory = {
+        buffer: buf,
+        push(e) {
+          this.buffer.push(e);
+        },
+        list() {
+          return this.buffer.slice();
+        },
+      };
+    }
+    loadEventsScript();
+  }, [seed]);
+
+  return (
+    <>
+      <BrikDevBar />
+      <div style={{ padding: 'var(--padding-xl)', fontFamily: 'var(--font-family-body)', maxWidth: 720 }}>
+        <h2 style={{ fontSize: 'var(--heading-md)', fontWeight: 700, color: 'var(--text-primary)', margin: 0 }}>
+          Events slot
+        </h2>
+        <p style={{ color: 'var(--text-secondary)', marginTop: 'var(--gap-sm)' }}>
+          Open the Events slot in the DevBar (bottom of the preview) to see the live event tail.
+          {seed
+            ? ' This story seeds a fake MemoryTransport with three events.'
+            : ' This story does NOT seed events — you should see the empty-state placeholder.'}
+        </p>
+        {seed && (
+          <button
+            type="button"
+            style={{
+              marginTop: 'var(--gap-md)',
+              padding: '8px 16px',
+              borderRadius: 'var(--border-radius-sm)',
+              border: '1px solid var(--border-secondary)',
+              background: 'var(--surface-primary)',
+              fontFamily: 'var(--font-family-label)',
+              fontSize: 'var(--label-sm)',
+              cursor: 'pointer',
+            }}
+            onClick={() => {
+              window.__brikEventsMemory?.push({
+                name: 'demo.clicked',
+                ts: Date.now(),
+                payload: { source: 'storybook' },
+              });
+            }}
+          >
+            Push demo event
+          </button>
+        )}
+      </div>
+    </>
+  );
+}
+
+/** @summary With seeded events */
+export const WithSeededEvents: Story = {
+  name: 'With seeded events',
+  render: () => <EventsDemo seed={true} />,
+};
+
+/** @summary Empty state */
+export const EmptyState: Story = {
+  name: 'No SDK loaded → empty state',
+  render: () => <EventsDemo seed={false} />,
+};

--- a/components/ui/BrikDevBar/widgets/FeedbackWidget.stories.tsx
+++ b/components/ui/BrikDevBar/widgets/FeedbackWidget.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+
+/**
+ * Brik Review — pin-drop feedback overlay (vanilla).
+ *
+ * Source: components/ui/BrikDevBar/widgets/feedback-widget.js (canonical).
+ *
+ * Audience: external clients reviewing pre-launch mockups. Auth via
+ * `data-review-token`. Pins POST to `portal.brikdesigns.com` (configurable
+ * via `data-api-url`).
+ *
+ * Distinct from `DevFeedbackWidget.tsx` (the React form-style widget for
+ * authenticated internal staff). Phase 2 (#467) widens this vanilla widget
+ * to support form-mode + user-auth so the two can converge.
+ *
+ * Configuration via script data-attrs:
+ *   - data-review-token="..."   required; widget no-ops without it
+ *   - data-api-url="..."        defaults to portal.brikdesigns.com
+ *   - data-variant-key="..."    optional; identifies which variant the pin lands on
+ */
+const meta: Meta = {
+  title: 'Dev Tools/widgets/Feedback (pin-drop)',
+  tags: ['surface-product'],
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj;
+
+function loadFeedbackScript(token: string) {
+  const MARKER = 'data-brik-feedback-loader';
+  const existing = document.querySelector(`script[${MARKER}]`);
+  if (existing) existing.remove();
+
+  const s = document.createElement('script');
+  s.src = '/brik-feedback-widget.js';
+  s.async = false;
+  s.setAttribute(MARKER, '');
+  s.setAttribute('data-review-token', token);
+  s.setAttribute('data-api-url', 'https://portal.brikdesigns.com');
+  document.head.appendChild(s);
+}
+
+function FeedbackDemo({ token }: { token: string }) {
+  useEffect(() => {
+    loadFeedbackScript(token);
+    return () => {
+      // Clean up overlay nodes if the widget mounted any
+      document.querySelectorAll('[class*="bfb-"]').forEach((n) => n.remove());
+    };
+  }, [token]);
+
+  return (
+    <div style={{ padding: 'var(--padding-xl)', fontFamily: 'var(--font-family-body)', maxWidth: 720 }}>
+      <h2 style={{ fontSize: 'var(--heading-md)', fontWeight: 700, color: 'var(--text-primary)', margin: 0 }}>
+        Pin-drop feedback widget
+      </h2>
+      <p style={{ color: 'var(--text-secondary)', marginTop: 'var(--gap-sm)' }}>
+        The toolbar should appear in the bottom-right of this preview. Toggle pin mode, then
+        click anywhere in the iframe to drop a pin and write a comment.
+      </p>
+      <p style={{ color: 'var(--text-muted)', fontSize: 'var(--body-sm)', marginTop: 'var(--gap-md)' }}>
+        Submissions in this story will fail the network call (no real review token) — the UI
+        renders fully but the POST will 401. That&apos;s expected for the demo.
+      </p>
+    </div>
+  );
+}
+
+/** @summary Default playground */
+export const Default: Story = {
+  name: 'Default (sample review token)',
+  render: () => <FeedbackDemo token="storybook-demo-token" />,
+};
+
+/** @summary Missing token */
+export const NoToken: Story = {
+  name: 'No token → widget stays disabled',
+  render: () => <FeedbackDemo token="" />,
+};

--- a/components/ui/BrikDevBar/widgets/InspectWidget.stories.tsx
+++ b/components/ui/BrikDevBar/widgets/InspectWidget.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import { BrikDevBar } from '../BrikDevBar';
+
+/**
+ * Brik Inspect — token & component auditor.
+ *
+ * Source: components/ui/BrikDevBar/widgets/inspect-widget.js (canonical).
+ *
+ * Already loaded automatically by `<BrikDevBar />` (BrikDevBar.tsx:85), so
+ * mounting the shell is sufficient. This story exists to document the widget
+ * surface and exercise its configuration knobs.
+ *
+ * Configuration via script data-attrs:
+ *   - data-auto-enable="1"  loads the toolbar; hover stays off until the user
+ *                            clicks the Inspect slot. Default behaviour.
+ *
+ * Activation paths:
+ *   1. Click the Inspect slot in the DevBar.
+ *   2. Append `?inspect=1` to the URL.
+ *   3. Cmd/Ctrl + Shift + I.
+ *   4. localStorage `brik-inspect-enabled=1` persists across sessions.
+ */
+const meta: Meta = {
+  title: 'Dev Tools/widgets/Inspect',
+  tags: ['surface-product'],
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj;
+
+function InspectDemo() {
+  return (
+    <>
+      <BrikDevBar />
+      <div style={{ padding: 'var(--padding-xl)', fontFamily: 'var(--font-family-body)', maxWidth: 720 }}>
+        <h2 style={{ ...{ fontSize: 'var(--heading-md)', fontWeight: 700, color: 'var(--text-primary)', margin: 0 } }}>
+          Brik Inspect
+        </h2>
+        <p style={{ color: 'var(--text-secondary)', marginTop: 'var(--gap-sm)' }}>
+          Hover any element to see its computed style audited against BDS tokens. Click to lock
+          the panel; click again or hit ESC to release. The inspect script is injected by{' '}
+          <code>BrikDevBar.tsx</code> on mount.
+        </p>
+
+        <div style={{ marginTop: 'var(--gap-xl)', display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
+          <SampleCard
+            title="Token-clean card"
+            body="Every value below routes through a BDS variable — Inspect should show all green."
+            style={{
+              padding: 'var(--padding-lg)',
+              border: '1px solid var(--border-secondary)',
+              borderRadius: 'var(--border-radius-md)',
+              background: 'var(--surface-primary)',
+              color: 'var(--text-primary)',
+            }}
+          />
+
+          <SampleCard
+            title="Hardcoded card (intentional)"
+            body="Same shape, but raw hex + px. Inspect should flag the hardcoded values — useful for
+                  testing that the auditor still catches them."
+            style={{
+              padding: '24px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '8px',
+              background: '#ffffff',
+              color: '#1b1b1b',
+            }}
+          />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function SampleCard({
+  title,
+  body,
+  style,
+}: {
+  title: string;
+  body: string;
+  style: React.CSSProperties;
+}) {
+  return (
+    <div style={style}>
+      <h3 style={{ margin: 0, fontSize: 'var(--heading-sm)', fontWeight: 600 }}>{title}</h3>
+      <p style={{ margin: 'var(--gap-sm) 0 0', fontSize: 'var(--body-sm)' }}>{body}</p>
+    </div>
+  );
+}
+
+/** @summary Live inspect demo */
+export const LiveDemo: Story = {
+  name: 'Live demo (hover sample cards)',
+  render: () => <InspectDemo />,
+};
+
+/** @summary URL auto-activation */
+export const AutoActivated: Story = {
+  name: 'Auto-activated via ?inspect=1',
+  render: () => {
+    useEffect(() => {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('inspect') !== '1') {
+        url.searchParams.set('inspect', '1');
+        window.history.replaceState({}, '', url.toString());
+      }
+    }, []);
+    return <InspectDemo />;
+  },
+};

--- a/components/ui/BrikDevBar/widgets/README.md
+++ b/components/ui/BrikDevBar/widgets/README.md
@@ -1,0 +1,27 @@
+# BrikDevBar — vanilla widgets (canonical source)
+
+This directory holds the canonical vanilla-JS source for the four Brik dev widgets:
+
+| File | Slot | What it does |
+|------|------|--------------|
+| `devbar.js` | shell | Renders the toolbar at the bottom of the page; exposes `window.BrikDevBar.register()` so other widgets can plug in slots. |
+| `inspect-widget.js` | inspect | Hover-to-audit token + component inspector. Auto-loaded by `BrikDevBar.tsx`. |
+| `feedback-widget.js` | feedback (pin) | Click-anywhere pin-drop overlay; POSTs comments to `portal.brikdesigns.com` with a review token. External-client surface. |
+| `events-widget.js` | events | Live-tail of `@brikdesigns/events` MemoryTransport buffer. |
+
+## Source-of-truth move (2026-05)
+
+Until #466, these widgets lived in `brik-llm/scripts/brik-dev-tool/widgets/` and BDS held only the React shells. BDS is now the canonical source — consumers (portal, renew-pms, brik-llm cache, BDS Storybook) are written to by `scripts/sync-devbar-widgets.sh` from this directory.
+
+Edit here, run `npm run sync:devbar-widgets`, commit the diffs in each affected repo.
+
+## Storybook
+
+Each widget has a story under `Dev Tools/widgets/*` exercising its bootstrap path. The `BrikDevBar` shell story (one level up) shows two slots registered via `useDevBarSlot` — that pattern is the React side.
+
+## Adding a new widget
+
+1. Drop the vanilla JS source into this directory.
+2. Co-locate a `.stories.tsx` next to it.
+3. Add destinations to `scripts/sync-devbar-widgets.sh`.
+4. If consumers should auto-load it (like `BrikDevBar.tsx` does for `inspect-widget.js`), add the `inject()` call there too.

--- a/components/ui/BrikDevBar/widgets/devbar.js
+++ b/components/ui/BrikDevBar/widgets/devbar.js
@@ -1,0 +1,375 @@
+/**
+ * Brik DevBar — unified bottom-pinned dev toolbar
+ *
+ * Provides a shared, branded dock that other widgets register into. Any widget
+ * loaded *after* devbar.js can attach itself via the global registration API;
+ * widgets loaded *before* it can still register through a queued fallback.
+ *
+ * Visibility model:
+ *   - Bar renders only if at least one widget registers.
+ *   - Each widget gates its own registration (review token, data-attr, etc.).
+ *   - User can collapse the bar; preference persists in localStorage.
+ *
+ * Widget registration API (window.BrikDevBar):
+ *
+ *   BrikDevBar.register({
+ *     id:         'inspect',           // unique string
+ *     label:      'Inspect',           // shown in expanded bar + aria-label
+ *     icon:       '<svg…/>' | string,  // inline SVG or emoji, 14px target
+ *     onActivate: (api) => { … },      // called when user clicks the slot
+ *     onDeactivate: (api) => { … },    // optional — called when user re-clicks
+ *     badge:      null,                // initial badge content (number/string)
+ *     order:      0,                   // lower = further left
+ *   });
+ *
+ *   BrikDevBar.unregister('inspect');
+ *   BrikDevBar.setBadge('inspect', 3);
+ *   BrikDevBar.setActive('inspect', true);  // mark slot as toggled on
+ *
+ * The API passes itself to onActivate handlers so widgets know where the
+ * bar lives and can position popovers above it.
+ *
+ * If devbar.js isn't loaded, widgets should fall back to their own standalone
+ * FAB — just check: `if (window.BrikDevBar) …` at init.
+ *
+ * Zero deps, standalone, BDS-branded to match the rest of brik-dev-tool.
+ */
+
+(function () {
+  'use strict';
+
+  // Re-entry guard (in case script is injected twice).
+  if (window.BrikDevBar && window.BrikDevBar.__initialized) return;
+
+  // ── BDS Tokens (mirror feedback-widget.js / inspect-widget.js) ──────────
+  const T = {
+    colorPoppyLight:       '#e35335',
+    colorPoppyDark:        '#b0351b',
+    colorPoppyLightest:    '#ffefeb',
+    colorGrayscaleWhite:   '#ffffff',
+    colorGrayscaleLighter: '#e0e0e0',
+    colorGrayscaleLight:   '#bdbdbd',
+    colorGrayscaleDark:    '#828282',
+    colorGrayscaleDarker:  '#4f4f4f',
+    colorGrayscaleDarkest: '#333333',
+    colorTanLightest:      '#f1f0ec',
+    backgroundBrandPrimary:'#e35335',
+    interactionBrandHover: '#b0351b',
+    textPrimary:   '#333333',
+    textMuted:     '#828282',
+    textInverse:   '#ffffff',
+    borderPrimary: '#e0e0e0',
+    fontFamily:    "'Poppins', system-ui, sans-serif",
+    fontSizeSm:    '11.54px',
+    fontSizeBody:  '14px',
+    fontWeightSemiBold: '600',
+    fontWeightBold:     '700',
+    space100: '4px',
+    space200: '8px',
+    space300: '12px',
+    space400: '16px',
+    radius100:  '4px',
+    radius200:  '8px',
+    radius300:  '12px',
+    radius400:  '16px',
+    radiusPill: '999px',
+  };
+
+  // ── State ───────────────────────────────────────────────────────────────
+  const slots = new Map();              // id → slot definition
+  const elRefs = { bar: null, list: null, logo: null };
+  let initialized = false;
+
+  // ── Font load (shared with sibling widgets) ────────────────────────────
+  if (!document.querySelector('link[href*="Poppins"]')) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap';
+    document.head.appendChild(link);
+  }
+
+  // ── Styles ──────────────────────────────────────────────────────────────
+  const css = `
+    .bdb-bar {
+      position: fixed;
+      bottom: ${T.space400};
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 2147483647;
+      display: inline-flex;
+      align-items: center;
+      gap: ${T.space200};
+      padding: ${T.space200} ${T.space300};
+      background: ${T.backgroundBrandPrimary};
+      color: ${T.colorGrayscaleWhite};
+      border: none;
+      border-radius: ${T.radius400};
+      box-shadow: 0 8px 28px rgba(0,0,0,0.22);
+      font-family: ${T.fontFamily};
+      font-size: ${T.fontSizeBody};
+    }
+
+    .bdb-logo {
+      display: inline-flex; align-items: center; gap: ${T.space200};
+      color: ${T.colorGrayscaleWhite};
+      font-weight: ${T.fontWeightBold};
+      font-size: ${T.fontSizeBody};
+      letter-spacing: -0.01em;
+      padding: 0 ${T.space100};
+      user-select: none;
+      pointer-events: none;
+    }
+    .bdb-logo__mark {
+      width: 22px; height: 22px;
+      display: inline-flex; align-items: center; justify-content: center;
+      flex-shrink: 0;
+    }
+    .bdb-logo__mark svg { width: 22px; height: 22px; display: block; }
+
+    .bdb-divider {
+      width: 1px; height: 18px;
+      background: rgba(255,255,255,0.28);
+      margin: 0 ${T.space100};
+    }
+
+    .bdb-list {
+      display: inline-flex;
+      align-items: center;
+      gap: ${T.space100};
+    }
+
+    .bdb-slot {
+      position: relative;
+      display: inline-flex; align-items: center; justify-content: center;
+      gap: ${T.space100};
+      padding: 0;
+      width: 40px; height: 40px;
+      background: transparent;
+      color: ${T.colorGrayscaleWhite};
+      border: none;
+      border-radius: ${T.radius200};
+      font-family: ${T.fontFamily};
+      font-size: ${T.fontSizeSm};
+      font-weight: ${T.fontWeightSemiBold};
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      transition: background 0.12s ease, color 0.12s ease;
+      line-height: 1;
+      white-space: nowrap;
+    }
+    .bdb-slot__label { display: none; }
+    .bdb-slot:hover { background: rgba(255,255,255,0.15); }
+    .bdb-slot[data-active="true"] {
+      background: ${T.colorGrayscaleWhite};
+      color: ${T.backgroundBrandPrimary};
+    }
+    .bdb-slot[data-active="true"]:hover { background: ${T.colorTanLightest}; }
+    .bdb-slot__icon {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 14px; height: 14px;
+    }
+    .bdb-slot__icon svg { width: 16px; height: 16px; }
+    .bdb-slot__badge {
+      position: absolute; top: -2px; right: -4px;
+      display: inline-flex; align-items: center; justify-content: center;
+      min-width: 14px; height: 14px;
+      padding: 0 3px;
+      border-radius: ${T.radiusPill};
+      background: ${T.colorGrayscaleDarkest};
+      color: ${T.colorGrayscaleWhite};
+      font-family: ${T.fontFamily};
+      font-size: 9px;
+      font-weight: ${T.fontWeightBold};
+      line-height: 1;
+      border: 1px solid ${T.colorGrayscaleWhite};
+    }
+    .bdb-slot[data-active="true"] .bdb-slot__badge {
+      background: ${T.colorGrayscaleWhite};
+      color: ${T.backgroundBrandPrimary};
+    }
+
+  `;
+
+  function injectStyles() {
+    if (document.querySelector('style[data-brik-devbar]')) return;
+    const style = document.createElement('style');
+    style.setAttribute('data-brik-devbar', '');
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+
+  // ── Brand logomark (Brik) ──────────────────────────────────────────────
+  // Inline SVG of the Brik logomark on its own Poppy rounded-square bg,
+  // baked-in to match the surrounding bar color. IDs are prefixed so they
+  // don't collide with anything on the host page.
+  const LOGO_SVG = `
+<svg width="22" height="22" viewBox="0 0 104 104" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+<g clip-path="url(#bdb-logo-clip)">
+<rect width="104" height="104" rx="12" fill="#E35335"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M104 0H0V104H104V0ZM70.044 35.7735C66.768 33.4995 63.0977 32.3625 59.033 32.3625C55.4537 32.3625 52.3597 33.2071 49.751 34.8964C47.1423 36.5207 45.201 38.7947 43.927 41.7183V18.3071C43.927 16.812 42.7953 15.6 41.3992 15.6H28.5278C27.1317 15.6 26 16.812 26 18.3071V85.0107C26 86.5058 27.1317 87.7178 28.5278 87.7178H41.3992C42.7953 87.7178 43.927 86.5058 43.927 85.0107V79.0442C45.201 81.9679 47.1423 84.2743 49.751 85.9636C52.3597 87.5879 55.4537 88.4 59.033 88.4C63.0977 88.4 66.768 87.2955 70.044 85.0865C73.32 82.8125 75.8983 79.5639 77.779 75.3408C79.6597 71.0527 80.6 66.05 80.6 60.3325C80.6 54.6151 79.6597 49.6448 77.779 45.4217C75.8983 41.1986 73.32 37.9825 70.044 35.7735ZM46.475 52.1462C48.2343 50.1321 50.4487 49.125 53.118 49.125C55.9087 49.125 58.1533 50.1321 59.852 52.1462C61.6113 54.0953 62.491 56.8241 62.491 60.3325C62.491 63.9059 61.6113 66.6997 59.852 68.7138C58.1533 70.6629 55.9087 71.6375 53.118 71.6375C50.4487 71.6375 48.2343 70.6304 46.475 68.6163C44.7157 66.6022 43.836 63.841 43.836 60.3325C43.836 56.8891 44.7157 54.1603 46.475 52.1462Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="bdb-logo-clip"><rect width="104" height="104" rx="12" fill="white"/></clipPath>
+</defs>
+</svg>`;
+
+  // ── DOM ─────────────────────────────────────────────────────────────────
+  function buildBar() {
+    if (elRefs.bar) return;
+
+    const bar = document.createElement('div');
+    bar.className = 'bdb-bar';
+    bar.setAttribute('role', 'toolbar');
+    bar.setAttribute('aria-label', 'Brik DevBar');
+
+    const logo = document.createElement('div');
+    logo.className = 'bdb-logo';
+    logo.innerHTML = `<span class="bdb-logo__mark">${LOGO_SVG}</span><span>brik</span>`;
+    bar.appendChild(logo);
+
+    const divider = document.createElement('span');
+    divider.className = 'bdb-divider';
+    bar.appendChild(divider);
+
+    const list = document.createElement('div');
+    list.className = 'bdb-list';
+    list.setAttribute('role', 'group');
+    bar.appendChild(list);
+
+    document.body.appendChild(bar);
+
+    elRefs.bar = bar;
+    elRefs.list = list;
+    elRefs.logo = logo;
+  }
+
+  // ── Slot rendering ──────────────────────────────────────────────────────
+  function renderSlot(def) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'bdb-slot';
+    btn.setAttribute('data-slot-id', def.id);
+    btn.setAttribute('data-active', 'false');
+    btn.setAttribute('aria-label', def.label);
+    btn.setAttribute('title', def.label);
+    btn.innerHTML = `
+      <span class="bdb-slot__icon">${def.icon || ''}</span>
+      <span class="bdb-slot__label">${escapeHtml(def.label)}</span>
+      ${def.badge != null ? `<span class="bdb-slot__badge">${escapeHtml(String(def.badge))}</span>` : ''}
+    `;
+
+    btn.addEventListener('click', () => {
+      const wasActive = btn.getAttribute('data-active') === 'true';
+      if (wasActive) {
+        setActive(def.id, false);
+        if (typeof def.onDeactivate === 'function') def.onDeactivate(api);
+      } else {
+        setActive(def.id, true);
+        if (typeof def.onActivate === 'function') def.onActivate(api);
+      }
+    });
+
+    return btn;
+  }
+
+  function resort() {
+    if (!elRefs.list) return;
+    const ordered = Array.from(slots.values()).sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    elRefs.list.innerHTML = '';
+    for (const def of ordered) {
+      const el = renderSlot(def);
+      elRefs.list.appendChild(el);
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────
+  function register(def) {
+    if (!def || !def.id || !def.label) {
+      console.warn('[BrikDevBar] register() requires { id, label }');
+      return;
+    }
+    slots.set(def.id, { order: 0, badge: null, ...def });
+    if (!initialized) {
+      injectStyles();
+      buildBar();
+      initialized = true;
+    }
+    resort();
+    return api;
+  }
+
+  function unregister(id) {
+    if (!slots.has(id)) return;
+    slots.delete(id);
+    resort();
+    if (slots.size === 0 && elRefs.bar) {
+      elRefs.bar.remove();
+      elRefs.bar = null;
+      elRefs.list = null;
+      elRefs.logo = null;
+      initialized = false;
+    }
+  }
+
+  function setBadge(id, value) {
+    const slot = slots.get(id);
+    if (!slot) return;
+    slot.badge = value;
+    const btn = elRefs.list?.querySelector(`[data-slot-id="${id}"]`);
+    if (!btn) return;
+    let badgeEl = btn.querySelector('.bdb-slot__badge');
+    if (value == null) {
+      if (badgeEl) badgeEl.remove();
+      return;
+    }
+    if (!badgeEl) {
+      badgeEl = document.createElement('span');
+      badgeEl.className = 'bdb-slot__badge';
+      btn.appendChild(badgeEl);
+    }
+    badgeEl.textContent = String(value);
+  }
+
+  function setActive(id, active) {
+    const btn = elRefs.list?.querySelector(`[data-slot-id="${id}"]`);
+    if (btn) btn.setAttribute('data-active', String(!!active));
+    // Also clear any other active slots if this one was activated — single-select behavior.
+    if (active && elRefs.list) {
+      for (const other of elRefs.list.querySelectorAll('.bdb-slot[data-active="true"]')) {
+        if (other.getAttribute('data-slot-id') !== id) other.setAttribute('data-active', 'false');
+      }
+    }
+  }
+
+  function isRegistered(id) {
+    return slots.has(id);
+  }
+
+  const api = {
+    __initialized: true,
+    register,
+    unregister,
+    setBadge,
+    setActive,
+    isRegistered,
+    // Position helpers for widgets rendering popovers anchored above the bar.
+    getBarRect: () => (elRefs.bar ? elRefs.bar.getBoundingClientRect() : null),
+    getSlotRect: (id) => {
+      const btn = elRefs.list?.querySelector(`[data-slot-id="${id}"]`);
+      return btn ? btn.getBoundingClientRect() : null;
+    },
+  };
+
+  // ── Flush any queued registrations posted before this script loaded ─────
+  // Widgets may do:  (window.BrikDevBarQueue = window.BrikDevBarQueue || []).push(def)
+  // so they can register even if devbar.js loads later.
+  window.BrikDevBar = api;
+  if (Array.isArray(window.BrikDevBarQueue)) {
+    for (const def of window.BrikDevBarQueue) register(def);
+    window.BrikDevBarQueue = [];
+  }
+})();

--- a/components/ui/BrikDevBar/widgets/events-widget.js
+++ b/components/ui/BrikDevBar/widgets/events-widget.js
@@ -1,0 +1,385 @@
+/**
+ * Brik DevBar — Events slot
+ *
+ * Subscribes to the @brikdesigns/events MemoryTransport buffer (exposed on
+ * window.__brikEventsMemory) and renders a live-tail panel of the most
+ * recent events firing on the page. Use cases:
+ *   - Devs verify their new `analytics.track(...)` actually fires
+ *   - QA confirms the right events emit at the right moment
+ *   - Agents grab a JSON dump of events to paste into prompts
+ *
+ * If MemoryTransport isn't initialized (SDK not loaded on this page), the
+ * slot still registers but shows a helpful "no events yet" placeholder.
+ * Polls every 500ms for a late-arriving MemoryTransport.
+ *
+ * Registers as slot id "events" (order 40 — after inspect, before any
+ * future tools).
+ */
+
+(function () {
+  'use strict';
+
+  // Re-entry guard
+  if (window.__brikEventsWidgetInitialized) return;
+  window.__brikEventsWidgetInitialized = true;
+
+  // Shared BDS tokens (mirror of the T block in sibling widgets).
+  const T = {
+    poppy: '#e35335',
+    poppyDark: '#b0351b',
+    white: '#ffffff',
+    tanLightest: '#f1f0ec',
+    grayLighter: '#e0e0e0',
+    grayLight: '#bdbdbd',
+    grayDark: '#828282',
+    grayDarker: '#4f4f4f',
+    grayDarkest: '#333333',
+    fontFamily: "'Poppins', system-ui, sans-serif",
+    fontFamilyMono:
+      "'JetBrains Mono', ui-monospace, SF Mono, Menlo, Consolas, monospace",
+  };
+
+  const css = `
+    .bev-panel {
+      position: fixed; bottom: 72px; left: 50%;
+      transform: translateX(-50%);
+      width: 480px; max-width: calc(100vw - 32px);
+      max-height: min(60vh, 560px);
+      z-index: 2147483644;
+      background: ${T.white};
+      color: ${T.grayDarkest};
+      border: 1px solid ${T.grayLighter};
+      border-radius: 12px;
+      box-shadow: 0 12px 48px rgba(0,0,0,0.18);
+      font-family: ${T.fontFamily};
+      display: flex; flex-direction: column;
+      overflow: hidden;
+    }
+    .bev-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 16px;
+      border-bottom: 1px solid ${T.grayLighter};
+      gap: 8px;
+    }
+    .bev-title {
+      font-size: 11px;
+      font-weight: 700;
+      color: ${T.grayDark};
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .bev-count {
+      display: inline-flex; align-items: center;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: ${T.poppy};
+      color: ${T.white};
+      font-family: ${T.fontFamily};
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+    }
+    .bev-actions {
+      display: inline-flex; gap: 6px;
+    }
+    .bev-action-btn {
+      background: transparent;
+      color: ${T.grayDarker};
+      border: 1px solid ${T.grayLighter};
+      border-radius: 999px;
+      padding: 4px 10px;
+      font-family: ${T.fontFamily};
+      font-size: 11px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+    }
+    .bev-action-btn:hover {
+      background: ${T.poppy};
+      color: ${T.white};
+      border-color: ${T.poppy};
+    }
+
+    .bev-list {
+      overflow-y: auto;
+      padding: 4px 0;
+      background: ${T.tanLightest};
+    }
+    .bev-empty {
+      padding: 32px 16px;
+      text-align: center;
+      color: ${T.grayDark};
+      font-size: 12px;
+      font-family: ${T.fontFamily};
+    }
+    .bev-empty code {
+      display: inline-block;
+      margin-top: 8px;
+      padding: 4px 8px;
+      background: ${T.white};
+      border: 1px solid ${T.grayLighter};
+      border-radius: 4px;
+      font-family: ${T.fontFamilyMono};
+      font-size: 11px;
+      color: ${T.poppyDark};
+    }
+
+    .bev-row {
+      padding: 8px 14px;
+      border-bottom: 1px solid ${T.grayLighter};
+      font-family: ${T.fontFamilyMono};
+      font-size: 11px;
+      line-height: 1.5;
+      background: ${T.white};
+      transition: background 0.12s ease;
+    }
+    .bev-row:hover { background: ${T.tanLightest}; }
+    .bev-row__top {
+      display: flex; align-items: baseline; justify-content: space-between;
+      gap: 8px;
+    }
+    .bev-row__name {
+      color: ${T.poppyDark};
+      font-weight: 600;
+      word-break: break-all;
+    }
+    .bev-row__time {
+      color: ${T.grayDark};
+      font-size: 10px;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .bev-row__props {
+      color: ${T.grayDarker};
+      margin-top: 4px;
+      word-break: break-word;
+    }
+    .bev-row__meta {
+      color: ${T.grayDark};
+      font-size: 10px;
+      margin-top: 2px;
+    }
+  `;
+
+  function injectStyles() {
+    if (document.querySelector('style[data-brik-events]')) return;
+    const s = document.createElement('style');
+    s.setAttribute('data-brik-events', '');
+    s.textContent = css;
+    document.head.appendChild(s);
+  }
+
+  function icon() {
+    return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8Z"/></svg>';
+  }
+
+  let panelEl = null;
+  let listEl = null;
+  let countEl = null;
+  let isOpen = false;
+  let unsubscribe = null;
+  let memory = null;
+  let memoryCheckIv = null;
+
+  // Count of new events since panel was last opened. Feeds the slot badge.
+  let unreadCount = 0;
+
+  function resolveMemory() {
+    if (memory) return memory;
+    const m = window.__brikEventsMemory;
+    if (m && typeof m.subscribe === 'function') {
+      memory = m;
+      return m;
+    }
+    return null;
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]),
+    );
+  }
+
+  function formatTime(iso) {
+    try {
+      const d = new Date(iso);
+      return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
+    } catch {
+      return '';
+    }
+  }
+
+  function formatProps(props) {
+    if (!props || Object.keys(props).length === 0) return '';
+    try {
+      return JSON.stringify(props);
+    } catch {
+      return '[unserializable]';
+    }
+  }
+
+  function renderList() {
+    if (!listEl) return;
+    const m = resolveMemory();
+    if (!m) {
+      listEl.innerHTML = `
+        <div class="bev-empty">
+          @brikdesigns/events not detected on this page.
+          <br><br>
+          Once your app calls <code>createAnalytics({ transports: [new MemoryTransport()] })</code>,
+          events will appear here live.
+        </div>
+      `;
+      if (countEl) countEl.textContent = '0';
+      return;
+    }
+    const events = m.getEvents();
+    if (events.length === 0) {
+      listEl.innerHTML = `<div class="bev-empty">No events yet. Call <code>analytics.track(...)</code> to see them here.</div>`;
+    } else {
+      // Newest first
+      listEl.innerHTML = events
+        .slice()
+        .reverse()
+        .map((ev) => `
+          <div class="bev-row">
+            <div class="bev-row__top">
+              <span class="bev-row__name">${escapeHtml(ev.name)}</span>
+              <span class="bev-row__time">${escapeHtml(formatTime(ev.timestamp))}</span>
+            </div>
+            ${ev.properties && Object.keys(ev.properties).length
+                ? `<div class="bev-row__props">${escapeHtml(formatProps(ev.properties))}</div>`
+                : ''}
+            <div class="bev-row__meta">${escapeHtml(ev.surface)} · ${escapeHtml((ev.distinct_id || '').slice(0, 18))}${ev.user_id ? ' · user:' + escapeHtml(ev.user_id.slice(0, 12)) : ''}</div>
+          </div>
+        `)
+        .join('');
+    }
+    if (countEl) countEl.textContent = String(events.length);
+  }
+
+  function buildPanel() {
+    if (panelEl) return panelEl;
+    panelEl = document.createElement('div');
+    panelEl.className = 'bev-panel';
+    panelEl.innerHTML = `
+      <div class="bev-header">
+        <div style="display:inline-flex;align-items:center;gap:8px;">
+          <span class="bev-title">Events</span>
+          <span class="bev-count" data-role="count">0</span>
+        </div>
+        <div class="bev-actions">
+          <button type="button" class="bev-action-btn" data-action="copy">Copy JSON</button>
+          <button type="button" class="bev-action-btn" data-action="clear">Clear</button>
+        </div>
+      </div>
+      <div class="bev-list" data-role="list"></div>
+    `;
+    document.body.appendChild(panelEl);
+    listEl = panelEl.querySelector('[data-role="list"]');
+    countEl = panelEl.querySelector('[data-role="count"]');
+    panelEl.querySelector('[data-action="copy"]').addEventListener('click', () => {
+      const m = resolveMemory();
+      const payload = m ? m.getEvents() : [];
+      try {
+        navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+      } catch (err) {
+        console.error('[bev] clipboard write failed:', err);
+      }
+    });
+    panelEl.querySelector('[data-action="clear"]').addEventListener('click', () => {
+      const m = resolveMemory();
+      if (m) m.clear();
+      renderList();
+    });
+    return panelEl;
+  }
+
+  function openPanel() {
+    buildPanel();
+    panelEl.style.display = 'flex';
+    isOpen = true;
+    unreadCount = 0;
+    updateBadge();
+    renderList();
+    // Subscribe to live updates while open
+    const m = resolveMemory();
+    if (m && !unsubscribe) {
+      unsubscribe = m.subscribe(() => {
+        if (isOpen) renderList();
+      });
+    }
+  }
+
+  function closePanel() {
+    if (panelEl) panelEl.style.display = 'none';
+    isOpen = false;
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+    window.BrikDevBar?.setActive?.('events', false);
+  }
+
+  function updateBadge() {
+    if (!window.BrikDevBar?.setBadge) return;
+    window.BrikDevBar.setBadge('events', unreadCount > 0 ? unreadCount : null);
+  }
+
+  // Background subscriber: increments unread count when panel is closed
+  // so the slot badge tells you activity happened.
+  function ensureBackgroundSubscribe() {
+    const m = resolveMemory();
+    if (!m || m.__brikEventsBgSubscribed) return;
+    m.__brikEventsBgSubscribed = true;
+    m.subscribe(() => {
+      if (!isOpen) {
+        unreadCount++;
+        updateBadge();
+      }
+    });
+  }
+
+  // Register with the DevBar (queue fallback if it loads later).
+  function register() {
+    injectStyles();
+    const def = {
+      id: 'events',
+      label: 'Events',
+      icon: icon(),
+      order: 40,
+      onActivate: () => openPanel(),
+      onDeactivate: () => closePanel(),
+    };
+    if (window.BrikDevBar) {
+      window.BrikDevBar.register(def);
+    } else {
+      window.BrikDevBarQueue = window.BrikDevBarQueue || [];
+      window.BrikDevBarQueue.push(def);
+    }
+
+    // Poll briefly for a late-loaded MemoryTransport so the background
+    // subscriber hooks up even if the SDK initializes after us.
+    ensureBackgroundSubscribe();
+    memoryCheckIv = setInterval(() => {
+      if (resolveMemory()) {
+        ensureBackgroundSubscribe();
+        clearInterval(memoryCheckIv);
+        memoryCheckIv = null;
+      }
+    }, 500);
+    // Give up after 30s — SDK clearly isn't loading here.
+    setTimeout(() => {
+      if (memoryCheckIv) {
+        clearInterval(memoryCheckIv);
+        memoryCheckIv = null;
+      }
+    }, 30000);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', register);
+  } else {
+    register();
+  }
+})();

--- a/components/ui/BrikDevBar/widgets/feedback-widget.js
+++ b/components/ui/BrikDevBar/widgets/feedback-widget.js
@@ -1,0 +1,795 @@
+/**
+ * Brik Design Review — Feedback Widget
+ *
+ * Lightweight, zero-dependency script that overlays on mockup pages.
+ * Clients can click anywhere to drop a pin and leave a comment.
+ * Supports screenshot attachments via clipboard paste, file upload, or drag-drop.
+ * Comments are POSTed to the Brik Client Portal API.
+ *
+ * Injected automatically by deploy-mockups.sh before Netlify deploy.
+ *
+ * Configuration via data attributes on the script tag:
+ *   <script src="feedback-widget.js"
+ *     data-review-token="abc123"
+ *     data-api-url="https://portal.brikdesigns.com"
+ *     data-variant-key="a">
+ *   </script>
+ */
+
+(function () {
+  'use strict';
+
+  // ── Config ──────────────────────────────────────────────────────────────
+  const script = document.currentScript;
+  const REVIEW_TOKEN = script?.getAttribute('data-review-token') || '';
+  const API_URL = script?.getAttribute('data-api-url') || 'https://portal.brikdesigns.com';
+  const VARIANT_KEY = script?.getAttribute('data-variant-key') || '';
+
+  if (!REVIEW_TOKEN) {
+    console.warn('[Brik Feedback] No review token configured. Widget disabled.');
+    return;
+  }
+
+  // ── State ───────────────────────────────────────────────────────────────
+  let feedbackMode = false;
+  let pins = [];
+  let pendingPin = null;
+  let authorName = localStorage.getItem('brik-feedback-name') || '';
+  let authorEmail = localStorage.getItem('brik-feedback-email') || '';
+  let screenshotBase64 = null;
+
+  // ── Styles ──────────────────────────────────────────────────────────────
+  const ACCENT = '#4665f5'; // fallback if BDS tokens unavailable
+
+  const css = `
+    .bfb-toolbar {
+      position: fixed;
+      bottom: var(--space-lg, 24px);
+      right: var(--space-lg, 24px);
+      z-index: 99999;
+      display: flex;
+      gap: var(--space-sm, 8px);
+      align-items: center;
+    }
+    .bfb-btn {
+      background: var(--background-brand-primary, ${ACCENT});
+      color: #fff;
+      border: none;
+      border-radius: var(--radius-button, 100px);
+      padding: var(--space-sm, 12px) var(--space-md, 20px);
+      font-family: var(--typography-font-family-label, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif);
+      font-size: var(--label-sm, 14px);
+      font-weight: var(--font-weight-bold, 600);
+      letter-spacing: var(--letter-spacing-wide, 0);
+      line-height: 1;
+      text-decoration: none;
+      text-transform: uppercase;
+      cursor: pointer;
+      box-shadow: var(--elevation-md, 0 4px 24px rgba(0,0,0,0.3));
+      transition: background var(--duration-fast, 0.15s) var(--ease-default, ease),
+                  transform var(--duration-fast, 0.15s) var(--ease-default, ease);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--space-xs, 6px);
+      box-sizing: border-box;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+    }
+    .bfb-btn svg {
+      width: var(--icon-md, 16px);
+      height: var(--icon-md, 16px);
+      flex-shrink: 0;
+    }
+    .bfb-btn:hover { opacity: 0.9; transform: translateY(-1px); }
+    .bfb-btn--active { background: #ef4444; }
+    .bfb-btn--active:hover { background: #dc2626; }
+
+    .bfb-pin {
+      position: absolute;
+      width: 28px;
+      height: 28px;
+      background: var(--background-brand-primary, ${ACCENT});
+      border: 2px solid #fff;
+      border-radius: 50%;
+      transform: translate(-50%, -50%);
+      z-index: 99998;
+      cursor: pointer;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 700;
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+      transition: transform 0.15s;
+    }
+    .bfb-pin:hover { transform: translate(-50%, -50%) scale(1.15); }
+    .bfb-pin--pending { background: #f59e0b; animation: bfb-pulse 1.5s infinite; }
+
+    @keyframes bfb-pulse {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(245,158,11,0.4); }
+      50% { box-shadow: 0 0 0 8px rgba(245,158,11,0); }
+    }
+
+    .bfb-form {
+      position: fixed;
+      z-index: 100000;
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 8px 40px rgba(0,0,0,0.25);
+      padding: 20px;
+      width: 320px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    }
+    .bfb-form h3 {
+      margin: 0 0 14px;
+      font-size: 15px;
+      font-weight: 600;
+      color: #1b1b1b;
+    }
+    .bfb-form input, .bfb-form textarea {
+      width: 100%;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 10px 12px;
+      font-size: 14px;
+      font-family: inherit;
+      margin-bottom: 10px;
+      box-sizing: border-box;
+      transition: border-color 0.15s;
+    }
+    .bfb-form input:focus, .bfb-form textarea:focus {
+      outline: none;
+      border-color: var(--border-brand-primary, ${ACCENT});
+    }
+    .bfb-form textarea { resize: vertical; min-height: 80px; }
+    .bfb-form-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+    .bfb-form-actions button {
+      border: none;
+      border-radius: 8px;
+      padding: 8px 16px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .bfb-submit { background: var(--background-brand-primary, ${ACCENT}); color: #fff; }
+    .bfb-submit:hover { background: #3550d4; }
+    .bfb-submit:disabled { opacity: 0.5; cursor: not-allowed; }
+    .bfb-cancel { background: #f3f3f3; color: #666; }
+    .bfb-cancel:hover { background: #e8e8e8; }
+
+    .bfb-context {
+      background: #f0f2ff;
+      border: 1px solid #dde1fc;
+      border-radius: 6px;
+      padding: 8px 10px;
+      margin-bottom: 10px;
+      font-size: 12px;
+      color: #444;
+      line-height: 1.4;
+    }
+    .bfb-context strong {
+      color: var(--text-brand-primary, ${ACCENT});
+      font-weight: 600;
+    }
+    .bfb-context-row {
+      display: flex;
+      gap: 4px;
+    }
+    .bfb-context-label {
+      color: #888;
+      min-width: 50px;
+    }
+
+    .bfb-toast {
+      position: fixed;
+      bottom: 80px;
+      right: 24px;
+      z-index: 100001;
+      background: #1b1b1b;
+      color: #fff;
+      padding: 12px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+      box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+      animation: bfb-fadein 0.2s;
+    }
+    @keyframes bfb-fadein {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .bfb-screenshot-zone {
+      border: 2px dashed #ddd;
+      border-radius: 8px;
+      padding: 10px;
+      margin-bottom: 10px;
+      text-align: center;
+      font-size: 12px;
+      color: #888;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+      position: relative;
+    }
+    .bfb-screenshot-zone:hover,
+    .bfb-screenshot-zone--dragover {
+      border-color: var(--border-brand-primary, ${ACCENT});
+      background: #f0f2ff;
+    }
+    .bfb-screenshot-zone input[type="file"] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+    }
+    .bfb-screenshot-preview {
+      position: relative;
+      display: inline-block;
+      margin-bottom: 10px;
+    }
+    .bfb-screenshot-preview img {
+      max-width: 100%;
+      max-height: 120px;
+      border-radius: 6px;
+      border: 1px solid #ddd;
+      display: block;
+    }
+    .bfb-screenshot-remove {
+      position: absolute;
+      top: -6px;
+      right: -6px;
+      width: 20px;
+      height: 20px;
+      background: #ef4444;
+      color: #fff;
+      border: 2px solid #fff;
+      border-radius: 50%;
+      font-size: 12px;
+      line-height: 16px;
+      text-align: center;
+      cursor: pointer;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+    }
+    .bfb-screenshot-remove:hover { background: #dc2626; }
+
+    .bfb-crosshair { cursor: crosshair !important; }
+    .bfb-crosshair * { cursor: crosshair !important; }
+
+    .bfb-pin-tooltip {
+      position: absolute;
+      background: #1b1b1b;
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 13px;
+      font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+      max-width: 240px;
+      z-index: 99999;
+      pointer-events: none;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+      white-space: pre-wrap;
+    }
+    .bfb-pin-tooltip::after {
+      content: '';
+      position: absolute;
+      top: -6px;
+      left: 14px;
+      border-left: 6px solid transparent;
+      border-right: 6px solid transparent;
+      border-bottom: 6px solid #1b1b1b;
+    }
+  `;
+
+  // ── Inject styles ───────────────────────────────────────────────────────
+  const style = document.createElement('style');
+  style.textContent = css;
+  document.head.appendChild(style);
+
+  // ── Load existing feedback ──────────────────────────────────────────────
+  async function loadExistingPins() {
+    try {
+      const res = await fetch(`${API_URL}/api/review/${REVIEW_TOKEN}`);
+      if (!res.ok) return;
+      const { review } = await res.json();
+      if (!review?.design_feedback) return;
+
+      const variantFeedback = review.design_feedback.filter(
+        (f) => f.variant_key === VARIANT_KEY && f.pin_x != null
+      );
+
+      variantFeedback.forEach((f, i) => {
+        pins.push({
+          id: f.id,
+          x: f.pin_x,
+          y: f.pin_y,
+          comment: f.comment,
+          author: f.author_name,
+          number: i + 1,
+        });
+      });
+
+      renderPins();
+    } catch (e) {
+      console.warn('[Brik Feedback] Could not load existing feedback:', e);
+    }
+  }
+
+  // ── Render pins on page ─────────────────────────────────────────────────
+  function renderPins() {
+    document.querySelectorAll('.bfb-pin:not(.bfb-pin--pending)').forEach((el) => el.remove());
+
+    pins.forEach((pin) => {
+      const el = document.createElement('div');
+      el.className = 'bfb-pin';
+      el.textContent = String(pin.number);
+      el.style.left = pin.x + '%';
+      el.style.top = pin.y + 'px';
+
+      el.addEventListener('mouseenter', (e) => showTooltip(e, pin));
+      el.addEventListener('mouseleave', hideTooltip);
+
+      document.body.appendChild(el);
+    });
+  }
+
+  // ── Tooltip ─────────────────────────────────────────────────────────────
+  let tooltipEl = null;
+
+  function showTooltip(e, pin) {
+    hideTooltip();
+    tooltipEl = document.createElement('div');
+    tooltipEl.className = 'bfb-pin-tooltip';
+    tooltipEl.textContent = `${pin.author}: ${pin.comment}`;
+
+    const rect = e.target.getBoundingClientRect();
+    tooltipEl.style.left = (rect.left + window.scrollX) + 'px';
+    tooltipEl.style.top = (rect.bottom + window.scrollY + 8) + 'px';
+
+    document.body.appendChild(tooltipEl);
+  }
+
+  function hideTooltip() {
+    if (tooltipEl) {
+      tooltipEl.remove();
+      tooltipEl = null;
+    }
+  }
+
+  // ── Toolbar ─────────────────────────────────────────────────────────────
+  const toolbar = document.createElement('div');
+  toolbar.className = 'bfb-toolbar';
+
+  const feedbackBtn = document.createElement('button');
+  feedbackBtn.className = 'bfb-btn';
+  feedbackBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg> Leave feedback';
+
+  feedbackBtn.addEventListener('click', () => {
+    feedbackMode = !feedbackMode;
+    if (feedbackMode) {
+      feedbackBtn.className = 'bfb-btn bfb-btn--active';
+      feedbackBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg> Cancel';
+      document.documentElement.classList.add('bfb-crosshair');
+      toast('Click anywhere on the page to drop a pin');
+    } else {
+      deactivate();
+    }
+  });
+
+  const backBtn = document.createElement('a');
+  backBtn.className = 'bfb-btn';
+  backBtn.href = 'index.html';
+  backBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg> All styles';
+
+  toolbar.appendChild(backBtn);
+  toolbar.appendChild(feedbackBtn);
+  document.body.appendChild(toolbar);
+
+  function deactivate() {
+    feedbackMode = false;
+    feedbackBtn.className = 'bfb-btn';
+    feedbackBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg> Leave feedback';
+    document.documentElement.classList.remove('bfb-crosshair');
+    removePendingPin();
+    removeForm();
+  }
+
+  // ── Section detection ──────────────────────────────────────────────────
+  function detectSectionContext(target) {
+    const ctx = {};
+
+    // Find nearest <section> ancestor with section classes
+    const section = target.closest('section[class*="section--"], [class*="section--"]');
+    if (section) {
+      // Extract section type from class: "section section--hero" → "hero"
+      const typeMatch = section.className.match(/section--([a-z-]+)/);
+      if (typeMatch) ctx.section_type = typeMatch[1];
+
+      // aria-label is the human-readable name
+      if (section.getAttribute('aria-label')) ctx.section_label = section.getAttribute('aria-label');
+
+      // id for anchoring
+      if (section.id) ctx.section_id = section.id;
+
+      // Look for <!-- Source: home.md Section-XX --> comment above the section
+      let prev = section.previousSibling;
+      while (prev) {
+        if (prev.nodeType === 8) { // Comment node
+          const commentMatch = prev.textContent.trim().match(/Source:\s*(.+)/);
+          if (commentMatch) {
+            ctx.content_source = commentMatch[1].trim();
+            break;
+          }
+        }
+        // Stop if we hit another element
+        if (prev.nodeType === 1) break;
+        prev = prev.previousSibling;
+      }
+
+      // Section number from DOM order
+      const allSections = document.querySelectorAll('section[class*="section--"]');
+      const idx = Array.from(allSections).indexOf(section);
+      if (idx >= 0) ctx.section_number = idx + 1;
+    }
+
+    // Detect layout class on nearest layout container
+    const layout = target.closest('[class*="layout--"]');
+    if (layout) {
+      const layoutMatch = layout.className.match(/layout--([a-z0-9-]+)/);
+      if (layoutMatch) ctx.layout = layoutMatch[1];
+    }
+
+    // Detect the clicked element type
+    const el = target.closest('a, button, h1, h2, h3, h4, img, video, input, textarea, p, li, span');
+    if (el) ctx.element_tag = el.tagName.toLowerCase();
+
+    return ctx;
+  }
+
+  // ── Click to pin ────────────────────────────────────────────────────────
+  let currentSectionContext = null;
+
+  document.addEventListener('click', (e) => {
+    if (!feedbackMode) return;
+    if (e.target.closest('.bfb-toolbar, .bfb-form, .bfb-pin')) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    removePendingPin();
+    removeForm();
+
+    const x = ((e.pageX) / document.documentElement.scrollWidth) * 100;
+    const y = e.pageY;
+
+    // Detect section context before creating the pin overlay
+    currentSectionContext = detectSectionContext(e.target);
+
+    pendingPin = document.createElement('div');
+    pendingPin.className = 'bfb-pin bfb-pin--pending';
+    pendingPin.textContent = '?';
+    pendingPin.style.left = x + '%';
+    pendingPin.style.top = y + 'px';
+    document.body.appendChild(pendingPin);
+
+    showForm(x, y, e.clientX, e.clientY);
+  }, true);
+
+  // ── Comment form ────────────────────────────────────────────────────────
+  let formEl = null;
+
+  function showForm(pinX, pinY, screenX, screenY) {
+    removeForm();
+
+    formEl = document.createElement('div');
+    formEl.className = 'bfb-form';
+
+    // Position form near click but keep on screen
+    const formWidth = 320;
+    const formHeight = 280;
+    let left = screenX + 20;
+    let top = screenY - 20;
+
+    if (left + formWidth > window.innerWidth - 20) {
+      left = screenX - formWidth - 20;
+    }
+    if (top + formHeight > window.innerHeight - 20) {
+      top = window.innerHeight - formHeight - 20;
+    }
+    if (top < 20) top = 20;
+
+    formEl.style.left = left + 'px';
+    formEl.style.top = top + 'px';
+
+    // Build context display
+    const ctx = currentSectionContext || {};
+    let contextHtml = '';
+    if (ctx.section_type || ctx.section_label) {
+      const parts = [];
+      if (ctx.section_number) parts.push(`<span class="bfb-context-label">Section</span> <strong>${ctx.section_number}: ${(ctx.section_type || '').replace(/-/g, ' ')}</strong>`);
+      else if (ctx.section_type) parts.push(`<span class="bfb-context-label">Section</span> <strong>${ctx.section_type.replace(/-/g, ' ')}</strong>`);
+      if (ctx.section_label && ctx.section_label !== ctx.section_type) parts.push(`<span class="bfb-context-label">Label</span> ${esc(ctx.section_label)}`);
+      if (ctx.element_tag) parts.push(`<span class="bfb-context-label">Element</span> &lt;${ctx.element_tag}&gt;`);
+      if (ctx.layout) parts.push(`<span class="bfb-context-label">Layout</span> ${ctx.layout}`);
+      contextHtml = `<div class="bfb-context">${parts.map(p => `<div class="bfb-context-row">${p}</div>`).join('')}</div>`;
+    }
+
+    formEl.innerHTML = `
+      <h3>Leave a comment</h3>
+      ${contextHtml}
+      <input type="text" class="bfb-name" placeholder="Your name" value="${esc(authorName)}" autocomplete="off" data-1p-ignore />
+      <input type="text" class="bfb-email" placeholder="Email (optional)" value="${esc(authorEmail)}" autocomplete="off" data-1p-ignore />
+      <textarea class="bfb-comment" placeholder="What are your thoughts?" data-1p-ignore></textarea>
+      <div class="bfb-screenshot-zone">
+        \uD83D\uDCCE Paste, drag, or <u>upload</u> a screenshot
+        <input type="file" accept="image/*" />
+      </div>
+      <div class="bfb-form-actions">
+        <button type="button" class="bfb-cancel">Cancel</button>
+        <button type="button" class="bfb-submit">Submit</button>
+      </div>
+    `;
+
+    // Wire screenshot zone events
+    const ssZone = formEl.querySelector('.bfb-screenshot-zone');
+    const ssInput = ssZone.querySelector('input[type="file"]');
+    ssInput.addEventListener('change', (e) => {
+      if (e.target.files[0]) processImageFile(e.target.files[0]);
+    });
+    ssZone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      ssZone.classList.add('bfb-screenshot-zone--dragover');
+    });
+    ssZone.addEventListener('dragleave', () => {
+      ssZone.classList.remove('bfb-screenshot-zone--dragover');
+    });
+    ssZone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      ssZone.classList.remove('bfb-screenshot-zone--dragover');
+      const file = e.dataTransfer?.files[0];
+      if (file) processImageFile(file);
+    });
+
+    formEl.querySelector('.bfb-cancel').addEventListener('click', () => {
+      screenshotBase64 = null;
+      removePendingPin();
+      removeForm();
+    });
+
+    formEl.querySelector('.bfb-submit').addEventListener('click', () => {
+      submitFeedback(pinX, pinY);
+    });
+
+    // Submit on Cmd/Ctrl+Enter
+    formEl.querySelector('.bfb-comment').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        submitFeedback(pinX, pinY);
+      }
+    });
+
+    document.body.appendChild(formEl);
+
+    // Focus the right field
+    if (!authorName) {
+      formEl.querySelector('.bfb-name').focus();
+    } else {
+      formEl.querySelector('.bfb-comment').focus();
+    }
+  }
+
+  async function submitFeedback(pinX, pinY) {
+    if (!formEl) return;
+
+    const name = formEl.querySelector('.bfb-name').value.trim();
+    const email = formEl.querySelector('.bfb-email').value.trim();
+    const comment = formEl.querySelector('.bfb-comment').value.trim();
+
+    if (!name || !comment) {
+      toast('Please enter your name and a comment');
+      return;
+    }
+
+    const submitBtn = formEl.querySelector('.bfb-submit');
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Sending...';
+
+    // Remember name/email for next time
+    authorName = name;
+    authorEmail = email;
+    localStorage.setItem('brik-feedback-name', name);
+    localStorage.setItem('brik-feedback-email', email);
+
+    try {
+      const res = await fetch(`${API_URL}/api/review/${REVIEW_TOKEN}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          variant_key: VARIANT_KEY,
+          author_name: name,
+          author_email: email || undefined,
+          comment,
+          pin_x: Math.round(pinX * 100) / 100,
+          pin_y: Math.round(pinY),
+          viewport_width: window.innerWidth,
+          page_url: window.location.href,
+          section_context: Object.keys(currentSectionContext || {}).length > 0 ? currentSectionContext : undefined,
+          screenshot_base64: screenshotBase64 || undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'Failed to submit');
+      }
+
+      // Convert pending pin to permanent
+      const pinNumber = pins.length + 1;
+      pins.push({ x: pinX, y: pinY, comment, author: name, number: pinNumber });
+
+      screenshotBase64 = null;
+      removePendingPin();
+      removeForm();
+      renderPins();
+      deactivate();
+      toast('Feedback sent — thank you!');
+    } catch (err) {
+      console.error('[Brik Feedback]', err);
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Submit';
+      toast('Could not send feedback. Please try again.');
+    }
+  }
+
+  function removePendingPin() {
+    if (pendingPin) {
+      pendingPin.remove();
+      pendingPin = null;
+    }
+  }
+
+  function removeForm() {
+    if (formEl) {
+      formEl.remove();
+      formEl = null;
+    }
+  }
+
+  // ── Toast ───────────────────────────────────────────────────────────────
+  function toast(msg) {
+    const el = document.createElement('div');
+    el.className = 'bfb-toast';
+    el.textContent = msg;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 3000);
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+  function esc(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  // ── Screenshot processing ──────────────────────────────────────────────
+  const MAX_IMG_WIDTH = 1200;
+  const JPEG_QUALITY = 0.75;
+
+  function processImageFile(file) {
+    if (!file || !file.type.startsWith('image/')) return;
+    const reader = new FileReader();
+    reader.onload = (e) => resizeAndStore(e.target.result);
+    reader.readAsDataURL(file);
+  }
+
+  function resizeAndStore(dataUrl) {
+    const img = new Image();
+    img.onload = () => {
+      let { width, height } = img;
+      if (width > MAX_IMG_WIDTH) {
+        height = Math.round(height * (MAX_IMG_WIDTH / width));
+        width = MAX_IMG_WIDTH;
+      }
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      canvas.getContext('2d').drawImage(img, 0, 0, width, height);
+      screenshotBase64 = canvas.toDataURL('image/jpeg', JPEG_QUALITY);
+      renderScreenshotPreview();
+    };
+    img.src = dataUrl;
+  }
+
+  function renderScreenshotPreview() {
+    if (!formEl) return;
+    // Remove any existing preview
+    formEl.querySelector('.bfb-screenshot-preview')?.remove();
+    formEl.querySelector('.bfb-screenshot-zone')?.remove();
+
+    if (!screenshotBase64) {
+      // Re-insert the upload zone before the actions
+      const actions = formEl.querySelector('.bfb-form-actions');
+      if (actions) actions.before(createScreenshotZone());
+      return;
+    }
+
+    const preview = document.createElement('div');
+    preview.className = 'bfb-screenshot-preview';
+
+    const thumb = document.createElement('img');
+    thumb.src = screenshotBase64;
+    preview.appendChild(thumb);
+
+    const removeBtn = document.createElement('div');
+    removeBtn.className = 'bfb-screenshot-remove';
+    removeBtn.textContent = '\u00d7';
+    removeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      screenshotBase64 = null;
+      renderScreenshotPreview();
+    });
+    preview.appendChild(removeBtn);
+
+    // Insert before actions
+    const actions = formEl.querySelector('.bfb-form-actions');
+    if (actions) actions.before(preview);
+  }
+
+  function createScreenshotZone() {
+    const zone = document.createElement('div');
+    zone.className = 'bfb-screenshot-zone';
+    zone.innerHTML = '\uD83D\uDCCE Paste, drag, or <u>upload</u> a screenshot';
+
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = 'image/*';
+    fileInput.addEventListener('change', (e) => {
+      if (e.target.files[0]) processImageFile(e.target.files[0]);
+    });
+    zone.appendChild(fileInput);
+
+    zone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      zone.classList.add('bfb-screenshot-zone--dragover');
+    });
+    zone.addEventListener('dragleave', () => {
+      zone.classList.remove('bfb-screenshot-zone--dragover');
+    });
+    zone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      zone.classList.remove('bfb-screenshot-zone--dragover');
+      const file = e.dataTransfer?.files[0];
+      if (file) processImageFile(file);
+    });
+
+    return zone;
+  }
+
+  // Global paste handler — only active when feedback form is open
+  document.addEventListener('paste', (e) => {
+    if (!formEl) return;
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+        processImageFile(item.getAsFile());
+        return;
+      }
+    }
+  });
+
+  // ── Init ────────────────────────────────────────────────────────────────
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadExistingPins);
+  } else {
+    loadExistingPins();
+  }
+})();

--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -1,0 +1,1212 @@
+/**
+ * Brik Design Inspect — Token & Component Inspector
+ *
+ * Lightweight, zero-dependency overlay that audits mockup and product pages
+ * against Brik Design System (BDS) rules. Built to give agents (and humans)
+ * a fast way to identify token usage, BDS component classes, and hardcoded
+ * values that should be tokenized.
+ *
+ * Sister to feedback-widget.js — uses the same BDS token block and Poppins
+ * font for visual consistency.
+ *
+ * Enable via:
+ *   1. Query param:        ?inspect=1
+ *   2. Script data-attr:   data-auto-enable="1"  (loads toolbar; doesn't activate hover)
+ *   3. localStorage:       brik-inspect-enabled=1  (auto-activates from prior session)
+ *
+ * Inject alongside feedback-widget.js (same deploy pipeline):
+ *   <script src="inspect-widget.js" data-auto-enable="1"></script>
+ *
+ * Output:
+ *   - Hover  → floating pill (selector + size + BDS/violation badges)
+ *   - Click  → locked panel (full property breakdown, copy report)
+ *   - Scan   → page-wide JSON violation report copied to clipboard
+ *
+ * Keyboard:  Cmd/Ctrl + Shift + I  toggles inspect mode.  ESC closes.
+ */
+
+(function () {
+  'use strict';
+
+  // ── Config ──────────────────────────────────────────────────────────────
+  const script = document.currentScript;
+  const AUTO_ENABLE = script?.getAttribute('data-auto-enable') === '1';
+  const URL_ENABLED = /[?&]inspect=1\b/.test(location.search);
+  const LS_ENABLED = localStorage.getItem('brik-inspect-enabled') === '1';
+  const SHOULD_ENABLE = AUTO_ENABLE || URL_ENABLED || LS_ENABLED;
+
+  if (!SHOULD_ENABLE) return;
+
+  // Token prefixes considered valid BDS tokens. Anything not starting with
+  // one of these is treated as an unknown custom var (still surfaced, but
+  // flagged so agents can decide whether to canonicalize it).
+  const VALID_TOKEN_PREFIXES = [
+    '--color-', '--text-', '--background-', '--surface-', '--border-',
+    '--padding-', '--space-', '--spacing-', '--gap-', '--margin-',
+    '--font-family-', '--typography-', '--font-size-', '--font-weight-',
+    '--body-', '--heading-', '--display-', '--label-',
+    '--line-height-', '--letter-spacing-',
+    '--border-radius-', '--radius-',
+    '--shadow-', '--elevation-',
+    '--transition-', '--motion-', '--duration-', '--easing-',
+    '--breakpoint-', '--z-', '--interaction-',
+  ];
+
+  // Properties we audit. Order matters for panel display.
+  const AUDIT_PROPS = [
+    'color', 'background-color', 'background', 'background-image',
+    'border', 'border-color', 'border-width', 'border-radius',
+    'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+    'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+    'gap', 'row-gap', 'column-gap',
+    'font-family', 'font-size', 'font-weight', 'line-height', 'letter-spacing',
+    'box-shadow', 'opacity', 'transition',
+  ];
+
+  // Patterns that indicate a hardcoded value (when not wrapped in var()).
+  const HEX_RE = /#[0-9a-fA-F]{3,8}\b/;
+  const RGB_RE = /\brgba?\s*\(/;
+  const HSL_RE = /\bhsla?\s*\(/;
+  const RAW_PX_RE = /\b\d*\.?\d+px\b/;
+
+  // Classes to ignore when inspecting (widget chrome).
+  // bdb- = Brik DevBar shell — must be excluded so clicking DevBar slots
+  // while inspect is active doesn't capture the click.
+  const IGNORE_CLASS_PREFIXES = ['bfb-', 'bi-', 'bps-', 'bdb-'];
+
+  // Padding/margin longhands collapse under their shorthand if shorthand exists.
+  const LONGHAND_GROUPS = {
+    padding: ['padding-top', 'padding-right', 'padding-bottom', 'padding-left'],
+    margin: ['margin-top', 'margin-right', 'margin-bottom', 'margin-left'],
+  };
+
+  // ── BDS Tokens (Brik Design System — standalone inline values) ─────────
+  // Names match figma-tokens.css exactly; values inlined for zero-dependency
+  // deploy. Mirror the T block in feedback-widget.js — keep them in sync.
+  const T = {
+    // Primitives
+    colorPoppyLight:       '#e35335', // --color-poppy-light
+    colorPoppyDark:        '#b0351b', // --color-poppy-dark
+    colorPoppyLightest:    '#ffefeb', // --color-poppy-lightest
+    colorPoppyLighter:     '#ffa693', // --color-poppy-lighter
+    colorGrayscaleWhite:   '#ffffff', // --color-grayscale-white
+    colorGrayscaleLightest:'#f7f7f7', // --color-grayscale-lightest
+    colorGrayscaleLighter: '#e0e0e0', // --color-grayscale-lighter
+    colorGrayscaleLight:   '#bdbdbd', // --color-grayscale-light
+    colorGrayscaleDark:    '#828282', // --color-grayscale-dark
+    colorGrayscaleDarker:  '#4f4f4f', // --color-grayscale-darker
+    colorGrayscaleDarkest: '#333333', // --color-grayscale-darkest
+    colorTanLightest:      '#f1f0ec', // --color-tan-lightest
+    // Semantic surfaces (light theme — inspector mirrors feedback widget)
+    backgroundBrandPrimary: '#e35335', // --background-brand-primary
+    interactionBrandHover:  '#b0351b', // --interaction-background-brand-primary-hover
+    textPrimary:   '#333333', // --text-primary
+    textSecondary: '#4f4f4f', // --text-secondary
+    textMuted:     '#828282', // --text-muted
+    textInverse:   '#ffffff', // --text-inverse
+    borderPrimary: '#e0e0e0', // --border-primary
+    // Status (kept neutral to BDS — used for OK/warn states in panel)
+    statusOk:   '#3aa86b',
+    statusWarn: '#e3a335',
+    statusErr:  '#d83a3a',
+    // Typography
+    fontFamily:         "'Poppins', system-ui, sans-serif",
+    fontFamilyMono:     "'JetBrains Mono', ui-monospace, SF Mono, Menlo, Consolas, monospace",
+    fontSizeXs:         '10.26px', // --font-size-25
+    fontSizeSm:         '11.54px', // --font-size-50
+    fontSizeBody:       '14px',    // --font-size-75
+    fontSizeMd:         '16px',    // --font-size-100
+    fontWeightMedium:   '500',
+    fontWeightSemiBold: '600',
+    fontWeightBold:     '700',
+    lineHeightTight:    '1.3',
+    lineHeightNormal:   '150%',
+    // Space
+    space100: '4px',  // --space-100
+    space200: '8px',  // --space-200
+    space300: '12px', // --space-300
+    space400: '16px', // --space-400
+    space500: '20px', // --space-500
+    space600: '24px', // --space-600
+    // Border radius
+    radius100: '4px',   // --border-radius-100
+    radius200: '8px',   // --border-radius-200
+    radius300: '12px',  // --border-radius-300
+    radiusPill:'999px', // --border-radius-pill
+  };
+
+  // ── State ───────────────────────────────────────────────────────────────
+  let active = false;
+  let hoveredEl = null;
+  let lockedEl = null;
+  let rulesIndex = null;
+
+  // ── BDS inspector manifest ──────────────────────────────────────────────
+  // Optional runtime manifest exported by BDS at build time. Lets the inspect
+  // widget show component status, Storybook URLs, and token values. The
+  // manifest URL can be overridden via data-manifest-url on the script tag;
+  // defaults to /bds-manifest.json (same-origin).
+  const MANIFEST_URL =
+    script?.getAttribute('data-manifest-url') || '/bds-manifest.json';
+  let manifest = null; // { bds_version, components: {}, tokens: {} }
+  async function loadManifest() {
+    try {
+      // 'no-cache' revalidates with the server on each load (ETag/Last-
+      // Modified) so a freshly-synced manifest is picked up immediately
+      // after a BDS deploy, without re-downloading when unchanged.
+      const res = await fetch(MANIFEST_URL, { cache: 'no-cache' });
+      if (!res.ok) return;
+      manifest = await res.json();
+      // Expose for debugging + cross-widget reuse (e.g. the Events slot could
+      // enrich its display with token/component context in a future iteration).
+      if (typeof window !== 'undefined') window.__brikInspectManifest = manifest;
+    } catch {
+      // Missing manifest is fine — the widget degrades to its older behavior.
+    }
+  }
+
+  // Live Storybook story index. Used to verify manifest-emitted story IDs
+  // actually resolve before we render an "Open in Storybook" link — the
+  // BDS manifest currently hardcodes `components-${slug}--primary`, which
+  // does not match the real story tree (stories live under deeper paths
+  // like `components-indicator-badge--overview`). Until the brik-bds
+  // manifest builder reads the live index, we validate client-side.
+  //   storybookIndex === null  → not yet loaded (or CORS/404 failure)
+  //   storybookIndex instanceof Set → known-valid story IDs
+  let storybookIndex = null;
+  async function loadStorybookIndex() {
+    try {
+      const base = getStorybookBase().replace(/\/+$/, '');
+      const res = await fetch(`${base}/index.json`, { cache: 'no-cache', mode: 'cors' });
+      if (!res.ok) return;
+      const data = await res.json();
+      storybookIndex = new Set(Object.keys(data.entries || {}));
+      // If the user already has a panel open when the index resolves,
+      // re-render so the now-validated button appears without reopen.
+      if (lockedEl && panelEl && panelEl.style.display !== 'none') {
+        openPanel(lockedEl);
+      }
+    } catch {
+      // CORS failure, offline, or missing index — button falls back to
+      // hidden. Local-dev Storybooks expose /index.json by default.
+    }
+  }
+
+  // ── Font load (match feedback widget) ──────────────────────────────────
+  if (!document.querySelector('link[href*="Poppins"]')) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap';
+    document.head.appendChild(link);
+  }
+
+  // ── Styles ──────────────────────────────────────────────────────────────
+  const css = `
+    .bi-toolbar {
+      position: fixed; top: ${T.space600}; left: ${T.space600};
+      z-index: 2147483646;
+      display: inline-flex; gap: ${T.space200}; align-items: center;
+      font-family: ${T.fontFamily};
+    }
+    .bi-btn {
+      background: ${T.colorGrayscaleDarkest};
+      color: ${T.colorGrayscaleWhite};
+      border: none;
+      border-radius: ${T.radiusPill};
+      padding: ${T.space300} ${T.space500};
+      font-family: ${T.fontFamily};
+      font-size: ${T.fontSizeBody};
+      font-weight: ${T.fontWeightSemiBold};
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.22);
+      transition: background 0.15s ease, transform 0.15s ease;
+      display: inline-flex; align-items: center; gap: ${T.space200};
+      line-height: 1; height: 40px; white-space: nowrap;
+      box-sizing: border-box; -webkit-appearance: none; appearance: none;
+    }
+    .bi-btn:hover { background: ${T.colorGrayscaleDarker}; transform: translateY(-1px); }
+    .bi-btn--active { background: ${T.backgroundBrandPrimary}; }
+    .bi-btn--active:hover { background: ${T.interactionBrandHover}; }
+
+    .bi-outline {
+      position: fixed; pointer-events: none; z-index: 2147483640;
+      border: 2px solid ${T.backgroundBrandPrimary};
+      border-radius: ${T.radius100};
+      box-shadow: 0 0 0 1px rgba(227,83,53,0.35), 0 0 0 9999px rgba(51,51,51,0.06);
+      transition: top 0.08s ease-out, left 0.08s ease-out, width 0.08s ease-out, height 0.08s ease-out;
+    }
+    .bi-outline--locked {
+      border-color: ${T.colorPoppyDark};
+      box-shadow: 0 0 0 1px rgba(176,53,27,0.45);
+    }
+
+    .bi-pill {
+      position: fixed; z-index: 2147483645; pointer-events: none;
+      background: ${T.colorGrayscaleDarkest};
+      color: ${T.colorGrayscaleWhite};
+      padding: ${T.space200} ${T.space300};
+      border-radius: ${T.radius200};
+      font-family: ${T.fontFamilyMono};
+      font-size: ${T.fontSizeXs};
+      line-height: 1.4;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.22);
+      max-width: 320px;
+    }
+    .bi-pill__tag { color: ${T.colorPoppyLighter}; }
+    .bi-pill__class { color: ${T.colorTanLightest}; }
+    .bi-pill__size {
+      color: ${T.colorGrayscaleLight};
+      font-size: ${T.fontSizeXs};
+    }
+    .bi-pill__badge {
+      display: inline-block; margin-left: ${T.space200};
+      padding: 2px 6px; border-radius: ${T.radius100};
+      font-size: 10px; font-weight: ${T.fontWeightBold};
+      font-family: ${T.fontFamily};
+      letter-spacing: 0.04em; text-transform: uppercase;
+    }
+    .bi-pill__badge--bds  { background: ${T.statusOk}; color: ${T.colorGrayscaleWhite}; }
+    .bi-pill__badge--warn { background: ${T.backgroundBrandPrimary}; color: ${T.colorGrayscaleWhite}; }
+
+    .bi-panel {
+      position: fixed; top: 76px; left: ${T.space600};
+      width: 380px; max-height: calc(100vh - 96px); overflow-y: auto;
+      z-index: 2147483644;
+      background: ${T.colorGrayscaleWhite};
+      color: ${T.textPrimary};
+      border: 1px solid ${T.borderPrimary};
+      border-radius: ${T.radius300};
+      box-shadow: 0 12px 48px rgba(0,0,0,0.18);
+      font-family: ${T.fontFamily};
+      font-size: ${T.fontSizeBody};
+      line-height: ${T.lineHeightNormal};
+    }
+    .bi-panel__header {
+      padding: ${T.space300} ${T.space400};
+      border-bottom: 1px solid ${T.borderPrimary};
+      display: flex; align-items: center; justify-content: space-between;
+      position: sticky; top: 0; background: ${T.colorGrayscaleWhite};
+      border-radius: ${T.radius300} ${T.radius300} 0 0;
+      gap: ${T.space200};
+    }
+    .bi-panel__title {
+      font-family: ${T.fontFamilyMono};
+      font-size: ${T.fontSizeBody};
+      font-weight: ${T.fontWeightSemiBold};
+      color: ${T.textPrimary};
+      word-break: break-all;
+    }
+    .bi-panel__close {
+      background: transparent; border: none;
+      color: ${T.textMuted};
+      font-size: 20px; cursor: pointer; padding: 0 ${T.space100};
+      line-height: 1; flex-shrink: 0;
+    }
+    .bi-panel__close:hover { color: ${T.textPrimary}; }
+
+    .bi-panel__section {
+      padding: ${T.space300} ${T.space400};
+      border-bottom: 1px solid ${T.borderPrimary};
+    }
+    .bi-panel__section:last-child { border-bottom: none; }
+    .bi-panel__section-title {
+      font-family: ${T.fontFamily};
+      font-size: ${T.fontSizeXs};
+      font-weight: ${T.fontWeightBold};
+      color: ${T.textMuted};
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: ${T.space200};
+    }
+
+    .bi-row {
+      display: flex; gap: ${T.space200}; align-items: flex-start;
+      padding: 3px 0;
+      font-family: ${T.fontFamilyMono};
+    }
+    .bi-row__label {
+      color: ${T.textMuted};
+      flex: 0 0 110px;
+      font-size: ${T.fontSizeSm};
+    }
+    .bi-row__value {
+      flex: 1; min-width: 0;
+      font-size: ${T.fontSizeSm};
+      word-break: break-word;
+      color: ${T.textPrimary};
+    }
+    .bi-token { color: ${T.backgroundBrandPrimary}; font-weight: ${T.fontWeightMedium}; }
+    .bi-token--unknown { color: ${T.statusWarn}; }
+    .bi-computed {
+      color: ${T.textMuted};
+      font-size: ${T.fontSizeXs};
+      margin-left: ${T.space200};
+    }
+    .bi-hardcoded { color: ${T.statusErr}; font-weight: ${T.fontWeightSemiBold}; }
+    .bi-hardcoded::before { content: '⚠ '; color: ${T.statusErr}; }
+    .bi-swatch {
+      display: inline-block; width: 10px; height: 10px;
+      border-radius: ${T.radius100};
+      border: 1px solid ${T.borderPrimary};
+      margin-right: ${T.space100}; vertical-align: middle;
+    }
+
+    .bi-summary {
+      display: flex; gap: ${T.space200}; flex-wrap: wrap;
+      margin-bottom: ${T.space200};
+    }
+    .bi-stat {
+      background: ${T.colorTanLightest}; color: ${T.textPrimary};
+      padding: ${T.space100} ${T.space200};
+      border-radius: ${T.radius100};
+      font-family: ${T.fontFamily};
+      font-size: ${T.fontSizeSm};
+      font-weight: ${T.fontWeightSemiBold};
+      display: inline-flex; align-items: center; gap: ${T.space100};
+    }
+    .bi-stat--warn { background: ${T.colorPoppyLightest}; color: ${T.colorPoppyDark}; }
+    .bi-stat--ok   { background: rgba(58,168,107,0.12); color: #1f7a4a; }
+
+    .bi-class-chip {
+      display: inline-block;
+      padding: 2px 6px; margin: 2px ${T.space100} 2px 0;
+      background: ${T.colorTanLightest};
+      border-radius: ${T.radius100};
+      font-family: ${T.fontFamilyMono};
+      font-size: ${T.fontSizeXs};
+      color: ${T.textSecondary};
+    }
+    .bi-class-chip--bds {
+      background: rgba(58,168,107,0.12); color: #1f7a4a;
+    }
+
+    .bi-actions {
+      display: flex; gap: ${T.space200};
+      padding: ${T.space300} ${T.space400};
+    }
+    .bi-action-btn {
+      background: ${T.colorGrayscaleWhite};
+      color: ${T.textPrimary};
+      border: 1px solid ${T.borderPrimary};
+      border-radius: ${T.radiusPill};
+      padding: ${T.space200} ${T.space300};
+      font-family: ${T.fontFamily};
+      font-size: ${T.fontSizeSm};
+      font-weight: ${T.fontWeightSemiBold};
+      cursor: pointer;
+      flex: 1;
+      transition: background 0.12s ease, color 0.12s ease;
+    }
+    .bi-action-btn:hover {
+      background: ${T.backgroundBrandPrimary};
+      color: ${T.colorGrayscaleWhite};
+      border-color: ${T.backgroundBrandPrimary};
+    }
+  `;
+
+  // ── Utilities ───────────────────────────────────────────────────────────
+  function injectStyles() {
+    const style = document.createElement('style');
+    style.textContent = css;
+    style.setAttribute('data-brik-inspect', '');
+    document.head.appendChild(style);
+  }
+
+  function isIgnoredEl(el) {
+    if (!el) return true;
+    // Walk up ancestors so a click on a child (e.g. svg inside .bdb-slot)
+    // is still recognised as widget chrome and skipped.
+    let node = el;
+    while (node && node !== document.body && node.nodeType === 1) {
+      if (node.classList) {
+        for (const cls of node.classList) {
+          for (const prefix of IGNORE_CLASS_PREFIXES) {
+            if (cls.startsWith(prefix)) return true;
+          }
+        }
+      }
+      node = node.parentElement;
+    }
+    return false;
+  }
+
+  function describeEl(el) {
+    const tag = el.tagName.toLowerCase();
+    const classes = Array.from(el.classList || []);
+    const id = el.id ? `#${el.id}` : '';
+    const classStr = classes.length ? '.' + classes.join('.') : '';
+    return { tag, id, classes, selector: `${tag}${id}${classStr}` };
+  }
+
+  function findBdsRoot(el) {
+    let node = el;
+    while (node && node !== document.body) {
+      const classes = Array.from(node.classList || []);
+      const bdsClass = classes.find((c) => c.startsWith('bds-') && !c.includes('__') && !c.includes('--'));
+      if (bdsClass) {
+        const meta = manifest?.components?.[bdsClass] || null;
+        return { root: node, component: bdsClass, meta };
+      }
+      node = node.parentElement;
+    }
+    return null;
+  }
+
+  // Look up a token's manifest entry by name (e.g. "--color-poppy-light").
+  function findTokenMeta(tokenName) {
+    return manifest?.tokens?.[tokenName] || null;
+  }
+
+  // ── A11y runtime checks ─────────────────────────────────────────────────
+  //
+  // Lightweight per-element accessibility audit. Not a replacement for a
+  // proper axe-core run in CI — this is fast, in-browser, and good enough
+  // to catch obvious violations in the QA loop.
+  //
+  // What it checks:
+  //   - Contrast ratio of the element's color vs its effective background
+  //     (WCAG AA thresholds: 4.5 for normal text, 3.0 for ≥18pt or ≥14pt bold).
+  //   - Interactive elements (button, a, [role=button], inputs) missing an
+  //     accessible name (no text, no aria-label, no aria-labelledby, no title).
+  //   - Images without alt attribute.
+  //   - Form inputs without an associated label.
+  //
+  // Returns { contrast, nameCheck, issues: [] }. issues is the array rendered
+  // in the panel's Accessibility section.
+
+  function parseColorToRgb(str) {
+    if (!str) return null;
+    const match = str.match(/rgba?\(([^)]+)\)/i);
+    if (!match) return null;
+    const parts = match[1].split(',').map((s) => parseFloat(s.trim()));
+    if (parts.length < 3) return null;
+    return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 };
+  }
+
+  function relativeLuminance(rgb) {
+    const toLinear = (c) => {
+      const s = c / 255;
+      return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * toLinear(rgb.r) + 0.7152 * toLinear(rgb.g) + 0.0722 * toLinear(rgb.b);
+  }
+
+  function contrastRatio(fg, bg) {
+    const l1 = relativeLuminance(fg);
+    const l2 = relativeLuminance(bg);
+    const lighter = Math.max(l1, l2);
+    const darker = Math.min(l1, l2);
+    return (lighter + 0.05) / (darker + 0.05);
+  }
+
+  // Walk up ancestors to find the first opaque (alpha === 1) background.
+  // Most hovered elements have transparent bg; we need the blended backdrop.
+  function effectiveBackground(el) {
+    let node = el;
+    while (node && node !== document.documentElement) {
+      const cs = getComputedStyle(node);
+      const bg = parseColorToRgb(cs.backgroundColor);
+      if (bg && bg.a === 1) return bg;
+      node = node.parentElement;
+    }
+    // Default to white if we never hit an opaque ancestor.
+    return { r: 255, g: 255, b: 255, a: 1 };
+  }
+
+  function auditContrast(el) {
+    const cs = getComputedStyle(el);
+    const fg = parseColorToRgb(cs.color);
+    if (!fg) return null;
+    const bg = effectiveBackground(el);
+    const ratio = contrastRatio(fg, bg);
+    const sizePx = parseFloat(cs.fontSize) || 16;
+    const weight = parseInt(cs.fontWeight, 10) || 400;
+    // WCAG "large text" = ≥18pt (24px) OR ≥14pt bold (18.66px @ weight ≥700).
+    const isLarge = sizePx >= 24 || (sizePx >= 18.66 && weight >= 700);
+    const threshold = isLarge ? 3.0 : 4.5;
+    return {
+      ratio,
+      rounded: Math.round(ratio * 100) / 100,
+      threshold,
+      passesAA: ratio >= threshold,
+      passesAAA: ratio >= (isLarge ? 4.5 : 7),
+      isLarge,
+      fg: `rgb(${fg.r}, ${fg.g}, ${fg.b})`,
+      bg: `rgb(${bg.r}, ${bg.g}, ${bg.b})`,
+    };
+  }
+
+  function isInteractive(el) {
+    const tag = el.tagName.toLowerCase();
+    if (['button', 'a', 'select', 'textarea'].includes(tag)) return true;
+    if (tag === 'input' && el.type !== 'hidden') return true;
+    const role = el.getAttribute('role');
+    if (role && ['button', 'link', 'menuitem', 'tab', 'checkbox', 'radio', 'switch', 'combobox', 'textbox'].includes(role)) return true;
+    if (el.hasAttribute('tabindex') && el.getAttribute('tabindex') !== '-1') return true;
+    return false;
+  }
+
+  function hasAccessibleName(el) {
+    if (el.getAttribute('aria-label')?.trim()) return true;
+    if (el.getAttribute('aria-labelledby')?.trim()) return true;
+    if (el.getAttribute('title')?.trim()) return true;
+    const text = (el.textContent || '').trim();
+    if (text.length > 0) return true;
+    // Images use alt
+    if (el.tagName === 'IMG' && el.getAttribute('alt')?.trim()) return true;
+    // Inputs can be labeled by a <label for> or wrapping <label>
+    if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') {
+      if (el.id && document.querySelector(`label[for="${CSS.escape(el.id)}"]`)) return true;
+      if (el.closest('label')) return true;
+      if (el.getAttribute('placeholder')?.trim()) return true; // weak but counted
+    }
+    return false;
+  }
+
+  function auditA11y(el) {
+    const issues = [];
+    const contrast = auditContrast(el);
+    if (contrast && !contrast.passesAA) {
+      issues.push({
+        severity: 'error',
+        code: 'contrast-aa',
+        message: `Contrast ${contrast.rounded}:1 fails WCAG AA (needs ≥${contrast.threshold}:1)`,
+      });
+    }
+
+    const interactive = isInteractive(el);
+    if (interactive && !hasAccessibleName(el)) {
+      issues.push({
+        severity: 'error',
+        code: 'name-missing',
+        message: `Interactive ${el.tagName.toLowerCase()} has no accessible name (aria-label, text, or title)`,
+      });
+    }
+
+    if (el.tagName === 'IMG' && !el.hasAttribute('alt')) {
+      issues.push({
+        severity: 'error',
+        code: 'img-alt-missing',
+        message: 'img element missing alt attribute (use empty alt="" for decorative)',
+      });
+    }
+
+    // Soft checks
+    const role = el.getAttribute('role');
+    if (role === 'button' && el.tagName !== 'BUTTON') {
+      issues.push({
+        severity: 'info',
+        code: 'role-button-on-non-button',
+        message: `role="button" on <${el.tagName.toLowerCase()}> — prefer native <button> for keyboard + focus defaults`,
+      });
+    }
+
+    if (el.getAttribute('tabindex') && parseInt(el.getAttribute('tabindex'), 10) > 0) {
+      issues.push({
+        severity: 'warn',
+        code: 'positive-tabindex',
+        message: `tabindex="${el.getAttribute('tabindex')}" — positive values rarely needed; disrupts tab order`,
+      });
+    }
+
+    return { contrast, interactive, issues };
+  }
+
+  function findBemRoot(el) {
+    let node = el;
+    while (node && node !== document.body) {
+      const classes = Array.from(node.classList || []);
+      const block = classes.find((c) =>
+        !c.startsWith('bds-') &&
+        !c.includes('__') && !c.includes('--') &&
+        !IGNORE_CLASS_PREFIXES.some((p) => c.startsWith(p))
+      );
+      if (block) return { root: node, component: block };
+      node = node.parentElement;
+    }
+    return null;
+  }
+
+  // ── Stylesheet rule index ───────────────────────────────────────────────
+  function buildRulesIndex() {
+    if (rulesIndex) return rulesIndex;
+    const rules = [];
+    for (const sheet of Array.from(document.styleSheets)) {
+      let sheetRules;
+      try { sheetRules = sheet.cssRules; } catch (e) { continue; }
+      if (!sheetRules) continue;
+      walkRules(sheetRules, rules);
+    }
+    rulesIndex = rules;
+    return rules;
+  }
+
+  function walkRules(cssRules, out) {
+    for (const rule of Array.from(cssRules)) {
+      if (rule.type === CSSRule.STYLE_RULE) {
+        const selectors = rule.selectorText.split(',').map((s) => s.trim());
+        for (const sel of selectors) {
+          out.push({ selector: sel, style: rule.style, specificity: calcSpecificity(sel) });
+        }
+      } else if (rule.cssRules) {
+        walkRules(rule.cssRules, out);
+      }
+    }
+  }
+
+  function calcSpecificity(sel) {
+    const ids = (sel.match(/#[\w-]+/g) || []).length;
+    const classes = (sel.match(/\.[\w-]+|\[[^\]]+\]|:(?!:)[\w-]+(?:\([^)]*\))?/g) || []).length;
+    const elements = (sel.match(/(?:^|[\s>+~])([a-z][\w-]*)/gi) || []).length;
+    return ids * 10000 + classes * 100 + elements;
+  }
+
+  function getDeclaredValue(el, prop) {
+    if (el.style) {
+      const inline = el.style.getPropertyValue(prop);
+      if (inline) return { value: inline, origin: 'inline' };
+    }
+    const rules = buildRulesIndex();
+    let best = null;
+    for (const rule of rules) {
+      let matches = false;
+      try { matches = el.matches(rule.selector); } catch (e) { continue; }
+      if (!matches) continue;
+      const val = rule.style.getPropertyValue(prop);
+      if (!val) continue;
+      if (!best || rule.specificity >= best.specificity) {
+        best = { value: val, origin: rule.selector, specificity: rule.specificity };
+      }
+    }
+    return best;
+  }
+
+  function extractTokens(raw) {
+    const tokens = [];
+    const re = /var\(\s*(--[\w-]+)/g;
+    let m;
+    while ((m = re.exec(raw)) !== null) tokens.push(m[1]);
+    return tokens;
+  }
+
+  function isValidToken(name) {
+    return VALID_TOKEN_PREFIXES.some((p) => name.startsWith(p));
+  }
+
+  function findHardcodedFragments(raw) {
+    const stripped = raw.replace(/var\([^)]*\)/g, '');
+    const hits = [];
+    const hex = stripped.match(new RegExp(HEX_RE.source, 'g'));
+    if (hex) hits.push(...hex);
+    if (RGB_RE.test(stripped)) {
+      const rgb = stripped.match(/\brgba?\s*\([^)]+\)/g);
+      if (rgb) hits.push(...rgb);
+    }
+    if (HSL_RE.test(stripped)) {
+      const hsl = stripped.match(/\bhsla?\s*\([^)]+\)/g);
+      if (hsl) hits.push(...hsl);
+    }
+    const px = stripped.match(new RegExp(RAW_PX_RE.source, 'g'));
+    if (px) hits.push(...px.filter((v) => v !== '0px' && v !== '1px'));
+    return hits;
+  }
+
+  function auditProp(el, prop) {
+    const declared = getDeclaredValue(el, prop);
+    const computed = getComputedStyle(el).getPropertyValue(prop).trim();
+    if (!declared && !computed) return null;
+    const raw = declared ? declared.value : '';
+    const tokens = extractTokens(raw);
+    const hardcoded = raw ? findHardcodedFragments(raw) : [];
+    return {
+      prop,
+      declared: declared ? declared.value.trim() : null,
+      origin: declared ? declared.origin : null,
+      computed,
+      tokens,
+      unknownTokens: tokens.filter((t) => !isValidToken(t)),
+      hardcoded,
+      isViolation: hardcoded.length > 0 && tokens.length === 0,
+    };
+  }
+
+  function auditEl(el) {
+    const results = [];
+    for (const prop of AUDIT_PROPS) {
+      const r = auditProp(el, prop);
+      if (r && (r.declared || r.tokens.length || r.hardcoded.length)) {
+        results.push(r);
+      }
+    }
+    return collapseLonghands(results);
+  }
+
+  // Hide longhand rows when shorthand carries the value (or both are 0).
+  function collapseLonghands(audits) {
+    const byProp = new Map(audits.map((a) => [a.prop, a]));
+    const drop = new Set();
+    for (const [shorthand, longhands] of Object.entries(LONGHAND_GROUPS)) {
+      const sh = byProp.get(shorthand);
+      // Drop noise: longhand rows that are 0px with no token, when shorthand exists.
+      for (const lh of longhands) {
+        const row = byProp.get(lh);
+        if (!row) continue;
+        const isNoise = row.declared === '0px' && row.tokens.length === 0 && row.hardcoded.length === 0;
+        if (isNoise && sh) drop.add(lh);
+      }
+      // Also drop the shorthand row if it's just "0px" but a longhand has the real value.
+      if (sh && sh.declared === '0px' && sh.tokens.length === 0) {
+        const longhandHasValue = longhands.some((lh) => {
+          const row = byProp.get(lh);
+          return row && (row.tokens.length > 0 || row.hardcoded.length > 0);
+        });
+        if (longhandHasValue) drop.add(shorthand);
+      }
+    }
+    return audits.filter((a) => !drop.has(a.prop));
+  }
+
+  // ── UI: toolbar + outline + pill + panel ────────────────────────────────
+  let toolbarEl, toggleBtn, outlineEl, pillEl, panelEl;
+
+  function buildToolbar() {
+    toolbarEl = document.createElement('div');
+    toolbarEl.className = 'bi-toolbar';
+
+    toggleBtn = document.createElement('button');
+    toggleBtn.className = 'bi-btn';
+    toggleBtn.type = 'button';
+    toggleBtn.innerHTML = `${iconCrosshair()} Inspect`;
+    toggleBtn.addEventListener('click', toggleActive);
+    toolbarEl.appendChild(toggleBtn);
+
+    // Scan capability moved into the locked-panel actions (Copy report /
+    // Scan page). Standalone toolbar only needs the Inspect toggle.
+
+    document.body.appendChild(toolbarEl);
+  }
+
+  // DevBar integration: if the DevBar shell is present (or loading soon),
+  // register a single Inspect slot. The page-wide Scan capability lives
+  // inside the locked Inspect panel (see scanAndCopyReport action button)
+  // rather than as its own top-level slot.
+  function registerWithDevBar() {
+    const def = [
+      {
+        id: 'inspect',
+        label: 'Inspect',
+        icon: iconCrosshair(),
+        order: 20,
+        onActivate: () => { if (!active) toggleActive(); },
+        onDeactivate: () => { if (active) toggleActive(); },
+      },
+    ];
+    if (window.BrikDevBar) {
+      for (const d of def) window.BrikDevBar.register(d);
+      return true;
+    }
+    // Queue for devbar.js if it loads after us.
+    window.BrikDevBarQueue = window.BrikDevBarQueue || [];
+    for (const d of def) window.BrikDevBarQueue.push(d);
+    // If a BrikDevBar never materializes, we fall back to the standalone toolbar.
+    return false;
+  }
+
+  function iconCrosshair() {
+    return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="3" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="21"/><line x1="3" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="21" y2="12"/></svg>';
+  }
+
+  function iconScan() {
+    return '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><line x1="3" y1="12" x2="21" y2="12"/></svg>';
+  }
+
+  function toggleActive() {
+    active = !active;
+    // Standalone toolbar (only exists if DevBar wasn't present at init)
+    if (toggleBtn) {
+      toggleBtn.classList.toggle('bi-btn--active', active);
+      toggleBtn.innerHTML = active ? `${iconCrosshair()} Inspecting…` : `${iconCrosshair()} Inspect`;
+    }
+    // Sync DevBar slot active state so the pill visually matches.
+    if (window.BrikDevBar?.isRegistered?.('inspect')) {
+      window.BrikDevBar.setActive('inspect', active);
+    }
+    localStorage.setItem('brik-inspect-enabled', active ? '1' : '0');
+    if (!active) {
+      clearOutline();
+      hidePill();
+      closePanel();
+      hoveredEl = null;
+      lockedEl = null;
+    }
+  }
+
+  function ensureOutline() {
+    if (outlineEl) return outlineEl;
+    outlineEl = document.createElement('div');
+    outlineEl.className = 'bi-outline';
+    document.body.appendChild(outlineEl);
+    return outlineEl;
+  }
+
+  function drawOutline(el, locked) {
+    if (!el) return clearOutline();
+    const o = ensureOutline();
+    const r = el.getBoundingClientRect();
+    o.style.top = `${r.top}px`;
+    o.style.left = `${r.left}px`;
+    o.style.width = `${r.width}px`;
+    o.style.height = `${r.height}px`;
+    o.classList.toggle('bi-outline--locked', !!locked);
+    o.style.display = 'block';
+  }
+
+  function clearOutline() {
+    if (outlineEl) outlineEl.style.display = 'none';
+  }
+
+  function showPill(el, x, y) {
+    if (!pillEl) {
+      pillEl = document.createElement('div');
+      pillEl.className = 'bi-pill';
+      document.body.appendChild(pillEl);
+    }
+    const desc = describeEl(el);
+    const bds = findBdsRoot(el);
+    const r = el.getBoundingClientRect();
+    const violations = auditEl(el).filter((a) => a.isViolation).length;
+    pillEl.innerHTML = `
+      <span class="bi-pill__tag">${desc.tag}</span><span class="bi-pill__class">${desc.classes.length ? '.' + desc.classes.join('.') : ''}</span>
+      ${bds ? '<span class="bi-pill__badge bi-pill__badge--bds">BDS</span>' : ''}
+      ${violations ? `<span class="bi-pill__badge bi-pill__badge--warn">${violations}</span>` : ''}
+      <br><span class="bi-pill__size">${Math.round(r.width)} × ${Math.round(r.height)}</span>
+    `;
+    const pad = 14;
+    let px = x + pad, py = y + pad;
+    const pw = 340, ph = 60;
+    if (px + pw > window.innerWidth) px = x - pw - pad;
+    if (py + ph > window.innerHeight) py = y - ph - pad;
+    pillEl.style.left = `${px}px`;
+    pillEl.style.top = `${py}px`;
+    pillEl.style.display = 'block';
+  }
+
+  function hidePill() {
+    if (pillEl) pillEl.style.display = 'none';
+  }
+
+  function openPanel(el) {
+    const desc = describeEl(el);
+    const bds = findBdsRoot(el);
+    const bem = !bds ? findBemRoot(el) : null;
+    const r = el.getBoundingClientRect();
+    const audits = auditEl(el);
+    const violations = audits.filter((a) => a.isViolation);
+    const tokenUses = audits.filter((a) => a.tokens.length > 0);
+    const unknownTokens = audits.flatMap((a) => a.unknownTokens);
+
+    if (!panelEl) {
+      panelEl = document.createElement('div');
+      panelEl.className = 'bi-panel';
+      document.body.appendChild(panelEl);
+    }
+
+    const componentBlock = bds?.meta ? renderComponentBlock(bds.meta) : '';
+    const a11y = auditA11y(el);
+    const a11yErrors = a11y.issues.filter((i) => i.severity === 'error').length;
+
+    panelEl.innerHTML = `
+      <div class="bi-panel__header">
+        <div class="bi-panel__title">${escapeHtml(desc.selector)}</div>
+        <button class="bi-panel__close" type="button" aria-label="Close">×</button>
+      </div>
+      <div class="bi-panel__section">
+        <div class="bi-summary">
+          <span class="bi-stat">${Math.round(r.width)} × ${Math.round(r.height)}</span>
+          ${bds ? `<span class="bi-stat bi-stat--ok">${bds.meta ? escapeHtml(bds.meta.name) : 'BDS · ' + escapeHtml(bds.component)}${bds.meta?.status && bds.meta.status !== 'stable' ? ' · ' + escapeHtml(bds.meta.status) : ''}</span>` : ''}
+          ${bem ? `<span class="bi-stat">BEM · ${escapeHtml(bem.component)}</span>` : ''}
+          <span class="bi-stat ${tokenUses.length ? 'bi-stat--ok' : ''}">${tokenUses.length} tokens</span>
+          <span class="bi-stat ${violations.length ? 'bi-stat--warn' : 'bi-stat--ok'}">${violations.length} violations</span>
+          <span class="bi-stat ${a11yErrors ? 'bi-stat--warn' : 'bi-stat--ok'}" title="Accessibility issues">${a11yErrors} a11y</span>
+        </div>
+        <div>${desc.classes.map((c) => `<span class="bi-class-chip ${c.startsWith('bds-') ? 'bi-class-chip--bds' : ''}">${escapeHtml(c)}</span>`).join('')}</div>
+      </div>
+      ${componentBlock}
+      ${renderA11yBlock(a11y)}
+      ${unknownTokens.length ? `
+      <div class="bi-panel__section">
+        <div class="bi-panel__section-title">Unknown tokens</div>
+        ${unknownTokens.map((t) => `<div class="bi-row"><span class="bi-token bi-token--unknown">${escapeHtml(t)}</span></div>`).join('')}
+      </div>` : ''}
+      <div class="bi-panel__section">
+        <div class="bi-panel__section-title">Properties</div>
+        ${audits.map(renderAuditRow).join('')}
+      </div>
+      <div class="bi-actions">
+        <button class="bi-action-btn" type="button" data-action="copy-selector">Copy selector</button>
+        <button class="bi-action-btn" type="button" data-action="copy-report">Copy report</button>
+        <button class="bi-action-btn" type="button" data-action="scan-page">Scan page</button>
+      </div>
+    `;
+
+    panelEl.querySelector('.bi-panel__close').addEventListener('click', closePanel);
+    panelEl.querySelector('[data-action="copy-selector"]').addEventListener('click', () => {
+      navigator.clipboard.writeText(desc.selector);
+    });
+    panelEl.querySelector('[data-action="copy-report"]').addEventListener('click', () => {
+      const report = {
+        selector: desc.selector,
+        bdsComponent: bds?.component || null,
+        bemComponent: bem?.component || null,
+        size: { w: r.width, h: r.height },
+        audits,
+      };
+      navigator.clipboard.writeText(JSON.stringify(report, null, 2));
+    });
+    panelEl.querySelector('[data-action="scan-page"]').addEventListener('click', () => {
+      scanAndCopyReport();
+    });
+    panelEl.style.display = 'block';
+  }
+
+  function renderAuditRow(a) {
+    const parts = [];
+    if (a.declared) {
+      let val = escapeHtml(a.declared);
+      val = val.replace(/var\(\s*(--[\w-]+)/g, (m, token) => {
+        const tokenMeta = findTokenMeta(token);
+        const cls = isValidToken(token) ? 'bi-token' : 'bi-token bi-token--unknown';
+        const titleAttr = tokenMeta
+          ? ` title="${escapeHtml(tokenMeta.value)}${tokenMeta.description ? ' \u2014 ' + escapeHtml(tokenMeta.description) : ''}"`
+          : '';
+        return `var(<span class="${cls}"${titleAttr}>${token}</span>`;
+      });
+      for (const h of a.hardcoded) {
+        val = val.replace(h, `<span class="bi-hardcoded">${escapeHtml(h)}</span>`);
+      }
+      parts.push(val);
+    }
+    const swatch = isColorProp(a.prop) && a.computed ? `<span class="bi-swatch" style="background:${a.computed}"></span>` : '';
+    const computedStr = a.computed && a.computed !== a.declared ? `<span class="bi-computed">→ ${escapeHtml(a.computed)}</span>` : '';
+    return `
+      <div class="bi-row">
+        <span class="bi-row__label">${a.prop}</span>
+        <span class="bi-row__value">${swatch}${parts.join('') || `<span class="bi-computed">${escapeHtml(a.computed)}</span>`}${computedStr}</span>
+      </div>
+    `;
+  }
+
+  function renderComponentBlock(meta) {
+    if (!meta) return '';
+    const statusClass =
+      meta.status === 'deprecated' ? 'bi-stat--warn'
+        : meta.status === 'experimental' ? '' // neutral
+        : 'bi-stat--ok';
+    const intro = meta.introduced_in ? ` · v${escapeHtml(meta.introduced_in)}` : '';
+    const deprecated = meta.deprecated_in
+      ? ` · deprecated v${escapeHtml(meta.deprecated_in)}${meta.replaced_by ? ', use ' + escapeHtml(meta.replaced_by) : ''}`
+      : '';
+    // Only emit the Storybook link when we can verify the story ID resolves
+    // on the live Storybook. Manifest paths can go stale (components move
+    // between categories, stories get renamed) and a 404 link is worse than
+    // no link. If the index hasn't loaded yet, suppress the button rather
+    // than render a maybe-broken one.
+    const storybookHref = resolveStorybookHref(meta.storybook_url);
+    const a11yNotes = (meta.a11y?.notes ?? [])
+      .map((n) => `<div class="bi-row"><span class="bi-row__value" style="flex:1;color:#4f4f4f;">\u267F ${escapeHtml(n)}</span></div>`)
+      .join('');
+    return `
+      <div class="bi-panel__section">
+        <div class="bi-panel__section-title">Component</div>
+        <div class="bi-summary">
+          <span class="bi-stat ${statusClass}">${escapeHtml(meta.status)}${intro}${deprecated}</span>
+          ${storybookHref ? `<a class="bi-stat" href="${escapeHtml(storybookHref)}" target="_blank" rel="noopener" style="text-decoration:none;">Open in Storybook \u2197</a>` : ''}
+        </div>
+        ${meta.description ? `<div class="bi-row"><span class="bi-row__value" style="flex:1;">${escapeHtml(meta.description)}</span></div>` : ''}
+        ${a11yNotes}
+      </div>
+    `;
+  }
+
+  function renderA11yBlock(a11y) {
+    const { contrast, issues } = a11y;
+    if (!contrast && issues.length === 0) return '';
+
+    const contrastBadge = contrast
+      ? `<span class="bi-stat ${contrast.passesAA ? 'bi-stat--ok' : 'bi-stat--warn'}" title="${contrast.fg} on ${contrast.bg}">WCAG AA contrast ${contrast.rounded}:1${contrast.isLarge ? ' (lg)' : ''} \u2014 needs ${contrast.threshold}:1</span>`
+      : '';
+    const aaaBadge = contrast?.passesAAA
+      ? `<span class="bi-stat bi-stat--ok">AAA \u2713</span>`
+      : '';
+
+    const issueRows = issues.map((i) => {
+      const color = i.severity === 'error' ? '#d83a3a' : i.severity === 'warn' ? '#e3a335' : '#828282';
+      return `
+        <div class="bi-row">
+          <span class="bi-row__label" style="color:${color};flex:0 0 60px;">${escapeHtml(i.severity)}</span>
+          <span class="bi-row__value">${escapeHtml(i.message)} <span class="bi-computed">[${escapeHtml(i.code)}]</span></span>
+        </div>
+      `;
+    }).join('');
+
+    return `
+      <div class="bi-panel__section">
+        <div class="bi-panel__section-title">Accessibility</div>
+        ${(contrastBadge || aaaBadge) ? `<div class="bi-summary" style="margin-bottom:8px;">${contrastBadge}${aaaBadge}</div>` : ''}
+        ${issueRows || (issues.length === 0 && contrast?.passesAA ? '<div class="bi-row"><span class="bi-row__value" style="color:#3aa86b;">No runtime accessibility issues detected.</span></div>' : '')}
+      </div>
+    `;
+  }
+
+  // Storybook base URL — defaults to BDS's published Chromatic build
+  // (primary visual review tool). Override via data-storybook-base to point
+  // at localhost:6006 for local dev, storybook.brikdesigns.com for the
+  // Netlify mirror, or a branch-specific Chromatic build URL.
+  function getStorybookBase() {
+    return script?.getAttribute('data-storybook-base')
+      || 'https://69b8918cac3056b39424d5d3-jtcwcnhshz.chromatic.com';
+  }
+
+  // Build a Storybook deep link, or return '' if the target story ID isn't
+  // in the live index. Accepts either a relative path (`/?path=/story/<id>`)
+  // or an absolute URL. When we can't verify (index not loaded), we return
+  // '' to hide the button rather than link to a 404.
+  function resolveStorybookHref(storybookUrl) {
+    if (!storybookUrl) return '';
+    if (/^https?:\/\//i.test(storybookUrl)) return storybookUrl;
+    const match = storybookUrl.match(/\/story\/([^&?#]+)/);
+    const storyId = match ? match[1] : null;
+    if (!storyId) return '';
+    if (storybookIndex && !storybookIndex.has(storyId)) return '';
+    if (!storybookIndex) return ''; // unverified — hide until index loads
+    const base = getStorybookBase().replace(/\/+$/, '');
+    return `${base}${storybookUrl}`;
+  }
+
+  function isColorProp(prop) {
+    return prop === 'color' || prop.includes('background') || prop.includes('border-color');
+  }
+
+  function closePanel() {
+    if (panelEl) panelEl.style.display = 'none';
+    lockedEl = null;
+    drawOutline(hoveredEl, false);
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+
+  // ── Page-wide scan ──────────────────────────────────────────────────────
+  function scanAndCopyReport() {
+    const all = document.querySelectorAll('body *');
+    const violations = [];
+    let scanned = 0;
+    let bdsCount = 0;
+    for (const el of all) {
+      if (isIgnoredEl(el)) continue;
+      scanned++;
+      const bds = findBdsRoot(el);
+      if (bds && bds.root === el) bdsCount++;
+      const audits = auditEl(el);
+      const elViolations = audits.filter((a) => a.isViolation);
+      if (elViolations.length > 0) {
+        violations.push({
+          selector: describeEl(el).selector,
+          bdsComponent: bds?.component || null,
+          violations: elViolations.map((v) => ({
+            prop: v.prop, declared: v.declared,
+            hardcoded: v.hardcoded, computed: v.computed,
+          })),
+        });
+      }
+    }
+    const report = {
+      url: location.href,
+      scannedAt: new Date().toISOString(),
+      totals: {
+        scanned,
+        bdsComponents: bdsCount,
+        elementsWithViolations: violations.length,
+        totalViolations: violations.reduce((n, v) => n + v.violations.length, 0),
+      },
+      violations,
+    };
+    navigator.clipboard.writeText(JSON.stringify(report, null, 2));
+    alert(
+      `Brik Inspect — Page scan\n\n` +
+      `${scanned} elements scanned\n` +
+      `${bdsCount} BDS components found\n` +
+      `${report.totals.totalViolations} violations across ${violations.length} elements\n\n` +
+      `Full report copied to clipboard.`
+    );
+  }
+
+  // ── Event handlers ──────────────────────────────────────────────────────
+  function onMouseMove(e) {
+    if (!active || lockedEl) return;
+    const el = e.target;
+    if (!el || isIgnoredEl(el)) return;
+    hoveredEl = el;
+    drawOutline(el, false);
+    showPill(el, e.clientX, e.clientY);
+  }
+
+  function onClick(e) {
+    if (!active) return;
+    const el = e.target;
+    if (!el || isIgnoredEl(el)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    lockedEl = el;
+    hidePill();
+    drawOutline(el, true);
+    openPanel(el);
+  }
+
+  function onKey(e) {
+    if (e.key === 'Escape') {
+      if (lockedEl) closePanel();
+      else if (active) toggleActive();
+    }
+    if ((e.key === 'i' || e.key === 'I') && (e.metaKey || e.ctrlKey) && e.shiftKey) {
+      e.preventDefault();
+      toggleActive();
+    }
+  }
+
+  function onScrollOrResize() {
+    if (lockedEl) drawOutline(lockedEl, true);
+    else if (hoveredEl && active) drawOutline(hoveredEl, false);
+  }
+
+  // ── Init ────────────────────────────────────────────────────────────────
+  function init() {
+    injectStyles();
+    registerWithDevBar();
+    // Fetch the BDS inspector manifest + live Storybook index in parallel.
+    // Both are best-effort: missing manifest → class-name-only behavior;
+    // missing index → Storybook deep-link button is suppressed until
+    // (or unless) the index resolves.
+    loadManifest();
+    loadStorybookIndex();
+    // Fall back to standalone toolbar after a tick if the DevBar never
+    // renders (e.g. devbar.js wasn't injected on this page).
+    setTimeout(() => {
+      if (!window.BrikDevBar) buildToolbar();
+    }, 80);
+    document.addEventListener('mousemove', onMouseMove, true);
+    document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('scroll', onScrollOrResize, true);
+    window.addEventListener('resize', onScrollOrResize);
+    if (LS_ENABLED) toggleActive();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "populate-notion": "node scripts/populate-notion-tokens.js",
     "propagate": "bash scripts/propagate.sh",
     "propagate:dry": "bash scripts/propagate.sh --dry-run",
+    "sync:devbar-widgets": "bash scripts/sync-devbar-widgets.sh",
     "prepare": "husky || true",
     "prepublishOnly": "rm -rf dist && npm run build:lib",
     "verify:blueprints-astro": "node scripts/verify-blueprints-astro-exports.mjs"

--- a/scripts/sync-devbar-widgets.sh
+++ b/scripts/sync-devbar-widgets.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Sync canonical devbar widgets from BDS to all known consumers.
+#
+# Source of truth: components/ui/BrikDevBar/widgets/
+# Run after editing any vanilla widget in BDS.
+#
+# Destinations (per #466 sync map):
+#   - brik-client-portal/public/                  (browser-served)
+#   - brik-client-portal/scripts/mockup-shared/   (mockup pipeline)
+#   - renew-pms/public/                            (browser-served)
+#   - brik-bds/.storybook/public/                  (Storybook iframe)
+#   - brik-llm/scripts/brik-dev-tool/widgets/     (Astro mockup pipeline cache)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve the BDS primary checkout regardless of whether we run from primary
+# or a worktree. --git-common-dir returns the primary's .git directory.
+COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null)"
+if [[ -z "$COMMON_DIR" ]]; then
+  echo "Error: not a git repo (run from inside brik-bds or a brik-bds worktree)" >&2
+  exit 1
+fi
+COMMON_DIR="$(cd "$COMMON_DIR" && pwd)"
+BDS_PRIMARY="$(dirname "$COMMON_DIR")"
+
+# WIDGETS reads from the *current* worktree (so edits in this worktree
+# propagate without committing first). Falls back to BDS primary.
+WORKTREE_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+WIDGETS="$WORKTREE_ROOT/components/ui/BrikDevBar/widgets"
+[[ -d "$WIDGETS" ]] || WIDGETS="$BDS_PRIMARY/components/ui/BrikDevBar/widgets"
+
+GH_ROOT="$(cd "$BDS_PRIMARY/../.." && pwd)"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+
+sync_one() {
+  local src="$1" dest="$2" label="$3"
+  if [[ -d "$(dirname "$dest")" ]]; then
+    cp "$src" "$dest"
+    echo -e "  ${GREEN}✓${NC} $label"
+  else
+    echo -e "  ${YELLOW}-${NC} $label  (skipped — destination dir missing)"
+  fi
+}
+
+echo "Syncing canonical devbar widgets from $WIDGETS"
+echo ""
+
+# brik-client-portal mirror (mockup pipeline)
+PORTAL_MIRROR="$GH_ROOT/product/brik-client-portal/scripts/mockup-shared"
+sync_one "$WIDGETS/devbar.js"          "$PORTAL_MIRROR/devbar.js"          "portal mirror     devbar.js"
+sync_one "$WIDGETS/feedback-widget.js" "$PORTAL_MIRROR/feedback-widget.js" "portal mirror     feedback-widget.js"
+sync_one "$WIDGETS/inspect-widget.js"  "$PORTAL_MIRROR/inspect-widget.js"  "portal mirror     inspect-widget.js"
+sync_one "$WIDGETS/events-widget.js"   "$PORTAL_MIRROR/events-widget.js"   "portal mirror     events-widget.js"
+
+# brik-client-portal public/ (browser-served)
+PORTAL_PUBLIC="$GH_ROOT/product/brik-client-portal/public"
+sync_one "$WIDGETS/devbar.js"         "$PORTAL_PUBLIC/brik-devbar.js"        "portal public/    brik-devbar.js"
+sync_one "$WIDGETS/inspect-widget.js" "$PORTAL_PUBLIC/brik-inspect.js"       "portal public/    brik-inspect.js"
+sync_one "$WIDGETS/events-widget.js"  "$PORTAL_PUBLIC/brik-events-widget.js" "portal public/    brik-events-widget.js"
+
+# renew-pms public/ (browser-served)
+RENEW_PUBLIC="$GH_ROOT/product/renew-pms/public"
+sync_one "$WIDGETS/devbar.js"         "$RENEW_PUBLIC/brik-devbar.js"        "renew-pms public/ brik-devbar.js"
+sync_one "$WIDGETS/inspect-widget.js" "$RENEW_PUBLIC/brik-inspect.js"       "renew-pms public/ brik-inspect.js"
+sync_one "$WIDGETS/events-widget.js"  "$RENEW_PUBLIC/brik-events-widget.js" "renew-pms public/ brik-events-widget.js"
+
+# BDS Storybook preview iframe
+BDS_STORYBOOK_PUBLIC="$BDS_PRIMARY/.storybook/public"
+sync_one "$WIDGETS/devbar.js"         "$BDS_STORYBOOK_PUBLIC/brik-devbar.js"        "bds storybook     brik-devbar.js"
+sync_one "$WIDGETS/inspect-widget.js" "$BDS_STORYBOOK_PUBLIC/brik-inspect.js"       "bds storybook     brik-inspect.js"
+sync_one "$WIDGETS/feedback-widget.js" "$BDS_STORYBOOK_PUBLIC/brik-feedback-widget.js" "bds storybook     brik-feedback-widget.js"
+sync_one "$WIDGETS/events-widget.js"  "$BDS_STORYBOOK_PUBLIC/brik-events-widget.js" "bds storybook     brik-events-widget.js"
+
+# brik-llm cache (Astro mockup pipeline reads from here via inject-widgets.sh)
+LLM_WIDGETS="$GH_ROOT/brik/brik-llm/scripts/brik-dev-tool/widgets"
+sync_one "$WIDGETS/devbar.js"          "$LLM_WIDGETS/devbar.js"          "brik-llm cache    devbar.js"
+sync_one "$WIDGETS/inspect-widget.js"  "$LLM_WIDGETS/inspect-widget.js"  "brik-llm cache    inspect-widget.js"
+sync_one "$WIDGETS/feedback-widget.js" "$LLM_WIDGETS/feedback-widget.js" "brik-llm cache    feedback-widget.js"
+sync_one "$WIDGETS/events-widget.js"   "$LLM_WIDGETS/events-widget.js"   "brik-llm cache    events-widget.js"
+
+# BDS inspector manifest — built by scripts/build-inspector-manifest.mjs.
+# The inspect widget reads it for component status + token enrichment.
+BDS_MANIFEST="$BDS_PRIMARY/dist/bds-manifest.json"
+if [[ -f "$BDS_MANIFEST" ]]; then
+  echo ""
+  sync_one "$BDS_MANIFEST" "$PORTAL_PUBLIC/bds-manifest.json"      "portal public/    bds-manifest.json"
+  sync_one "$BDS_MANIFEST" "$RENEW_PUBLIC/bds-manifest.json"       "renew-pms public/ bds-manifest.json"
+  sync_one "$BDS_MANIFEST" "$BDS_STORYBOOK_PUBLIC/bds-manifest.json" "bds storybook     bds-manifest.json"
+else
+  echo ""
+  echo -e "  ${YELLOW}-${NC} bds-manifest.json  (not built — run 'npm run build:inspector-manifest' first)"
+fi
+
+echo ""
+echo "Done. Commit the sync in each affected repo."


### PR DESCRIPTION
Phase 1 of the dev-tool reconciliation (`brikdesigns/brik-llm#352`). Closes `brikdesigns/brik-bds#466`.

## What changed

- New `components/ui/BrikDevBar/widgets/` co-located with the React shell holds canonical `devbar.js`, `inspect-widget.js`, `feedback-widget.js`, `events-widget.js`
- New `scripts/sync-devbar-widgets.sh` pushes to all 7 existing destinations + the brik-llm cache. Same content as today; only the source-of-truth pointer moves
- Three new Storybook stories under **Dev Tools/widgets/**: Inspect (live demo + URL auto-activate), Feedback (default + no-token states), Events (seeded buffer + empty state)
- `npm run sync:devbar-widgets` script
- `BrikDevBar.tsx` source comment + sync-script reference updated

## Why

BDS is now the canonical source of truth for the vanilla widgets. Until this PR they lived in `brik-llm/scripts/brik-dev-tool/widgets/` and BDS held only React shells; that mismatch made the React `DevFeedbackWidget.tsx` accidentally diverge from `feedback-widget.js`. Phase 2 (`brik-bds#467`) widens the vanilla feedback widget so the React parallel can eventually retire.

## Sync direction

Reversed. BDS source → 11 destinations (in one pass):

| Repo | Path | Files |
|------|------|-------|
| brik-client-portal | `public/` | `brik-{devbar,inspect,events-widget}.js` |
| brik-client-portal | `scripts/mockup-shared/` | all 4 widgets |
| renew-pms | `public/` | `brik-{devbar,inspect,events-widget}.js` |
| brik-bds | `.storybook/public/` | all 4 widgets |
| brik-llm | `scripts/brik-dev-tool/widgets/` (cache) | all 4 widgets |

Plus `bds-manifest.json` to portal, renew-pms, and BDS Storybook (already a separate sync hop).

The brik-llm cache is preserved because **`inject-widgets.sh`** (Astro mockup deploy pipeline used by vale-partners-mockups, etc.) reads from it. Treating it as a sync target preserves zero-breakage; npm-distributing those widgets to Astro repos is a separate, larger change.

## Consumer-breakage check

`diff -q` clean across portal `public/`, renew-pms `public/`, and brik-llm `widgets/` after running `npm run sync:devbar-widgets`. Source content is byte-identical to what was already deployed today; only the writer changed.

## Out of scope (sequenced)

- **Phase 2** (`brik-bds#467`) — widen `feedback-widget.js` to support form-mode + user-auth, so it can absorb the parallel React `DevFeedbackWidget` UI
- **Phase 3** (`brikdesigns#54`) — wire onto `brikdesigns` staging (blocked on Phase 2)
- **Companion brik-llm PR** — convert `sync-downstream.sh` into a thin caller of this script (or delete; cache writes happen here now)

## Test plan

- [x] `npm run typecheck` — 0 errors (3 new `.stories.tsx` files compile)
- [x] `npm run sync:devbar-widgets` — all 11 destinations + 3 manifest copies updated
- [x] `diff -q` byte-identity check on portal/renew-pms/brik-llm cache
- [x] `pr-task.sh` 8-check gate including Storybook Build (18s) — PASS
- [ ] Visual confirm new stories render in Chromatic / deploy preview (delegated to reviewer)

Refs `brikdesigns/brik-llm#352`