### PR TITLE
feat(blueprints): ship services_3col_card_grid renderers (Astro + React)

### DIFF
--- a/blueprints/blueprint-library.json
+++ b/blueprints/blueprint-library.json
@@ -560,6 +560,31 @@
       "required_facts": []
     },
     {
+      "key": "services_3col_card_grid",
+      "name": "3-Column Service Card Grid",
+      "section_type": "services",
+      "industries": [
+        "universal",
+        "saas",
+        "ecommerce",
+        "corporate"
+      ],
+      "moods": [
+        "approachable",
+        "professional",
+        "modern",
+        "warm"
+      ],
+      "layout_spec": "Light background section. Centered section header (eyebrow optional + heading + optional one-line subhead). 3-column grid of service cards below. Each card: top image area (3:2 aspect) showing service-specific 3D illustration or photo on a light backdrop; below, a small ServiceTag (icon variant, accent color) + service name (heading/sm, 700 weight) + 1-2 sentence description (body/sm, on light) + 'Learn more' ghost-variant link-button. Optional 'Has Options' positive-status badge anchored top-right of card when the service exposes multiple offerings. Cards have rounded corners (border-radius-md), no border at rest, optional subtle hover lift. Grid gap is generous (24-28px). Collapses to 2-col at <992px, 1-col at <768px.",
+      "css_hints": ".services-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--gap-lg); } .service-card { background: var(--surface-primary); border-radius: var(--border-radius-md); overflow: hidden; position: relative; } .service-card__media { aspect-ratio: 3/2; background: var(--surface-secondary); } .service-card__body { padding: var(--padding-lg); display: flex; flex-direction: column; gap: var(--gap-md); } .service-card__has-options { position: absolute; top: var(--gap-md); right: var(--gap-md); }",
+      "source": "brikdesigns.com /services/{slug} index pages — service-line card grid pattern (PR #477 spec)",
+      "tier": "internal",
+      "is_active": true,
+      "version": "1.0.0",
+      "last_reviewed": "2026-05-09",
+      "required_facts": []
+    },
+    {
       "key": "contact_form_split",
       "name": "Contact — Form + Info Split",
       "section_type": "cta",

--- a/content-system/blueprints/astro/BlueprintDispatcher.astro
+++ b/content-system/blueprints/astro/BlueprintDispatcher.astro
@@ -58,6 +58,7 @@ import HeroSplit6040 from './HeroSplit6040.astro';
 import HeroInteriorMinimal from './HeroInteriorMinimal.astro';
 import StatsDarkBar from './StatsDarkBar.astro';
 import ServicesDetailTwoColumn from './ServicesDetailTwoColumn.astro';
+import Services3ColCardGrid from './Services3ColCardGrid.astro';
 import AboutStorySplit from './AboutStorySplit.astro';
 import TestimonialsFeaturedLarge from './TestimonialsFeaturedLarge.astro';
 import CtaSplitContact from './CtaSplitContact.astro';
@@ -72,6 +73,7 @@ const BLUEPRINT_REGISTRY = {
   hero_interior_minimal: HeroInteriorMinimal,
   stats_dark_bar: StatsDarkBar,
   services_detail_two_column: ServicesDetailTwoColumn,
+  services_3col_card_grid: Services3ColCardGrid,
   about_story_split: AboutStorySplit,
   testimonials_featured_large: TestimonialsFeaturedLarge,
   cta_split_contact: CtaSplitContact,

--- a/content-system/blueprints/astro/Services3ColCardGrid.astro
+++ b/content-system/blueprints/astro/Services3ColCardGrid.astro
@@ -1,0 +1,386 @@
+---
+/**
+ * services_3col_card_grid — 3-column service card grid with top
+ * illustration, service-line badge, name, description, "Has Options"
+ * indicator, and "Learn more" link. Drives the brikdesigns.com
+ * service-line index pages (e.g. /services/information).
+ *
+ * Spec: blueprints/proposals/services_3col_card_grid.md (PR #477).
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading            — section heading (h2)
+ *   - section.subheading         — optional eyebrow text (uppercase)
+ *   - section.body               — optional one-line lead under heading
+ *   - section.items[]            — REQUIRED, each card
+ *       - title                  — service name (h3)
+ *       - description            — body copy
+ *       - href?                  — Learn more target (omitted → no CTA)
+ *       - imageUrl?              — top-image src (omitted → category label fallback)
+ *       - category?              — ServiceCategory slug (drives accent color)
+ *       - hasOptions?            — true → top-right "Has Options" pill
+ *
+ * required_facts: []. Section-driven.
+ *
+ * ## Renderer parity note
+ *
+ * This Astro renderer is the simplified content-equivalent of the
+ * canonical React renderer (Services3ColCardGrid.tsx). The React
+ * version composes BDS primitives directly — ServiceTag (with
+ * per-service icon resolution), Card, LinkButton, Badge, Frame, Stack,
+ * Grid. Astro consumers don't pull React, so this version replaces the
+ * ServiceTag glyph with a category-colored label and the BDS
+ * components with hand-rolled HTML+CSS that consumes the same tokens.
+ * Visual rhythm and a11y semantics are preserved; the React renderer
+ * is canonical for pixel parity to brikdesigns.com Webflow.
+ *
+ * CSS custom properties — variation API per BDS convention:
+ *   --bp-services-grid-bg            (default: var(--page-primary))
+ *   --bp-services-grid-card-bg       (default: var(--surface-primary))
+ *   --bp-services-grid-card-radius   (default: var(--border-radius-md))
+ *   --bp-services-grid-gap           (default: var(--gap-lg))
+ *   --bp-services-grid-image-bg      (default: var(--surface-secondary))
+ *   --bp-services-grid-hover-lift    (default: 0 — opt in to translateY(-4px))
+ *
+ * Atmosphere CSS files MUST NOT override `--surface-*`/`--text-*`/
+ * `--border-*` per the cascade rules — those stay theme-layer.
+ *
+ * a11y: section uses h2 + aria-labelledby; cards are <ul role="list">
+ * of <li>; each card title is an <h3> nested under the section h2.
+ * Description copy uses --text-primary (NOT --text-secondary) to clear
+ * AA at 14–16px on light surfaces (BDS contrast burndown #40).
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+const headingId = `bp-services-grid-${section.sectionKey}-h`;
+
+const categoryLabels: Record<NonNullable<typeof section.items[number]['category']>, string> = {
+  brand: 'Brand',
+  marketing: 'Marketing',
+  information: 'Information',
+  product: 'Product',
+  service: 'Back Office',
+};
+---
+
+<section
+  class="bp-services-grid"
+  aria-labelledby={headingId}
+  data-blueprint-key="services_3col_card_grid"
+>
+  <div class="bp-services-grid__container">
+    <header class="bp-services-grid__header">
+      {section.subheading && (
+        <p class="bp-services-grid__eyebrow">{section.subheading}</p>
+      )}
+      <h2 id={headingId} class="bp-services-grid__heading">{section.heading}</h2>
+      {section.body && (
+        <p class="bp-services-grid__lead">{section.body}</p>
+      )}
+    </header>
+
+    <ul class="bp-services-grid__list" role="list">
+      {section.items.map((item) => {
+        const category = item.category ?? null;
+        const categoryLabel = category ? categoryLabels[category] : null;
+        return (
+          <li class="bp-services-grid__item">
+            <article
+              class="bp-services-grid__card"
+              data-category={category ?? undefined}
+            >
+              <div class="bp-services-grid__media">
+                {item.imageUrl ? (
+                  <img
+                    src={item.imageUrl}
+                    alt=""
+                    class="bp-services-grid__image"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                ) : (
+                  categoryLabel && (
+                    <span class="bp-services-grid__media-fallback" aria-hidden="true">
+                      {categoryLabel}
+                    </span>
+                  )
+                )}
+                {item.hasOptions && (
+                  <span class="bp-services-grid__has-options">Has Options</span>
+                )}
+              </div>
+
+              <div class="bp-services-grid__body">
+                {categoryLabel && (
+                  <p class="bp-services-grid__category-row">
+                    <span class="bp-services-grid__category-pill">
+                      {categoryLabel}
+                    </span>
+                  </p>
+                )}
+                <h3 class="bp-services-grid__title">{item.title}</h3>
+                {item.description && (
+                  <p class="bp-services-grid__description">{item.description}</p>
+                )}
+                {item.href && (
+                  <p class="bp-services-grid__cta-row">
+                    <a class="bp-services-grid__cta" href={item.href}>
+                      Learn more
+                      <span aria-hidden="true" class="bp-services-grid__cta-arrow">→</span>
+                    </a>
+                  </p>
+                )}
+              </div>
+            </article>
+          </li>
+        );
+      })}
+    </ul>
+  </div>
+</section>
+
+<style>
+  .bp-services-grid {
+    background: var(--bp-services-grid-bg, var(--page-primary));
+    padding-block: clamp(var(--padding-xl), 7vw, var(--padding-huge));
+    padding-block-end: clamp(var(--padding-huge), 9vw, calc(var(--padding-huge) * 1.5));
+  }
+
+  .bp-services-grid__container {
+    max-width: 1280px;
+    margin-inline: auto;
+    padding-inline: var(--padding-lg);
+  }
+
+  /* ── Section header ─────────────────────────────────────────── */
+
+  .bp-services-grid__header {
+    max-width: 72ch;
+    margin-bottom: var(--padding-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+  }
+
+  .bp-services-grid__eyebrow {
+    margin: 0;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-brand-primary);
+  }
+
+  .bp-services-grid__heading {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--font-line-height-tight);
+    color: var(--text-primary);
+  }
+
+  .bp-services-grid__lead {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--font-line-height-relaxed);
+    color: var(--text-primary);
+  }
+
+  /* ── Card grid ──────────────────────────────────────────────── */
+
+  .bp-services-grid__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--bp-services-grid-gap, var(--gap-lg));
+  }
+
+  @media (min-width: 768px) {
+    .bp-services-grid__list {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 992px) {
+    .bp-services-grid__list {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .bp-services-grid__item {
+    display: flex;
+  }
+
+  /* ── Card ───────────────────────────────────────────────────── */
+
+  .bp-services-grid__card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    background: var(--bp-services-grid-card-bg, var(--surface-primary));
+    border-radius: var(--bp-services-grid-card-radius, var(--border-radius-md));
+    overflow: hidden;
+    transform: translateY(0);
+    transition:
+      transform 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1)),
+      box-shadow 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));
+  }
+
+  .bp-services-grid__card:hover {
+    transform: translateY(calc(var(--bp-services-grid-hover-lift, 0) * -4px));
+  }
+
+  /* ── Media (top image area, 3:2) ────────────────────────────── */
+
+  .bp-services-grid__media {
+    position: relative;
+    aspect-ratio: 3 / 2;
+    background: var(--bp-services-grid-image-bg, var(--surface-secondary));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+  }
+
+  .bp-services-grid__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .bp-services-grid__media-fallback {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-500);
+    font-weight: var(--font-weight-semibold);
+    color: var(--text-primary);
+    opacity: 0.55;
+    letter-spacing: 0.02em;
+  }
+
+  /* ── Has-Options badge (top-right of media) ─────────────────── */
+
+  .bp-services-grid__has-options {
+    position: absolute;
+    top: var(--gap-md);
+    right: var(--gap-md);
+    padding: 4px 10px;
+    background: var(--background-positive);
+    color: var(--text-on-color-dark);
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.02em;
+    border-radius: 999px;
+    line-height: 1.2;
+  }
+
+  /* ── Card body ──────────────────────────────────────────────── */
+
+  .bp-services-grid__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    padding: var(--padding-lg);
+  }
+
+  .bp-services-grid__category-row {
+    margin: 0;
+    display: flex;
+  }
+
+  .bp-services-grid__category-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    background: var(--surface-secondary);
+    color: var(--text-primary);
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-semibold);
+    border-radius: 999px;
+    line-height: 1.2;
+    letter-spacing: 0.02em;
+  }
+
+  /* Service-category accent — mirrors the React ServiceTag color axis. */
+  .bp-services-grid__card[data-category='brand'] .bp-services-grid__category-pill {
+    background: var(--theme-yellow-yellow-light, #fff4cc);
+    color: var(--theme-yellow-yellow-dark, #5b4500);
+  }
+  .bp-services-grid__card[data-category='marketing'] .bp-services-grid__category-pill {
+    background: var(--theme-green-green-light, #d6f1da);
+    color: var(--theme-green-green-dark, #1f5b2e);
+  }
+  .bp-services-grid__card[data-category='information'] .bp-services-grid__category-pill {
+    background: var(--theme-blue-blue-light, #d6e4f5);
+    color: var(--theme-blue-blue-dark, #1f3d70);
+  }
+  .bp-services-grid__card[data-category='product'] .bp-services-grid__category-pill {
+    background: var(--theme-purple-purple-light, #ead6f5);
+    color: var(--theme-purple-purple-dark, #4a1f70);
+  }
+  .bp-services-grid__card[data-category='service'] .bp-services-grid__category-pill {
+    background: var(--theme-orange-orange-light, #ffe1cc);
+    color: var(--theme-orange-orange-dark, #663300);
+  }
+
+  .bp-services-grid__title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-500);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--font-line-height-tight);
+    color: var(--text-primary);
+  }
+
+  .bp-services-grid__description {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-300);
+    line-height: var(--font-line-height-relaxed);
+    color: var(--text-primary);
+  }
+
+  .bp-services-grid__cta-row {
+    margin: 0;
+    margin-top: auto;
+  }
+
+  .bp-services-grid__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-md);
+    color: var(--text-brand-primary);
+    text-decoration: none;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-300);
+    font-weight: var(--font-weight-semibold);
+    line-height: 1.4;
+    transition: gap 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));
+  }
+
+  .bp-services-grid__cta:hover,
+  .bp-services-grid__cta:focus-visible {
+    gap: calc(var(--gap-md) + 4px);
+  }
+
+  .bp-services-grid__cta:focus-visible {
+    outline: 2px solid var(--border-focus, var(--text-brand-primary));
+    outline-offset: 4px;
+    border-radius: 2px;
+  }
+
+  .bp-services-grid__cta-arrow {
+    display: inline-block;
+    transition: transform 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));
+  }
+</style>

--- a/content-system/blueprints/astro/index.ts
+++ b/content-system/blueprints/astro/index.ts
@@ -50,6 +50,7 @@ export { default as HeroSplit6040 }             from './HeroSplit6040.astro';
 export { default as HeroInteriorMinimal }       from './HeroInteriorMinimal.astro';
 export { default as StatsDarkBar }              from './StatsDarkBar.astro';
 export { default as ServicesDetailTwoColumn }   from './ServicesDetailTwoColumn.astro';
+export { default as Services3ColCardGrid }      from './Services3ColCardGrid.astro';
 export { default as AboutStorySplit }           from './AboutStorySplit.astro';
 export { default as TestimonialsFeaturedLarge } from './TestimonialsFeaturedLarge.astro';
 export { default as CtaSplitContact }           from './CtaSplitContact.astro';

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -25,6 +25,7 @@ export type KnownBlueprintKey =
   | 'hero_interior_minimal'
   | 'services_numbered_rows'
   | 'services_detail_two_column'
+  | 'services_3col_card_grid'
   | 'features_3col_icon_grid'
   | 'features_alternating_split'
   | 'features_bento_asymmetric'
@@ -63,6 +64,19 @@ export interface BlueprintSection {
   readonly items: readonly {
     readonly title: string;
     readonly description: string;
+    /**
+     * Optional per-item fields used by richer blueprints (e.g.
+     * `services_3col_card_grid`). Additive — existing blueprints that
+     * only consume `title` + `description` are unaffected. New
+     * blueprints requiring additional structured per-item data should
+     * add their fields here as `readonly ...?` rather than introducing
+     * a separate items shape.
+     */
+    readonly href?: string;
+    readonly imageUrl?: string;
+    /** ServiceCategory slug — see `ServiceTag` props in `@brikdesigns/bds`. */
+    readonly category?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
+    readonly hasOptions?: boolean;
   }[];
   readonly cta: {
     readonly label: string;

--- a/content-system/blueprints/react/BlueprintDispatcher.tsx
+++ b/content-system/blueprints/react/BlueprintDispatcher.tsx
@@ -1,0 +1,100 @@
+/**
+ * BlueprintDispatcher (React) — reads `section.visualNotes.blueprintKey`
+ * for each section in the array and renders the corresponding React
+ * component. Unknown keys render `<BlueprintFallback>`.
+ *
+ * This is the React twin of `../astro/BlueprintDispatcher.astro`. The
+ * Astro dispatcher is the canonical entry-point for Astro consumers
+ * (`@brikdesigns/bds/blueprints-astro`). This React dispatcher is the
+ * entry-point for Next.js / React consumers — primarily
+ * brikdesigns.com. The two share `BlueprintProps`, `BlueprintSection`,
+ * `ClientFacts`, and `ResolvedTheme` from `../astro/types` (types are
+ * framework-agnostic; the file lives in `astro/` for historical
+ * reasons since Astro shipped first).
+ *
+ * Adding a new blueprint = one import + one registry entry here +
+ * one barrel export in `./index.ts`. Keep the React registry in
+ * lockstep with the Astro registry — both must list the same keys.
+ *
+ * ## Contract
+ *
+ *   Props:
+ *     - sections      — ordered array of BlueprintSection
+ *     - clientFacts   — passed through to every blueprint
+ *     - theme         — passed through to every blueprint
+ *
+ *   Behavior:
+ *     - section.visualNotes.blueprintKey ∈ BLUEPRINT_REGISTRY →
+ *         renders the matching component with full BlueprintProps
+ *     - section.visualNotes.blueprintKey ∉ BLUEPRINT_REGISTRY →
+ *         renders BlueprintFallback (which emits a
+ *         data-blueprint-unknown-key attribute for CI grep)
+ *     - section.visualNotes is null → falls back
+ *
+ * ## v0.1 React registry (1 blueprint)
+ *
+ * The React renderer surface starts with `services_3col_card_grid`,
+ * the blueprint that drives brikdesigns.com service-line index pages.
+ * Subsequent React renderers (HeroSplit6040, HeroInteriorMinimal,
+ * etc. — Workstream A in the gap audit) ship in their own PRs and
+ * each appends one entry here.
+ */
+import type { ComponentType } from 'react';
+
+import type {
+  BlueprintProps,
+  BlueprintSection,
+  ClientFacts,
+  KnownBlueprintKey,
+  ResolvedTheme,
+} from '../astro/types';
+
+import { Services3ColCardGrid } from './Services3ColCardGrid';
+import { BlueprintFallback } from './BlueprintFallback';
+
+const BLUEPRINT_REGISTRY: Partial<
+  Record<KnownBlueprintKey, ComponentType<BlueprintProps>>
+> = {
+  services_3col_card_grid: Services3ColCardGrid,
+};
+
+interface Props {
+  sections: readonly BlueprintSection[];
+  clientFacts: ClientFacts;
+  theme: ResolvedTheme;
+}
+
+/**
+ * BlueprintDispatcher — single React entry-point for rendering a
+ * page body composed of BlueprintSection[].
+ *
+ * @example
+ * ```tsx
+ * <BlueprintDispatcher
+ *   sections={page.sections}
+ *   clientFacts={facts}
+ *   theme={theme}
+ * />
+ * ```
+ */
+export function BlueprintDispatcher({ sections, clientFacts, theme }: Props) {
+  return (
+    <>
+      {sections.map((section) => {
+        const key = section.visualNotes?.blueprintKey;
+        const Component =
+          (key && BLUEPRINT_REGISTRY[key]) || BlueprintFallback;
+        return (
+          <Component
+            key={section.sectionKey}
+            section={section}
+            clientFacts={clientFacts}
+            theme={theme}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+export default BlueprintDispatcher;

--- a/content-system/blueprints/react/BlueprintFallback.css
+++ b/content-system/blueprints/react/BlueprintFallback.css
@@ -1,0 +1,52 @@
+/*
+ * BlueprintFallback (React) — visible stub for an unknown blueprint
+ * key. Mirrors `../astro/BlueprintFallback.astro` styling 1:1.
+ */
+
+.bp-fallback {
+  padding: var(--padding-xl) var(--padding-lg);
+  background: var(--surface-secondary);
+  border: 2px dashed var(--border-secondary);
+  margin-block: var(--gap-md);
+}
+
+.bp-fallback__container {
+  max-width: 960px;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}
+
+.bp-fallback__label {
+  margin: 0;
+  font-family: var(--font-family-label);
+  font-size: var(--font-size-200);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+
+.bp-fallback__key,
+.bp-fallback__meta,
+.bp-fallback__hint {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-300);
+  line-height: var(--font-line-height-relaxed);
+  color: var(--text-secondary);
+}
+
+.bp-fallback__hint {
+  font-size: var(--font-size-200);
+  max-width: 72ch;
+}
+
+.bp-fallback code {
+  font-family: var(--font-family-mono, ui-monospace, monospace);
+  font-size: 0.9em;
+  padding: 0 4px;
+  background: var(--surface-primary);
+  border-radius: 2px;
+}

--- a/content-system/blueprints/react/BlueprintFallback.tsx
+++ b/content-system/blueprints/react/BlueprintFallback.tsx
@@ -1,0 +1,53 @@
+/**
+ * BlueprintFallback (React) — renders when BlueprintDispatcher
+ * encounters a `visualNotes.blueprintKey` that is not in
+ * BLUEPRINT_REGISTRY. Mirrors `../astro/BlueprintFallback.astro`:
+ * a loud visible stub with a CI-greppable
+ * `data-blueprint-unknown-key` attribute.
+ *
+ * Zero-sized or silent fallbacks defeat the whole point of the
+ * scaffold-task preflight — see the Astro twin for the full
+ * rationale.
+ *
+ * Contract: BlueprintProps (same shape as every renderer). Reads
+ * `section.visualNotes.blueprintKey` to report what was unmatched.
+ */
+import type { BlueprintProps } from '../astro/types';
+import './BlueprintFallback.css';
+
+interface Props extends BlueprintProps {}
+
+export function BlueprintFallback({ section }: Props) {
+  const unknownKey = section.visualNotes?.blueprintKey ?? null;
+  const attrValue = unknownKey ?? '__null__';
+
+  return (
+    <section
+      className="bp-fallback"
+      data-blueprint-key="__fallback__"
+      data-blueprint-unknown-key={attrValue}
+      aria-label="Blueprint not yet shipped"
+    >
+      <div className="bp-fallback__container">
+        <p className="bp-fallback__label">Blueprint not yet shipped</p>
+        <p className="bp-fallback__key">
+          Key:{' '}
+          <code>{unknownKey ?? '(none — section has no blueprintKey)'}</code>
+        </p>
+        <p className="bp-fallback__meta">
+          Section: <code>{section.sectionKey}</code> · Type:{' '}
+          <code>{section.sectionType}</code>
+        </p>
+        <p className="bp-fallback__hint">
+          CI will block publish on any client repo whose built{' '}
+          <code>dist/</code> contains{' '}
+          <code>data-blueprint-unknown-key=</code>. Add a renderer for
+          this key in <code>@brikdesigns/bds</code> and bump the
+          package version, or remove the key from the content.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default BlueprintFallback;

--- a/content-system/blueprints/react/Services3ColCardGrid.css
+++ b/content-system/blueprints/react/Services3ColCardGrid.css
@@ -1,0 +1,180 @@
+/*
+ * Services3ColCardGrid — React renderer styles.
+ *
+ * The renderer composes BDS primitives (Card, Stack, Grid, Frame,
+ * ServiceTag, LinkButton, Badge) — these styles only handle:
+ *   - section-level container + padding + heading rhythm
+ *   - card overflow clipping for the top image (Card has no built-in
+ *     clipping, so we add it here)
+ *   - the `--bp-*` variation API
+ *
+ * No `--surface-*` / `--text-*` / `--border-*` overrides — those stay
+ * theme-layer per the cascade rules. Token naming follows the
+ * canonical registry; semantic spacing uses `--gap-*` / `--padding-*`
+ * (mode-spacing-aware once BDS issue #340 ships the dormant modes).
+ */
+
+.bp-services-grid {
+  background: var(--bp-services-grid-bg, var(--page-primary));
+  padding-block: clamp(var(--padding-xl), 7vw, var(--padding-huge));
+  padding-block-end: clamp(
+    var(--padding-huge),
+    9vw,
+    calc(var(--padding-huge) * 1.5)
+  );
+}
+
+.bp-services-grid__container {
+  max-width: 1280px;
+  margin-inline: auto;
+  padding-inline: var(--padding-lg);
+}
+
+/* ── Section header ────────────────────────────────────────────── */
+
+.bp-services-grid__header {
+  max-width: 72ch;
+  margin-bottom: var(--padding-xl);
+}
+
+.bp-services-grid__eyebrow {
+  margin: 0;
+  font-family: var(--font-family-label);
+  font-size: var(--font-size-200);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-brand-primary);
+}
+
+.bp-services-grid__heading {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+}
+
+.bp-services-grid__lead {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-400);
+  line-height: var(--font-line-height-relaxed);
+  color: var(--text-primary);
+}
+
+/* ── Card grid ─────────────────────────────────────────────────── */
+
+.bp-services-grid__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Override BDS Grid's default 3-column fixed shape for narrow viewports.
+ * The component renders as `display: grid` with 3 columns; we only need
+ * to add the responsive collapse since BDS Grid itself does not. */
+@media (max-width: 991.98px) {
+  .bp-services-grid__list.bp-services-grid__list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 767.98px) {
+  .bp-services-grid__list.bp-services-grid__list {
+    grid-template-columns: 1fr;
+  }
+}
+
+.bp-services-grid__item {
+  display: flex;
+}
+
+/* ── Card overflow clip + variation API ─────────────────────────── */
+
+.bp-services-grid__card {
+  /* Card defaults to `border-radius: var(--border-radius-md)`. The
+   * variation API lets consumers swap that per-instance. */
+  border-radius: var(--bp-services-grid-card-radius, var(--border-radius-md));
+  background: var(--bp-services-grid-card-bg, var(--surface-primary));
+  overflow: hidden;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(0);
+  transition:
+    transform 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1)),
+    box-shadow 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));
+}
+
+.bp-services-grid__card:hover {
+  transform: translateY(calc(var(--bp-services-grid-hover-lift, 0) * -4px));
+}
+
+/* ── Media wrapper (positioning context for has-options badge) ──── */
+
+.bp-services-grid__media-wrap {
+  position: relative;
+}
+
+.bp-services-grid__media {
+  background: var(--bp-services-grid-image-bg, var(--surface-secondary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bp-services-grid__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.bp-services-grid__media-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Scale the ServiceTag icon up visually inside the media area. */
+  transform: scale(2);
+  transform-origin: center;
+}
+
+/* ── Has-Options badge — anchored top-right of the media ───────── */
+
+.bp-services-grid__has-options {
+  position: absolute;
+  top: var(--gap-md);
+  right: var(--gap-md);
+  display: inline-flex;
+}
+
+/* ── Card body ─────────────────────────────────────────────────── */
+
+.bp-services-grid__body {
+  padding: var(--padding-lg);
+  flex: 1 1 auto;
+}
+
+.bp-services-grid__title {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-500);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+}
+
+.bp-services-grid__description {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-300);
+  line-height: var(--font-line-height-relaxed);
+  color: var(--text-primary);
+}
+
+.bp-services-grid__cta-row {
+  margin-top: auto;
+  /* Anchor the LinkButton to the bottom of the card body so all cards
+   * align horizontally regardless of description length. */
+}

--- a/content-system/blueprints/react/Services3ColCardGrid.stories.tsx
+++ b/content-system/blueprints/react/Services3ColCardGrid.stories.tsx
@@ -1,0 +1,235 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Services3ColCardGrid } from './Services3ColCardGrid';
+import type { BlueprintProps } from '../astro/types';
+
+/* ─── Fixtures ─────────────────────────────────────────────────── */
+
+const baseTheme: BlueprintProps['theme'] = {
+  themeMode: 'light',
+  atmosphere: 'none',
+  navigationArchetype: 'utility-first',
+  footerArchetype: 'four_col_directory',
+};
+
+const baseClientFacts: BlueprintProps['clientFacts'] = {
+  brandName: 'Brik Designs',
+  tagline: null,
+  valueProposition: null,
+  services: [],
+  phone: null,
+  email: null,
+  address: null,
+  hours: [],
+  heroImageUrl: null,
+  logoUrl: null,
+  logoVariants: {},
+};
+
+/**
+ * "Information Design Services" fixture — six service cards modeled
+ * on the brikdesigns.com /services/information page that drives this
+ * blueprint. Image URLs are placeholder; the production CMS supplies
+ * Webflow-hosted illustrations.
+ */
+const informationServicesSection: BlueprintProps['section'] = {
+  sectionKey: 'services-grid-default',
+  sectionType: 'services',
+  heading: 'Information Design Services',
+  subheading: 'Brik Designs',
+  body: 'Make complex information scannable, memorable, and beautifully on-brand.',
+  cta: null,
+  visualNotes: {
+    blueprintKey: 'services_3col_card_grid',
+    moodKeywords: ['approachable', 'modern'],
+    layoutBlueprint: 'services_3col_card_grid',
+    imageOpportunity: 'service-line illustration per card',
+    animationSuggestion: null,
+    illustrationOpportunity: '3D persona scene per service',
+  },
+  items: [
+    {
+      title: 'Information Design',
+      description:
+        'Turn dense data and dense reports into a clean visual story your audience will actually read.',
+      href: '/services/information/information-design',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Information+Design',
+      category: 'information',
+    },
+    {
+      title: 'Infographics',
+      description:
+        'One-screen explanations of how something works — for proposals, decks, and on-page content.',
+      href: '/services/information/infographics',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Infographics',
+      category: 'information',
+      hasOptions: true,
+    },
+    {
+      title: 'Patient Experience Mapping',
+      description:
+        'Visualize the patient journey end-to-end so every touchpoint can be improved with intent.',
+      href: '/services/information/patient-experience-mapping',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Patient+Journey',
+      category: 'information',
+    },
+    {
+      title: 'Customer Journey Mapping',
+      description:
+        'A diagram of how customers find, evaluate, and stay with you — sized for a stakeholder readout.',
+      href: '/services/information/customer-journey-mapping',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Customer+Journey',
+      category: 'information',
+    },
+    {
+      title: 'Process Documentation',
+      description:
+        'A repeatable visual SOP — the operations equivalent of a brand book — so handoffs survive growth.',
+      href: '/services/information/process-documentation',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Process+Docs',
+      category: 'information',
+      hasOptions: true,
+    },
+    {
+      title: 'Wayfinding & Signage',
+      description:
+        'On-brand signage systems that get patients, customers, and staff to the right place every time.',
+      href: '/services/information/wayfinding',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Wayfinding',
+      category: 'information',
+    },
+  ],
+};
+
+const baseProps: BlueprintProps = {
+  section: informationServicesSection,
+  clientFacts: baseClientFacts,
+  theme: baseTheme,
+};
+
+/* ─── Meta ─────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof Services3ColCardGrid> = {
+  title: 'Blueprints/services_3col_card_grid',
+  component: Services3ColCardGrid,
+  tags: ['surface-web', 'surface-shared'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Three-column service card grid blueprint. Drives the brikdesigns.com `/services/{slug}` index pages. Each card composes BDS primitives — Card frame, Frame for the 3:2 image, ServiceTag for the category badge, LinkButton for the "Learn more" CTA, and Badge for the optional "Has Options" pill. Description copy uses `--text-primary` to clear AA contrast at 14–16px (BDS contrast burndown #40).',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Services3ColCardGrid>;
+
+/* ─── Stories ──────────────────────────────────────────────────── */
+
+/**
+ * @summary Six "Information Design" service cards — the canonical fixture.
+ */
+export const Default: Story = {
+  args: baseProps,
+};
+
+/**
+ * @summary No images — falls back to oversized ServiceTag icon per card.
+ *
+ * Illustration assets are optional. When the CMS hasn't supplied an
+ * image, the blueprint shows the ServiceTag icon (sized up) inside
+ * the 3:2 frame so the grid keeps consistent rhythm.
+ */
+export const NoImages: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...informationServicesSection,
+      sectionKey: 'services-grid-no-images',
+      items: informationServicesSection.items.map((item) => ({
+        ...item,
+        imageUrl: undefined,
+      })),
+    },
+  },
+};
+
+/**
+ * @summary One card flagged with `hasOptions` — "Has Options" badge anchors top-right.
+ */
+export const HasOptions: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...informationServicesSection,
+      sectionKey: 'services-grid-has-options',
+      items: informationServicesSection.items.slice(0, 3).map((item, idx) => ({
+        ...item,
+        hasOptions: idx === 1,
+      })),
+    },
+  },
+};
+
+/**
+ * @summary Mixed service categories — verifies the per-category accent color axis.
+ *
+ * The brikdesigns.com /services/ index page mixes all five categories
+ * (brand, marketing, information, product, service). The card body's
+ * ServiceTag adapts its accent color via the BDS `category` prop.
+ */
+export const MixedCategories: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...informationServicesSection,
+      sectionKey: 'services-grid-mixed',
+      heading: 'All Services',
+      subheading: 'Brik Designs',
+      body: 'A category-spanning view — each card carries its service-line accent.',
+      items: [
+        {
+          title: 'Brand Identity Bundle',
+          description: 'Logo, type, color, and applications in one pass.',
+          href: '/services/brand/brand-identity-bundle',
+          imageUrl: 'https://placehold.co/480x320/fff4cc/5b4500?text=Brand',
+          category: 'brand',
+          hasOptions: true,
+        },
+        {
+          title: 'Web Design & Development',
+          description: 'Custom sites, content, and CMS — built for growth and easy edits.',
+          href: '/services/marketing/web-design-development',
+          imageUrl: 'https://placehold.co/480x320/d6f1da/1f5b2e?text=Marketing',
+          category: 'marketing',
+        },
+        {
+          title: 'Information Design',
+          description: 'Make complex information scannable and on-brand.',
+          href: '/services/information/information-design',
+          imageUrl: 'https://placehold.co/480x320/d6e4f5/1f3d70?text=Information',
+          category: 'information',
+        },
+      ],
+    },
+  },
+};
+
+/**
+ * @summary Atmosphere overlay — `clean-bright`. Verifies blueprint surface tokens stay theme-layer.
+ *
+ * Renders the same default fixture but with `theme.atmosphere =
+ * 'clean-bright'`. Use the Theme Switcher addon to swap atmospheres
+ * — the blueprint must NOT redefine `--surface-*` / `--text-*` /
+ * `--border-*` tokens; those stay theme-layer and atmosphere CSS
+ * already overrides them.
+ */
+export const AtmosphereCleanBright: Story = {
+  args: {
+    ...baseProps,
+    theme: { ...baseTheme, atmosphere: 'clean-bright' },
+  },
+};

--- a/content-system/blueprints/react/Services3ColCardGrid.tsx
+++ b/content-system/blueprints/react/Services3ColCardGrid.tsx
@@ -1,0 +1,198 @@
+/**
+ * Services3ColCardGrid — React renderer for the
+ * `services_3col_card_grid` blueprint. Composes BDS primitives
+ * (`Card`, `ServiceTag`, `LinkButton`, `Badge`, `Stack`, `Grid`,
+ * `Frame`) per the spec at
+ * `blueprints/proposals/services_3col_card_grid.md`.
+ *
+ * Drives brikdesigns.com service-line index pages (e.g.
+ * `/services/information`). Astro twin lives at
+ * `../astro/Services3ColCardGrid.astro` and ships a simplified visual
+ * for non-React consumers — see that file's header for parity notes.
+ *
+ * Contract: BlueprintProps. The same shape every blueprint renderer
+ * accepts. Per-card data comes from `section.items[]`; richer fields
+ * (`href`, `imageUrl`, `category`, `hasOptions`) are optional extensions
+ * to the items shape and degrade cleanly when absent.
+ *
+ * CSS custom properties — variation API:
+ *   --bp-services-grid-bg            (default: var(--page-primary))
+ *   --bp-services-grid-card-bg       (default: var(--surface-primary))
+ *   --bp-services-grid-card-radius   (default: var(--border-radius-md))
+ *   --bp-services-grid-gap           (default: var(--gap-lg))
+ *   --bp-services-grid-image-bg      (default: var(--surface-secondary))
+ *   --bp-services-grid-hover-lift    (default: 0 — set to 1 for lift)
+ *
+ * Atmosphere CSS files MUST NOT override `--surface-*`/`--text-*`/
+ * `--border-*` per the cascade rules — those stay theme-layer.
+ *
+ * a11y: section is a `<section>` with aria-labelledby pointing at the
+ * h2; cards are an unordered list with `role="list"` (CSS resets
+ * sometimes strip role from styled `<ul>`); each card title is an h3.
+ * Description copy uses `--text-primary` to clear AA at body sizes
+ * (BDS contrast burndown #40).
+ *
+ * @summary 3-column service card grid with top illustration, badge, name, description, "Learn more".
+ */
+import { type CSSProperties } from 'react';
+
+import {
+  Badge,
+  Card,
+  Frame,
+  Grid,
+  LinkButton,
+  ServiceTag,
+  Stack,
+  type ServiceCategory,
+} from '../../../components';
+
+import type { BlueprintProps } from '../astro/types';
+import './Services3ColCardGrid.css';
+
+interface Props extends BlueprintProps {}
+
+/**
+ * Services3ColCardGrid — 3-column service card grid blueprint renderer.
+ *
+ * Renders each `section.items[]` entry as a service card with optional
+ * top image (3:2), service-line badge, h3 title, body description,
+ * and ghost "Learn more" link. The "Has Options" pill anchors
+ * top-right of the media when `item.hasOptions` is true.
+ *
+ * @example
+ * ```tsx
+ * <Services3ColCardGrid section={section} clientFacts={facts} theme={theme} />
+ * ```
+ */
+export function Services3ColCardGrid({ section }: Props) {
+  const headingId = `bp-services-grid-${section.sectionKey}-h`;
+
+  return (
+    <section
+      className="bp-services-grid"
+      aria-labelledby={headingId}
+      data-blueprint-key="services_3col_card_grid"
+    >
+      <div className="bp-services-grid__container">
+        <Stack
+          as="header"
+          gap="md"
+          className="bp-services-grid__header"
+        >
+          {section.subheading && (
+            <p className="bp-services-grid__eyebrow">{section.subheading}</p>
+          )}
+          <h2 id={headingId} className="bp-services-grid__heading">
+            {section.heading}
+          </h2>
+          {section.body && (
+            <p className="bp-services-grid__lead">{section.body}</p>
+          )}
+        </Stack>
+
+        <Grid
+          as="ul"
+          columns={3}
+          gap="lg"
+          className="bp-services-grid__list"
+          role="list"
+        >
+          {section.items.map((item, idx) => {
+            const category = (item.category ?? null) as ServiceCategory | null;
+            return (
+              <li
+                key={`${section.sectionKey}-${idx}`}
+                className="bp-services-grid__item"
+              >
+                <Card
+                  variant="outlined"
+                  padding="none"
+                  className="bp-services-grid__card"
+                >
+                  <div className="bp-services-grid__media-wrap">
+                    <Frame
+                      customRatio="3 / 2"
+                      fit="cover"
+                      className="bp-services-grid__media"
+                    >
+                      {item.imageUrl ? (
+                        <img
+                          src={item.imageUrl}
+                          alt=""
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      ) : (
+                        category && (
+                          <span
+                            className="bp-services-grid__media-fallback"
+                            aria-hidden="true"
+                          >
+                            <ServiceTag
+                              category={category}
+                              variant="icon"
+                              size="lg"
+                              serviceName={item.title}
+                            />
+                          </span>
+                        )
+                      )}
+                    </Frame>
+                    {item.hasOptions && (
+                      <span className="bp-services-grid__has-options">
+                        <Badge status="positive" size="sm" appearance="solid">
+                          Has Options
+                        </Badge>
+                      </span>
+                    )}
+                  </div>
+
+                  <Stack
+                    gap="md"
+                    className="bp-services-grid__body"
+                  >
+                    {category && (
+                      <ServiceTag
+                        category={category}
+                        variant="icon-text"
+                        size="sm"
+                        serviceName={item.title}
+                      />
+                    )}
+                    <h3 className="bp-services-grid__title">{item.title}</h3>
+                    {item.description && (
+                      <p className="bp-services-grid__description">
+                        {item.description}
+                      </p>
+                    )}
+                    {item.href && (
+                      <div className="bp-services-grid__cta-row">
+                        <LinkButton
+                          href={item.href}
+                          variant="ghost"
+                          size="sm"
+                          iconAfter={
+                            <span aria-hidden="true" style={ARROW_STYLE}>
+                              →
+                            </span>
+                          }
+                        >
+                          Learn more
+                        </LinkButton>
+                      </div>
+                    )}
+                  </Stack>
+                </Card>
+              </li>
+            );
+          })}
+        </Grid>
+      </div>
+    </section>
+  );
+}
+
+const ARROW_STYLE: CSSProperties = { display: 'inline-block' };
+
+export default Services3ColCardGrid;

--- a/content-system/blueprints/react/index.ts
+++ b/content-system/blueprints/react/index.ts
@@ -1,0 +1,47 @@
+/**
+ * `@brikdesigns/bds` blueprints-react surface.
+ *
+ * React renderers for the Brik blueprint library. Twin of
+ * `../astro/index.ts` for React / Next.js consumers (primarily
+ * brikdesigns.com). Types are shared with the Astro surface via
+ * `../astro/types` since they are framework-agnostic.
+ *
+ * Consumers import from the package root:
+ *
+ *   import {
+ *     BlueprintDispatcher,
+ *     Services3ColCardGrid,
+ *   } from '@brikdesigns/bds';
+ *
+ * Renderers ship through the main library bundle (Vite multi-export
+ * via `lib-entry.ts`); no separate sub-path import is needed.
+ *
+ * ## v0.1 scope
+ *
+ *   Services3ColCardGrid (this PR — the brikdesigns.com
+ *     /services/{slug} index-page driver).
+ *
+ * Subsequent renderers — HeroSplit6040, HeroInteriorMinimal,
+ * ServicesDetailTwoColumn, CtaDarkCentered, AboutStorySplit,
+ * SiteHeader, SiteFooter — ship in their own PRs (Workstream A).
+ */
+
+// ── Contract types — re-exported from the framework-agnostic source ──
+export type {
+  KnownBlueprintKey,
+  BlueprintSection,
+  ClientFacts,
+  ResolvedThemeMode,
+  ResolvedAtmosphere,
+  ResolvedNavArchetype,
+  ResolvedFooterArchetype,
+  ResolvedTheme,
+  BlueprintProps,
+} from '../astro/types';
+
+// ── Blueprint renderers ─────────────────────────────────────────
+export { Services3ColCardGrid } from './Services3ColCardGrid';
+
+// ── Dispatch surface ────────────────────────────────────────────
+export { BlueprintDispatcher } from './BlueprintDispatcher';
+export { BlueprintFallback } from './BlueprintFallback';

--- a/lib-entry.ts
+++ b/lib-entry.ts
@@ -3,3 +3,9 @@ export * from './components';
 
 // BDS token types and utilities
 export * from './tokens';
+
+// BDS Blueprint React renderers — twin of `./blueprints-astro` for
+// React / Next.js consumers. Ships through the main bundle so consumers
+// import via `import { BlueprintDispatcher, Services3ColCardGrid } from
+// '@brikdesigns/bds'` (no separate sub-path required).
+export * from './content-system/blueprints/react';

--- a/scripts/verify-blueprints-astro-exports.mjs
+++ b/scripts/verify-blueprints-astro-exports.mjs
@@ -671,11 +671,12 @@ const expectedFiles = [
   'dist/content-system/blueprints/astro/types.d.ts',
   // Barrel (source — excluded from tsc compile)
   'content-system/blueprints/astro/index.ts',
-  // Components (source, .astro) — all 8 v0.1 shipped blueprints
+  // Components (source, .astro) — v0.1 shipped blueprints + later additions
   'content-system/blueprints/astro/HeroSplit6040.astro',
   'content-system/blueprints/astro/HeroInteriorMinimal.astro',
   'content-system/blueprints/astro/StatsDarkBar.astro',
   'content-system/blueprints/astro/ServicesDetailTwoColumn.astro',
+  'content-system/blueprints/astro/Services3ColCardGrid.astro',
   'content-system/blueprints/astro/AboutStorySplit.astro',
   'content-system/blueprints/astro/TestimonialsFeaturedLarge.astro',
   'content-system/blueprints/astro/CtaSplitContact.astro',

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,7 +14,9 @@
     "lib-entry.ts",
     "components/**/*",
     "tokens/index.ts",
-    "types/**/*"
+    "types/**/*",
+    "content-system/blueprints/react/**/*.ts",
+    "content-system/blueprints/react/**/*.tsx"
   ],
   "exclude": [
     "node_modules",

--- a/tsconfig.content-system.json
+++ b/tsconfig.content-system.json
@@ -23,6 +23,7 @@
     "**/*.stories.ts",
     "**/*.stories.tsx",
     "**/*.test.ts",
-    "content-system/blueprints/astro/index.ts"
+    "content-system/blueprints/astro/index.ts",
+    "content-system/blueprints/react/**"
   ]
 }


### PR DESCRIPTION
## Summary
- feat(blueprints): ship services_3col_card_grid renderers (Astro + React)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)