### PR TITLE
docs(layout-contexts): repoint dead TOKEN-REFERENCE.md link to canonical Primitives URL

### DIFF
--- a/docs/LAYOUT-CONTEXTS.md
+++ b/docs/LAYOUT-CONTEXTS.md
@@ -2,7 +2,7 @@
 
 Typography and layout conventions per surface type. Consumers stop inventing per-sheet hierarchy; every page, sheet, form, and card reads the same.
 
-Companion to [`COMPONENT-PATTERNS.md`](./COMPONENT-PATTERNS.md) and [`TOKEN-REFERENCE.md`](./TOKEN-REFERENCE.md). Every token referenced here is defined in [`tokens/figma-tokens.css`](../tokens/figma-tokens.css).
+Companion to [`COMPONENT-PATTERNS.md`](./COMPONENT-PATTERNS.md) and the canonical [Primitives](https://design.brikdesigns.com/docs/primitives) registry. Every token referenced here is defined in [`tokens/figma-tokens.css`](../tokens/figma-tokens.css).
 
 ---
 


### PR DESCRIPTION
## Summary

Trailing fix from #496. \`docs/LAYOUT-CONTEXTS.md:5\` cited \`TOKEN-REFERENCE.md\` as a companion doc; that file was deleted as poisoned. Repointed to the canonical [Primitives](https://design.brikdesigns.com/docs/primitives) registry.

## Why this is a one-line fix instead of a deletion

Original Phase 3.5 plan was MIGRATE→DELETE for LAYOUT-CONTEXTS.md. After reading the file and tracing references, that plan was wrong:

- **Token names are current** (post 2026-04-02 rename), not poisoned like TOKEN-REFERENCE.md / GRID-SYSTEM.md.
- **Four-context typography framework** (Page / Sheet / Form / Card) is genuinely unique content not duplicated by docs-site primitives pages.
- **Downstream code actively cites it** as the canonical rules source:
  - 4 SheetTypography components carry \`@see\` JSDoc pointing here (\`SheetHelperText\`, \`SheetFieldLabel\`, \`SheetSectionTitle\`, \`SheetFieldValue\`)
  - \`SheetTypography.css\` references the rules
  - \`SheetTypography.stories.tsx\` references the no-dividers rule
  - \`docs-site/content/docs/components/sheet-typography.mdx\` links here as the rules source
  - \`brik-client-portal/docs/intel-architecture.md\` cites this 3× as a companion spec

Deleting would orphan all those citations and lose the four-context framework + anti-patterns + cross-context rules.

## Test plan

- [x] \`npm run validate\` (token lint, JSDoc lint, blueprint validate, typecheck, Storybook build) — all green
- [x] Pre-commit hooks pass (no \`--no-verify\`)
- [x] Repointed link reaches the live canonical site

🤖 Generated with [Claude Code](https://claude.com/claude-code)