### PR TITLE
feat(blueprints): ship support_plan_callout_split renderers (Astro + React)

### DIFF
--- a/blueprints/blueprint-library.json
+++ b/blueprints/blueprint-library.json
@@ -342,6 +342,31 @@
       "required_facts": []
     },
     {
+      "key": "support_plan_callout_split",
+      "name": "Support Plan Callout — Illustration + Plan Card Split",
+      "section_type": "cta",
+      "industries": [
+        "universal",
+        "saas",
+        "ecommerce",
+        "corporate"
+      ],
+      "moods": [
+        "approachable",
+        "warm",
+        "professional",
+        "trustworthy"
+      ],
+      "layout_spec": "Light section. Centered section header (heading + subhead) above. Below: two-column split, content-region (illustration block) left, plan card right. Illustration block: persona/scene composition with floating UI elements (chat bubble, message tile, optional photo) — composed via the BDS MarketingIllustration primitive (PR #484), NOT a baked image. Plan card: surface-secondary background, rounded-lg corners, padded generously. Card content: plan name (heading/sm), 2-sentence description (body/sm, on light), 'Learn more' primary CTA (size md). Two-column collapses to stacked at <992px (illustration goes above card on mobile). Section also supports an 'illustration-omitted' variant where the card centers max-width 720px.",
+      "css_hints": ".support-plan-callout { padding-block: clamp(var(--padding-xl), 9vw, var(--padding-huge)); background: var(--page-primary); } .support-plan-callout__split { display: grid; grid-template-columns: 1fr 1fr; gap: var(--gap-xl); align-items: center; } .support-plan-callout__card { background: var(--surface-secondary); border-radius: var(--border-radius-lg); padding: var(--padding-xl); display: flex; flex-direction: column; gap: var(--gap-md); align-items: flex-start; } @media (max-width: 991.98px) { .support-plan-callout__split { grid-template-columns: 1fr; } }",
+      "source": "brikdesigns.com /services/{slug} 'Monthly support services' cross-sell section (PR #477 spec)",
+      "tier": "internal",
+      "is_active": true,
+      "version": "1.0.0",
+      "last_reviewed": "2026-05-09",
+      "required_facts": []
+    },
+    {
       "key": "cta_split_contact",
       "name": "Split CTA with Contact",
       "section_type": "cta",

--- a/content-system/blueprints/astro/BlueprintDispatcher.astro
+++ b/content-system/blueprints/astro/BlueprintDispatcher.astro
@@ -59,6 +59,7 @@ import HeroInteriorMinimal from './HeroInteriorMinimal.astro';
 import StatsDarkBar from './StatsDarkBar.astro';
 import ServicesDetailTwoColumn from './ServicesDetailTwoColumn.astro';
 import Services3ColCardGrid from './Services3ColCardGrid.astro';
+import SupportPlanCalloutSplit from './SupportPlanCalloutSplit.astro';
 import AboutStorySplit from './AboutStorySplit.astro';
 import TestimonialsFeaturedLarge from './TestimonialsFeaturedLarge.astro';
 import CtaSplitContact from './CtaSplitContact.astro';
@@ -74,6 +75,7 @@ const BLUEPRINT_REGISTRY = {
   stats_dark_bar: StatsDarkBar,
   services_detail_two_column: ServicesDetailTwoColumn,
   services_3col_card_grid: Services3ColCardGrid,
+  support_plan_callout_split: SupportPlanCalloutSplit,
   about_story_split: AboutStorySplit,
   testimonials_featured_large: TestimonialsFeaturedLarge,
   cta_split_contact: CtaSplitContact,

--- a/content-system/blueprints/astro/SupportPlanCalloutSplit.astro
+++ b/content-system/blueprints/astro/SupportPlanCalloutSplit.astro
@@ -1,0 +1,293 @@
+---
+/**
+ * support_plan_callout_split — section header + two-column split with a
+ * marketing illustration scene on the left and a plan callout card on
+ * the right. Drives brikdesigns.com's "Monthly support services"
+ * cross-sell section on /services/{slug} pages.
+ *
+ * Spec: blueprints/proposals/support_plan_callout_split.md (PR #477).
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading           — section heading (h2)
+ *   - section.subheading        — optional eyebrow text (uppercase)
+ *   - section.body              — optional one-line lead under heading
+ *   - section.items[0]          — REQUIRED — { title: plan name, description: plan description }
+ *   - section.cta               — REQUIRED — { label, url } for the plan CTA
+ *   - section.illustration      — optional structured scene; when omitted the card centers full-width
+ *
+ * required_facts: []. Section-driven.
+ *
+ * ## Renderer parity note
+ *
+ * The illustration block is rendered by emitting the same HTML +
+ * `bds-marketing-illustration__*` classes as the BDS
+ * `<MarketingIllustration>` React primitive. Consumers that import
+ * `@brikdesigns/bds/styles.css` (every BDS-using site) get the same
+ * tile slot positions, accent fills, and container-query sizing that
+ * the React renderer produces — no CSS duplication, no Astro island
+ * required.
+ *
+ * Avatar tiles render as plain `<img>` (no Avatar component) — Avatar
+ * adds an initials fallback ring that requires React state, which the
+ * Astro renderer omits in favor of a naive `<img>` with the same
+ * dimensions and border-radius. Visual difference is invisible at the
+ * sizes used in this scene.
+ *
+ * CSS custom properties — variation API:
+ *   --bp-support-plan-callout-bg          (default: var(--page-primary))
+ *   --bp-support-plan-callout-card-bg     (default: var(--surface-secondary))
+ *   --bp-support-plan-callout-card-radius (default: var(--border-radius-lg))
+ *   --bp-support-plan-callout-gap         (default: var(--gap-xl))
+ *   --bp-support-plan-callout-card-pad    (default: var(--padding-xl))
+ *
+ * a11y: section uses h2 + aria-labelledby; plan card has h3 nested
+ * under section h2; illustration is `role="img"` with aria-label
+ * synthesized from tile content. CTA passes AA at size="md" (16px
+ * label) — DO NOT downgrade to size="sm" on this surface.
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+const headingId = `bp-support-plan-callout-${section.sectionKey}-h`;
+const plan = section.items?.[0];
+const cta = section.cta;
+const illustration = section.illustration;
+const ratio = illustration?.ratio ?? 'square';
+const variant = illustration?.variant ?? 'persona-cluster';
+const tiles = illustration?.tiles ?? [];
+const ariaLabel = tiles
+  .map((t: any) => ('alt' in t ? t.alt : 'content' in t ? t.content : ''))
+  .filter(Boolean)
+  .join(', ');
+
+const hasIllustration = illustration && tiles.length > 0;
+---
+
+<section
+  class="bp-support-plan-callout"
+  data-blueprint-key="support_plan_callout_split"
+  data-has-illustration={hasIllustration ? 'true' : 'false'}
+  aria-labelledby={section.heading ? headingId : undefined}
+>
+  <div class="bp-support-plan-callout__container">
+    {(section.heading || section.subheading || section.body) && (
+      <header class="bp-support-plan-callout__header">
+        {section.subheading && (
+          <p class="bp-support-plan-callout__eyebrow">{section.subheading}</p>
+        )}
+        {section.heading && (
+          <h2 id={headingId} class="bp-support-plan-callout__heading">{section.heading}</h2>
+        )}
+        {section.body && (
+          <p class="bp-support-plan-callout__lead">{section.body}</p>
+        )}
+      </header>
+    )}
+
+    <div class="bp-support-plan-callout__split">
+      {hasIllustration && (
+        <div
+          class={`bds-marketing-illustration bds-marketing-illustration--${variant} bds-marketing-illustration--ratio-${ratio} bp-support-plan-callout__illustration`}
+          role="img"
+          aria-label={ariaLabel || undefined}
+        >
+          {tiles.map((tile: any, i: number) => {
+            const slotIndex = Math.min(i, 4);
+            const accentClass = tile.accent
+              ? ` bds-marketing-illustration__tile--accent-${tile.accent}`
+              : '';
+            const tileClass =
+              `bds-marketing-illustration__tile ` +
+              `bds-marketing-illustration__tile--${tile.kind} ` +
+              `bds-marketing-illustration__slot-${slotIndex}` +
+              accentClass;
+
+            if (tile.kind === 'avatar') {
+              return (
+                <div class={tileClass}>
+                  <img
+                    src={tile.src}
+                    alt={tile.alt}
+                    class="bds-marketing-illustration__photo"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </div>
+              );
+            }
+            if (tile.kind === 'photo') {
+              return (
+                <div class={tileClass}>
+                  <img
+                    src={tile.src}
+                    alt={tile.alt}
+                    class="bds-marketing-illustration__photo"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </div>
+              );
+            }
+            if (tile.kind === 'chat-bubble') {
+              return (
+                <div class={tileClass}>
+                  <div class="bds-marketing-illustration__chat-bubble">
+                    {tile.content}
+                  </div>
+                </div>
+              );
+            }
+            if (tile.kind === 'message') {
+              return (
+                <div class={tileClass}>
+                  <div class="bds-marketing-illustration__message">
+                    {tile.content && <span>{tile.content}</span>}
+                  </div>
+                </div>
+              );
+            }
+            return (
+              <div class={tileClass}>
+                <div class="bds-marketing-illustration__shape" aria-hidden="true" />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {plan && (
+        <article class="bp-support-plan-callout__card">
+          <h3 class="bp-support-plan-callout__plan-name">{plan.title}</h3>
+          {plan.description && (
+            <p class="bp-support-plan-callout__plan-description">{plan.description}</p>
+          )}
+          {cta && (
+            <a
+              class="bds-button bds-button--primary bds-button--md bp-support-plan-callout__cta"
+              href={cta.url}
+            >
+              <span class="bds-button__content">{cta.label}</span>
+            </a>
+          )}
+        </article>
+      )}
+    </div>
+  </div>
+</section>
+
+<style>
+  .bp-support-plan-callout {
+    background: var(--bp-support-plan-callout-bg, var(--page-primary));
+    padding-block: clamp(var(--padding-xl), 9vw, var(--padding-huge));
+  }
+
+  .bp-support-plan-callout__container {
+    max-width: 1280px;
+    margin-inline: auto;
+    padding-inline: var(--padding-lg);
+  }
+
+  /* ── Section header ─────────────────────────────────────────── */
+
+  .bp-support-plan-callout__header {
+    text-align: center;
+    max-width: 72ch;
+    margin-inline: auto;
+    margin-bottom: var(--padding-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+  }
+
+  .bp-support-plan-callout__eyebrow {
+    margin: 0;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-brand-primary);
+  }
+
+  .bp-support-plan-callout__heading {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--font-line-height-tight);
+    color: var(--text-primary);
+  }
+
+  .bp-support-plan-callout__lead {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--font-line-height-relaxed);
+    color: var(--text-primary);
+  }
+
+  /* ── Two-column split ───────────────────────────────────────── */
+
+  .bp-support-plan-callout__split {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--bp-support-plan-callout-gap, var(--gap-xl));
+    align-items: center;
+  }
+
+  .bp-support-plan-callout[data-has-illustration='false']
+    .bp-support-plan-callout__split {
+    grid-template-columns: 1fr;
+    max-width: 720px;
+    margin-inline: auto;
+  }
+
+  @media (max-width: 991.98px) {
+    .bp-support-plan-callout__split {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Illustration first on mobile (matches Webflow source order). */
+  .bp-support-plan-callout__illustration {
+    order: 1;
+  }
+  .bp-support-plan-callout__card {
+    order: 2;
+  }
+
+  /* ── Plan card ──────────────────────────────────────────────── */
+
+  .bp-support-plan-callout__card {
+    background: var(--bp-support-plan-callout-card-bg, var(--surface-secondary));
+    border-radius: var(--bp-support-plan-callout-card-radius, var(--border-radius-lg));
+    padding: var(--bp-support-plan-callout-card-pad, var(--padding-xl));
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    align-items: flex-start;
+  }
+
+  .bp-support-plan-callout__plan-name {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-500);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--font-line-height-tight);
+    color: var(--text-primary);
+  }
+
+  .bp-support-plan-callout__plan-description {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-300);
+    line-height: var(--font-line-height-relaxed);
+    color: var(--text-primary);
+  }
+
+  .bp-support-plan-callout__cta {
+    margin-top: var(--gap-md);
+  }
+</style>

--- a/content-system/blueprints/astro/index.ts
+++ b/content-system/blueprints/astro/index.ts
@@ -51,6 +51,7 @@ export { default as HeroInteriorMinimal }       from './HeroInteriorMinimal.astr
 export { default as StatsDarkBar }              from './StatsDarkBar.astro';
 export { default as ServicesDetailTwoColumn }   from './ServicesDetailTwoColumn.astro';
 export { default as Services3ColCardGrid }      from './Services3ColCardGrid.astro';
+export { default as SupportPlanCalloutSplit }   from './SupportPlanCalloutSplit.astro';
 export { default as AboutStorySplit }           from './AboutStorySplit.astro';
 export { default as TestimonialsFeaturedLarge } from './TestimonialsFeaturedLarge.astro';
 export { default as CtaSplitContact }           from './CtaSplitContact.astro';

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -26,6 +26,7 @@ export type KnownBlueprintKey =
   | 'services_numbered_rows'
   | 'services_detail_two_column'
   | 'services_3col_card_grid'
+  | 'support_plan_callout_split'
   | 'features_3col_icon_grid'
   | 'features_alternating_split'
   | 'features_bento_asymmetric'
@@ -82,6 +83,27 @@ export interface BlueprintSection {
     readonly label: string;
     readonly url: string;
   } | null;
+  /**
+   * Optional structured illustration data for blueprints that compose a
+   * decorative scene (e.g. `support_plan_callout_split`). Mirrors the
+   * `MarketingIllustration` primitive's prop contract — duplicated here so
+   * `BlueprintSection` stays framework-agnostic and the contract type
+   * doesn't import from `components/`.
+   *
+   * Additive, optional — existing blueprints that don't compose scenes
+   * are unaffected.
+   */
+  readonly illustration?: {
+    readonly variant?: 'persona-cluster';
+    readonly ratio?: 'square' | 'portrait' | 'landscape';
+    readonly tiles: ReadonlyArray<
+      | { readonly kind: 'avatar'; readonly src: string; readonly alt: string; readonly name?: string }
+      | { readonly kind: 'photo'; readonly src: string; readonly alt: string }
+      | { readonly kind: 'chat-bubble'; readonly content: string; readonly accent?: 'brand-primary' | 'positive' | 'neutral' | 'inverse' }
+      | { readonly kind: 'message'; readonly content?: string; readonly accent?: 'brand-primary' | 'positive' | 'neutral' | 'inverse' }
+      | { readonly kind: 'shape'; readonly accent?: 'brand-primary' | 'positive' | 'neutral' | 'inverse' }
+    >;
+  };
   readonly visualNotes: {
     readonly blueprintKey: KnownBlueprintKey | null;
     readonly moodKeywords: readonly string[];

--- a/content-system/blueprints/react/BlueprintDispatcher.tsx
+++ b/content-system/blueprints/react/BlueprintDispatcher.tsx
@@ -50,12 +50,14 @@ import type {
 } from '../astro/types';
 
 import { Services3ColCardGrid } from './Services3ColCardGrid';
+import { SupportPlanCalloutSplit } from './SupportPlanCalloutSplit';
 import { BlueprintFallback } from './BlueprintFallback';
 
 const BLUEPRINT_REGISTRY: Partial<
   Record<KnownBlueprintKey, ComponentType<BlueprintProps>>
 > = {
   services_3col_card_grid: Services3ColCardGrid,
+  support_plan_callout_split: SupportPlanCalloutSplit,
 };
 
 interface Props {

--- a/content-system/blueprints/react/SupportPlanCalloutSplit.css
+++ b/content-system/blueprints/react/SupportPlanCalloutSplit.css
@@ -1,0 +1,127 @@
+/*
+ * SupportPlanCalloutSplit — React renderer styles.
+ *
+ * Section frame + two-column split + plan-card surface. The
+ * illustration block uses the BDS `MarketingIllustration` primitive
+ * which carries its own internal styling — these rules only handle:
+ *   - section padding-block + container max-width
+ *   - centered section header rhythm
+ *   - the responsive split + collapse behavior
+ *   - plan card variation API (`--bp-*` props)
+ *
+ * No `--surface-*` / `--text-*` / `--border-*` overrides — those stay
+ * theme-layer per the cascade rules.
+ */
+
+.bp-support-plan-callout {
+  background: var(--bp-support-plan-callout-bg, var(--page-primary));
+  padding-block: clamp(var(--padding-xl), 9vw, var(--padding-huge));
+}
+
+.bp-support-plan-callout__container {
+  max-width: 1280px;
+  margin-inline: auto;
+  padding-inline: var(--padding-lg);
+}
+
+/* ── Section header ────────────────────────────────────────────── */
+
+.bp-support-plan-callout__header {
+  text-align: center;
+  max-width: 72ch;
+  margin-inline: auto;
+  margin-bottom: var(--padding-xl);
+}
+
+.bp-support-plan-callout__eyebrow {
+  margin: 0;
+  font-family: var(--font-family-label);
+  font-size: var(--font-size-200);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-brand-primary);
+}
+
+.bp-support-plan-callout__heading {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+}
+
+.bp-support-plan-callout__lead {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-400);
+  line-height: var(--font-line-height-relaxed);
+  color: var(--text-primary);
+}
+
+/* ── Two-column split ──────────────────────────────────────────── */
+
+.bp-support-plan-callout__split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--bp-support-plan-callout-gap, var(--gap-xl));
+  align-items: center;
+}
+
+.bp-support-plan-callout[data-has-illustration='false']
+  .bp-support-plan-callout__split {
+  grid-template-columns: 1fr;
+  max-width: 720px;
+  margin-inline: auto;
+}
+
+@media (max-width: 991.98px) {
+  .bp-support-plan-callout__split {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Illustration first on mobile (matches Webflow source order). */
+.bp-support-plan-callout__illustration {
+  order: 1;
+}
+.bp-support-plan-callout__card {
+  order: 2;
+}
+
+/* ── Plan card ─────────────────────────────────────────────────── */
+
+.bp-support-plan-callout__card {
+  /* Override the BDS Card outlined variant so the plan card reads as a
+   * filled callout panel — same visual the Webflow source ships. */
+  background: var(--bp-support-plan-callout-card-bg, var(--surface-secondary));
+  border: none;
+  border-radius: var(--bp-support-plan-callout-card-radius, var(--border-radius-lg));
+}
+
+.bp-support-plan-callout__card-stack {
+  padding: var(--bp-support-plan-callout-card-pad, var(--padding-xl));
+  align-items: flex-start;
+}
+
+.bp-support-plan-callout__plan-name {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-500);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+}
+
+.bp-support-plan-callout__plan-description {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-300);
+  line-height: var(--font-line-height-relaxed);
+  color: var(--text-primary);
+}
+
+.bp-support-plan-callout__cta {
+  margin-top: var(--gap-md);
+}

--- a/content-system/blueprints/react/SupportPlanCalloutSplit.stories.tsx
+++ b/content-system/blueprints/react/SupportPlanCalloutSplit.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { SupportPlanCalloutSplit } from './SupportPlanCalloutSplit';
+import type { BlueprintProps } from '../astro/types';
+
+/* ─── Fixtures ─────────────────────────────────────────────────── */
+
+const baseTheme: BlueprintProps['theme'] = {
+  themeMode: 'light',
+  atmosphere: 'none',
+  navigationArchetype: 'utility-first',
+  footerArchetype: 'four_col_directory',
+};
+
+const baseClientFacts: BlueprintProps['clientFacts'] = {
+  brandName: 'Brik Designs',
+  tagline: null,
+  valueProposition: null,
+  services: [],
+  phone: null,
+  email: null,
+  address: null,
+  hours: [],
+  heroImageUrl: null,
+  logoUrl: null,
+  logoVariants: {},
+};
+
+/**
+ * "Monthly support services" fixture — the brikdesigns.com cross-sell
+ * section that drives this blueprint. Persona-cluster illustration on
+ * the left, plan callout card on the right.
+ */
+const supportSection: BlueprintProps['section'] = {
+  sectionKey: 'support-plan-default',
+  sectionType: 'cta',
+  heading: 'Monthly support services',
+  subheading: null,
+  body: 'Keep momentum after launch — ongoing design partnership for the post-rollout work that compounds into growth.',
+  cta: {
+    label: 'Learn more',
+    url: '/services/monthly-support',
+  },
+  illustration: {
+    variant: 'persona-cluster',
+    ratio: 'square',
+    tiles: [
+      {
+        kind: 'avatar',
+        src: 'https://placehold.co/240x240/eaf1fb/1f3d70?text=Sam',
+        alt: 'Strategist Sam',
+      },
+      {
+        kind: 'chat-bubble',
+        content: 'How can I help today?',
+        accent: 'brand-primary',
+      },
+      { kind: 'message', accent: 'positive' },
+      {
+        kind: 'photo',
+        src: 'https://placehold.co/220x220/ffe1cc/663300?text=Olivia',
+        alt: 'Operations Olivia',
+      },
+      {
+        kind: 'chat-bubble',
+        content: 'We need an email campaign',
+        accent: 'neutral',
+      },
+    ],
+  },
+  visualNotes: {
+    blueprintKey: 'support_plan_callout_split',
+    moodKeywords: ['approachable', 'warm'],
+    layoutBlueprint: 'support_plan_callout_split',
+    imageOpportunity: 'persona avatars + photo tile',
+    animationSuggestion: null,
+    illustrationOpportunity: 'persona-cluster scene',
+  },
+  items: [
+    {
+      title: 'Brik Continuity Plan',
+      description:
+        'A predictable monthly cadence — strategic check-ins, design execution, and a single point of contact who already knows your business.',
+    },
+  ],
+};
+
+const baseProps: BlueprintProps = {
+  section: supportSection,
+  clientFacts: baseClientFacts,
+  theme: baseTheme,
+};
+
+/* ─── Meta ─────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof SupportPlanCalloutSplit> = {
+  title: 'Blueprints/support_plan_callout_split',
+  component: SupportPlanCalloutSplit,
+  tags: ['surface-web', 'surface-shared'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Section header + two-column split: persona-cluster illustration on the left, plan callout card on the right. Drives the brikdesigns.com `/services/{slug}` "Monthly support services" cross-sell. Uses the BDS `MarketingIllustration` primitive (PR #484) for the scene. Plan card text uses `--text-primary` to clear AA on `--surface-secondary`; CTA uses `LinkButton size="md"` to clear AA at the brand-poppy fill.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SupportPlanCalloutSplit>;
+
+/* ─── Stories ──────────────────────────────────────────────────── */
+
+/**
+ * @summary Default split — persona-cluster scene + plan card.
+ */
+export const Default: Story = {
+  args: baseProps,
+};
+
+/**
+ * @summary No illustration — plan card centers full-width (max 720px).
+ *
+ * The blueprint supports an "illustration omitted" variant so consumers
+ * can drop the cross-sell card on pages where the scene doesn't fit.
+ */
+export const NoIllustration: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...supportSection,
+      sectionKey: 'support-plan-no-illustration',
+      illustration: undefined,
+    },
+  },
+};
+
+/**
+ * @summary No section header — card + illustration stand alone.
+ *
+ * For consumers that want to slot this blueprint inside an already-
+ * titled context (e.g. inside an existing services page section).
+ */
+export const NoHeader: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...supportSection,
+      sectionKey: 'support-plan-no-header',
+      heading: null,
+      subheading: null,
+      body: null,
+    },
+  },
+};
+
+/**
+ * @summary Atmosphere overlay — `warm-soft`. Verifies blueprint surfaces stay theme-layer.
+ *
+ * Renders the same default fixture under the `warm-soft` atmosphere.
+ * Use the Theme Switcher addon to compare. The blueprint must NOT
+ * redefine `--surface-*` / `--text-*` / `--border-*` tokens; the
+ * atmosphere CSS already handles those.
+ */
+export const AtmosphereWarmSoft: Story = {
+  args: {
+    ...baseProps,
+    theme: { ...baseTheme, atmosphere: 'warm-soft' },
+  },
+};

--- a/content-system/blueprints/react/SupportPlanCalloutSplit.tsx
+++ b/content-system/blueprints/react/SupportPlanCalloutSplit.tsx
@@ -1,0 +1,133 @@
+/**
+ * SupportPlanCalloutSplit — React renderer for the
+ * `support_plan_callout_split` blueprint. Composes the
+ * `MarketingIllustration` primitive (PR #484) on the left with a
+ * plan-callout `Card` on the right, with an optional centered section
+ * header above. Drives brikdesigns.com's "Monthly support services"
+ * cross-sell section on `/services/{slug}` pages.
+ *
+ * Astro twin lives at `../astro/SupportPlanCalloutSplit.astro` and
+ * mirrors the same illustration HTML shape using the canonical
+ * `bds-marketing-illustration__*` classes — visual parity is exact
+ * for any consumer that imports `@brikdesigns/bds/styles.css`.
+ *
+ * Contract: BlueprintProps. The illustration data lives on
+ * `section.illustration` (an additive optional field on
+ * `BlueprintSection`); the plan info lives on `section.items[0]` plus
+ * `section.cta`.
+ *
+ * CSS custom properties — variation API:
+ *   --bp-support-plan-callout-bg          (default: var(--page-primary))
+ *   --bp-support-plan-callout-card-bg     (default: var(--surface-secondary))
+ *   --bp-support-plan-callout-card-radius (default: var(--border-radius-lg))
+ *   --bp-support-plan-callout-gap         (default: var(--gap-xl))
+ *   --bp-support-plan-callout-card-pad    (default: var(--padding-xl))
+ *
+ * a11y: section is a `<section>` with `aria-labelledby` pointing at
+ * the h2; plan card title is an h3 nested under the section h2;
+ * MarketingIllustration emits `role="img"` with synthesized
+ * aria-label. CTA uses `LinkButton` size="md" — DO NOT downgrade to
+ * "sm" on this surface (white-on-poppy at 14px fails AA per the
+ * BDS contrast burndown).
+ *
+ * @summary Section header + illustration + plan-callout card split.
+ */
+import {
+  Card,
+  LinkButton,
+  MarketingIllustration,
+  Stack,
+  type IllustrationTile,
+} from '../../../components';
+
+import type { BlueprintProps } from '../astro/types';
+import './SupportPlanCalloutSplit.css';
+
+interface Props extends BlueprintProps {}
+
+export function SupportPlanCalloutSplit({ section }: Props) {
+  const headingId = `bp-support-plan-callout-${section.sectionKey}-h`;
+  const plan = section.items?.[0];
+  const cta = section.cta;
+  const illustration = section.illustration;
+  const hasIllustration =
+    illustration !== undefined && illustration.tiles.length > 0;
+
+  return (
+    <section
+      className="bp-support-plan-callout"
+      data-blueprint-key="support_plan_callout_split"
+      data-has-illustration={hasIllustration ? 'true' : 'false'}
+      aria-labelledby={section.heading ? headingId : undefined}
+    >
+      <div className="bp-support-plan-callout__container">
+        {(section.heading || section.subheading || section.body) && (
+          <Stack
+            as="header"
+            gap="md"
+            className="bp-support-plan-callout__header"
+          >
+            {section.subheading && (
+              <p className="bp-support-plan-callout__eyebrow">
+                {section.subheading}
+              </p>
+            )}
+            {section.heading && (
+              <h2
+                id={headingId}
+                className="bp-support-plan-callout__heading"
+              >
+                {section.heading}
+              </h2>
+            )}
+            {section.body && (
+              <p className="bp-support-plan-callout__lead">{section.body}</p>
+            )}
+          </Stack>
+        )}
+
+        <div className="bp-support-plan-callout__split">
+          {hasIllustration && (
+            <MarketingIllustration
+              variant={illustration.variant ?? 'persona-cluster'}
+              ratio={illustration.ratio ?? 'square'}
+              tiles={illustration.tiles as IllustrationTile[]}
+              className="bp-support-plan-callout__illustration"
+            />
+          )}
+
+          {plan && (
+            <Card
+              variant="outlined"
+              padding="none"
+              className="bp-support-plan-callout__card"
+            >
+              <Stack gap="md" className="bp-support-plan-callout__card-stack">
+                <h3 className="bp-support-plan-callout__plan-name">
+                  {plan.title}
+                </h3>
+                {plan.description && (
+                  <p className="bp-support-plan-callout__plan-description">
+                    {plan.description}
+                  </p>
+                )}
+                {cta && (
+                  <LinkButton
+                    href={cta.url}
+                    variant="primary"
+                    size="md"
+                    className="bp-support-plan-callout__cta"
+                  >
+                    {cta.label}
+                  </LinkButton>
+                )}
+              </Stack>
+            </Card>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default SupportPlanCalloutSplit;

--- a/content-system/blueprints/react/index.ts
+++ b/content-system/blueprints/react/index.ts
@@ -41,6 +41,7 @@ export type {
 
 // ── Blueprint renderers ─────────────────────────────────────────
 export { Services3ColCardGrid } from './Services3ColCardGrid';
+export { SupportPlanCalloutSplit } from './SupportPlanCalloutSplit';
 
 // ── Dispatch surface ────────────────────────────────────────────
 export { BlueprintDispatcher } from './BlueprintDispatcher';

--- a/scripts/verify-blueprints-astro-exports.mjs
+++ b/scripts/verify-blueprints-astro-exports.mjs
@@ -677,6 +677,7 @@ const expectedFiles = [
   'content-system/blueprints/astro/StatsDarkBar.astro',
   'content-system/blueprints/astro/ServicesDetailTwoColumn.astro',
   'content-system/blueprints/astro/Services3ColCardGrid.astro',
+  'content-system/blueprints/astro/SupportPlanCalloutSplit.astro',
   'content-system/blueprints/astro/AboutStorySplit.astro',
   'content-system/blueprints/astro/TestimonialsFeaturedLarge.astro',
   'content-system/blueprints/astro/CtaSplitContact.astro',


### PR DESCRIPTION
## Summary
- feat(blueprints): ship support_plan_callout_split renderers (Astro + React)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)