### PR TITLE
chore(release): 0.62.0 → 0.63.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.62.0",
+      "version": "0.63.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Releases the [blueprints primitives-composition refactor](https://github.com/brikdesigns/brik-bds/pull/501) to consumers.

After merge: tag \`v0.63.0\` → Release workflow → publish to GitHub Packages.

## What ships in 0.63.0

- **Compose primitives, never reimplement** — every blueprint renderer (React + Astro) now composes \`<LinkButton>\` / \`<Breadcrumb>\` / \`bds-button\` markup instead of raw \`<a>\` with custom CSS classes
- **Tokens only** — every primitive \`--font-size-N\` reference swept to semantic \`--label-\` / \`--body-\` / \`--heading-\` / \`--display-\` aliases
- **Canonical doc updates** — \`COMPONENT-PATTERNS.md\` §"Compose primitives" + \`STORYBOOK-WRITING-GUIDE.md\` §"Story title prefix"
- **Story title fix** — \`HeroSplitImageCardOverlay\` moved from parallel \`Blueprints/\` to canonical \`Theming/Blueprints/\` sidebar group

## Consumer impact

Once published, [brikdesigns/brikdesigns#78](https://github.com/brikdesigns/brikdesigns/pull/78) can delete its \`hero-blueprint-overrides.css\` workaround — the bugs that necessitated it (#499 CTA contrast, #500 starting-at suppression, breadcrumb-current opacity) are all fixed by composition.

## Changes

\`package.json\` + \`package-lock.json\` version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)