### PR TITLE
refactor(blueprints): compose BDS primitives + semantic font tokens

### DIFF
--- a/content-system/blueprints/astro/AboutStorySplit.astro
+++ b/content-system/blueprints/astro/AboutStorySplit.astro
@@ -97,7 +97,7 @@ const callout = section.items[0];
   .bp-about-story-split__eyebrow {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -107,7 +107,7 @@ const callout = section.items[0];
   .bp-about-story-split__heading {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-about-story-split-heading-color, var(--text-primary));
@@ -116,7 +116,7 @@ const callout = section.items[0];
   .bp-about-story-split__body {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--line-height-relaxed);
     color: var(--bp-about-story-split-body-color, var(--text-secondary));
     max-width: 65ch;
@@ -138,7 +138,7 @@ const callout = section.items[0];
   .bp-about-story-split__quote-text {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-500);
+    font-size: var(--heading-md);
     font-style: normal;
     line-height: var(--line-height-relaxed);
     color: var(--text-primary);
@@ -146,7 +146,7 @@ const callout = section.items[0];
 
   .bp-about-story-split__quote-cite {
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-style: normal;
     letter-spacing: 0.04em;
     text-transform: uppercase;

--- a/content-system/blueprints/astro/BlueprintFallback.astro
+++ b/content-system/blueprints/astro/BlueprintFallback.astro
@@ -72,7 +72,7 @@ const attrValue = unknownKey ?? '__null__';
   .bp-fallback__label {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-semibold);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -84,13 +84,13 @@ const attrValue = unknownKey ?? '__null__';
   .bp-fallback__hint {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     line-height: var(--line-height-relaxed);
     color: var(--text-secondary);
   }
 
   .bp-fallback__hint {
-    font-size: var(--font-size-200);
+    font-size: var(--body-lg);
     max-width: 72ch;
   }
 

--- a/content-system/blueprints/astro/CtaDarkCentered.astro
+++ b/content-system/blueprints/astro/CtaDarkCentered.astro
@@ -71,7 +71,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
   .bp-cta-dark-centered__heading {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-700), 4vw, var(--font-size-1000));
+    font-size: clamp(var(--heading-xl), 4vw, var(--display-sm));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-cta-dark-centered-heading-color, var(--text-inverse, var(--color-grayscale-white)));
@@ -80,7 +80,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
   .bp-cta-dark-centered__body {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--line-height-relaxed);
     color: var(--bp-cta-dark-centered-body-color, var(--text-secondary-inverse, var(--color-grayscale-lightest)));
     max-width: 55ch;
@@ -94,7 +94,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
     background: var(--bp-cta-dark-centered-cta-bg, var(--background-brand-primary));
     color: var(--bp-cta-dark-centered-cta-color, var(--text-on-color-dark, var(--text-inverse)));
     font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
+    font-size: var(--label-xl);
     font-weight: var(--font-weight-semibold);
     text-decoration: none;
     border-radius: var(--border-radius-md);

--- a/content-system/blueprints/astro/CtaDarkCentered.astro
+++ b/content-system/blueprints/astro/CtaDarkCentered.astro
@@ -43,7 +43,7 @@ const headingId = `bp-cta-dark-centered-${section.sectionKey}-h`;
       <p class="bp-cta-dark-centered__body">{section.body}</p>
     )}
     {section.cta && (
-      <a href={section.cta.url} class="bp-cta-dark-centered__cta">{section.cta.label}</a>
+      <a href={section.cta.url} class="bds-button bds-button--primary bds-button--lg"><span class="bds-button__content">{section.cta.label}</span></a>
     )}
   </div>
 </section>

--- a/content-system/blueprints/astro/CtaSplitContact.astro
+++ b/content-system/blueprints/astro/CtaSplitContact.astro
@@ -118,7 +118,7 @@ const email = clientFacts.email;
   .bp-cta-split-contact__heading {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-cta-split-contact-heading-color, var(--text-primary));
@@ -127,7 +127,7 @@ const email = clientFacts.email;
   .bp-cta-split-contact__body {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--line-height-relaxed);
     color: var(--bp-cta-split-contact-body-color, var(--text-secondary));
     max-width: 55ch;
@@ -141,7 +141,7 @@ const email = clientFacts.email;
     background: var(--background-brand-primary);
     color: var(--text-on-color-dark, var(--text-inverse));
     font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
+    font-size: var(--label-xl);
     font-weight: var(--font-weight-semibold);
     text-decoration: none;
     border-radius: var(--border-radius-md);
@@ -196,7 +196,7 @@ const email = clientFacts.email;
 
   .bp-cta-split-contact__method-label {
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--text-secondary);
@@ -204,7 +204,7 @@ const email = clientFacts.email;
 
   .bp-cta-split-contact__method-value {
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-500);
+    font-size: var(--heading-md);
     font-weight: var(--font-weight-semibold);
   }
 </style>

--- a/content-system/blueprints/astro/CtaSplitContact.astro
+++ b/content-system/blueprints/astro/CtaSplitContact.astro
@@ -51,7 +51,7 @@ const email = clientFacts.email;
         <p class="bp-cta-split-contact__body">{section.body}</p>
       )}
       {section.cta && (
-        <a href={section.cta.url} class="bp-cta-split-contact__cta">{section.cta.label}</a>
+        <a href={section.cta.url} class="bds-button bds-button--primary bds-button--md"><span class="bds-button__content">{section.cta.label}</span></a>
       )}
     </div>
 

--- a/content-system/blueprints/astro/Features3ColBrandedDark.astro
+++ b/content-system/blueprints/astro/Features3ColBrandedDark.astro
@@ -154,7 +154,7 @@ const headingId = `bp-features-branded-dark-${section.sectionKey}-h`;
   .bp-features-branded-dark__eyebrow {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -165,7 +165,7 @@ const headingId = `bp-features-branded-dark-${section.sectionKey}-h`;
   .bp-features-branded-dark__heading {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
     font-weight: var(--font-weight-semibold);
     line-height: var(--font-line-height-tight);
     color: var(--text-on-color-dark);
@@ -174,7 +174,7 @@ const headingId = `bp-features-branded-dark-${section.sectionKey}-h`;
   .bp-features-branded-dark__lead {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--font-line-height-relaxed);
     color: var(--text-on-color-dark);
     opacity: 0.85;
@@ -279,7 +279,7 @@ const headingId = `bp-features-branded-dark-${section.sectionKey}-h`;
   .bp-features-branded-dark__title {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-500);
+    font-size: var(--heading-md);
     font-weight: var(--font-weight-bold);
     line-height: var(--font-line-height-tight);
     color: var(--text-on-color-dark);
@@ -291,7 +291,7 @@ const headingId = `bp-features-branded-dark-${section.sectionKey}-h`;
   .bp-features-branded-dark__description {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--font-line-height-relaxed);
     color: var(--text-on-color-dark);
   }
@@ -303,7 +303,7 @@ const headingId = `bp-features-branded-dark-${section.sectionKey}-h`;
     gap: var(--gap-md);
     color: var(--text-on-color-dark);
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     font-weight: var(--font-weight-bold);
     line-height: 1.4;
   }

--- a/content-system/blueprints/astro/HeroInteriorMinimal.astro
+++ b/content-system/blueprints/astro/HeroInteriorMinimal.astro
@@ -46,7 +46,7 @@ const cta = section.cta;
     <h1 id={headingId} class="bp-hero-interior-minimal__headline">{headline}</h1>
     {lead && <p class="bp-hero-interior-minimal__lead">{lead}</p>}
     {cta && (
-      <a href={cta.url} class="bp-hero-interior-minimal__cta">{cta.label}</a>
+      <a href={cta.url} class="bds-button bds-button--primary bds-button--md"><span class="bds-button__content">{cta.label}</span></a>
     )}
   </div>
 </section>

--- a/content-system/blueprints/astro/HeroInteriorMinimal.astro
+++ b/content-system/blueprints/astro/HeroInteriorMinimal.astro
@@ -73,7 +73,7 @@ const cta = section.cta;
   .bp-hero-interior-minimal__eyebrow {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -83,7 +83,7 @@ const cta = section.cta;
   .bp-hero-interior-minimal__headline {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-700), 4vw, var(--font-size-1000));
+    font-size: clamp(var(--heading-xl), 4vw, var(--display-sm));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-hero-interior-headline-color, var(--text-primary));
@@ -92,7 +92,7 @@ const cta = section.cta;
   .bp-hero-interior-minimal__lead {
     margin: var(--space-sm) 0 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--line-height-relaxed);
     color: var(--bp-hero-interior-lead-color, var(--text-secondary));
   }
@@ -105,7 +105,7 @@ const cta = section.cta;
     background: var(--background-brand-primary);
     color: var(--text-on-color-dark, var(--text-inverse));
     font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
+    font-size: var(--label-xl);
     font-weight: var(--font-weight-semibold);
     text-decoration: none;
     border-radius: var(--border-radius-md);

--- a/content-system/blueprints/astro/HeroSplit6040.astro
+++ b/content-system/blueprints/astro/HeroSplit6040.astro
@@ -153,7 +153,7 @@ const imageAlt = '';
   .bp-hero-split-60-40__eyebrow {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -164,9 +164,9 @@ const imageAlt = '';
     margin: 0;
     font-family: var(--font-family-heading);
     font-size: clamp(
-      var(--font-size-800),
+      var(--heading-xxl),
       5vw,
-      var(--font-size-1100)
+      var(--display-sm)
     );
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
@@ -192,7 +192,7 @@ const imageAlt = '';
   .bp-hero-split-60-40__lead {
     margin: var(--space-sm) 0 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--line-height-relaxed);
     color: var(--bp-hero-split-lead-color, var(--text-secondary));
     max-width: 55ch;
@@ -207,7 +207,7 @@ const imageAlt = '';
     background: var(--background-brand-primary);
     color: var(--text-on-color-dark, var(--text-inverse));
     font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
+    font-size: var(--label-xl);
     font-weight: var(--font-weight-semibold);
     text-decoration: none;
     border-radius: var(--border-radius-md);
@@ -258,7 +258,7 @@ const imageAlt = '';
   .bp-hero-split-60-40__missing-label {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     color: var(--text-muted, var(--color-grayscale-dark));
     text-align: center;
   }

--- a/content-system/blueprints/astro/HeroSplit6040.astro
+++ b/content-system/blueprints/astro/HeroSplit6040.astro
@@ -80,8 +80,8 @@ const imageAlt = '';
       <h1 id={headingId} class="bp-hero-split-60-40__headline">{headline}</h1>
       {lead && <p class="bp-hero-split-60-40__lead">{lead}</p>}
       {cta && (
-        <a href={cta.url} class="bp-hero-split-60-40__cta">
-          {cta.label}
+        <a href={cta.url} class="bds-button bds-button--primary bds-button--md">
+          <span class="bds-button__content">{cta.label}</span>
         </a>
       )}
     </div>

--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -7,10 +7,17 @@
  * the page image and an optional price overlay (price label + price
  * value + secondary CTA).
  *
- * Drives `/services/{cat}/{slug}` style pages — the pattern that
- * surfaced as the failure zone where agents were inventing layouts
- * (overproducing extra CTAs, hallucinating pricing fields) because
- * no canonical blueprint covered the shape.
+ * Drives `/services/{cat}/{slug}` style pages.
+ *
+ * Composes BDS canonical classes per docs/COMPONENT-PATTERNS.md
+ * §"Compose primitives — never reimplement them":
+ *   - Breadcrumb trail → `bds-breadcrumb` markup pattern
+ *   - Left CTA → `bds-button bds-button--inverse bds-button--md` pattern
+ *   - Price-card CTA → `bds-button bds-button--primary bds-button--sm` pattern
+ *
+ * The Astro twin can't import the React Breadcrumb / LinkButton
+ * components directly, but it MUST emit the same canonical class
+ * structure so `dist/styles.css` styles the markup identically.
  *
  * ── Contract ─────────────────────────────────────────────────────
  * Props: BlueprintProps (universal across every blueprint).
@@ -24,26 +31,22 @@
  *   - section.visualNotes.blueprintKey === 'hero_split_image_card_overlay'
  *
  * ── required_facts ───────────────────────────────────────────────
- * None at the clientFacts level — this blueprint sources every visible
- * field from the section. If `priceCard` is omitted, the right column
- * renders the non-hallucinatable `data-content-needed` stub.
+ * None at the clientFacts level. If `priceCard` is omitted, the right
+ * column renders the non-hallucinatable `data-content-needed` stub.
  *
  * ── CSS custom properties (per-client override surface) ──────────
  *   --bp-hero-img-card-bg          (default: var(--page-brand-primary, var(--page-secondary)))
  *   --bp-hero-img-card-padding-y   (default: clamp block)
  *   --bp-hero-img-card-headline-color (default: var(--text-primary))
  *   --bp-hero-img-card-eyebrow-color  (default: var(--text-primary))
- *   --bp-hero-img-card-breadcrumb-color (default: var(--text-brand-primary))
  *   --bp-hero-img-card-card-bg     (default: var(--surface-primary))
  *   --bp-hero-img-card-radius      (default: var(--border-radius-lg))
  *
  * ── a11y (WCAG 2.1 AA) ───────────────────────────────────────────
  * - Heading is h1 (hero blueprints own the page's singular h1).
  * - aria-labelledby wires the section landmark to the h1 id.
- * - Breadcrumb uses <nav aria-label="Breadcrumb"> with an ordered list
- *   and aria-current="page" on the last (typically link-less) item.
- * - Price overlay's "Starting at" label is presentational — visible
- *   text reads naturally so no aria-label is needed.
+ * - Breadcrumb uses the `bds-breadcrumb` pattern (nav + aria-label,
+ *   aria-current="page" on the final crumb).
  * - Image alt: empty string (decorative) when omitted; consumer can
  *   provide informational alt via section.priceCard.imageAlt.
  */
@@ -70,31 +73,25 @@ const cta = section.cta;
   <div class="bp-hero-img-card__container">
     <div class="bp-hero-img-card__content">
       {breadcrumb.length > 0 && (
-        <nav class="bp-hero-img-card__breadcrumb" aria-label="Breadcrumb">
-          <ol class="bp-hero-img-card__breadcrumb-list">
-            {breadcrumb.map((item, idx) => {
-              const isLast = idx === breadcrumb.length - 1;
-              return (
-                <li class="bp-hero-img-card__breadcrumb-item">
-                  {item.href && !isLast ? (
-                    <a href={item.href} class="bp-hero-img-card__breadcrumb-link">
-                      {item.label}
-                    </a>
-                  ) : (
-                    <span
-                      class="bp-hero-img-card__breadcrumb-current"
-                      aria-current={isLast ? 'page' : undefined}
-                    >
-                      {item.label}
-                    </span>
-                  )}
-                  {!isLast && (
-                    <span class="bp-hero-img-card__breadcrumb-sep" aria-hidden="true">/</span>
-                  )}
-                </li>
-              );
-            })}
-          </ol>
+        <nav class="bds-breadcrumb bp-hero-img-card__breadcrumb" aria-label="Breadcrumb">
+          {breadcrumb.map((item, idx) => {
+            const isLast = idx === breadcrumb.length - 1;
+            return (
+              <span style="display: contents;">
+                {idx > 0 && (
+                  <span class="bds-breadcrumb__separator" aria-hidden="true">/</span>
+                )}
+                {isLast || !item.href ? (
+                  <span
+                    class="bds-breadcrumb__current"
+                    aria-current={isLast ? 'page' : undefined}
+                  >{item.label}</span>
+                ) : (
+                  <a href={item.href} class="bds-breadcrumb__link">{item.label}</a>
+                )}
+              </span>
+            );
+          })}
         </nav>
       )}
 
@@ -105,8 +102,8 @@ const cta = section.cta;
       {lead && <p class="bp-hero-img-card__lead">{lead}</p>}
 
       {cta && (
-        <a href={cta.url} class="bp-hero-img-card__cta">
-          {cta.label}
+        <a href={cta.url} class="bds-button bds-button--inverse bds-button--md">
+          <span class="bds-button__content">{cta.label}</span>
         </a>
       )}
     </div>
@@ -124,15 +121,15 @@ const cta = section.cta;
         </div>
         {(priceCard.priceLabel || priceCard.price || priceCard.cta) && (
           <div class="bp-hero-img-card__price">
-            {priceCard.priceLabel && (
+            {priceCard.priceLabel && priceCard.price && (
               <p class="bp-hero-img-card__price-label">{priceCard.priceLabel}</p>
             )}
             {priceCard.price && (
               <p class="bp-hero-img-card__price-value">{priceCard.price}</p>
             )}
             {priceCard.cta && (
-              <a href={priceCard.cta.url} class="bp-hero-img-card__price-cta">
-                {priceCard.cta.label}
+              <a href={priceCard.cta.url} class="bds-button bds-button--primary bds-button--sm">
+                <span class="bds-button__content">{priceCard.cta.label}</span>
               </a>
             )}
           </div>
@@ -182,59 +179,17 @@ const cta = section.cta;
     display: flex;
     flex-direction: column;
     gap: var(--gap-md);
+    align-items: flex-start;
   }
 
   .bp-hero-img-card__breadcrumb {
     margin-bottom: var(--gap-sm);
   }
 
-  .bp-hero-img-card__breadcrumb-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--gap-xs, 4px);
-    font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
-    font-weight: var(--font-weight-medium);
-    color: var(--bp-hero-img-card-breadcrumb-color, var(--text-brand-primary));
-  }
-
-  .bp-hero-img-card__breadcrumb-item {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--gap-xs, 4px);
-  }
-
-  .bp-hero-img-card__breadcrumb-link {
-    color: inherit;
-    text-decoration: none;
-    transition: opacity 120ms ease-out;
-  }
-
-  .bp-hero-img-card__breadcrumb-link:hover {
-    text-decoration: underline;
-  }
-
-  .bp-hero-img-card__breadcrumb-link:focus-visible {
-    outline: 2px solid var(--border-focus, currentColor);
-    outline-offset: 2px;
-    border-radius: 2px;
-  }
-
-  .bp-hero-img-card__breadcrumb-current {
-    opacity: 0.7;
-  }
-
-  .bp-hero-img-card__breadcrumb-sep {
-    opacity: 0.5;
-  }
-
   .bp-hero-img-card__eyebrow {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-semibold);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -244,7 +199,7 @@ const cta = section.cta;
   .bp-hero-img-card__headline {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-700), 5vw, var(--font-size-1000));
+    font-size: clamp(var(--heading-xl), 5vw, var(--heading-xxl));
     font-weight: var(--font-weight-bold);
     line-height: var(--line-height-tight, 1.05);
     color: var(--bp-hero-img-card-headline-color, var(--text-primary));
@@ -253,36 +208,10 @@ const cta = section.cta;
   .bp-hero-img-card__lead {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     line-height: var(--line-height-relaxed, 1.5);
     color: var(--text-primary);
     max-width: 55ch;
-  }
-
-  .bp-hero-img-card__cta {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--gap-xs);
-    margin-top: var(--gap-sm);
-    padding: var(--padding-sm) var(--padding-lg);
-    background: var(--background-primary, var(--text-primary));
-    color: var(--text-on-color-dark, var(--text-inverse));
-    font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
-    font-weight: var(--font-weight-semibold);
-    text-decoration: none;
-    border-radius: var(--border-radius-md);
-    align-self: flex-start;
-    transition: opacity 120ms ease-out;
-  }
-
-  .bp-hero-img-card__cta:hover {
-    opacity: 0.92;
-  }
-
-  .bp-hero-img-card__cta:focus-visible {
-    outline: 2px solid var(--border-focus, currentColor);
-    outline-offset: 2px;
   }
 
   .bp-hero-img-card__media-card {
@@ -314,12 +243,13 @@ const cta = section.cta;
     flex-direction: column;
     gap: var(--gap-xs);
     padding-inline: var(--padding-sm);
+    align-items: flex-start;
   }
 
   .bp-hero-img-card__price-label {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-semibold);
     color: var(--text-primary);
   }
@@ -327,36 +257,10 @@ const cta = section.cta;
   .bp-hero-img-card__price-value {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-600);
+    font-size: var(--heading-lg);
     font-weight: var(--font-weight-bold);
     color: var(--text-primary);
     line-height: 1;
-  }
-
-  .bp-hero-img-card__price-cta {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: var(--gap-xs);
-    padding: var(--padding-sm) var(--padding-lg);
-    background: var(--background-brand-primary);
-    color: var(--text-on-color-dark, var(--text-inverse));
-    font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
-    font-weight: var(--font-weight-semibold);
-    text-decoration: none;
-    border-radius: var(--border-radius-md);
-    align-self: flex-start;
-    transition: opacity 120ms ease-out;
-  }
-
-  .bp-hero-img-card__price-cta:hover {
-    opacity: 0.92;
-  }
-
-  .bp-hero-img-card__price-cta:focus-visible {
-    outline: 2px solid var(--border-focus, currentColor);
-    outline-offset: 2px;
   }
 
   .bp-hero-img-card__missing {
@@ -373,7 +277,7 @@ const cta = section.cta;
   .bp-hero-img-card__missing-label {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     color: var(--text-secondary);
     text-align: center;
   }

--- a/content-system/blueprints/astro/Services3ColCardGrid.astro
+++ b/content-system/blueprints/astro/Services3ColCardGrid.astro
@@ -167,7 +167,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
   .bp-services-grid__eyebrow {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -177,7 +177,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
   .bp-services-grid__heading {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
     font-weight: var(--font-weight-semibold);
     line-height: var(--font-line-height-tight);
     color: var(--text-primary);
@@ -186,7 +186,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
   .bp-services-grid__lead {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--font-line-height-relaxed);
     color: var(--text-primary);
   }
@@ -259,7 +259,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
 
   .bp-services-grid__media-fallback {
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-500);
+    font-size: var(--heading-md);
     font-weight: var(--font-weight-semibold);
     color: var(--text-primary);
     opacity: 0.55;
@@ -276,7 +276,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
     background: var(--background-positive);
     color: var(--text-on-color-dark);
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-semibold);
     letter-spacing: 0.02em;
     border-radius: 999px;
@@ -304,7 +304,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
     background: var(--surface-secondary);
     color: var(--text-primary);
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-semibold);
     border-radius: 999px;
     line-height: 1.2;
@@ -336,7 +336,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
   .bp-services-grid__title {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-500);
+    font-size: var(--heading-md);
     font-weight: var(--font-weight-semibold);
     line-height: var(--font-line-height-tight);
     color: var(--text-primary);
@@ -345,7 +345,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
   .bp-services-grid__description {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     line-height: var(--font-line-height-relaxed);
     color: var(--text-primary);
   }
@@ -362,7 +362,7 @@ const categoryLabels: Record<NonNullable<typeof section.items[number]['category'
     color: var(--text-brand-primary);
     text-decoration: none;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     font-weight: var(--font-weight-semibold);
     line-height: 1.4;
     transition: gap 200ms var(--easing-ease-out, cubic-bezier(0, 0, 0.2, 1));

--- a/content-system/blueprints/astro/ServicesDetailTwoColumn.astro
+++ b/content-system/blueprints/astro/ServicesDetailTwoColumn.astro
@@ -84,7 +84,7 @@ const headingId = `bp-services-two-col-${section.sectionKey}-h`;
   .bp-services-two-col__eyebrow {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -94,7 +94,7 @@ const headingId = `bp-services-two-col-${section.sectionKey}-h`;
   .bp-services-two-col__heading {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-services-two-col-heading-color, var(--text-primary));
@@ -103,7 +103,7 @@ const headingId = `bp-services-two-col-${section.sectionKey}-h`;
   .bp-services-two-col__lead {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--line-height-relaxed);
     color: var(--text-secondary);
   }
@@ -133,7 +133,7 @@ const headingId = `bp-services-two-col-${section.sectionKey}-h`;
   .bp-services-two-col__item-title {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-500);
+    font-size: var(--heading-md);
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-services-two-col-item-title-color, var(--text-primary));
@@ -142,7 +142,7 @@ const headingId = `bp-services-two-col-${section.sectionKey}-h`;
   .bp-services-two-col__item-desc {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     line-height: var(--line-height-relaxed);
     color: var(--bp-services-two-col-item-desc-color, var(--text-secondary));
   }

--- a/content-system/blueprints/astro/SiteHeader.astro
+++ b/content-system/blueprints/astro/SiteHeader.astro
@@ -221,7 +221,7 @@ function isCurrent(href: string): boolean {
     color: var(--bp-site-header-text-color);
     text-decoration: none;
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-500);
+    font-size: var(--heading-md);
     font-weight: var(--font-weight-semibold);
     line-height: 1;
   }
@@ -260,7 +260,7 @@ function isCurrent(href: string): boolean {
     color: var(--bp-site-header-text-color);
     text-decoration: none;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
+    font-size: var(--label-xl);
     font-weight: var(--font-weight-medium);
     padding: var(--space-xs) 0;
     border-bottom: 2px solid transparent;
@@ -293,7 +293,7 @@ function isCurrent(href: string): boolean {
     color: var(--bp-site-header-text-color);
     text-decoration: none;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
+    font-size: var(--label-xl);
     font-weight: var(--font-weight-medium);
   }
 
@@ -311,7 +311,7 @@ function isCurrent(href: string): boolean {
     background: var(--bp-site-header-cta-bg);
     color: var(--bp-site-header-cta-color);
     font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
+    font-size: var(--label-xl);
     font-weight: var(--font-weight-semibold);
     text-decoration: none;
     border-radius: var(--border-radius-md);
@@ -392,7 +392,7 @@ function isCurrent(href: string): boolean {
     color: var(--bp-site-header-text-color);
     text-decoration: none;
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-600);
+    font-size: var(--heading-lg);
     display: block;
   }
 

--- a/content-system/blueprints/astro/StatsDarkBar.astro
+++ b/content-system/blueprints/astro/StatsDarkBar.astro
@@ -125,7 +125,7 @@ const items = section.items;
 
   .bp-stats-dark-bar__value {
     font-family: var(--font-family-display, var(--font-family-heading));
-    font-size: clamp(var(--font-size-700), 4vw, var(--font-size-900));
+    font-size: clamp(var(--heading-xl), 4vw, var(--heading-huge));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-stats-dark-bar-value-color, var(--text-inverse, var(--color-grayscale-white)));
@@ -133,7 +133,7 @@ const items = section.items;
 
   .bp-stats-dark-bar__label {
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     letter-spacing: 0.04em;
     text-transform: uppercase;
     color: var(--bp-stats-dark-bar-label-color, var(--text-secondary-inverse, var(--color-grayscale-lightest)));

--- a/content-system/blueprints/astro/SupportPlanCalloutSplit.astro
+++ b/content-system/blueprints/astro/SupportPlanCalloutSplit.astro
@@ -204,7 +204,7 @@ const hasIllustration = illustration && tiles.length > 0;
   .bp-support-plan-callout__eyebrow {
     margin: 0;
     font-family: var(--font-family-label);
-    font-size: var(--font-size-200);
+    font-size: var(--label-lg);
     font-weight: var(--font-weight-medium);
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -214,7 +214,7 @@ const hasIllustration = illustration && tiles.length > 0;
   .bp-support-plan-callout__heading {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
     font-weight: var(--font-weight-semibold);
     line-height: var(--font-line-height-tight);
     color: var(--text-primary);
@@ -223,7 +223,7 @@ const hasIllustration = illustration && tiles.length > 0;
   .bp-support-plan-callout__lead {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-400);
+    font-size: var(--heading-sm);
     line-height: var(--font-line-height-relaxed);
     color: var(--text-primary);
   }
@@ -273,7 +273,7 @@ const hasIllustration = illustration && tiles.length > 0;
   .bp-support-plan-callout__plan-name {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: var(--font-size-500);
+    font-size: var(--heading-md);
     font-weight: var(--font-weight-semibold);
     line-height: var(--font-line-height-tight);
     color: var(--text-primary);
@@ -282,7 +282,7 @@ const hasIllustration = illustration && tiles.length > 0;
   .bp-support-plan-callout__plan-description {
     margin: 0;
     font-family: var(--font-family-body);
-    font-size: var(--font-size-300);
+    font-size: var(--body-xl);
     line-height: var(--font-line-height-relaxed);
     color: var(--text-primary);
   }

--- a/content-system/blueprints/astro/TestimonialsFeaturedLarge.astro
+++ b/content-system/blueprints/astro/TestimonialsFeaturedLarge.astro
@@ -91,7 +91,7 @@ const featured = section.items[0];
 
   .bp-testimonials-featured__mark {
     font-family: var(--font-family-display, var(--font-family-heading));
-    font-size: clamp(var(--font-size-1000), 8vw, var(--font-size-1200));
+    font-size: clamp(var(--display-sm), 8vw, var(--display-md));
     line-height: 1;
     color: var(--bp-testimonials-featured-mark-color, var(--text-brand-primary));
   }
@@ -99,7 +99,7 @@ const featured = section.items[0];
   .bp-testimonials-featured__quote-text {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--font-size-500), 2.5vw, var(--font-size-700));
+    font-size: clamp(var(--heading-md), 2.5vw, var(--heading-xl));
     font-weight: var(--font-weight-medium);
     line-height: var(--line-height-relaxed);
     color: var(--bp-testimonials-featured-quote-color, var(--text-primary));
@@ -108,7 +108,7 @@ const featured = section.items[0];
 
   .bp-testimonials-featured__cite {
     font-family: var(--font-family-label);
-    font-size: var(--font-size-300);
+    font-size: var(--label-xl);
     font-style: normal;
     letter-spacing: 0.04em;
     text-transform: uppercase;

--- a/content-system/blueprints/react/AboutStorySplit.css
+++ b/content-system/blueprints/react/AboutStorySplit.css
@@ -37,7 +37,7 @@
 .bp-about-story-split__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -47,7 +47,7 @@
 .bp-about-story-split__heading {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+  font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--bp-about-story-split-heading-color, var(--text-primary));
@@ -56,7 +56,7 @@
 .bp-about-story-split__body {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--bp-about-story-split-body-color, var(--text-primary));
   max-width: 65ch;
@@ -79,7 +79,7 @@
 .bp-about-story-split__quote-text {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-500);
+  font-size: var(--heading-md);
   font-style: normal;
   line-height: var(--font-line-height-relaxed);
   color: var(--text-primary);
@@ -87,7 +87,7 @@
 
 .bp-about-story-split__quote-cite {
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-style: normal;
   letter-spacing: 0.04em;
   text-transform: uppercase;

--- a/content-system/blueprints/react/BlueprintFallback.css
+++ b/content-system/blueprints/react/BlueprintFallback.css
@@ -21,7 +21,7 @@
 .bp-fallback__label {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-semibold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -33,13 +33,13 @@
 .bp-fallback__hint {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-300);
+  font-size: var(--body-xl);
   line-height: var(--font-line-height-relaxed);
   color: var(--text-secondary);
 }
 
 .bp-fallback__hint {
-  font-size: var(--font-size-200);
+  font-size: var(--body-lg);
   max-width: 72ch;
 }
 

--- a/content-system/blueprints/react/CtaDarkCentered.css
+++ b/content-system/blueprints/react/CtaDarkCentered.css
@@ -1,6 +1,10 @@
 /*
  * CtaDarkCentered — React renderer styles. Mirrors
- * `../astro/CtaDarkCentered.astro` with canonical token names.
+ * `../astro/CtaDarkCentered.astro`.
+ *
+ * Per docs/COMPONENT-PATTERNS.md: CTA styling lives in `.bds-button`
+ * (LinkButton). This file owns ONLY layout + non-component text styles.
+ * Font sizes use semantic aliases.
  */
 
 .bp-cta-dark-centered {
@@ -25,7 +29,7 @@
 .bp-cta-dark-centered__heading {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-700), 4vw, var(--font-size-1000));
+  font-size: clamp(var(--heading-xl), 4vw, var(--display-sm));
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--bp-cta-dark-centered-heading-color, var(--text-on-color-dark));
@@ -34,33 +38,9 @@
 .bp-cta-dark-centered__body {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--bp-cta-dark-centered-body-color, var(--text-on-color-dark));
   opacity: 0.85;
   max-width: 55ch;
-}
-
-.bp-cta-dark-centered__cta {
-  display: inline-flex;
-  align-items: center;
-  margin-top: var(--gap-md);
-  padding: var(--gap-md) var(--padding-xl);
-  background: var(--bp-cta-dark-centered-cta-bg, var(--background-brand-primary));
-  color: var(--bp-cta-dark-centered-cta-color, var(--text-on-color-dark));
-  font-family: var(--font-family-label);
-  font-size: var(--font-size-300);
-  font-weight: var(--font-weight-semibold);
-  text-decoration: none;
-  border-radius: var(--border-radius-md);
-  transition: background 120ms ease-out;
-}
-
-.bp-cta-dark-centered__cta:hover {
-  background: var(--background-brand-primary-hover, var(--background-brand-primary));
-}
-
-.bp-cta-dark-centered__cta:focus-visible {
-  outline: 2px solid var(--border-focus, var(--background-brand-primary));
-  outline-offset: 2px;
 }

--- a/content-system/blueprints/react/CtaDarkCentered.tsx
+++ b/content-system/blueprints/react/CtaDarkCentered.tsx
@@ -7,6 +7,7 @@
  *
  * @summary Closing CTA on dark surface, centered.
  */
+import { LinkButton } from '../../../components/ui/Button/LinkButton';
 import type { BlueprintProps } from '../astro/types';
 import './CtaDarkCentered.css';
 
@@ -29,9 +30,9 @@ export function CtaDarkCentered({ section }: Props) {
           <p className="bp-cta-dark-centered__body">{section.body}</p>
         )}
         {section.cta && (
-          <a href={section.cta.url} className="bp-cta-dark-centered__cta">
+          <LinkButton href={section.cta.url} variant="primary" size="lg">
             {section.cta.label}
-          </a>
+          </LinkButton>
         )}
       </div>
     </section>

--- a/content-system/blueprints/react/Features3ColBrandedDark.css
+++ b/content-system/blueprints/react/Features3ColBrandedDark.css
@@ -36,7 +36,7 @@
 .bp-features-branded-dark__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -47,7 +47,7 @@
 .bp-features-branded-dark__heading {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+  font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--text-on-color-dark);
@@ -56,7 +56,7 @@
 .bp-features-branded-dark__lead {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--text-on-color-dark);
   opacity: 0.85;
@@ -174,7 +174,7 @@
 .bp-features-branded-dark__title {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-500);
+  font-size: var(--heading-md);
   font-weight: var(--font-weight-bold);
   line-height: var(--font-line-height-tight);
   color: var(--text-on-color-dark);
@@ -184,7 +184,7 @@
 .bp-features-branded-dark__description {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--text-on-color-dark);
 }
@@ -196,7 +196,7 @@
   gap: var(--gap-md);
   color: var(--text-on-color-dark);
   font-family: var(--font-family-body);
-  font-size: var(--font-size-300);
+  font-size: var(--body-xl);
   font-weight: var(--font-weight-bold);
   line-height: 1.4;
 }

--- a/content-system/blueprints/react/HeroInteriorMinimal.css
+++ b/content-system/blueprints/react/HeroInteriorMinimal.css
@@ -1,10 +1,10 @@
 /*
  * HeroInteriorMinimal — React renderer styles.
+ * Mirrors `../astro/HeroInteriorMinimal.astro`.
  *
- * Mirrors `../astro/HeroInteriorMinimal.astro` visually. Token names
- * use canonical equivalents that actually resolve in dist/tokens.css
- * (the Astro source's `--space-xl` / `--line-height-tight` fall back
- * to browser defaults — broken-token fix is tracked separately).
+ * Per docs/COMPONENT-PATTERNS.md: CTA styling lives in `.bds-button`
+ * (LinkButton). This file owns ONLY layout + non-component text styles.
+ * Font sizes use semantic aliases.
  */
 
 .bp-hero-interior-minimal {
@@ -22,12 +22,13 @@
   display: flex;
   flex-direction: column;
   gap: var(--gap-md);
+  align-items: flex-start;
 }
 
 .bp-hero-interior-minimal__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -37,7 +38,7 @@
 .bp-hero-interior-minimal__headline {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-700), 4vw, var(--font-size-1000));
+  font-size: clamp(var(--heading-xl), 4vw, var(--display-sm));
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--bp-hero-interior-headline-color, var(--text-primary));
@@ -46,32 +47,7 @@
 .bp-hero-interior-minimal__lead {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--bp-hero-interior-lead-color, var(--text-primary));
-}
-
-.bp-hero-interior-minimal__cta {
-  display: inline-flex;
-  align-items: center;
-  margin-top: var(--gap-md);
-  padding: var(--gap-md) var(--padding-lg);
-  background: var(--background-brand-primary);
-  color: var(--text-on-color-dark);
-  font-family: var(--font-family-label);
-  font-size: var(--font-size-300);
-  font-weight: var(--font-weight-semibold);
-  text-decoration: none;
-  border-radius: var(--border-radius-md);
-  align-self: flex-start;
-  transition: background 120ms ease-out;
-}
-
-.bp-hero-interior-minimal__cta:hover {
-  background: var(--background-brand-primary-hover, var(--background-brand-primary));
-}
-
-.bp-hero-interior-minimal__cta:focus-visible {
-  outline: 2px solid var(--border-focus, var(--background-brand-primary));
-  outline-offset: 2px;
 }

--- a/content-system/blueprints/react/HeroInteriorMinimal.tsx
+++ b/content-system/blueprints/react/HeroInteriorMinimal.tsx
@@ -16,6 +16,7 @@
  *
  * @summary Interior page hero — eyebrow + h1 + optional lead, no image.
  */
+import { LinkButton } from '../../../components/ui/Button/LinkButton';
 import type { BlueprintProps } from '../astro/types';
 import './HeroInteriorMinimal.css';
 
@@ -43,9 +44,9 @@ export function HeroInteriorMinimal({ section }: Props) {
         </h1>
         {lead && <p className="bp-hero-interior-minimal__lead">{lead}</p>}
         {cta && (
-          <a href={cta.url} className="bp-hero-interior-minimal__cta">
+          <LinkButton href={cta.url} variant="primary" size="md">
             {cta.label}
-          </a>
+          </LinkButton>
         )}
       </div>
     </section>

--- a/content-system/blueprints/react/HeroSplit6040.css
+++ b/content-system/blueprints/react/HeroSplit6040.css
@@ -1,9 +1,16 @@
 /*
  * HeroSplit6040 — React renderer styles. Mirrors
- * `../astro/HeroSplit6040.astro`. Uses canonical token names that
- * resolve in dist/tokens.css (Astro source's `--space-*` /
- * `--line-height-*` / `--size-container-xl` references silently fall
- * back to browser defaults — broken-token fix tracked separately).
+ * `../astro/HeroSplit6040.astro`.
+ *
+ * Per docs/COMPONENT-PATTERNS.md §"Compose primitives" + §"Tokens only":
+ *   - CTA styling lives in `.bds-button` (LinkButton).
+ *   - This file owns ONLY layout + non-component text styles.
+ *   - Font sizes use semantic aliases, never primitives.
+ *
+ * Canon gap: the headline clamp upper bound (font-size-1100, ~88px)
+ * has no semantic alias between heading-xxl (font-size-800) and
+ * display-sm (font-size-1400). Closest-fit semantic mapped below;
+ * a follow-up should add `--heading-3xl` to fill the gap.
  */
 
 .bp-hero-split-60-40 {
@@ -35,12 +42,13 @@
   display: flex;
   flex-direction: column;
   gap: var(--gap-md);
+  align-items: flex-start;
 }
 
 .bp-hero-split-60-40__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -50,7 +58,7 @@
 .bp-hero-split-60-40__headline {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-800), 5vw, var(--font-size-1100));
+  font-size: clamp(var(--heading-xxl), 5vw, var(--display-sm));
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--bp-hero-split-headline-color, var(--text-primary));
@@ -71,36 +79,10 @@
 .bp-hero-split-60-40__lead {
   margin: var(--gap-md) 0 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--bp-hero-split-lead-color, var(--text-primary));
   max-width: 55ch;
-}
-
-.bp-hero-split-60-40__cta {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--gap-md);
-  margin-top: var(--gap-lg);
-  padding: var(--gap-md) var(--padding-lg);
-  background: var(--background-brand-primary);
-  color: var(--text-on-color-dark);
-  font-family: var(--font-family-label);
-  font-size: var(--font-size-300);
-  font-weight: var(--font-weight-semibold);
-  text-decoration: none;
-  border-radius: var(--border-radius-md);
-  align-self: flex-start;
-  transition: background 120ms ease-out;
-}
-
-.bp-hero-split-60-40__cta:hover {
-  background: var(--background-brand-primary-hover, var(--background-brand-primary));
-}
-
-.bp-hero-split-60-40__cta:focus-visible {
-  outline: 2px solid var(--border-focus, var(--background-brand-primary));
-  outline-offset: 2px;
 }
 
 .bp-hero-split-60-40__media {
@@ -131,7 +113,7 @@
 .bp-hero-split-60-40__missing-label {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-300);
+  font-size: var(--body-xl);
   color: var(--text-secondary);
   text-align: center;
 }

--- a/content-system/blueprints/react/HeroSplit6040.tsx
+++ b/content-system/blueprints/react/HeroSplit6040.tsx
@@ -9,6 +9,7 @@
  *
  * @summary 60/40 split hero — headline left, photo right.
  */
+import { LinkButton } from '../../../components/ui/Button/LinkButton';
 import type { BlueprintProps } from '../astro/types';
 import './HeroSplit6040.css';
 
@@ -38,9 +39,9 @@ export function HeroSplit6040({ section, clientFacts }: Props) {
           </h1>
           {lead && <p className="bp-hero-split-60-40__lead">{lead}</p>}
           {cta && (
-            <a href={cta.url} className="bp-hero-split-60-40__cta">
+            <LinkButton href={cta.url} variant="primary" size="md">
               {cta.label}
-            </a>
+            </LinkButton>
           )}
         </div>
 

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -1,7 +1,13 @@
 /*
  * HeroSplitImageCardOverlay — React renderer styles. Mirrors
- * `../astro/HeroSplitImageCardOverlay.astro`. Token names match the
- * canonical surface that resolves in `dist/tokens.css`.
+ * `../astro/HeroSplitImageCardOverlay.astro`.
+ *
+ * Per docs/COMPONENT-PATTERNS.md §"Compose primitives" + §"Tokens only":
+ *   - Breadcrumb styling lives in `.bds-breadcrumb` (Breadcrumb component).
+ *   - CTA styling lives in `.bds-button` (LinkButton component).
+ *   - This file owns ONLY the layout + non-component text styles
+ *     (eyebrow, headline, lead, image card, price label/value, missing
+ *     state). Font sizes use semantic aliases, never primitives.
  */
 
 .bp-hero-img-card {
@@ -36,59 +42,17 @@
   display: flex;
   flex-direction: column;
   gap: var(--gap-md);
+  align-items: flex-start;
 }
 
 .bp-hero-img-card__breadcrumb {
   margin-bottom: var(--gap-sm);
 }
 
-.bp-hero-img-card__breadcrumb-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
-  font-weight: var(--font-weight-medium);
-  color: var(--bp-hero-img-card-breadcrumb-color, var(--text-brand-primary));
-}
-
-.bp-hero-img-card__breadcrumb-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.bp-hero-img-card__breadcrumb-link {
-  color: inherit;
-  text-decoration: none;
-  transition: opacity 120ms ease-out;
-}
-
-.bp-hero-img-card__breadcrumb-link:hover {
-  text-decoration: underline;
-}
-
-.bp-hero-img-card__breadcrumb-link:focus-visible {
-  outline: 2px solid var(--border-focus, currentColor);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
-.bp-hero-img-card__breadcrumb-current {
-  opacity: 0.7;
-}
-
-.bp-hero-img-card__breadcrumb-sep {
-  opacity: 0.5;
-}
-
 .bp-hero-img-card__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-semibold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -98,7 +62,7 @@
 .bp-hero-img-card__headline {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-700), 5vw, var(--font-size-1000));
+  font-size: clamp(var(--heading-xl), 5vw, var(--heading-xxl));
   font-weight: var(--font-weight-bold);
   line-height: var(--font-line-height-tight, 1.05);
   color: var(--bp-hero-img-card-headline-color, var(--text-primary));
@@ -107,36 +71,10 @@
 .bp-hero-img-card__lead {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-300);
+  font-size: var(--body-xl);
   line-height: var(--font-line-height-relaxed, 1.5);
   color: var(--text-primary);
   max-width: 55ch;
-}
-
-.bp-hero-img-card__cta {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--gap-xs);
-  margin-top: var(--gap-sm);
-  padding: var(--padding-sm) var(--padding-lg);
-  background: var(--background-primary, var(--text-primary));
-  color: var(--text-on-color-dark, var(--text-inverse));
-  font-family: var(--font-family-label);
-  font-size: var(--font-size-300);
-  font-weight: var(--font-weight-semibold);
-  text-decoration: none;
-  border-radius: var(--border-radius-md);
-  align-self: flex-start;
-  transition: opacity 120ms ease-out;
-}
-
-.bp-hero-img-card__cta:hover {
-  opacity: 0.92;
-}
-
-.bp-hero-img-card__cta:focus-visible {
-  outline: 2px solid var(--border-focus, currentColor);
-  outline-offset: 2px;
 }
 
 .bp-hero-img-card__media-card {
@@ -168,12 +106,13 @@
   flex-direction: column;
   gap: var(--gap-xs);
   padding-inline: var(--padding-sm);
+  align-items: flex-start;
 }
 
 .bp-hero-img-card__price-label {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--text-primary);
 }
@@ -181,36 +120,10 @@
 .bp-hero-img-card__price-value {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-600);
+  font-size: var(--heading-lg);
   font-weight: var(--font-weight-bold);
   color: var(--text-primary);
   line-height: 1;
-}
-
-.bp-hero-img-card__price-cta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: var(--gap-xs);
-  padding: var(--padding-sm) var(--padding-lg);
-  background: var(--background-brand-primary);
-  color: var(--text-on-color-dark, var(--text-inverse));
-  font-family: var(--font-family-label);
-  font-size: var(--font-size-300);
-  font-weight: var(--font-weight-semibold);
-  text-decoration: none;
-  border-radius: var(--border-radius-md);
-  align-self: flex-start;
-  transition: opacity 120ms ease-out;
-}
-
-.bp-hero-img-card__price-cta:hover {
-  opacity: 0.92;
-}
-
-.bp-hero-img-card__price-cta:focus-visible {
-  outline: 2px solid var(--border-focus, currentColor);
-  outline-offset: 2px;
 }
 
 .bp-hero-img-card__missing {
@@ -227,7 +140,7 @@
 .bp-hero-img-card__missing-label {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-300);
+  font-size: var(--body-xl);
   color: var(--text-secondary);
   text-align: center;
 }

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -111,7 +111,7 @@ const withAudienceCascade = (Story: () => JSX.Element) => (
 /* ─── Meta ─────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof HeroSplitImageCardOverlay> = {
-  title: 'Blueprints/hero_split_image_card_overlay',
+  title: 'Theming/Blueprints/hero_split_image_card_overlay',
   component: HeroSplitImageCardOverlay,
   tags: ['surface-web', 'surface-shared'],
   decorators: [withAudienceCascade],

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -7,8 +7,16 @@
  *
  * Drives `/services/{cat}/{slug}` style pages.
  *
+ * Composes BDS primitives per docs/COMPONENT-PATTERNS.md
+ * §"Compose primitives — never reimplement them":
+ *   - Breadcrumb trail → `<Breadcrumb items={...} />`
+ *   - Left CTA → `<LinkButton variant="inverse">`
+ *   - Price-card CTA → `<LinkButton variant="primary">`
+ *
  * @summary Interior-page split hero with image card + optional price overlay.
  */
+import { Breadcrumb } from '../../../components/ui/Breadcrumb/Breadcrumb';
+import { LinkButton } from '../../../components/ui/Button/LinkButton';
 import type { BlueprintProps } from '../astro/types';
 import './HeroSplitImageCardOverlay.css';
 
@@ -32,40 +40,10 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
       <div className="bp-hero-img-card__container">
         <div className="bp-hero-img-card__content">
           {breadcrumb.length > 0 && (
-            <nav className="bp-hero-img-card__breadcrumb" aria-label="Breadcrumb">
-              <ol className="bp-hero-img-card__breadcrumb-list">
-                {breadcrumb.map((item, idx) => {
-                  const isLast = idx === breadcrumb.length - 1;
-                  return (
-                    <li
-                      key={`${item.label}-${idx}`}
-                      className="bp-hero-img-card__breadcrumb-item"
-                    >
-                      {item.href && !isLast ? (
-                        <a href={item.href} className="bp-hero-img-card__breadcrumb-link">
-                          {item.label}
-                        </a>
-                      ) : (
-                        <span
-                          className="bp-hero-img-card__breadcrumb-current"
-                          aria-current={isLast ? 'page' : undefined}
-                        >
-                          {item.label}
-                        </span>
-                      )}
-                      {!isLast && (
-                        <span
-                          className="bp-hero-img-card__breadcrumb-sep"
-                          aria-hidden="true"
-                        >
-                          /
-                        </span>
-                      )}
-                    </li>
-                  );
-                })}
-              </ol>
-            </nav>
+            <Breadcrumb
+              className="bp-hero-img-card__breadcrumb"
+              items={breadcrumb.map((item) => ({ label: item.label, href: item.href }))}
+            />
           )}
 
           {eyebrow && <p className="bp-hero-img-card__eyebrow">{eyebrow}</p>}
@@ -77,9 +55,9 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
           {lead && <p className="bp-hero-img-card__lead">{lead}</p>}
 
           {cta && (
-            <a href={cta.url} className="bp-hero-img-card__cta">
+            <LinkButton href={cta.url} variant="inverse" size="md">
               {cta.label}
-            </a>
+            </LinkButton>
           )}
         </div>
 
@@ -96,7 +74,7 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
             </div>
             {(priceCard.priceLabel || priceCard.price || priceCard.cta) && (
               <div className="bp-hero-img-card__price">
-                {priceCard.priceLabel && (
+                {priceCard.priceLabel && priceCard.price && (
                   <p className="bp-hero-img-card__price-label">
                     {priceCard.priceLabel}
                   </p>
@@ -105,12 +83,9 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
                   <p className="bp-hero-img-card__price-value">{priceCard.price}</p>
                 )}
                 {priceCard.cta && (
-                  <a
-                    href={priceCard.cta.url}
-                    className="bp-hero-img-card__price-cta"
-                  >
+                  <LinkButton href={priceCard.cta.url} variant="primary" size="sm">
                     {priceCard.cta.label}
-                  </a>
+                  </LinkButton>
                 )}
               </div>
             )}

--- a/content-system/blueprints/react/Services3ColCardGrid.css
+++ b/content-system/blueprints/react/Services3ColCardGrid.css
@@ -40,7 +40,7 @@
 .bp-services-grid__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -50,7 +50,7 @@
 .bp-services-grid__heading {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+  font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--text-primary);
@@ -59,7 +59,7 @@
 .bp-services-grid__lead {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--text-primary);
 }
@@ -159,7 +159,7 @@
 .bp-services-grid__title {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-500);
+  font-size: var(--heading-md);
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--text-primary);
@@ -168,7 +168,7 @@
 .bp-services-grid__description {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-300);
+  font-size: var(--body-xl);
   line-height: var(--font-line-height-relaxed);
   color: var(--text-primary);
 }

--- a/content-system/blueprints/react/ServicesDetailTwoColumn.css
+++ b/content-system/blueprints/react/ServicesDetailTwoColumn.css
@@ -30,7 +30,7 @@
 .bp-services-two-col__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -40,7 +40,7 @@
 .bp-services-two-col__heading {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+  font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--bp-services-two-col-heading-color, var(--text-primary));
@@ -49,7 +49,7 @@
 .bp-services-two-col__lead {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--text-primary);
 }
@@ -79,7 +79,7 @@
 .bp-services-two-col__item-title {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-500);
+  font-size: var(--heading-md);
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--bp-services-two-col-item-title-color, var(--text-primary));
@@ -88,7 +88,7 @@
 .bp-services-two-col__item-desc {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-300);
+  font-size: var(--body-xl);
   line-height: var(--font-line-height-relaxed);
   color: var(--bp-services-two-col-item-desc-color, var(--text-primary));
 }

--- a/content-system/blueprints/react/SupportPlanCalloutSplit.css
+++ b/content-system/blueprints/react/SupportPlanCalloutSplit.css
@@ -36,7 +36,7 @@
 .bp-support-plan-callout__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);
-  font-size: var(--font-size-200);
+  font-size: var(--label-lg);
   font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -46,7 +46,7 @@
 .bp-support-plan-callout__heading {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: clamp(var(--font-size-600), 3.5vw, var(--font-size-900));
+  font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--text-primary);
@@ -55,7 +55,7 @@
 .bp-support-plan-callout__lead {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-400);
+  font-size: var(--heading-sm);
   line-height: var(--font-line-height-relaxed);
   color: var(--text-primary);
 }
@@ -108,7 +108,7 @@
 .bp-support-plan-callout__plan-name {
   margin: 0;
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-500);
+  font-size: var(--heading-md);
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-tight);
   color: var(--text-primary);
@@ -117,7 +117,7 @@
 .bp-support-plan-callout__plan-description {
   margin: 0;
   font-family: var(--font-family-body);
-  font-size: var(--font-size-300);
+  font-size: var(--body-xl);
   line-height: var(--font-line-height-relaxed);
   color: var(--text-primary);
 }

--- a/docs/COMPONENT-PATTERNS.md
+++ b/docs/COMPONENT-PATTERNS.md
@@ -116,6 +116,56 @@ All values come from semantic tokens. No hardcoded values, no primitives.
 Validate every token reference against `tokens/` before using it.
 
 
+## Compose primitives — never reimplement them
+
+Section blocks (blueprints) and BDS components MUST compose existing
+primitives instead of reimplementing them with raw HTML and custom CSS.
+The catalog only delivers consistency if everything goes through it.
+
+```tsx
+/* Correct — compose */
+import { LinkButton } from '../../components/ui/Button/LinkButton';
+import { Breadcrumb } from '../../components/ui/Breadcrumb/Breadcrumb';
+
+<Breadcrumb items={breadcrumb} />
+<LinkButton href={cta.url} variant="primary" size="md">
+  {cta.label}
+</LinkButton>
+```
+
+```tsx
+/* Wrong — raw HTML with custom classes */
+<nav className="bp-hero__breadcrumb">
+  <ol>{breadcrumb.map(...)}</ol>
+</nav>
+<a href={cta.url} className="bp-hero__cta">
+  {cta.label}
+</a>
+```
+
+```astro
+<!-- Astro: still composes BDS classes via the canonical button pattern -->
+<a href={cta.url} class="bds-button bds-button--primary bds-button--md">
+  <span class="bds-button__content">{cta.label}</span>
+</a>
+```
+
+**Why:** Existing-pattern in the codebase is not proof-of-correctness.
+Reimplementing primitives with custom classes:
+- breaks variant + size consistency (consumers can't switch a CTA to outline)
+- duplicates a11y handling (focus rings, keyboard nav, aria-current)
+- duplicates contrast / token logic (every blueprint re-derives the
+  same brand-on-page-bg contrast tradeoffs the Button component
+  already solved once)
+- causes story-shape drift (the BDS component story shows one shape,
+  the blueprint story shows a different shape rendered by raw HTML)
+
+**Before writing JSX** — query `bds-find` or the Storybook MCP to confirm
+which primitives exist. If a primitive doesn't exist that the blueprint
+needs, build the primitive first (separate PR) and consume it from the
+blueprint, not the other way around.
+
+
 ## Props
 
 Every component follows these conventions:

--- a/docs/STORYBOOK-WRITING-GUIDE.md
+++ b/docs/STORYBOOK-WRITING-GUIDE.md
@@ -129,6 +129,31 @@ Never combine two prop axes in one story. Write `Sizes` and `Variants` as
 separate stories — never `SizesAndVariants`. If a story name needs "and"
 to describe it, split it.
 
+### Story title prefix — match the existing sidebar tree
+
+Before writing `title:` in a story meta, **read the sibling stories'
+titles in the same folder**. The sidebar tree is shared across all of
+Storybook; introducing a parallel top-level group fragments it.
+
+Canonical prefixes currently in use:
+
+| Folder | Title prefix |
+| --- | --- |
+| `components/ui/<Component>` | `Components/<Group>/<component>` (e.g. `Components/Action/button`) |
+| `content-system/blueprints/react/<Blueprint>` | `Theming/Blueprints/<blueprint_key>` |
+| Storybook recipes / docs | `Recipes/<Topic>` |
+
+```tsx
+/* Correct — matches existing sidebar tree */
+title: 'Theming/Blueprints/hero_split_image_card_overlay'
+
+/* Wrong — creates a parallel "Blueprints" top-level group */
+title: 'Blueprints/hero_split_image_card_overlay'
+```
+
+If you genuinely need a new top-level group (rare), update this table
+in the same PR so the convention stays canonical.
+
 ### Surface taxonomy — every story declares one
 
 Every component story carries exactly one surface tag in its meta:


### PR DESCRIPTION
## Why this PR exists

Surfaced during the [brikdesigns hero-blueprint adoption](https://github.com/brikdesigns/brikdesigns/pull/78): the shipped blueprint catalog (5 hero/CTA renderers across React + Astro) bypassed the system the catalog exists to deliver. **Existing pattern in the codebase was treated as canonical and propagated through new work; in fact the existing pattern was off-script.**

Three concrete violations across all blueprints:

1. **Raw `<a>` styled with custom CSS classes** instead of `<LinkButton>` / canonical `bds-button` markup
2. **Raw breadcrumb HTML** (in `HeroSplitImageCardOverlay`) instead of `<Breadcrumb>` / `bds-breadcrumb` markup
3. **Primitive `--font-size-N` tokens** instead of semantic `--label-` / `--body-` / `--heading-` / `--display-` aliases

This PR brings the catalog back to the system. The same fixes lift the canonical rules into the docs so future agents (and humans) can't repeat the trap.

## Canonical doc updates

- **`docs/COMPONENT-PATTERNS.md`** — NEW §"Compose primitives — never reimplement them" with React + Astro examples and the rationale. Sister rule to the existing §"Tokens only".
- **`docs/STORYBOOK-WRITING-GUIDE.md`** — NEW §"Story title prefix" capturing the canonical sidebar tree (`Theming/Blueprints/`, `Components/`, `Recipes/`).

## Code changes (35 files)

### React renderers — raw `<a>` CTAs → `<LinkButton>`
- `HeroSplit6040.tsx`, `HeroInteriorMinimal.tsx`, `CtaDarkCentered.tsx`, `HeroSplitImageCardOverlay.tsx` (left + price-card CTAs)

### Astro renderers — raw `<a>` → canonical `bds-button` markup
- All 5 above + `CtaSplitContact.astro` use `<a class="bds-button bds-button--{variant} bds-button--{size}"><span class="bds-button__content">{label}</span></a>` per the existing `SupportPlanCalloutSplit.astro` precedent

### Breadcrumb composition (HeroSplitImageCardOverlay only)
- React: `<Breadcrumb items={...} />`
- Astro: canonical `bds-breadcrumb` markup pattern

### Story title fix
- `HeroSplitImageCardOverlay.stories.tsx`: `'Blueprints/...'` → `'Theming/Blueprints/...'`

### Font-token sweep (107 → 0 instances)
Every primitive `var(--font-size-N)` across blueprint CSS + Astro `<style>` swept to the role-appropriate semantic alias. Mapping table per role + value committed in the part-2 commit message.

## Canon gaps surfaced (follow-up)

1. **`--font-size-1000` / `--font-size-1100` / `--font-size-1200`** lack semantic aliases. Closest-fit (`--display-sm`, `--display-md`) used in clamp upper bounds. Follow-up: consider `--heading-3xl` / `--heading-4xl`.
2. **`--font-size-400`** has only `--heading-sm` as semantic alias (no `--body-2xl` between `--body-xl` and `--body-huge`). Body-role rules at primitive 400 are mapped to `--heading-sm` — canon-valid since size token decouples from family token. Follow-up: consider `--body-2xl` if the design intent is family-aligned.

## Net diff

35 files changed, 291 insertions(+), 483 deletions(-) — net **-192 lines** (most of the deletion is custom CTA + breadcrumb CSS that BDS primitives now own).

## Validation

- ✅ typecheck — clean
- ✅ canonical-check — 0 violations across 456 files
- ✅ canonical-class-check — 0 violations
- ✅ lint-tokens — no violations
- ✅ lint-jsdoc — clean
- ✅ validate:blueprints — registry valid (32 blueprints)
- ✅ verify-blueprints-astro-exports — passed (exports + render + a11y)
- ✅ build-storybook — successful
- ✅ Pre-push validate:full — all 8 checks passed

## Consumer sync plan

- [ ] Portal: `npm update @brikdesigns/bds` after merge + 0.63.0 publish
- [ ] renew-pms: submodule bump
- [ ] **brikdesigns/brikdesigns#78** can delete its `hero-blueprint-overrides.css` workaround once 0.63.0 lands — the CTA contrast + breadcrumb-current opacity bugs that necessitated it are gone

## Bundling

This supersedes the planned 0.62.1 patch issues:
- #499 (CTA token chain) — fixed by composition (LinkButton owns CTA styling)
- #500 (icon eyebrow + Starting at suppression) — partially fixed (Starting-at suppression now in HeroSplitImageCardOverlay code; icon eyebrow still deferred — `subheading` text is suppressed when null, audience-keyed icon support remains a separate feature add)

Recommend tagging this as **0.63.0** (minor: structural change, not patch) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)