### PR TITLE
refactor(storybook): collapse blueprint stories to Playground + meaningful states

### DIFF
--- a/content-system/blueprints/react/Features3ColBrandedDark.stories.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Features3ColBrandedDark } from './Features3ColBrandedDark';
 import type { BlueprintProps } from '../astro/types';
+import { baseTheme, baseClientFacts } from './_fixtures';
 
 /* ─── Demo data-audience cascade ────────────────────────────────────
  *
@@ -45,26 +46,7 @@ const audienceCascadeStyles = `
 
 /* ─── Fixtures ─────────────────────────────────────────────────── */
 
-const baseTheme: BlueprintProps['theme'] = {
-  themeMode: 'dark',
-  atmosphere: 'none',
-  navigationArchetype: 'utility-first',
-  footerArchetype: 'four_col_directory',
-};
-
-const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
-  tagline: null,
-  valueProposition: null,
-  services: [],
-  phone: null,
-  email: null,
-  address: null,
-  hours: [],
-  heroImageUrl: null,
-  logoUrl: null,
-  logoVariants: {},
-};
+const darkTheme: BlueprintProps['theme'] = { ...baseTheme, themeMode: 'dark' };
 
 /**
  * "Other Service Lines" fixture — the brikdesigns.com cross-sell
@@ -111,7 +93,7 @@ const otherServiceLinesSection: BlueprintProps['section'] = {
 const baseProps: BlueprintProps = {
   section: otherServiceLinesSection,
   clientFacts: baseClientFacts,
-  theme: baseTheme,
+  theme: darkTheme,
 };
 
 /* ─── Decorator — injects the demo audience cascade ─────────────── */
@@ -149,33 +131,25 @@ type Story = StoryObj<typeof Features3ColBrandedDark>;
 /**
  * @summary Three cards — brand / marketing / back-office. The brikdesigns "Other Service Lines" fixture.
  */
-export const Default: Story = {
+export const Playground: Story = {
   args: baseProps,
 };
 
 /**
- * @summary Two cards — narrow grid, centers on desktop.
+ * @summary Wrapped — four+ cards force the grid to a second row.
+ *
+ * Distinct meaningful state from `Playground` because the row-wrap
+ * behavior at the desktop breakpoint is the layout property worth
+ * verifying. Per-card content variants (missing image, audience
+ * accent) are exercised by the leaf component stories, not duplicated
+ * here.
  */
-export const TwoCards: Story = {
+export const Wrapped: Story = {
   args: {
     ...baseProps,
     section: {
       ...otherServiceLinesSection,
-      sectionKey: 'features-branded-dark-2-cards',
-      items: otherServiceLinesSection.items.slice(0, 2),
-    },
-  },
-};
-
-/**
- * @summary Four cards — wraps to a second row at the desktop breakpoint.
- */
-export const FourCards: Story = {
-  args: {
-    ...baseProps,
-    section: {
-      ...otherServiceLinesSection,
-      sectionKey: 'features-branded-dark-4-cards',
+      sectionKey: 'features-branded-dark-wrapped',
       items: [
         ...otherServiceLinesSection.items,
         {
@@ -186,32 +160,5 @@ export const FourCards: Story = {
         },
       ],
     },
-  },
-};
-
-/**
- * @summary No images — falls back to oversized ServiceTag icon per card.
- */
-export const NoImages: Story = {
-  args: {
-    ...baseProps,
-    section: {
-      ...otherServiceLinesSection,
-      sectionKey: 'features-branded-dark-no-images',
-      items: otherServiceLinesSection.items.map((item) => ({
-        ...item,
-        imageUrl: undefined,
-      })),
-    },
-  },
-};
-
-/**
- * @summary Atmosphere overlay — `editorial-luxury` — verifies the dark surface stays compatible.
- */
-export const AtmosphereEditorialLuxury: Story = {
-  args: {
-    ...baseProps,
-    theme: { ...baseTheme, atmosphere: 'editorial-luxury' },
   },
 };

--- a/content-system/blueprints/react/Services3ColCardGrid.stories.tsx
+++ b/content-system/blueprints/react/Services3ColCardGrid.stories.tsx
@@ -2,33 +2,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Services3ColCardGrid } from './Services3ColCardGrid';
 import type { BlueprintProps } from '../astro/types';
+import { baseTheme, baseClientFacts } from './_fixtures';
 
 /* ─── Fixtures ─────────────────────────────────────────────────── */
 
-const baseTheme: BlueprintProps['theme'] = {
-  themeMode: 'light',
-  atmosphere: 'none',
-  navigationArchetype: 'utility-first',
-  footerArchetype: 'four_col_directory',
-};
-
-const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
-  tagline: null,
-  valueProposition: null,
-  services: [],
-  phone: null,
-  email: null,
-  address: null,
-  hours: [],
-  heroImageUrl: null,
-  logoUrl: null,
-  logoVariants: {},
-};
-
 /**
  * "Information Design Services" fixture — six service cards modeled
- * on the brikdesigns.com /services/information page that drives this
+ * on the brikdesigns.com `/services/information` page that drives this
  * blueprint. Image URLs are placeholder; the production CMS supplies
  * Webflow-hosted illustrations.
  */
@@ -131,105 +111,15 @@ type Story = StoryObj<typeof Services3ColCardGrid>;
 
 /**
  * @summary Six "Information Design" service cards — the canonical fixture.
+ *
+ * Single Playground story per ADR-006: shape-only blueprint stories
+ * carry one canonical state, not a fan-out of content variations.
+ * Per-card affordances (`hasOptions`, missing `imageUrl`, accent
+ * `category`) are exercised by the leaf component stories
+ * (`Card.stories.tsx`, `ServiceTag.stories.tsx`, `Frame.stories.tsx`).
+ * Atmosphere variants are switched via the Theme Switcher addon —
+ * not encoded as separate stories.
  */
-export const Default: Story = {
+export const Playground: Story = {
   args: baseProps,
-};
-
-/**
- * @summary No images — falls back to oversized ServiceTag icon per card.
- *
- * Illustration assets are optional. When the CMS hasn't supplied an
- * image, the blueprint shows the ServiceTag icon (sized up) inside
- * the 3:2 frame so the grid keeps consistent rhythm.
- */
-export const NoImages: Story = {
-  args: {
-    ...baseProps,
-    section: {
-      ...informationServicesSection,
-      sectionKey: 'services-grid-no-images',
-      items: informationServicesSection.items.map((item) => ({
-        ...item,
-        imageUrl: undefined,
-      })),
-    },
-  },
-};
-
-/**
- * @summary One card flagged with `hasOptions` — "Has Options" badge anchors top-right.
- */
-export const HasOptions: Story = {
-  args: {
-    ...baseProps,
-    section: {
-      ...informationServicesSection,
-      sectionKey: 'services-grid-has-options',
-      items: informationServicesSection.items.slice(0, 3).map((item, idx) => ({
-        ...item,
-        hasOptions: idx === 1,
-      })),
-    },
-  },
-};
-
-/**
- * @summary Mixed service categories — verifies the per-category accent color axis.
- *
- * The brikdesigns.com /services/ index page mixes all five categories
- * (brand, marketing, information, product, service). The card body's
- * ServiceTag adapts its accent color via the BDS `category` prop.
- */
-export const MixedCategories: Story = {
-  args: {
-    ...baseProps,
-    section: {
-      ...informationServicesSection,
-      sectionKey: 'services-grid-mixed',
-      heading: 'All Services',
-      subheading: 'Brik Designs',
-      body: 'A category-spanning view — each card carries its service-line accent.',
-      items: [
-        {
-          title: 'Brand Identity Bundle',
-          description: 'Logo, type, color, and applications in one pass.',
-          href: '/services/brand/brand-identity-bundle',
-          imageUrl: 'https://placehold.co/480x320/fff4cc/5b4500?text=Brand',
-          category: 'brand',
-          hasOptions: true,
-        },
-        {
-          title: 'Web Design & Development',
-          description: 'Custom sites, content, and CMS — built for growth and easy edits.',
-          href: '/services/marketing/web-design-development',
-          imageUrl: 'https://placehold.co/480x320/d6f1da/1f5b2e?text=Marketing',
-          category: 'marketing',
-        },
-        {
-          title: 'Information Design',
-          description: 'Make complex information scannable and on-brand.',
-          href: '/services/information/information-design',
-          imageUrl: 'https://placehold.co/480x320/d6e4f5/1f3d70?text=Information',
-          category: 'information',
-        },
-      ],
-    },
-  },
-};
-
-/**
- * @summary Atmosphere overlay — `clean-bright`. Verifies blueprint surface tokens stay theme-layer.
- *
- * Renders the same default fixture but with `theme.atmosphere =
- * 'clean-bright'`. Use the Theme Switcher addon to swap atmospheres
- * — the blueprint must NOT redefine `--surface-*` / `--text-*` /
- * `--border-*` tokens; those stay theme-layer and atmosphere CSS
- * already overrides them.
- */
-export const AtmosphereCleanBright: Story = {
-  args: {
-    ...baseProps,
-    theme: { ...baseTheme, atmosphere: 'clean-bright' },
-  },
 };

--- a/content-system/blueprints/react/SupportPlanCalloutSplit.stories.tsx
+++ b/content-system/blueprints/react/SupportPlanCalloutSplit.stories.tsx
@@ -2,29 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { SupportPlanCalloutSplit } from './SupportPlanCalloutSplit';
 import type { BlueprintProps } from '../astro/types';
+import { baseTheme, baseClientFacts } from './_fixtures';
 
 /* ─── Fixtures ─────────────────────────────────────────────────── */
-
-const baseTheme: BlueprintProps['theme'] = {
-  themeMode: 'light',
-  atmosphere: 'none',
-  navigationArchetype: 'utility-first',
-  footerArchetype: 'four_col_directory',
-};
-
-const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
-  tagline: null,
-  valueProposition: null,
-  services: [],
-  phone: null,
-  email: null,
-  address: null,
-  hours: [],
-  heroImageUrl: null,
-  logoUrl: null,
-  logoVariants: {},
-};
 
 /**
  * "Monthly support services" fixture — the brikdesigns.com cross-sell
@@ -116,15 +96,19 @@ type Story = StoryObj<typeof SupportPlanCalloutSplit>;
 /**
  * @summary Default split — persona-cluster scene + plan card.
  */
-export const Default: Story = {
+export const Playground: Story = {
   args: baseProps,
 };
 
 /**
- * @summary No illustration — plan card centers full-width (max 720px).
+ * @summary No illustration — plan card centers full-width.
  *
- * The blueprint supports an "illustration omitted" variant so consumers
- * can drop the cross-sell card on pages where the scene doesn't fit.
+ * Distinct meaningful state from `Playground`: the layout collapses
+ * from two-column split to a single centered card. Worth a separate
+ * story because the visual rhythm changes substantially. The
+ * "no header" / atmosphere variants are not separate stories —
+ * they're trivial prop differences exercised at the leaf-component
+ * stories or via the Theme Switcher addon.
  */
 export const NoIllustration: Story = {
   args: {
@@ -134,39 +118,5 @@ export const NoIllustration: Story = {
       sectionKey: 'support-plan-no-illustration',
       illustration: undefined,
     },
-  },
-};
-
-/**
- * @summary No section header — card + illustration stand alone.
- *
- * For consumers that want to slot this blueprint inside an already-
- * titled context (e.g. inside an existing services page section).
- */
-export const NoHeader: Story = {
-  args: {
-    ...baseProps,
-    section: {
-      ...supportSection,
-      sectionKey: 'support-plan-no-header',
-      heading: null,
-      subheading: null,
-      body: null,
-    },
-  },
-};
-
-/**
- * @summary Atmosphere overlay — `warm-soft`. Verifies blueprint surfaces stay theme-layer.
- *
- * Renders the same default fixture under the `warm-soft` atmosphere.
- * Use the Theme Switcher addon to compare. The blueprint must NOT
- * redefine `--surface-*` / `--text-*` / `--border-*` tokens; the
- * atmosphere CSS already handles those.
- */
-export const AtmosphereWarmSoft: Story = {
-  args: {
-    ...baseProps,
-    theme: { ...baseTheme, atmosphere: 'warm-soft' },
   },
 };

--- a/content-system/blueprints/react/_fixtures.ts
+++ b/content-system/blueprints/react/_fixtures.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared blueprint-story fixtures.
+ *
+ * `baseTheme` and `baseClientFacts` were duplicated verbatim across
+ * every blueprint story file. Extracted here so a single source-of-truth
+ * change propagates to every fixture, and the per-story files can focus
+ * on the *section shape* that's distinctive about that blueprint.
+ *
+ * Keep this file fixture-only — no React, no decorators, no rendering.
+ * Decorators live next to their story (`withAudienceCascade` etc.) since
+ * they're per-blueprint affordances, not shared truth.
+ */
+import type { BlueprintProps } from '../astro/types';
+
+export const baseTheme: BlueprintProps['theme'] = {
+  themeMode: 'light',
+  atmosphere: 'none',
+  navigationArchetype: 'utility-first',
+  footerArchetype: 'four_col_directory',
+};
+
+export const baseClientFacts: BlueprintProps['clientFacts'] = {
+  brandName: 'Brik Designs',
+  tagline: null,
+  valueProposition: null,
+  services: [],
+  phone: null,
+  email: null,
+  address: null,
+  hours: [],
+  heroImageUrl: null,
+  logoUrl: null,
+  logoVariants: {},
+};


### PR DESCRIPTION
## Summary

Removes story-level slop on the three shipped blueprint renderers per ADR-006 ("Playground + one story per meaningful state, not a fan-out of content variations"). Companion to PR #495 (which ships [\`hero_split_image_card_overlay\`](https://github.com/brikdesigns/brik-bds/pull/495)) — this PR cleans the *existing* three blueprints so the new hero blueprint's single-Playground-state shape becomes the consistent pattern, not the outlier.

## Counts

| Blueprint | Before → After |
|---|---|
| \`Services3ColCardGrid\` | 5 stories → 1 (Playground) |
| \`Features3ColBrandedDark\` | 5 stories → 2 (Playground + Wrapped) |
| \`SupportPlanCalloutSplit\` | 4 stories → 2 (Playground + NoIllustration) |

## What was dropped

- **Per-card content variants** — \`NoImages\`, \`HasOptions\`, \`MixedCategories\`, \`TwoCards\`, \`FourCards\`. These are exercised by leaf component stories (\`Card\`, \`ServiceTag\`, \`Frame\`), not duplicated at the blueprint layer.
- **Atmosphere variants** — \`AtmosphereCleanBright\`, \`AtmosphereEditorialLuxury\`, \`AtmosphereWarmSoft\`. Atmosphere is a Theme Switcher addon affordance, not a per-story dimension.
- **\`NoHeader\`** (SupportPlanCalloutSplit) — trivial prop difference; the canonical Playground covers the meaningful shape.

## What was kept

- **\`Wrapped\`** (Features3ColBrandedDark, 4 cards) — distinct meaningful state. The desktop-breakpoint row-wrap is layout behavior worth verifying.
- **\`NoIllustration\`** (SupportPlanCalloutSplit) — distinct visual rhythm (single centered card vs two-column split).

## Bonus cleanup

\`baseTheme\` and \`baseClientFacts\` were duplicated verbatim across every blueprint story. Extracted to \`content-system/blueprints/react/_fixtures.ts\` so a single source-of-truth change propagates everywhere; per-story files now focus on the section shape distinctive to that blueprint.

## Deferred

Args-composition refactor (compose blueprint props from leaf-component story args per STORYBOOK-WRITING-GUIDE §"Args composition") is **deferred to a follow-up**. The section-shaped CMS API doesn't compose cleanly from leaf args without a broader rethink, and the slop sweep itself was the stated scope.

## Consumer sync plan

- [ ] Portal: \`npm update @brikdesigns/bds\` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: \`./scripts/bds-sync.sh\`

## Test plan

- [x] \`validate:full\` — all 8 checks pass
- [x] \`canonical-check\` + \`canonical-class-check\` — no violations
- [x] Storybook build successful

## Diff size

\`4 files changed, 67 insertions(+), 246 deletions(-)\` — net **-179 lines** of fixture duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)