### PR TITLE
docs(blueprints): propose 3 new marketing blueprints (specs only — Phase 1 of 3)

### DIFF
--- a/blueprints/proposals/features_3col_branded_dark.md
+++ b/blueprints/proposals/features_3col_branded_dark.md
@@ -1,0 +1,189 @@
+# Spec: `features_3col_branded_dark`
+
+**Status:** Proposed · awaiting review
+**Section type:** `features`
+**Driver:** brikdesigns.com "Other Service Lines" cross-sell module — dark section with brand-colored cards. Currently rendered as a custom one-off in the consumer repo.
+**Renderers required:** Astro + React
+
+---
+
+## Proposed JSON entry — `blueprint-library.json`
+
+```jsonc
+{
+  "key": "features_3col_branded_dark",
+  "name": "3-Column Brand-Colored Card Grid on Dark",
+  "section_type": "features",
+  "industries": ["universal", "small_business", "creative", "agency", "saas"],
+  "moods": ["bold", "modern", "luxury", "energetic"],
+  "layout_spec": "Dark section background (page-inverse). 3-column grid of cards, each card filled with its own brand color (passed in via item.brandColor — typically the audience/service-line `--brand-primary` for that subtree). Each card: oversized 3D illustration top (square aspect, 60-70% of card height), then card body with high-contrast title (heading/sm, on-color treatment), 1-sentence description (body/sm, on-color secondary), and ghost-style 'Learn more' link styled for the colored background. Cards are rounded (border-radius-lg), full-bleed image at top, body padding generous. Section header centered above grid, light text on dark surface. Optional eyebrow above heading. Cards collapse to 2-col at <992px, 1-col at <768px. Each card establishes its own data-audience subtree binding so its --brand-primary cascades correctly per the BDS scope-binding pattern.",
+  "css_hints": ".features-branded-dark { background: var(--page-inverse); padding-block: var(--padding-huge); } .features-branded-dark__grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--gap-lg); } .features-branded-dark__card { background: var(--bp-card-bg); border-radius: var(--border-radius-lg); overflow: hidden; display: flex; flex-direction: column; } .features-branded-dark__media { aspect-ratio: 1; padding: var(--padding-xl); display: flex; align-items: center; justify-content: center; } .features-branded-dark__body { padding: var(--padding-lg); display: flex; flex-direction: column; gap: var(--gap-sm); }",
+  "tier": "internal",
+  "version": "1.0.0",
+  "is_active": true,
+  "required_facts": []
+}
+```
+
+---
+
+## Why existing blueprints don't cover this
+
+| Existing | Why it doesn't fit |
+|---|---|
+| `features_3col_icon_grid` | Light bg + icon-led + no per-card brand color. Different visual paradigm. |
+| `features_alternating_split` | 2-col alternating, not 3-col grid. |
+| `features_bento_asymmetric` | Asymmetric, mood is editorial. Not the cross-sell brand-grid pattern. |
+| `services_*` patterns | Different section_type semantics — these are service-line CROSS-SELL cards, not the parent service cards on this page. |
+
+---
+
+## BDS primitive composition
+
+| Card region | BDS primitive | Notes |
+|---|---|---|
+| Section frame | `<section>` with `--page-inverse` background | Theme-cascade aware |
+| Grid container | Layout pattern (Grid/Stack — pending Workstream A primitive layer) | Use plain CSS grid for now via blueprint CSS |
+| Card frame | `Card` primitive with `padding="none"` `radius="lg"` | Per-card `data-audience` attribute drives `--brand-primary` cascade |
+| Top illustration area | Slot — full-bleed image with brand-colored backdrop | Image background is the card's brand color |
+| Card title | Heading slot — `heading/sm`, color via `--text-on-color-primary` | On-color text token (varies per brand contrast — light vs dark text picked automatically when token system supports it) |
+| Card description | Body slot — `body/sm`, color via `--text-on-color-secondary` | |
+| Learn more | `LinkButton` `variant="ghost"` `size="md"` (on-colored-bg variant) | Brand-color text on the card's bg — needs the on-color ghost variant |
+
+---
+
+## Per-card brand color binding
+
+This blueprint relies on the BDS scope-binding pattern documented in the [cascade docs](https://design.brikdesigns.com/docs/getting-started/cascade): each card sets `data-audience="brand|marketing|product|information|service"` on itself, which re-binds `--brand-primary` for that subtree to the matching service-line color from the canonical token registry.
+
+```html
+<div class="features-branded-dark__card" data-audience="brand">
+  <!-- card content uses --brand-primary, --on-color-primary, etc. -->
+</div>
+```
+
+The blueprint **MUST NOT** accept a raw hex color as a prop. Instead, `item.audience` selects the canonical brand. This keeps the card automatically theme-aware (dark mode, density modes) and prevents the parallel-taxonomy drift the BDS canon registry exists to stop.
+
+---
+
+## Content contract — `section.items`
+
+```typescript
+interface BrandedCardItem {
+  name: string;                    // h3
+  href: string;                    // Learn more target
+  description?: string;            // 1-sentence body
+  imageUrl?: string;               // top illustration
+  imageAlt?: string;               // a11y
+  audience: 'brand' | 'marketing' | 'information' | 'product' | 'service';
+}
+
+interface FeaturesBrandedDarkSection extends BlueprintProps {
+  section: {
+    eyebrow?: string;
+    heading: string;
+    subheading?: string;
+    items: BrandedCardItem[];      // typically 3, but blueprint handles 2-4
+  };
+}
+```
+
+---
+
+## CSS custom properties (variation API)
+
+```
+--bp-features-branded-dark-bg          (default: var(--page-inverse))
+--bp-features-branded-dark-card-radius (default: var(--border-radius-lg))
+--bp-features-branded-dark-gap         (default: var(--gap-lg))
+--bp-features-branded-dark-image-pad   (default: var(--padding-xl))
+```
+
+Per-card `--bp-card-bg` resolves from `data-audience` to the bound `--brand-primary` for that subtree.
+
+---
+
+## Mode awareness
+
+Spacing-mode-aware tokens for when BDS [#340] ships:
+
+| Mode | Section padding-block | Grid gap | Card body padding |
+|---|---|---|---|
+| compact | `--padding-xl` | `--gap-md` | `--padding-md` |
+| default | `--padding-huge` | `--gap-lg` | `--padding-lg` |
+| comfortable | `calc(var(--padding-huge) + var(--padding-lg))` | `--gap-xl` | `--padding-xl` |
+| spacious | `calc(var(--padding-huge) * 1.5)` | `--gap-huge` | `--padding-xl` |
+
+---
+
+## WCAG AA contrast — token guardrails
+
+Cards are filled with brand colors that vary per-audience. Contrast posture must be enforced via on-color tokens, not inline overrides:
+
+| Region | Use | Don't use |
+|---|---|---|
+| Card title text | `--text-on-color-primary` (resolves per-audience to light or dark, contrast-tested) | Hardcoded white |
+| Card description | `--text-on-color-secondary` | Hardcoded gray |
+| Learn more text | Brand-primary's contrast-paired link color | Hardcoded white-on-color |
+
+**Open contrast question (this is the real one):** Brik's poppy `#e35335` against white text fails AA at 14px (3.78:1). The brand audience's card is exactly that combination. Three resolution paths, **needs ADR-level decision**:
+
+1. **Bold body text on cards** — `font-weight: 600` boosts perceived contrast and is allowed by AA at 14px.
+2. **Larger body size** — promote card description to 16px, which passes at 3:1.
+3. **Lighten the brand red** — token-layer change, breaks Brik brand recognition.
+
+Default proposal: **bold weight on card title + body**, ship the rest of the system and queue the brand-red review as a follow-up ADR. Recommend this be a BDS-side decision tracked alongside [#40].
+
+---
+
+## Atmosphere compatibility
+
+| Atmosphere | Behavior |
+|---|---|
+| `none` | Default — clean dark surface |
+| `editorial-luxury` | Adds subtle vignette to card edges; safe |
+| `cinematic-dramatic` | Adds film-grain over section; cards still readable |
+| `clean-bright` | Off-pattern — doesn't apply to dark sections; consumer should avoid |
+
+Per cascade rule: atmospheres MUST NOT override `--page-*`, `--surface-*`, `--text-*`, `--border-*`. Decoration only.
+
+---
+
+## Renderer outputs
+
+- `content-system/blueprints/astro/Features3ColBrandedDark.astro`
+- `content-system/blueprints/react/Features3ColBrandedDark.tsx` (new directory)
+- Storybook stories:
+  - **Default** — 3 cards with brand/marketing/product audiences (the brikdesigns "Other Service Lines" fixture)
+  - **2 cards** — narrow grid
+  - **4 cards** — wraps to second row at desktop
+  - **No images** — color-block fallback
+  - **Mode: compact / comfortable** — spacing axis demonstration
+  - **Atmosphere: editorial-luxury** — overlay validation
+
+---
+
+## Open questions — please weigh in
+
+1. **Per-card image background.** Webflow shows the 3D illustration on a slightly-darker shade of the card's brand color (e.g., yellow card → darker-yellow image bg). Use canonical `--brand-primary-dark` from the audience subtree, or keep the same `--brand-primary` and rely on illustration to provide visual contrast? **Default proposal: same brand-primary**, keeps the system simpler.
+2. **Card hover.** Webflow has subtle scale-up on hover. Match (with `transform: scale(1.02)` + transition) or static? **Default proposal: subtle scale on hover, opt-out via `--bp-features-branded-dark-hover-scale: 1`.**
+3. **Audience scope binding.** The card's `data-audience` re-binds `--brand-primary` for the subtree. Should the blueprint also bind `--text-link` and `--border-brand-primary` to the same audience, or stop at `--brand-primary`? **Default proposal: bind the full brand-token set** so on-card links/borders also follow the audience.
+4. **Image fallback.** When no `imageUrl`, render an oversized `ServiceTag` (icon variant) centered, or keep the brand-color block clean with no glyph? **Default proposal: oversized icon fallback**, matches the services blueprint pattern.
+5. **Section heading alignment.** Webflow centers it. Allow left-align variant or lock to centered? **Default proposal: lock centered** for this blueprint; left-align is a different blueprint.
+
+---
+
+## Acceptance criteria
+
+- Composes BDS primitives only (zero one-off CSS in the consumer repo for this section)
+- Per-card brand color comes from `data-audience` subtree binding, never raw hex
+- Passes WCAG AA via on-color tokens (subject to open question #1 resolution on bold-vs-larger text)
+- Responds to `data-theme` and `data-mode-spacing` automatically
+- Atmospheres compose cleanly without overriding theme tokens
+- Tree-shakes when not used
+
+---
+
+## Sequencing
+
+Same as `services_3col_card_grid` — spec sign-off → JSON entry → Astro renderer → React renderer → Storybook stories → consumer adoption.

--- a/blueprints/proposals/services_3col_card_grid.md
+++ b/blueprints/proposals/services_3col_card_grid.md
@@ -92,6 +92,20 @@ Atmosphere CSS files MUST NOT override `--surface-*`, `--text-*`, `--border-*` p
 
 ---
 
+## WCAG AA contrast — token guardrails
+
+The brikdesigns.com a11y CI surfaced two known BDS-level contrast tensions on `/services/brand/logo-design` that this blueprint must NOT inherit. Authoring discipline:
+
+| Region | Use | Don't use | Why |
+|---|---|---|---|
+| Card description body | `--text-primary` (passes AA on `--surface-primary`) | `--text-secondary` (#828282 → 3.84:1 on white at 14px, fails AA) | Body copy must clear AA — the gray-on-white tension is tracked in BDS [#40] burndown. |
+| Card "Learn more" link | `LinkButton variant="ghost"` size `md` (default 14px label) | `LinkButton variant="primary"` size `sm` on light backgrounds | White-on-poppy `#e35335` = 3.78:1 at 14px. Small primary buttons are an open BDS contrast issue. |
+| Section heading | `--text-primary` | — | Always passes. |
+| Optional eyebrow | `--text-brand-primary` on light bg | small (<14px) brand-primary on light | Brand-primary at body sizes passes; tiny eyebrow text needs review. |
+| Has Options badge | `Badge status="positive"` (uses `--background-positive` + `--text-on-positive`) | inline color overrides | BDS Badge is contrast-tested. |
+
+**Acceptance:** Storybook story renders zero new color-contrast violations against the brikdesigns axe baseline. If the surfaced tokens force a regression, **this blueprint is the wrong shape — redesign rather than baseline-bypass**.
+
 ## Mode awareness
 
 The blueprint's spacing should respond to the `data-mode-spacing` attribute (BDS issue #340 — currently dormant). Recommend wiring this blueprint with the spacing-mode tokens at author time so it lights up when the dormant modes ship:

--- a/blueprints/proposals/services_3col_card_grid.md
+++ b/blueprints/proposals/services_3col_card_grid.md
@@ -1,0 +1,151 @@
+# Spec: `services_3col_card_grid`
+
+**Status:** Proposed · awaiting review
+**Section type:** `services`
+**Driver:** brikdesigns.com service-line page (e.g. `/services/information`) renders a 3-col service card grid with a top illustration, service-line badge, name, description, "Has Options" indicator, and "Learn more" link. None of the three existing `services_*` blueprints fit this shape.
+**Renderers required:** Astro (parity with existing blueprints) + React (Next.js consumers — brikdesigns.com)
+
+---
+
+## Proposed JSON entry — `blueprint-library.json`
+
+```jsonc
+{
+  "key": "services_3col_card_grid",
+  "name": "3-Column Service Card Grid",
+  "section_type": "services",
+  "industries": ["universal", "small_business", "creative", "saas", "marketing"],
+  "moods": ["approachable", "professional", "modern", "warm"],
+  "layout_spec": "Light background section. Centered section header (eyebrow optional + heading + optional one-line subhead). 3-column grid of service cards below. Each card: top image area (3:2 aspect) showing service-specific 3D illustration or photo on a light backdrop; below, a small ServiceTag (icon variant, accent color) + service name (heading/sm, 700 weight) + 1-2 sentence description (body/sm, muted) + 'Learn more' ghost-variant link-button. Optional 'Has Options' positive-status badge anchored top-right of card when the service exposes multiple offerings. Cards have rounded corners (border-radius-md), no border at rest, optional subtle hover lift. Grid gap is generous (24-28px). Collapses to 2-col at <992px, 1-col at <768px.",
+  "css_hints": ".services-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--gap-lg); } .service-card { background: var(--surface-primary); border-radius: var(--border-radius-md); overflow: hidden; position: relative; } .service-card__media { aspect-ratio: 3/2; background: var(--surface-secondary); } .service-card__body { padding: var(--padding-lg); display: flex; flex-direction: column; gap: var(--gap-sm); } .service-card__has-options { position: absolute; top: var(--gap-md); right: var(--gap-md); }",
+  "tier": "internal",
+  "version": "1.0.0",
+  "is_active": true,
+  "required_facts": []
+}
+```
+
+---
+
+## Why existing blueprints don't cover this
+
+| Existing | Why it doesn't fit |
+|---|---|
+| `features_3col_icon_grid` | Icon-led — no top-image area. Service cards lead with a 3D illustration of the deliverable, not an icon glyph. |
+| `services_numbered_rows` | Vertical numbered list, not a grid. Different IA. |
+| `services_detail_two_column` | Single-service detail layout. Wrong shape for category-index pages. |
+| `services_numbered_accordion` | Collapsed sections. No image. |
+
+---
+
+## BDS primitive composition (no one-off CSS)
+
+| Card region | BDS primitive | Notes |
+|---|---|---|
+| Card frame | `Card` (with `padding="none"` + `radius="md"`) | Body padding handled by inner wrapper |
+| Top image area | Slot — accepts `<img>` / Next `<Image>` / Astro `<Image>` | Aspect ratio + bg via component CSS, not consumer CSS |
+| Service-line badge | `ServiceTag` `variant="icon"` `size="md"` `serviceName={item.name}` | Resolves the per-service icon |
+| Has Options | `Badge` `status="positive"` `size="sm"` (label: "Has Options") | Absolute-positioned top-right of card |
+| Service name | Heading slot — uses `heading/sm` token (20px/bold) | No new typography preset |
+| Description | Body slot — uses `body/sm` token + `text-secondary` color | |
+| Learn more | `LinkButton` `variant="ghost"` `size="sm"` | Brand-color text, no fill |
+
+---
+
+## Content contract — `section.items`
+
+```typescript
+interface ServiceCardItem {
+  name: string;                    // h3
+  href: string;                    // Learn more target
+  description?: string;            // body, optional
+  imageUrl?: string;               // top image, optional
+  badge?: ServiceCategory;         // resolves ServiceTag icon
+  hasOptions?: boolean;            // shows "Has Options" badge
+}
+
+interface ServicesGridSection extends BlueprintProps {
+  section: {
+    eyebrow?: string;
+    heading: string;
+    subheading?: string;
+    items: ServiceCardItem[];
+  };
+}
+```
+
+---
+
+## CSS custom properties (variation API)
+
+Per BDS convention, the blueprint exposes `--bp-*` props for safe per-instance variation without forking:
+
+```
+--bp-services-grid-bg            (default: var(--page-primary))
+--bp-services-grid-card-radius   (default: var(--border-radius-md))
+--bp-services-grid-gap           (default: var(--gap-lg))
+--bp-services-grid-image-bg      (default: var(--surface-secondary))
+--bp-services-grid-hover-lift    (default: 0 — no lift; consumers can opt-in to translateY(-4px))
+```
+
+Atmosphere CSS files MUST NOT override `--surface-*`, `--text-*`, `--border-*` per the cascade rules — those stay theme-layer.
+
+---
+
+## Mode awareness
+
+The blueprint's spacing should respond to the `data-mode-spacing` attribute (BDS issue #340 — currently dormant). Recommend wiring this blueprint with the spacing-mode tokens at author time so it lights up when the dormant modes ship:
+
+| Mode | Padding | Gap |
+|---|---|---|
+| compact | `--padding-md` | `--gap-md` |
+| default | `--padding-lg` | `--gap-lg` |
+| comfortable | `--padding-xl` | `--gap-xl` |
+| spacious | `--padding-huge` | `--gap-huge` |
+
+---
+
+## Renderer outputs
+
+- `content-system/blueprints/astro/Services3ColCardGrid.astro` — Astro implementation, conforms to existing `BlueprintProps`
+- `content-system/blueprints/react/Services3ColCardGrid.tsx` — React implementation, same prop contract (new directory)
+- `BlueprintDispatcher.tsx` — React dispatcher, mirrors existing Astro dispatcher
+- Storybook stories:
+  - **Default** — 6 service cards (the brikdesigns Information Design fixture)
+  - **No images** — fallback to ServiceTag-only display
+  - **With Has Options badge** — one card flagged
+  - **Mode: compact / comfortable / spacious** — spacing axis demonstration once #340 is wired
+  - **Atmosphere: minimal-clinical / clean-bright / warm-soft** — atmosphere overlay validation
+
+---
+
+## Open questions — please weigh in
+
+1. **Hover treatment.** Webflow has no hover effect on service cards. `features_3col_icon_grid` has translateY + shadow. Match Webflow (no hover, opt-in via `--bp-services-grid-hover-lift`) or align with the `features_*` pattern (hover lift on by default)? **Default proposal: no hover.**
+2. **Image fallback.** When `imageUrl` is missing, show oversized `ServiceTag` (variant: icon, size: lg) centered in the image area, or collapse the image area entirely? **Default proposal: oversized icon fallback** so the grid keeps consistent rhythm.
+3. **"Has Options" badge wording.** Webflow uses literal "Has Options". Other Brik surfaces use "Multiple Tiers". Canonical label here? **Default proposal: "Has Options"** to match Webflow.
+4. **Card border-radius.** Webflow ~12px. `--border-radius-md` is currently 8px. Use existing token, or add a `--border-radius-card` (12px) as a card-specific token? **Default proposal: use `--border-radius-md`.** If we want a card-specific value, that's a token-layer decision, not blueprint-layer.
+5. **Section background.** Webflow uses a light-grey. Map to `--surface-secondary` or stay on `--page-primary`? **Default proposal: `--page-primary` with consumers free to override via atmosphere.**
+
+---
+
+## Acceptance criteria
+
+A consumer site (Astro or Next.js) renders this blueprint with `BlueprintDispatcher`, supplies a `section.items` array, and gets a pixel-faithful service-card grid that:
+
+- Composes BDS primitives only (no inline styles, no custom CSS in the consumer repo for this section)
+- Responds to `data-theme="dark"` automatically (token cascade)
+- Respects `data-mode-spacing` (once #340 ships)
+- Supports per-instance variation via `--bp-*` props
+- Passes WCAG 2.1 AA (semantic h3 list, aria-labelledby on the section, keyboard-focusable Learn more links)
+- Tree-shakes cleanly when not used
+
+---
+
+## Sequencing
+
+1. Spec review + sign-off (this PR)
+2. Author Astro renderer + JSON entry (existing blueprint pattern)
+3. Author React renderer + dispatcher (new for BDS)
+4. Storybook stories (5 variants above)
+5. Consumer adoption — `web/brikdesigns` service category page swaps custom CSS for `<BlueprintDispatcher blueprintKey="services_3col_card_grid" />`

--- a/blueprints/proposals/support_plan_callout_split.md
+++ b/blueprints/proposals/support_plan_callout_split.md
@@ -1,0 +1,200 @@
+# Spec: `support_plan_callout_split`
+
+**Status:** Proposed · awaiting review
+**Section type:** `cta` (cross-sell callout)
+**Driver:** brikdesigns.com "Monthly support services" section — illustration block on left, plan-card on right. Currently rendered as a custom one-off in the consumer repo with NO illustration block.
+**Renderers required:** Astro + React
+
+---
+
+## Proposed JSON entry — `blueprint-library.json`
+
+```jsonc
+{
+  "key": "support_plan_callout_split",
+  "name": "Support Plan Callout — Illustration + Plan Card Split",
+  "section_type": "cta",
+  "industries": ["universal", "small_business", "creative", "agency"],
+  "moods": ["approachable", "warm", "professional", "trustworthy"],
+  "layout_spec": "Light section. Centered section header (heading + subhead) above. Below: two-column split, content-region (illustration block) left, plan card right. Illustration block: persona/scene composition with floating UI elements (chat bubble, message tile, optional photo) — composed from primitives, NOT a baked-in illustration. Plan card: surface-secondary background, rounded-lg corners, padded generously. Card content: plan name (heading/sm), 2-sentence description (body/sm), 'Learn more' primary CTA. Two-column collapses to stacked at <992px (illustration goes above card on mobile). Section also supports an 'illustration-omitted' variant where the card centers full-width.",
+  "css_hints": ".support-plan-callout { padding-block: var(--padding-huge); background: var(--page-primary); } .support-plan-callout__split { display: grid; grid-template-columns: 1fr 1fr; gap: var(--gap-xl); align-items: center; } .support-plan-callout__illustration { aspect-ratio: 1; position: relative; } .support-plan-callout__card { background: var(--surface-secondary); border-radius: var(--border-radius-lg); padding: var(--padding-xl); display: flex; flex-direction: column; gap: var(--gap-md); align-items: flex-start; } @media (max-width: 991px) { .support-plan-callout__split { grid-template-columns: 1fr; } }",
+  "tier": "internal",
+  "version": "1.0.0",
+  "is_active": true,
+  "required_facts": []
+}
+```
+
+---
+
+## Why existing blueprints don't cover this
+
+| Existing | Why it doesn't fit |
+|---|---|
+| `cta_dark_centered` | Single CTA, dark surface, centered. Not a card-with-illustration shape. |
+| `cta_split_contact` | Split, but contact-form on right. Wrong content type. |
+| `contact_form_split` | Same — form-based. |
+| `features_alternating_split` | Generic feature copy + image. Doesn't represent the plan-card pattern (plan name + price-shaped CTA). |
+| Service detail page support CTA | Lives inside the service detail blueprint, not reusable here. |
+
+This is the first reusable cross-sell-to-plan blueprint in the catalog. Gap noted.
+
+---
+
+## BDS primitive composition
+
+| Region | BDS primitive | Notes |
+|---|---|---|
+| Section frame | Standard `<section>` with `--page-primary` | |
+| Section header | Heading + body slot, centered | `heading/lg` + `body/md` muted |
+| Illustration block | **Slot — composes from primitives, not a baked image** | See "Illustration composition" below |
+| Plan card | `Card` `radius="lg"` `padding="xl"` `surface="secondary"` | |
+| Plan card name | Heading slot — `heading/sm` | |
+| Plan card description | Body slot — `body/sm`, `--text-secondary` (note: passes AA at 14px on `--surface-secondary`, which is a slightly off-white that increases contrast) — verify when drafting Storybook story |
+| Plan card CTA | `LinkButton` `variant="primary"` `size="md"` | 16px label clears AA on `--background-brand-primary` |
+
+---
+
+## Illustration composition (the missing primitive opportunity)
+
+**Gap surfaced — this blueprint reveals BDS doesn't have a generic "illustration scene" primitive.** The Webflow design composes:
+
+- A persona avatar (circle photo)
+- A chat-bubble UI tile (rounded card with text)
+- A message-bubble (smaller rounded square)
+- A secondary photo or shape
+
+These are decorative compositions, not data-bearing UI. Two paths:
+
+**Option A — Build a `<MarketingIllustration>` primitive in BDS** that accepts a slot of "tiles" with an `Avatar`, `Tile`, `Bubble` API. Reusable across blueprints.
+
+**Option B — Inline composition inside this blueprint** (faster, less reusable).
+
+**Recommendation: Option A** — author a small `<MarketingIllustration>` primitive (Avatar + Tile + Bubble, with absolute-positioned layout) as a sibling deliverable to this blueprint. Maintains the system-lens commitment.
+
+For now, **the spec defines the slot contract**. The primitive author or this blueprint's Astro renderer fills it.
+
+```typescript
+interface IllustrationSlot {
+  type: 'persona-cluster';   // first variant — others can follow (product-cluster, data-cluster, etc.)
+  avatar?: { src: string; alt: string };
+  tiles?: Array<{
+    kind: 'chat-bubble' | 'message' | 'photo' | 'shape';
+    content?: string;        // for chat-bubble/message
+    src?: string;            // for photo
+    fill?: 'brand-primary' | 'positive' | 'neutral';  // canonical token reference
+  }>;
+}
+```
+
+---
+
+## Content contract
+
+```typescript
+interface SupportPlanCalloutSection extends BlueprintProps {
+  section: {
+    eyebrow?: string;
+    heading: string;
+    subheading?: string;
+    illustration?: IllustrationSlot;     // optional — when omitted, plan card centers
+    plan: {
+      name: string;
+      description: string;
+      ctaLabel: string;                  // typically "Learn more"
+      ctaHref: string;
+    };
+  };
+}
+```
+
+---
+
+## CSS custom properties (variation API)
+
+```
+--bp-support-plan-callout-bg          (default: var(--page-primary))
+--bp-support-plan-callout-card-bg     (default: var(--surface-secondary))
+--bp-support-plan-callout-card-radius (default: var(--border-radius-lg))
+--bp-support-plan-callout-gap         (default: var(--gap-xl))
+--bp-support-plan-callout-card-pad    (default: var(--padding-xl))
+```
+
+---
+
+## Mode awareness
+
+| Mode | Section padding-block | Card padding | Split gap |
+|---|---|---|---|
+| compact | `--padding-xl` | `--padding-lg` | `--gap-lg` |
+| default | `--padding-huge` | `--padding-xl` | `--gap-xl` |
+| comfortable | `calc(var(--padding-huge) + var(--padding-lg))` | `calc(var(--padding-xl) + var(--padding-md))` | `--gap-huge` |
+| spacious | `calc(var(--padding-huge) * 1.5)` | `--padding-huge` | `--gap-huge` |
+
+---
+
+## WCAG AA contrast — token guardrails
+
+| Region | Use | Don't use |
+|---|---|---|
+| Card description | `--text-primary` on `--surface-secondary` | `--text-secondary` at 14px (still 3.84:1 against light surfaces — `--surface-secondary` improves to ~4.05:1, still fails) |
+| CTA primary button | `LinkButton size="md"` (16px label) | `size="sm"` (14px hits the white-on-poppy 3.78:1 fail) |
+| Illustration tile text | Per-tile token resolved by `fill` prop | Hardcoded |
+
+**System-level gap noted:** `--text-secondary` fails AA at body sizes on every light surface in the system. This is the same thing tracked in BDS [#40] burndown but worth restating: it shows up in *every* blueprint that puts secondary body text on a light surface. Either (a) darken `--text-secondary` token, or (b) introduce a new `--text-secondary-aa` token reserved for ≤14px usage. **Recommend BDS-side discussion before this blueprint ships** — otherwise we're encoding the failure into a system primitive.
+
+---
+
+## Atmosphere compatibility
+
+| Atmosphere | Behavior |
+|---|---|
+| `none` | Default |
+| `warm-soft` | Adds subtle warm overlay, complements the persona-cluster illustration |
+| `clean-bright` | Sharp clean lines, default-friendly |
+| `editorial-luxury` | Adds vignette to section corners |
+
+---
+
+## Renderer outputs
+
+- `content-system/blueprints/astro/SupportPlanCalloutSplit.astro`
+- `content-system/blueprints/react/SupportPlanCalloutSplit.tsx`
+- (Optional sibling deliverable) `<MarketingIllustration>` primitive — see "Illustration composition" gap above
+- Storybook stories:
+  - **Default** — full split with persona-cluster illustration (brikdesigns Information Design fixture)
+  - **No illustration** — card centers full-width
+  - **Mode: compact / comfortable**
+  - **Atmosphere: warm-soft**
+
+---
+
+## Open questions — please weigh in
+
+1. **Build `<MarketingIllustration>` primitive now or inline it?** Reusable primitive is the system-lens answer. Confirms this is the right scope expansion. **Default proposal: build the primitive** as a sibling deliverable.
+2. **Plan card surface.** Webflow uses a slightly off-white surface. Map to `--surface-secondary` (an existing token) or introduce a `--surface-callout` (new token)? **Default proposal: `--surface-secondary`.**
+3. **Plan name typography.** Webflow uses heading-sm-weight. Match (`heading/sm`) or use a more visually-prominent `heading/md`? **Default proposal: `heading/sm`** for plan-card density.
+4. **Eyebrow on this blueprint.** Webflow has the section title only ("Monthly support services"), no eyebrow. Allow eyebrow as optional prop or omit from API? **Default proposal: optional**, leaving consumer choice.
+5. **Mobile order.** When stacked, illustration above or below the plan card? Webflow puts illustration first, but card-first might convert better. **Default proposal: illustration-first** to match Webflow.
+
+---
+
+## Acceptance criteria
+
+- Composes BDS primitives only (assumes `<MarketingIllustration>` ships as sibling)
+- Plan card text passes AA on `--surface-secondary` (verify in story)
+- CTA passes AA at `size="md"`
+- Responds to `data-theme`, `data-mode-spacing`, atmospheres
+- Stacks gracefully on mobile, illustration-first
+- Tree-shakes when not used
+
+---
+
+## Sequencing
+
+1. Spec sign-off (this PR)
+2. Resolve "build `MarketingIllustration` primitive" question — if yes, sibling primitive PR opens first
+3. JSON entry + Astro renderer
+4. React renderer
+5. Storybook stories
+6. Consumer adoption — brikdesigns.com service category page


### PR DESCRIPTION
## Summary

Opens a draft PR for design review of new marketing-section blueprints needed to unblock the brikdesigns.com Webflow → Next.js rebuild. **Specs only — no renderer code yet.** Implementation lands once review settles the open questions.

The three proposed blueprints (this PR ships the first; the other two land as commits to this branch):
1. **`services_3col_card_grid`** — 3-col service-card index grid with image, ServiceTag, name, description, optional "Has Options" badge, link-style CTA. ✅ in this commit
2. **`features_3col_branded_dark`** — 3-col colored-box-on-dark "Other Service Lines" pattern with brand-color cards on `--page-inverse` background. ⏳ pending
3. **`support_plan_callout_split`** — Two-pane: illustration block on left, plan name + description + CTA on right. ⏳ pending

## Why this PR

Marketing-section silo is the cost-leak we're closing. Today every Brik client repo (brikdesigns, birdwell-mutlak, vale-partners, memphis-dental, tncld) reauthors marketing sections in repo-local CSS. BDS already owns the cascade — tokens, atmospheres, layout archetypes, blueprint schema, Astro renderers — but consumers can't reach the section layer because (a) the React renderers don't exist for Next.js consumers and (b) several marketing patterns aren't in the catalog yet.

This PR series fixes (b). Workstream A (porting existing Astro blueprints to React) and Workstream C (wiring BDS issue #340 dormant spacing modes) follow.

## Spec format

Each spec markdown captures:
- Proposed `blueprint-library.json` entry
- Why existing blueprints don't cover the pattern (table of fits/misfits)
- BDS primitive composition (zero one-off CSS — every region maps to an existing primitive)
- Content contract (`section.items` shape per the framework-agnostic `BlueprintProps`)
- CSS custom property variation API (`--bp-*` props)
- Mode-spacing awareness (#340 dormant modes)
- Atmosphere compatibility
- Renderer outputs (Astro + React + Storybook stories)
- Acceptance criteria
- Open questions for review with proposed defaults

## Multi-platform alignment

Prop contracts in these specs are deliberately framework-agnostic — no `children: ReactNode`, no `onClick: MouseEvent`. SwiftUI/Compose can implement the same surface without breaking changes when iOS/Android consumers come online.

## Test plan

- [ ] Review `services_3col_card_grid` spec — answer 5 open questions
- [ ] Review `features_3col_branded_dark` spec (next commit)
- [ ] Review `support_plan_callout_split` spec (next commit)
- [ ] Sign off → flip PR out of draft
- [ ] Implementation PR (Astro renderers + JSON entries) follows
- [ ] React renderer PR follows (`blueprints-react/` new export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)