### PR TITLE
feat(marketing): add MarketingIllustration primitive (persona-cluster)

### DIFF
--- a/components/ui/MarketingIllustration/MarketingIllustration.css
+++ b/components/ui/MarketingIllustration/MarketingIllustration.css
@@ -1,0 +1,168 @@
+@layer bds-components {
+/* ─── MarketingIllustration — composable scene container ───── */
+
+.bds-marketing-illustration {
+  position: relative;
+  width: 100%;
+  display: block;
+  container-type: inline-size;
+  /* Tiles position relative to the container; sizes scale with cqi
+     (container query inline) so the illustration looks the same at
+     any container width without media queries. */
+}
+
+/* ─── Aspect ratio ────────────────────────────────────────── */
+
+.bds-marketing-illustration--ratio-square    { aspect-ratio: 1 / 1; }
+.bds-marketing-illustration--ratio-portrait  { aspect-ratio: 3 / 4; }
+.bds-marketing-illustration--ratio-landscape { aspect-ratio: 4 / 3; }
+
+/* ─── Tile base ───────────────────────────────────────────── */
+
+.bds-marketing-illustration__tile {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ─── Tile kinds ──────────────────────────────────────────── */
+
+.bds-marketing-illustration__photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.bds-marketing-illustration__tile--photo {
+  width: 22cqi;
+  height: 22cqi;
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--surface-secondary);
+}
+
+.bds-marketing-illustration__chat-bubble {
+  padding: var(--padding-sm) var(--padding-md);
+  border-radius: var(--border-radius-lg);
+  font-family: var(--font-family-body);
+  font-size: clamp(11px, 3.2cqi, 16px);
+  color: var(--text-on-color-dark);
+  background: var(--background-inverse);
+  white-space: nowrap;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.bds-marketing-illustration__message {
+  width: 26cqi;
+  height: 16cqi;
+  border-radius: var(--border-radius-md);
+  background: var(--surface-secondary);
+  display: flex;
+  align-items: flex-end;
+  padding: var(--padding-sm);
+  font-family: var(--font-family-body);
+  font-size: clamp(10px, 2.4cqi, 14px);
+  color: var(--text-secondary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.bds-marketing-illustration__shape {
+  width: 12cqi;
+  height: 12cqi;
+  border-radius: 50%;
+  background: var(--surface-secondary);
+}
+
+/* ─── Accent fills (canonical tokens, never raw hex) ─────── */
+
+.bds-marketing-illustration__tile--accent-brand-primary
+  > .bds-marketing-illustration__chat-bubble,
+.bds-marketing-illustration__tile--accent-brand-primary
+  > .bds-marketing-illustration__message,
+.bds-marketing-illustration__tile--accent-brand-primary
+  > .bds-marketing-illustration__shape {
+  background: var(--background-brand-primary);
+  color: var(--text-on-color-dark);
+}
+
+.bds-marketing-illustration__tile--accent-positive
+  > .bds-marketing-illustration__chat-bubble,
+.bds-marketing-illustration__tile--accent-positive
+  > .bds-marketing-illustration__message,
+.bds-marketing-illustration__tile--accent-positive
+  > .bds-marketing-illustration__shape {
+  background: var(--surface-positive);
+  color: var(--text-on-color-dark);
+}
+
+.bds-marketing-illustration__tile--accent-neutral
+  > .bds-marketing-illustration__chat-bubble,
+.bds-marketing-illustration__tile--accent-neutral
+  > .bds-marketing-illustration__message,
+.bds-marketing-illustration__tile--accent-neutral
+  > .bds-marketing-illustration__shape {
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
+.bds-marketing-illustration__tile--accent-inverse
+  > .bds-marketing-illustration__chat-bubble,
+.bds-marketing-illustration__tile--accent-inverse
+  > .bds-marketing-illustration__message,
+.bds-marketing-illustration__tile--accent-inverse
+  > .bds-marketing-illustration__shape {
+  background: var(--background-inverse);
+  color: var(--text-on-color-dark);
+}
+
+/* ─── Variant: persona-cluster — slot positions ─────────── */
+/* Slots 0-4 define the canonical persona-cluster composition.
+   Tiles beyond slot 4 stack at slot 4 (rare; consumers should keep
+   to 5 tiles). Positions are tuned for square aspect; portrait/
+   landscape use the same anchors with proportional adjustment. */
+
+.bds-marketing-illustration--persona-cluster
+  .bds-marketing-illustration__slot-0 {
+  top: 8%;
+  left: 6%;
+  transform: rotate(-3deg);
+}
+
+.bds-marketing-illustration--persona-cluster
+  .bds-marketing-illustration__slot-1 {
+  top: 16%;
+  right: 6%;
+  transform: rotate(2deg);
+}
+
+.bds-marketing-illustration--persona-cluster
+  .bds-marketing-illustration__slot-2 {
+  top: 44%;
+  left: 28%;
+  transform: rotate(-1deg);
+}
+
+.bds-marketing-illustration--persona-cluster
+  .bds-marketing-illustration__slot-3 {
+  top: 50%;
+  right: 10%;
+  transform: rotate(3deg);
+}
+
+.bds-marketing-illustration--persona-cluster
+  .bds-marketing-illustration__slot-4 {
+  bottom: 8%;
+  left: 18%;
+  transform: rotate(-2deg);
+}
+
+/* ─── Reduced-motion: drop the rotation ─────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .bds-marketing-illustration__tile {
+    transform: none !important;
+  }
+}
+}

--- a/components/ui/MarketingIllustration/MarketingIllustration.stories.tsx
+++ b/components/ui/MarketingIllustration/MarketingIllustration.stories.tsx
@@ -1,0 +1,199 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MarketingIllustration } from './MarketingIllustration';
+
+const meta: Meta<typeof MarketingIllustration> = {
+  title: 'Components/Marketing/marketing-illustration',
+  component: MarketingIllustration,
+  tags: ['surface-web'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Composable illustration scene primitive. Composes Avatars, photo circles, chat bubbles, message tiles, and accent shapes into a marketing-callout illustration. Replaces the per-consumer pattern of reinventing absolute-positioned scene compositions in repo-local CSS (BDS #480; surfaced in the `support_plan_callout_split` blueprint spec — PR #477).',
+      },
+    },
+  },
+  argTypes: {
+    variant: { control: 'select', options: ['persona-cluster'] },
+    ratio: { control: 'select', options: ['square', 'portrait', 'landscape'] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MarketingIllustration>;
+
+/* ─── Story-only: stable demo avatars (data URI, no network) ─── */
+
+const personaA =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" fill="#e4b596"/><circle cx="32" cy="26" r="10" fill="#fff"/><path d="M12 60c4-12 14-18 20-18s16 6 20 18z" fill="#fff"/></svg>',
+  );
+
+const personaB =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" fill="#a8c8b8"/><circle cx="32" cy="26" r="10" fill="#fff"/><path d="M12 60c4-12 14-18 20-18s16 6 20 18z" fill="#fff"/></svg>',
+  );
+
+/* ═══════════════════════════════════════════════════════════════
+   PLAYGROUND
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Default persona-cluster — 5 tiles, square aspect */
+export const Playground: Story = {
+  args: {
+    variant: 'persona-cluster',
+    ratio: 'square',
+    tiles: [
+      { kind: 'avatar', src: personaA, alt: 'Strategist Sam', name: 'Sam' },
+      { kind: 'chat-bubble', content: 'How can I help today?', accent: 'inverse' },
+      { kind: 'message', accent: 'positive' },
+      { kind: 'photo', src: personaB, alt: 'Operations Olivia' },
+      { kind: 'chat-bubble', content: 'We need an email campaign', accent: 'neutral' },
+    ],
+  },
+  render: (args) => (
+    <div style={{ width: 480 }}>
+      <MarketingIllustration {...args} />
+    </div>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   BLUEPRINT FIXTURE — what `support_plan_callout_split` would pass
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Fixture matching the support_plan_callout_split blueprint — Brik Marketing Support */
+export const SupportPlanCallout: Story = {
+  args: {
+    variant: 'persona-cluster',
+    ratio: 'square',
+    tiles: [
+      { kind: 'avatar', src: personaA, alt: 'Marketing Strategist', name: 'Sam' },
+      { kind: 'chat-bubble', content: 'How can I help today?', accent: 'inverse' },
+      { kind: 'message', accent: 'positive' },
+      { kind: 'photo', src: personaB, alt: 'Client' },
+      { kind: 'chat-bubble', content: 'We need an email campaign', accent: 'brand-primary' },
+    ],
+  },
+  render: (args) => (
+    <div style={{ width: 520 }}>
+      <MarketingIllustration {...args} />
+    </div>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   ACCENT FILLS
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary All accent options across chat-bubble + message + shape kinds */
+export const AccentFills: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(2, 1fr)',
+        gap: 'var(--gap-lg)',
+        width: 720,
+      }}
+    >
+      {(['brand-primary', 'positive', 'neutral', 'inverse'] as const).map((accent) => (
+        <div key={accent}>
+          <h4
+            style={{
+              margin: '0 0 var(--gap-sm)',
+              fontFamily: 'var(--font-family-label)',
+              fontSize: 'var(--label-sm)',
+              color: 'var(--text-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
+            accent={accent}
+          </h4>
+          <MarketingIllustration
+            variant="persona-cluster"
+            ratio="square"
+            tiles={[
+              { kind: 'avatar', src: personaA, alt: '' },
+              { kind: 'chat-bubble', content: 'Hello', accent },
+              { kind: 'message', accent },
+              { kind: 'photo', src: personaB, alt: '' },
+              { kind: 'shape', accent },
+            ]}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   ASPECT RATIOS
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary square / portrait / landscape — slot positions adapt */
+export const RatioVariants: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: 'var(--gap-lg)',
+        width: 960,
+      }}
+    >
+      {(['square', 'portrait', 'landscape'] as const).map((ratio) => (
+        <div key={ratio}>
+          <h4
+            style={{
+              margin: '0 0 var(--gap-sm)',
+              fontFamily: 'var(--font-family-label)',
+              fontSize: 'var(--label-sm)',
+              color: 'var(--text-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
+            ratio={ratio}
+          </h4>
+          <MarketingIllustration
+            variant="persona-cluster"
+            ratio={ratio}
+            tiles={[
+              { kind: 'avatar', src: personaA, alt: '' },
+              { kind: 'chat-bubble', content: 'Hi', accent: 'inverse' },
+              { kind: 'message', accent: 'positive' },
+              { kind: 'photo', src: personaB, alt: '' },
+              { kind: 'chat-bubble', content: 'Hello', accent: 'neutral' },
+            ]}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   MINIMAL — fewer tiles
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary 2-tile minimum — avatar + single bubble */
+export const Minimal: Story = {
+  args: {
+    variant: 'persona-cluster',
+    ratio: 'square',
+    tiles: [
+      { kind: 'avatar', src: personaA, alt: 'Strategist' },
+      { kind: 'chat-bubble', content: 'How can I help today?', accent: 'inverse' },
+    ],
+  },
+  render: (args) => (
+    <div style={{ width: 480 }}>
+      <MarketingIllustration {...args} />
+    </div>
+  ),
+};

--- a/components/ui/MarketingIllustration/MarketingIllustration.tsx
+++ b/components/ui/MarketingIllustration/MarketingIllustration.tsx
@@ -1,0 +1,170 @@
+import { type HTMLAttributes, type ReactNode } from 'react';
+import { Avatar } from '../Avatar';
+import { bdsClass } from '../../utils';
+import './MarketingIllustration.css';
+
+/**
+ * Illustration variant — defines the slot taxonomy and slot positions.
+ *
+ * `persona-cluster` is the marketing pattern of "two-people-talking" with
+ * scattered chat bubbles, photos, and accent shapes. Used in the
+ * `support_plan_callout_split` blueprint and similar marketing-callout
+ * compositions where you want a casual-conversational feeling.
+ *
+ * Future variants follow the same shape (data-driven tiles + variant-
+ * defined slot positions): `product-cluster`, `data-cluster`, etc. — each
+ * a sibling deliverable when a blueprint needs it.
+ */
+export type IllustrationVariant = 'persona-cluster';
+
+/**
+ * Visual accent for tile fills. Resolves to a canonical surface token
+ * via the cascade — never a raw hex. Multi-platform: `brand-primary`
+ * binds to whichever audience subtree the consumer set via
+ * `data-audience`.
+ */
+export type IllustrationAccent =
+  | 'brand-primary'
+  | 'positive'
+  | 'neutral'
+  | 'inverse';
+
+export type IllustrationRatio = 'square' | 'portrait' | 'landscape';
+
+export type IllustrationTile =
+  | { kind: 'avatar'; src: string; alt: string; name?: string }
+  | { kind: 'photo'; src: string; alt: string }
+  | { kind: 'chat-bubble'; content: string; accent?: IllustrationAccent }
+  | { kind: 'message'; content?: string; accent?: IllustrationAccent }
+  | { kind: 'shape'; accent?: IllustrationAccent };
+
+export interface MarketingIllustrationProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  /** Layout variant. Default `persona-cluster`. */
+  variant?: IllustrationVariant;
+  /**
+   * Tiles composed in the scene. Up to 5 tiles get distinct slot
+   * positions per the variant; additional tiles fall back to the last
+   * slot. Order determines slot placement (slot 0 first, slot 1 next).
+   */
+  tiles: IllustrationTile[];
+  /** Aspect ratio of the illustration container. Default `square`. */
+  ratio?: IllustrationRatio;
+}
+
+/**
+ * MarketingIllustration — composable illustration scene primitive.
+ *
+ * Composes Avatars, photo circles, chat bubbles, message tiles, and
+ * accent shapes into a marketing-callout illustration. Replaces the
+ * pattern of every consumer site reinventing absolute-positioned scene
+ * compositions in repo-local CSS (the gap surfaced in the
+ * `support_plan_callout_split` blueprint spec — BDS #480).
+ *
+ * @example
+ * ```tsx
+ * <MarketingIllustration
+ *   variant="persona-cluster"
+ *   tiles={[
+ *     { kind: 'avatar', src: '/people/persona-1.jpg', alt: 'Strategist Sam' },
+ *     { kind: 'chat-bubble', content: 'How can I help today?', accent: 'brand-primary' },
+ *     { kind: 'message', accent: 'positive' },
+ *     { kind: 'photo', src: '/people/persona-2.jpg', alt: 'Operations Olivia' },
+ *     { kind: 'chat-bubble', content: 'We need an email campaign', accent: 'neutral' },
+ *   ]}
+ * />
+ * ```
+ *
+ * Multi-platform note: the data-driven `tiles` array is portable
+ * (framework-agnostic JSON shape). SwiftUI/Compose ports would re-render
+ * each tile kind natively but consume the same content contract.
+ *
+ * @summary Composable marketing-illustration scene primitive.
+ */
+export function MarketingIllustration({
+  variant = 'persona-cluster',
+  tiles,
+  ratio = 'square',
+  className,
+  ...props
+}: MarketingIllustrationProps) {
+  return (
+    <div
+      className={bdsClass(
+        'bds-marketing-illustration',
+        `bds-marketing-illustration--${variant}`,
+        `bds-marketing-illustration--ratio-${ratio}`,
+        className,
+      )}
+      role="img"
+      aria-label={
+        tiles
+          .map((t) => ('alt' in t ? t.alt : 'content' in t ? t.content : ''))
+          .filter(Boolean)
+          .join(', ') || undefined
+      }
+      {...props}
+    >
+      {tiles.map((tile, i) => (
+        <Tile key={i} tile={tile} slotIndex={Math.min(i, 4)} />
+      ))}
+    </div>
+  );
+}
+
+/* ─── Tile sub-renderer ──────────────────────────────────────── */
+
+function Tile({ tile, slotIndex }: { tile: IllustrationTile; slotIndex: number }) {
+  const slotClass = `bds-marketing-illustration__slot-${slotIndex}`;
+  const accentClass = 'accent' in tile && tile.accent
+    ? `bds-marketing-illustration__tile--accent-${tile.accent}`
+    : undefined;
+
+  let inner: ReactNode;
+  switch (tile.kind) {
+    case 'avatar':
+      inner = <Avatar src={tile.src} alt={tile.alt} name={tile.name} size="lg" />;
+      break;
+    case 'photo':
+      inner = (
+        <img
+          src={tile.src}
+          alt={tile.alt}
+          className="bds-marketing-illustration__photo"
+        />
+      );
+      break;
+    case 'chat-bubble':
+      inner = (
+        <div className="bds-marketing-illustration__chat-bubble">
+          {tile.content}
+        </div>
+      );
+      break;
+    case 'message':
+      inner = (
+        <div className="bds-marketing-illustration__message">
+          {tile.content && <span>{tile.content}</span>}
+        </div>
+      );
+      break;
+    case 'shape':
+      inner = <div className="bds-marketing-illustration__shape" aria-hidden />;
+      break;
+  }
+
+  return (
+    <div
+      className={bdsClass(
+        'bds-marketing-illustration__tile',
+        `bds-marketing-illustration__tile--${tile.kind}`,
+        slotClass,
+        accentClass,
+      )}
+    >
+      {inner}
+    </div>
+  );
+}
+
+export default MarketingIllustration;

--- a/components/ui/MarketingIllustration/index.ts
+++ b/components/ui/MarketingIllustration/index.ts
@@ -1,0 +1,9 @@
+export {
+  MarketingIllustration,
+  type MarketingIllustrationProps,
+  type IllustrationVariant,
+  type IllustrationAccent,
+  type IllustrationRatio,
+  type IllustrationTile,
+} from './MarketingIllustration';
+export { default } from './MarketingIllustration';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -47,6 +47,7 @@ export * from './Footer';
 export * from './Form';
 export * from './Icons';
 export * from './InteractiveListItem';
+export * from './MarketingIllustration';
 export * from './Menu';
 export * from './Meter';
 export * from './Modal';


### PR DESCRIPTION
## Summary

Composable illustration scene primitive. Composes Avatars + photos + chat bubbles + message tiles + accent shapes into a marketing-callout illustration. Closes [#480](https://github.com/brikdesigns/brik-bds/issues/480) — the gap surfaced in the `support_plan_callout_split` blueprint spec ([PR #477](https://github.com/brikdesigns/brik-bds/pull/477)).

Without this, every consumer site (brikdesigns, birdwell-mutlak, vale-partners, ...) would reinvent absolute-positioned scene compositions in repo-local CSS — the silo pattern the system-lens architecture exists to prevent.

## API

```tsx
<MarketingIllustration
  variant="persona-cluster"
  ratio="square"
  tiles={[
    { kind: 'avatar', src, alt: 'Strategist Sam', name: 'Sam' },
    { kind: 'chat-bubble', content: 'How can I help today?', accent: 'inverse' },
    { kind: 'message', accent: 'positive' },
    { kind: 'photo', src, alt: 'Operations Olivia' },
    { kind: 'chat-bubble', content: 'We need an email campaign', accent: 'brand-primary' },
  ]}
/>
```

| Prop | Default | Notes |
|---|---|---|
| `variant` | `persona-cluster` | Only variant for v1; `product-cluster` / `data-cluster` follow when other blueprints need them |
| `tiles` | required | Data-driven; first 5 fill canonical slots, additional tiles stack at slot 4 |
| `ratio` | `square` | `square` / `portrait` / `landscape` |

Tile kinds: `avatar`, `photo`, `chat-bubble`, `message`, `shape`. Accents: `brand-primary`, `positive`, `neutral`, `inverse`.

## Composition discipline

- **Reuses BDS `Avatar`** for avatar tiles — no parallel taxonomy
- **All accent fills via canonical tokens** (`--background-brand-primary`, `--surface-positive`, `--surface-secondary`, `--background-inverse`) — never raw hex per the canon registry rule
- **Container queries** (`cqi` units) — tile sizes scale with the illustration's container width without media queries
- **Reduced-motion compliant** — `@media (prefers-reduced-motion: reduce)` drops the casual tile rotation per a11y discipline
- **Tagged `surface-web`** — marketing-specific, not a product-app primitive

## Multi-platform

Tiles array is JSON-portable — same content contract works for SwiftUI/Compose ports when iOS/Android land. The per-platform implementation differs (SwiftUI ZStack with offset/rotation modifiers; Compose Box with absolute positioning), but the input data shape is stable.

## Storybook coverage

| Story | What it shows |
|---|---|
| **Playground** | Default 5-tile persona-cluster, square aspect |
| **SupportPlanCallout** | Exact fixture for the blueprint that needs this primitive — drop-in for [#477](https://github.com/brikdesigns/brik-bds/pull/477) Phase B |
| **AccentFills** | All 4 accent options × all tile kinds in a 2×2 grid |
| **RatioVariants** | square / portrait / landscape side-by-side |
| **Minimal** | 2-tile minimum (avatar + bubble) |

## Validation

```
Token Lint        PASS
JSDoc Lint        PASS
Grid Audit        PASS
Theme Compliance  PASS
Blueprint Library PASS
Canonical Tokens  PASS
TypeScript        PASS
Storybook Build   PASS
─────────────────────
All 8 checks passed
```

## Sequencing

This is the third foundational BDS PR from the marketing-rebuild gap audit:

1. ✅ Layout primitives ([#482](https://github.com/brikdesigns/brik-bds/pull/482))
2. ✅ Spacing modes ([#483](https://github.com/brikdesigns/brik-bds/pull/483) — merged)
3. ✅ **MarketingIllustration (this PR)**

With these merged, blueprint impl ([#477](https://github.com/brikdesigns/brik-bds/pull/477) Phase B) can land cleanly.

## Test plan

- [ ] Open Storybook → `Components/Marketing/marketing-illustration` → all 5 stories render
- [ ] Verify SupportPlanCallout story matches the visual intent of the Webflow "Monthly support services" image
- [ ] Confirm reduced-motion preference removes tile rotation (DevTools → rendering tab → Emulate prefers-reduced-motion)
- [ ] Test container-query scaling — resize the Storybook frame and confirm tiles scale proportionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)