### PR TITLE
chore(release): 0.61.0 → 0.62.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.61.0",
+      "version": "0.62.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Releases [\`hero_split_image_card_overlay\`](https://github.com/brikdesigns/brik-bds/pull/495) blueprint to consumers (web/brikdesigns is the immediate adopter).

After merge: tag \`v0.62.0\` triggers Release workflow → publishes to GitHub Packages.

## Changes

\`package.json\` + \`package-lock.json\` version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)