### PR TITLE
docs(claude-md): add cross-repo + brik-secrets pointer (#357)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This is the **source of truth** for the Brik Design System React components.
 
+> **Cross-repo rules + canonical token registry + brik-secrets credential workflow** load via walk-up from `~/Documents/Github/CLAUDE.md`. For any credential operation (rotate, propagate, audit), use `brik-secrets <subcommand>` — never write a custom rotator. See `operations/security/bin/brik-secrets` in brik-llm.
+
 ## STOP — Canonical Token Registry (Non-Negotiable)
 
 > **Canonical names live at:** [https://design.brikdesigns.com/docs/primitives/color](https://design.brikdesigns.com/docs/primitives/color)


### PR DESCRIPTION
Closes brikdesigns/brik-llm#357 (this repo's slice of the 5-repo issue).

## Summary

Adds a 1-line pointer block near the top of `CLAUDE.md` referencing the cross-repo rules + brik-secrets credential workflow.

## Why

The 2026-05-08 discoverability audit found this repo's `CLAUDE.md` had no explicit reference to either. Coverage exists via the filesystem walk-up that auto-loads `~/Documents/Github/CLAUDE.md` regardless of per-repo content, so this is reinforcement (not a coverage gap) — it makes the per-repo file self-explanatory for human readers and surfaces the brik-secrets entry point alongside the existing per-repo doctrine.

## Test plan

- [x] One-line pointer block; no behavior change
- [x] gitleaks pre-commit passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)