### PR TITLE
feat(blueprints): ship features_3col_branded_dark renderers (Astro + React)

### DIFF
--- a/blueprints/blueprint-library.json
+++ b/blueprints/blueprint-library.json
@@ -167,6 +167,31 @@
       "required_facts": []
     },
     {
+      "key": "features_3col_branded_dark",
+      "name": "3-Column Brand-Colored Card Grid on Dark",
+      "section_type": "features",
+      "industries": [
+        "universal",
+        "saas",
+        "ecommerce",
+        "corporate"
+      ],
+      "moods": [
+        "bold",
+        "modern",
+        "luxury",
+        "energetic"
+      ],
+      "layout_spec": "Dark section background (page-inverse). 3-column grid of cards, each filled with its own brand color via [data-audience='X'] scope binding (re-binds --background-brand-primary per card). Card layout: oversized illustration top (1:1 aspect, ~60-70% of card height, padded inside the brand color), then card body with high-contrast title (heading/sm, font-weight bold for AA on saturated bg), 1-sentence description (body/sm at 16px regular for large-text 3:1 threshold), and 'Learn more' affordance with arrow. Cards rounded-lg, full-bleed image at top, body padding generous. Section header centered above grid in light text on dark surface. Optional eyebrow above heading. Cards collapse to 2-col at <992px, 1-col at <768px. Each card establishes its own data-audience subtree binding so its --brand-primary cascades correctly per the BDS scope-binding pattern (consumer site defines [data-audience='X'] cascade rules).",
+      "css_hints": ".features-branded-dark { background: var(--page-inverse); padding-block: clamp(var(--padding-xl), 9vw, var(--padding-huge)); color: var(--text-on-color-dark); } .features-branded-dark__grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--gap-lg); } .features-branded-dark__card { background: var(--background-brand-primary); border-radius: var(--border-radius-lg); overflow: hidden; } .features-branded-dark__media { aspect-ratio: 1; padding: var(--padding-xl); display: flex; align-items: center; justify-content: center; } .features-branded-dark__body { padding: var(--padding-lg); display: flex; flex-direction: column; gap: var(--gap-md); }",
+      "source": "brikdesigns.com /services/{slug} 'Other Service Lines' cross-sell module (PR #477 spec)",
+      "tier": "internal",
+      "is_active": true,
+      "version": "1.0.0",
+      "last_reviewed": "2026-05-09",
+      "required_facts": []
+    },
+    {
       "key": "features_alternating_split",
       "name": "Alternating Content Splits",
       "section_type": "features",

--- a/content-system/blueprints/astro/BlueprintDispatcher.astro
+++ b/content-system/blueprints/astro/BlueprintDispatcher.astro
@@ -60,6 +60,7 @@ import StatsDarkBar from './StatsDarkBar.astro';
 import ServicesDetailTwoColumn from './ServicesDetailTwoColumn.astro';
 import Services3ColCardGrid from './Services3ColCardGrid.astro';
 import SupportPlanCalloutSplit from './SupportPlanCalloutSplit.astro';
+import Features3ColBrandedDark from './Features3ColBrandedDark.astro';
 import AboutStorySplit from './AboutStorySplit.astro';
 import TestimonialsFeaturedLarge from './TestimonialsFeaturedLarge.astro';
 import CtaSplitContact from './CtaSplitContact.astro';
@@ -76,6 +77,7 @@ const BLUEPRINT_REGISTRY = {
   services_detail_two_column: ServicesDetailTwoColumn,
   services_3col_card_grid: Services3ColCardGrid,
   support_plan_callout_split: SupportPlanCalloutSplit,
+  features_3col_branded_dark: Features3ColBrandedDark,
   about_story_split: AboutStorySplit,
   testimonials_featured_large: TestimonialsFeaturedLarge,
   cta_split_contact: CtaSplitContact,

--- a/content-system/blueprints/astro/Features3ColBrandedDark.astro
+++ b/content-system/blueprints/astro/Features3ColBrandedDark.astro
@@ -1,0 +1,320 @@
+---
+/**
+ * features_3col_branded_dark — dark section, 3-column grid of cards
+ * filled with per-card brand colors. Each card sets `data-audience` to
+ * re-bind `--brand-primary` for that subtree. Drives brikdesigns.com's
+ * "Other Service Lines" cross-sell module.
+ *
+ * Spec: blueprints/proposals/features_3col_branded_dark.md (PR #477).
+ *
+ * Contract: BlueprintProps.
+ *   - section.heading           — section heading (h2, light text on dark)
+ *   - section.subheading        — optional eyebrow text (uppercase)
+ *   - section.body              — optional one-line lead under heading
+ *   - section.items[]           — REQUIRED, each card (typically 3, supports 2-4)
+ *       - title                 — service-line name (h3)
+ *       - description           — 1-sentence body
+ *       - href                  — Learn more target
+ *       - imageUrl?             — top illustration src (omitted → blank brand block)
+ *       - imageAlt?             — alt text for the illustration
+ *       - audience              — REQUIRED — drives `data-audience` re-binding
+ *
+ * required_facts: []. Section-driven.
+ *
+ * ## Audience scope binding (consumer responsibility)
+ *
+ * Each card emits `data-audience={item.audience}`. Inside that subtree,
+ * `--brand-primary` and `--background-brand-primary` resolve to the
+ * audience's color — but ONLY if the consumer site defines the
+ * `[data-audience='X']` cascade rules per
+ * `docs/theming/client-themes#per-audience-or-service-line-scope-binding`.
+ * Without those rules, every card resolves to the global brand color
+ * (visually broken — three identical cards).
+ *
+ * BDS ships the pattern, not the values. brikdesigns.com defines its
+ * five service-line bindings (`brand` → yellow, `marketing` → green,
+ * `information` → blue, `product` → purple, `service` → orange) in its
+ * own globals.css.
+ *
+ * ## Renderer parity note
+ *
+ * Astro renderer uses HTML+CSS+tokens (matches existing blueprint
+ * pattern). React renderer composes BDS primitives. Both emit the same
+ * `data-audience` attributes so the consumer's cascade works in both
+ * contexts.
+ *
+ * CSS custom properties — variation API:
+ *   --bp-features-branded-dark-bg          (default: var(--page-inverse))
+ *   --bp-features-branded-dark-card-radius (default: var(--border-radius-lg))
+ *   --bp-features-branded-dark-gap         (default: var(--gap-lg))
+ *   --bp-features-branded-dark-image-pad   (default: var(--padding-xl))
+ *   --bp-features-branded-dark-hover-scale (default: 1.02 — set to 1 to disable)
+ *
+ * a11y: section uses h2 + aria-labelledby; cards are <ul role="list">
+ * of <li>; card title is h3 nested under section h2. Card title uses
+ * --font-weight-bold and 18px to clear AA on saturated brand backgrounds
+ * (white-on-poppy is 3.78:1 at 14px regular per BDS contrast burndown
+ * #40 — bold weight + size promotion gets it into compliant range).
+ */
+import type { BlueprintProps } from './types';
+
+interface Props extends BlueprintProps {}
+
+const { section } = Astro.props;
+const headingId = `bp-features-branded-dark-${section.sectionKey}-h`;
+---
+
+<section
+  class="bp-features-branded-dark"
+  data-blueprint-key="features_3col_branded_dark"
+  aria-labelledby={section.heading ? headingId : undefined}
+>
+  <div class="bp-features-branded-dark__container">
+    {(section.heading || section.subheading || section.body) && (
+      <header class="bp-features-branded-dark__header">
+        {section.subheading && (
+          <p class="bp-features-branded-dark__eyebrow">{section.subheading}</p>
+        )}
+        {section.heading && (
+          <h2 id={headingId} class="bp-features-branded-dark__heading">
+            {section.heading}
+          </h2>
+        )}
+        {section.body && (
+          <p class="bp-features-branded-dark__lead">{section.body}</p>
+        )}
+      </header>
+    )}
+
+    <ul class="bp-features-branded-dark__grid" role="list">
+      {section.items.map((item) => (
+        <li class="bp-features-branded-dark__item">
+          <article
+            class="bp-features-branded-dark__card"
+            data-audience={item.audience ?? undefined}
+          >
+            <a class="bp-features-branded-dark__card-link" href={item.href ?? '#'}>
+              <div class="bp-features-branded-dark__media">
+                {item.imageUrl ? (
+                  <img
+                    src={item.imageUrl}
+                    alt={item.imageAlt ?? ''}
+                    class="bp-features-branded-dark__image"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                ) : (
+                  <span class="bp-features-branded-dark__image-fallback" aria-hidden="true" />
+                )}
+              </div>
+
+              <div class="bp-features-branded-dark__body">
+                <h3 class="bp-features-branded-dark__title">{item.title}</h3>
+                {item.description && (
+                  <p class="bp-features-branded-dark__description">{item.description}</p>
+                )}
+                <span class="bp-features-branded-dark__cta">
+                  Learn more
+                  <span aria-hidden="true" class="bp-features-branded-dark__cta-arrow">→</span>
+                </span>
+              </div>
+            </a>
+          </article>
+        </li>
+      ))}
+    </ul>
+  </div>
+</section>
+
+<style>
+  .bp-features-branded-dark {
+    background: var(--bp-features-branded-dark-bg, var(--page-inverse));
+    padding-block: clamp(var(--padding-xl), 9vw, var(--padding-huge));
+    color: var(--text-on-color-dark);
+  }
+
+  .bp-features-branded-dark__container {
+    max-width: 1280px;
+    margin-inline: auto;
+    padding-inline: var(--padding-lg);
+  }
+
+  /* ── Section header ─────────────────────────────────────────── */
+
+  .bp-features-branded-dark__header {
+    text-align: center;
+    max-width: 72ch;
+    margin-inline: auto;
+    margin-bottom: var(--padding-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+  }
+
+  .bp-features-branded-dark__eyebrow {
+    margin: 0;
+    font-family: var(--font-family-label);
+    font-size: var(--font-size-200);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-on-color-dark);
+    opacity: 0.85;
+  }
+
+  .bp-features-branded-dark__heading {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--font-line-height-tight);
+    color: var(--text-on-color-dark);
+  }
+
+  .bp-features-branded-dark__lead {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--font-line-height-relaxed);
+    color: var(--text-on-color-dark);
+    opacity: 0.85;
+  }
+
+  /* ── Card grid ──────────────────────────────────────────────── */
+
+  .bp-features-branded-dark__grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--bp-features-branded-dark-gap, var(--gap-lg));
+  }
+
+  @media (min-width: 768px) {
+    .bp-features-branded-dark__grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 992px) {
+    .bp-features-branded-dark__grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .bp-features-branded-dark__item {
+    display: flex;
+  }
+
+  /* ── Card ───────────────────────────────────────────────────── */
+
+  .bp-features-branded-dark__card {
+    width: 100%;
+    background: var(--background-brand-primary);
+    border-radius: var(--bp-features-branded-dark-card-radius, var(--border-radius-lg));
+    overflow: hidden;
+    transform: translateY(0) scale(1);
+    transition:
+      transform 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1)),
+      box-shadow 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));
+  }
+
+  .bp-features-branded-dark__card:hover {
+    transform: scale(var(--bp-features-branded-dark-hover-scale, 1.02));
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+  }
+
+  .bp-features-branded-dark__card-link {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .bp-features-branded-dark__card-link:focus-visible {
+    outline: 3px solid var(--text-on-color-dark);
+    outline-offset: -3px;
+  }
+
+  /* ── Media (top illustration area) ──────────────────────────── */
+
+  .bp-features-branded-dark__media {
+    aspect-ratio: 1 / 1;
+    padding: var(--bp-features-branded-dark-image-pad, var(--padding-xl));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+  }
+
+  .bp-features-branded-dark__image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    display: block;
+  }
+
+  .bp-features-branded-dark__image-fallback {
+    width: 60%;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: var(--text-on-color-dark);
+    opacity: 0.15;
+  }
+
+  /* ── Card body ──────────────────────────────────────────────── */
+
+  .bp-features-branded-dark__body {
+    padding: var(--padding-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    flex: 1 1 auto;
+  }
+
+  /* Bold weight + 18px size on title — the AA-clearing posture for
+   * white-on-poppy and similar saturated brand backgrounds. */
+  .bp-features-branded-dark__title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-500);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--font-line-height-tight);
+    color: var(--text-on-color-dark);
+  }
+
+  /* 16px regular description — clears 3:1 at large-text threshold.
+   * If consumer atmospheres tighten the contrast budget below this, the
+   * fix is on the brand-color side, not here. */
+  .bp-features-branded-dark__description {
+    margin: 0;
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-400);
+    line-height: var(--font-line-height-relaxed);
+    color: var(--text-on-color-dark);
+  }
+
+  .bp-features-branded-dark__cta {
+    margin-top: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-md);
+    color: var(--text-on-color-dark);
+    font-family: var(--font-family-body);
+    font-size: var(--font-size-300);
+    font-weight: var(--font-weight-bold);
+    line-height: 1.4;
+  }
+
+  .bp-features-branded-dark__cta-arrow {
+    display: inline-block;
+    transition: transform 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));
+  }
+
+  .bp-features-branded-dark__card-link:hover .bp-features-branded-dark__cta-arrow,
+  .bp-features-branded-dark__card-link:focus-visible .bp-features-branded-dark__cta-arrow {
+    transform: translateX(4px);
+  }
+</style>

--- a/content-system/blueprints/astro/index.ts
+++ b/content-system/blueprints/astro/index.ts
@@ -52,6 +52,7 @@ export { default as StatsDarkBar }              from './StatsDarkBar.astro';
 export { default as ServicesDetailTwoColumn }   from './ServicesDetailTwoColumn.astro';
 export { default as Services3ColCardGrid }      from './Services3ColCardGrid.astro';
 export { default as SupportPlanCalloutSplit }   from './SupportPlanCalloutSplit.astro';
+export { default as Features3ColBrandedDark }   from './Features3ColBrandedDark.astro';
 export { default as AboutStorySplit }           from './AboutStorySplit.astro';
 export { default as TestimonialsFeaturedLarge } from './TestimonialsFeaturedLarge.astro';
 export { default as CtaSplitContact }           from './CtaSplitContact.astro';

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -28,6 +28,7 @@ export type KnownBlueprintKey =
   | 'services_3col_card_grid'
   | 'support_plan_callout_split'
   | 'features_3col_icon_grid'
+  | 'features_3col_branded_dark'
   | 'features_alternating_split'
   | 'features_bento_asymmetric'
   | 'about_story_split'
@@ -78,6 +79,19 @@ export interface BlueprintSection {
     /** ServiceCategory slug — see `ServiceTag` props in `@brikdesigns/bds`. */
     readonly category?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
     readonly hasOptions?: boolean;
+    /**
+     * Audience slug for `data-audience` scope binding. Re-binds canonical
+     * brand tokens (`--brand-primary`, `--background-brand-primary`,
+     * `--text-brand-primary`, `--border-brand-primary`) within the rendered
+     * card so each card can carry its own service-line color. Used by
+     * `features_3col_branded_dark`. The consumer site MUST define the
+     * `[data-audience='X'] { … }` cascade rules per the BDS scope-binding
+     * docs (`docs/theming/client-themes`); BDS ships the pattern, not the
+     * audience-specific values.
+     */
+    readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
+    /** Alt text for `imageUrl`. Defaults to empty (decorative) when omitted. */
+    readonly imageAlt?: string;
   }[];
   readonly cta: {
     readonly label: string;

--- a/content-system/blueprints/react/BlueprintDispatcher.tsx
+++ b/content-system/blueprints/react/BlueprintDispatcher.tsx
@@ -51,6 +51,7 @@ import type {
 
 import { Services3ColCardGrid } from './Services3ColCardGrid';
 import { SupportPlanCalloutSplit } from './SupportPlanCalloutSplit';
+import { Features3ColBrandedDark } from './Features3ColBrandedDark';
 import { BlueprintFallback } from './BlueprintFallback';
 
 const BLUEPRINT_REGISTRY: Partial<
@@ -58,6 +59,7 @@ const BLUEPRINT_REGISTRY: Partial<
 > = {
   services_3col_card_grid: Services3ColCardGrid,
   support_plan_callout_split: SupportPlanCalloutSplit,
+  features_3col_branded_dark: Features3ColBrandedDark,
 };
 
 interface Props {

--- a/content-system/blueprints/react/Features3ColBrandedDark.css
+++ b/content-system/blueprints/react/Features3ColBrandedDark.css
@@ -1,0 +1,212 @@
+/*
+ * Features3ColBrandedDark — React renderer styles.
+ *
+ * Mirrors the Astro twin's visual exactly. Card backgrounds resolve
+ * via `--background-brand-primary`, which is re-bound by the consumer
+ * site's `[data-audience='X']` cascade rules. BDS ships the pattern;
+ * the consumer (brikdesigns.com) ships the audience-specific values.
+ *
+ * Bold + 18px title, 16px regular description — the AA-clearing
+ * posture for white-on-saturated-brand backgrounds (BDS contrast
+ * burndown #40).
+ */
+
+.bp-features-branded-dark {
+  background: var(--bp-features-branded-dark-bg, var(--page-inverse));
+  padding-block: clamp(var(--padding-xl), 9vw, var(--padding-huge));
+  color: var(--text-on-color-dark);
+}
+
+.bp-features-branded-dark__container {
+  max-width: 1280px;
+  margin-inline: auto;
+  padding-inline: var(--padding-lg);
+}
+
+/* ── Section header ────────────────────────────────────────────── */
+
+.bp-features-branded-dark__header {
+  text-align: center;
+  max-width: 72ch;
+  margin-inline: auto;
+  margin-bottom: var(--padding-xl);
+  align-items: center;
+}
+
+.bp-features-branded-dark__eyebrow {
+  margin: 0;
+  font-family: var(--font-family-label);
+  font-size: var(--font-size-200);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-on-color-dark);
+  opacity: 0.85;
+}
+
+.bp-features-branded-dark__heading {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-on-color-dark);
+}
+
+.bp-features-branded-dark__lead {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-400);
+  line-height: var(--font-line-height-relaxed);
+  color: var(--text-on-color-dark);
+  opacity: 0.85;
+}
+
+/* ── Card grid ─────────────────────────────────────────────────── */
+
+.bp-features-branded-dark__grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--bp-features-branded-dark-gap, var(--gap-lg));
+}
+
+@media (min-width: 768px) {
+  .bp-features-branded-dark__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 992px) {
+  .bp-features-branded-dark__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.bp-features-branded-dark__item {
+  display: flex;
+}
+
+/* ── Card ──────────────────────────────────────────────────────── */
+
+.bp-features-branded-dark__card {
+  width: 100%;
+  /* Override the BDS Card outlined variant — branded cards read as
+   * filled panels. Background resolves via --background-brand-primary,
+   * re-bound per-card by the consumer's [data-audience='X'] cascade. */
+  background: var(--background-brand-primary);
+  border: none;
+  border-radius: var(--bp-features-branded-dark-card-radius, var(--border-radius-lg));
+  overflow: hidden;
+  transform: translateY(0) scale(1);
+  transition:
+    transform 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1)),
+    box-shadow 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));
+}
+
+.bp-features-branded-dark__card:hover {
+  transform: scale(var(--bp-features-branded-dark-hover-scale, 1.02));
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+}
+
+.bp-features-branded-dark__card-link {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.bp-features-branded-dark__card-link:focus-visible {
+  outline: 3px solid var(--text-on-color-dark);
+  outline-offset: -3px;
+}
+
+/* ── Media (top illustration area) ─────────────────────────────── */
+
+.bp-features-branded-dark__media {
+  aspect-ratio: 1 / 1;
+  padding: var(--bp-features-branded-dark-image-pad, var(--padding-xl));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.bp-features-branded-dark__image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.bp-features-branded-dark__image-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Scale the ServiceTag icon up inside the media area. */
+  transform: scale(2.4);
+  transform-origin: center;
+}
+
+.bp-features-branded-dark__image-fallback--blank {
+  width: 60%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--text-on-color-dark);
+  opacity: 0.15;
+  transform: none;
+}
+
+/* ── Card body ─────────────────────────────────────────────────── */
+
+.bp-features-branded-dark__body {
+  padding: var(--padding-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  flex: 1 1 auto;
+}
+
+/* Bold + 18px — AA-clearing posture for white-on-saturated-brand. */
+.bp-features-branded-dark__title {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-500);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-on-color-dark);
+}
+
+/* 16px regular — clears 3:1 at the large-text threshold. */
+.bp-features-branded-dark__description {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-400);
+  line-height: var(--font-line-height-relaxed);
+  color: var(--text-on-color-dark);
+}
+
+.bp-features-branded-dark__cta {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-md);
+  color: var(--text-on-color-dark);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-300);
+  font-weight: var(--font-weight-bold);
+  line-height: 1.4;
+}
+
+.bp-features-branded-dark__cta-arrow {
+  display: inline-block;
+  transition: transform 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));
+}
+
+.bp-features-branded-dark__card-link:hover .bp-features-branded-dark__cta-arrow,
+.bp-features-branded-dark__card-link:focus-visible .bp-features-branded-dark__cta-arrow {
+  transform: translateX(4px);
+}

--- a/content-system/blueprints/react/Features3ColBrandedDark.stories.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.stories.tsx
@@ -1,0 +1,217 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Features3ColBrandedDark } from './Features3ColBrandedDark';
+import type { BlueprintProps } from '../astro/types';
+
+/* ─── Demo data-audience cascade ────────────────────────────────────
+ *
+ * BDS ships the scope-binding pattern but not audience-specific values
+ * — those live in each consumer's globals.css. Storybook needs the
+ * binding present somewhere so cards visualize in the right brand
+ * colors. This `<style>` block mirrors what brikdesigns.com would
+ * declare for its five service-line audiences.
+ *
+ * Per the cascade rules (`docs/theming/client-themes`), we re-bind
+ * `--background-brand-primary` and the related brand-* tokens inside
+ * the `[data-audience='X']` subtree. Components stay scope-blind.
+ */
+const audienceCascadeStyles = `
+[data-audience='brand'] {
+  --background-brand-primary: var(--theme-yellow-yellow-light);
+  --brand-primary: var(--theme-yellow-yellow-light);
+  --text-brand-primary: var(--theme-yellow-yellow-dark);
+}
+[data-audience='marketing'] {
+  --background-brand-primary: var(--theme-green-green-light);
+  --brand-primary: var(--theme-green-green-light);
+  --text-brand-primary: var(--theme-green-green-dark);
+}
+[data-audience='information'] {
+  --background-brand-primary: var(--theme-blue-blue-light);
+  --brand-primary: var(--theme-blue-blue-light);
+  --text-brand-primary: var(--theme-blue-blue-dark);
+}
+[data-audience='product'] {
+  --background-brand-primary: var(--theme-purple-purple-light);
+  --brand-primary: var(--theme-purple-purple-light);
+  --text-brand-primary: var(--theme-purple-purple-dark);
+}
+[data-audience='service'] {
+  --background-brand-primary: var(--theme-orange-orange-light);
+  --brand-primary: var(--theme-orange-orange-light);
+  --text-brand-primary: var(--theme-orange-orange-dark);
+}
+`;
+
+/* ─── Fixtures ─────────────────────────────────────────────────── */
+
+const baseTheme: BlueprintProps['theme'] = {
+  themeMode: 'dark',
+  atmosphere: 'none',
+  navigationArchetype: 'utility-first',
+  footerArchetype: 'four_col_directory',
+};
+
+const baseClientFacts: BlueprintProps['clientFacts'] = {
+  brandName: 'Brik Designs',
+  tagline: null,
+  valueProposition: null,
+  services: [],
+  phone: null,
+  email: null,
+  address: null,
+  hours: [],
+  heroImageUrl: null,
+  logoUrl: null,
+  logoVariants: {},
+};
+
+/**
+ * "Other Service Lines" fixture — the brikdesigns.com cross-sell
+ * module shown at the bottom of each /services/{slug} page. Three
+ * cards in service-line-distinct brand colors.
+ */
+const otherServiceLinesSection: BlueprintProps['section'] = {
+  sectionKey: 'features-branded-dark-default',
+  sectionType: 'features',
+  heading: 'Other Service Lines',
+  subheading: null,
+  body: 'A complete operating system for visual communication — explore the parts you haven’t yet.',
+  cta: null,
+  visualNotes: {
+    blueprintKey: 'features_3col_branded_dark',
+    moodKeywords: ['bold', 'modern'],
+    layoutBlueprint: 'features_3col_branded_dark',
+    imageOpportunity: '3D illustration per service line',
+    animationSuggestion: null,
+    illustrationOpportunity: 'service-line scene per card',
+  },
+  items: [
+    {
+      title: 'Brand',
+      description: 'Logo, identity, and brand systems that scale.',
+      href: '/services/brand',
+      audience: 'brand',
+    },
+    {
+      title: 'Marketing',
+      description: 'Web, email, and social design tied to growth metrics.',
+      href: '/services/marketing',
+      audience: 'marketing',
+    },
+    {
+      title: 'Back Office',
+      description: 'Operations design — SOPs, automation, internal tooling.',
+      href: '/services/back-office',
+      audience: 'service',
+    },
+  ],
+};
+
+const baseProps: BlueprintProps = {
+  section: otherServiceLinesSection,
+  clientFacts: baseClientFacts,
+  theme: baseTheme,
+};
+
+/* ─── Decorator — injects the demo audience cascade ─────────────── */
+
+const withAudienceCascade = (Story: () => JSX.Element) => (
+  <>
+    <style dangerouslySetInnerHTML={{ __html: audienceCascadeStyles }} />
+    <Story />
+  </>
+);
+
+/* ─── Meta ─────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof Features3ColBrandedDark> = {
+  title: 'Blueprints/features_3col_branded_dark',
+  component: Features3ColBrandedDark,
+  tags: ['surface-web', 'surface-shared'],
+  decorators: [withAudienceCascade],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Dark section with a 3-column grid of brand-colored cards. Each card emits `data-audience` to re-bind `--background-brand-primary` for that subtree per the BDS scope-binding pattern (`docs/theming/client-themes`). Stories include a demo cascade block that mirrors the brikdesigns.com five service-line bindings; consumer sites must declare an equivalent block. Card title uses bold weight + 18px, description 16px regular — the AA-clearing posture for white-on-saturated-brand backgrounds (BDS contrast burndown #40).',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Features3ColBrandedDark>;
+
+/* ─── Stories ──────────────────────────────────────────────────── */
+
+/**
+ * @summary Three cards — brand / marketing / back-office. The brikdesigns "Other Service Lines" fixture.
+ */
+export const Default: Story = {
+  args: baseProps,
+};
+
+/**
+ * @summary Two cards — narrow grid, centers on desktop.
+ */
+export const TwoCards: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...otherServiceLinesSection,
+      sectionKey: 'features-branded-dark-2-cards',
+      items: otherServiceLinesSection.items.slice(0, 2),
+    },
+  },
+};
+
+/**
+ * @summary Four cards — wraps to a second row at the desktop breakpoint.
+ */
+export const FourCards: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...otherServiceLinesSection,
+      sectionKey: 'features-branded-dark-4-cards',
+      items: [
+        ...otherServiceLinesSection.items,
+        {
+          title: 'Information',
+          description: 'Make complex information scannable and on-brand.',
+          href: '/services/information',
+          audience: 'information',
+        },
+      ],
+    },
+  },
+};
+
+/**
+ * @summary No images — falls back to oversized ServiceTag icon per card.
+ */
+export const NoImages: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...otherServiceLinesSection,
+      sectionKey: 'features-branded-dark-no-images',
+      items: otherServiceLinesSection.items.map((item) => ({
+        ...item,
+        imageUrl: undefined,
+      })),
+    },
+  },
+};
+
+/**
+ * @summary Atmosphere overlay — `editorial-luxury` — verifies the dark surface stays compatible.
+ */
+export const AtmosphereEditorialLuxury: Story = {
+  args: {
+    ...baseProps,
+    theme: { ...baseTheme, atmosphere: 'editorial-luxury' },
+  },
+};

--- a/content-system/blueprints/react/Features3ColBrandedDark.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.tsx
@@ -1,0 +1,164 @@
+/**
+ * Features3ColBrandedDark — React renderer for the
+ * `features_3col_branded_dark` blueprint. Dark section, 3-column grid
+ * of cards filled with per-card brand colors via `data-audience`
+ * scope binding. Drives brikdesigns.com's "Other Service Lines"
+ * cross-sell module on `/services/{slug}` pages.
+ *
+ * Astro twin lives at `../astro/Features3ColBrandedDark.astro` and
+ * mirrors the same DOM shape with the same `data-audience` attributes
+ * — the consumer site's `[data-audience='X']` cascade rules drive
+ * both renderers identically.
+ *
+ * Contract: BlueprintProps. Per-card data on `section.items[]`; each
+ * item carries an `audience` slug that emits `data-audience` on the
+ * card, re-binding `--brand-primary` for that subtree.
+ *
+ * ## Audience scope binding
+ *
+ * BDS ships the pattern, not the audience-specific values. The
+ * consumer (brikdesigns.com) defines `[data-audience='brand']`,
+ * `[data-audience='marketing']`, etc. in its globals.css with the
+ * matching service-line color tokens. Without those rules in place,
+ * cards render in the global brand color and the visual collapses to
+ * "three identical cards" — not a renderer bug, a missing-cascade bug
+ * on the consumer side.
+ *
+ * Storybook demonstrates the pattern via a stories-only cascade block.
+ *
+ * CSS custom properties — variation API:
+ *   --bp-features-branded-dark-bg          (default: var(--page-inverse))
+ *   --bp-features-branded-dark-card-radius (default: var(--border-radius-lg))
+ *   --bp-features-branded-dark-gap         (default: var(--gap-lg))
+ *   --bp-features-branded-dark-image-pad   (default: var(--padding-xl))
+ *   --bp-features-branded-dark-hover-scale (default: 1.02 — set to 1 to disable)
+ *
+ * a11y: section uses h2 + aria-labelledby; cards are an unordered
+ * list with role="list"; card title is h3. Card title uses
+ * `--font-weight-bold` and 18px to clear AA on saturated brand
+ * backgrounds; description uses 16px regular to clear at the
+ * large-text 3:1 threshold (BDS contrast burndown #40 — full
+ * resolution requires brand-color adjustment, tracked separately).
+ *
+ * @summary Dark section, 3-col grid of brand-colored cards (per-audience scope binding).
+ */
+import { Card, ServiceTag, Stack, type ServiceCategory } from '../../../components';
+
+import type { BlueprintProps } from '../astro/types';
+import './Features3ColBrandedDark.css';
+
+interface Props extends BlueprintProps {}
+
+export function Features3ColBrandedDark({ section }: Props) {
+  const headingId = `bp-features-branded-dark-${section.sectionKey}-h`;
+
+  return (
+    <section
+      className="bp-features-branded-dark"
+      data-blueprint-key="features_3col_branded_dark"
+      aria-labelledby={section.heading ? headingId : undefined}
+    >
+      <div className="bp-features-branded-dark__container">
+        {(section.heading || section.subheading || section.body) && (
+          <Stack
+            as="header"
+            gap="md"
+            className="bp-features-branded-dark__header"
+          >
+            {section.subheading && (
+              <p className="bp-features-branded-dark__eyebrow">
+                {section.subheading}
+              </p>
+            )}
+            {section.heading && (
+              <h2
+                id={headingId}
+                className="bp-features-branded-dark__heading"
+              >
+                {section.heading}
+              </h2>
+            )}
+            {section.body && (
+              <p className="bp-features-branded-dark__lead">{section.body}</p>
+            )}
+          </Stack>
+        )}
+
+        <ul className="bp-features-branded-dark__grid" role="list">
+          {section.items.map((item, idx) => {
+            const audience = item.audience ?? null;
+            return (
+              <li
+                key={`${section.sectionKey}-${idx}`}
+                className="bp-features-branded-dark__item"
+              >
+                <Card
+                  variant="outlined"
+                  padding="none"
+                  className="bp-features-branded-dark__card"
+                  data-audience={audience ?? undefined}
+                >
+                  <a
+                    className="bp-features-branded-dark__card-link"
+                    href={item.href ?? '#'}
+                  >
+                    <div className="bp-features-branded-dark__media">
+                      {item.imageUrl ? (
+                        <img
+                          src={item.imageUrl}
+                          alt={item.imageAlt ?? ''}
+                          className="bp-features-branded-dark__image"
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      ) : audience ? (
+                        <span
+                          className="bp-features-branded-dark__image-fallback"
+                          aria-hidden="true"
+                        >
+                          <ServiceTag
+                            category={audience as ServiceCategory}
+                            variant="icon"
+                            size="lg"
+                            serviceName={item.title}
+                          />
+                        </span>
+                      ) : (
+                        <span
+                          className="bp-features-branded-dark__image-fallback bp-features-branded-dark__image-fallback--blank"
+                          aria-hidden="true"
+                        />
+                      )}
+                    </div>
+
+                    <div className="bp-features-branded-dark__body">
+                      <h3 className="bp-features-branded-dark__title">
+                        {item.title}
+                      </h3>
+                      {item.description && (
+                        <p className="bp-features-branded-dark__description">
+                          {item.description}
+                        </p>
+                      )}
+                      <span className="bp-features-branded-dark__cta">
+                        Learn more
+                        <span
+                          aria-hidden="true"
+                          className="bp-features-branded-dark__cta-arrow"
+                        >
+                          →
+                        </span>
+                      </span>
+                    </div>
+                  </a>
+                </Card>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+export default Features3ColBrandedDark;

--- a/content-system/blueprints/react/index.ts
+++ b/content-system/blueprints/react/index.ts
@@ -42,6 +42,7 @@ export type {
 // ── Blueprint renderers ─────────────────────────────────────────
 export { Services3ColCardGrid } from './Services3ColCardGrid';
 export { SupportPlanCalloutSplit } from './SupportPlanCalloutSplit';
+export { Features3ColBrandedDark } from './Features3ColBrandedDark';
 
 // ── Dispatch surface ────────────────────────────────────────────
 export { BlueprintDispatcher } from './BlueprintDispatcher';

--- a/scripts/verify-blueprints-astro-exports.mjs
+++ b/scripts/verify-blueprints-astro-exports.mjs
@@ -678,6 +678,7 @@ const expectedFiles = [
   'content-system/blueprints/astro/ServicesDetailTwoColumn.astro',
   'content-system/blueprints/astro/Services3ColCardGrid.astro',
   'content-system/blueprints/astro/SupportPlanCalloutSplit.astro',
+  'content-system/blueprints/astro/Features3ColBrandedDark.astro',
   'content-system/blueprints/astro/AboutStorySplit.astro',
   'content-system/blueprints/astro/TestimonialsFeaturedLarge.astro',
   'content-system/blueprints/astro/CtaSplitContact.astro',


### PR DESCRIPTION
## Summary
- feat(blueprints): ship features_3col_branded_dark renderers (Astro + React)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

Generated with [Claude Code](https://claude.ai/code)