### PR TITLE
feat(blueprints): hero_split_image_card_overlay — eyebrow icon slot

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -56,7 +56,7 @@ interface Props extends BlueprintProps {}
 
 const { section } = Astro.props;
 
-const { breadcrumb = [], audience, priceCard } = section;
+const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
 const headingId = `bp-hero-img-card-${section.sectionKey}-h`;
 const eyebrow = section.subheading;
 const headline = section.heading ?? '';
@@ -93,6 +93,16 @@ const cta = section.cta;
             );
           })}
         </nav>
+      )}
+
+      {iconUrl && (
+        <img
+          src={iconUrl}
+          alt={iconAlt ?? ''}
+          class="bp-hero-img-card__icon"
+          loading="eager"
+          decoding="async"
+        />
       )}
 
       {eyebrow && <p class="bp-hero-img-card__eyebrow">{eyebrow}</p>}
@@ -184,6 +194,13 @@ const cta = section.cta;
 
   .bp-hero-img-card__breadcrumb {
     margin-bottom: var(--gap-sm);
+  }
+
+  .bp-hero-img-card__icon {
+    display: block;
+    width: var(--bp-hero-img-card-icon-size, 2.5rem);
+    height: var(--bp-hero-img-card-icon-size, 2.5rem);
+    object-fit: contain;
   }
 
   .bp-hero-img-card__eyebrow {

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -125,6 +125,19 @@ export interface BlueprintSection {
    */
   readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
   /**
+   * Optional eyebrow icon URL — an audience or category badge SVG/PNG
+   * rendered between the breadcrumb and the h1 in interior-page hero
+   * blueprints. Sourced from a category/service-line CMS row's badge
+   * column (e.g. `service_lines.primary_badge_url`).
+   *
+   * Renders as a plain `<img>` sized via `--bp-hero-img-card-icon-size`.
+   * Pair with `iconAlt` for an informational alt; default empty (decorative).
+   *
+   * Additive, optional — blueprints without an eyebrow icon slot ignore it.
+   */
+  readonly iconUrl?: string;
+  readonly iconAlt?: string;
+  /**
    * Optional price-card overlay payload for hero blueprints that show
    * an image with a price/CTA card pinned to it (e.g.
    * `hero_split_image_card_overlay`). Top-level slot rather than an

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -49,6 +49,13 @@
   margin-bottom: var(--gap-sm);
 }
 
+.bp-hero-img-card__icon {
+  display: block;
+  width: var(--bp-hero-img-card-icon-size, 2.5rem);
+  height: var(--bp-hero-img-card-icon-size, 2.5rem);
+  object-fit: contain;
+}
+
 .bp-hero-img-card__eyebrow {
   margin: 0;
   font-family: var(--font-family-label);

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -23,7 +23,7 @@ import './HeroSplitImageCardOverlay.css';
 interface Props extends BlueprintProps {}
 
 export function HeroSplitImageCardOverlay({ section }: Props) {
-  const { breadcrumb = [], audience, priceCard } = section;
+  const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
   const headingId = `bp-hero-img-card-${section.sectionKey}-h`;
   const eyebrow = section.subheading;
   const headline = section.heading ?? '';
@@ -43,6 +43,16 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
             <Breadcrumb
               className="bp-hero-img-card__breadcrumb"
               items={breadcrumb.map((item) => ({ label: item.label, href: item.href }))}
+            />
+          )}
+
+          {iconUrl && (
+            <img
+              src={iconUrl}
+              alt={iconAlt ?? ''}
+              className="bp-hero-img-card__icon"
+              loading="eager"
+              decoding="async"
             />
           )}
 


### PR DESCRIPTION
Adds optional \`iconUrl\` + \`iconAlt\` slots to \`BlueprintSection\`. The \`hero_split_image_card_overlay\` blueprint renders the icon in the eyebrow position (between breadcrumb and h1) when present.

## Why

Surfaced during the [brikdesigns#78 adoption](https://github.com/brikdesigns/brikdesigns/pull/78). Live Webflow service detail pages render a small audience badge icon above the h1 — sourced from \`service_lines.primary_badge_url\` in the CMS. The blueprint had no slot for it, so consumers couldn't surface the icon without escaping the blueprint's content column.

## API additions (additive, optional)

\`\`\`ts
readonly iconUrl?: string;
readonly iconAlt?: string;
\`\`\`

Existing blueprint sections without these fields are unaffected.

## Render

Both React + Astro twins emit:

\`\`\`tsx
{iconUrl && (
  <img
    src={iconUrl}
    alt={iconAlt ?? ''}
    className="bp-hero-img-card__icon"
    loading="eager"
    decoding="async"
  />
)}
\`\`\`

Sized via the per-blueprint custom property \`--bp-hero-img-card-icon-size\` (default \`2.5rem\`).

## Consumer pickup ([brikdesigns#78](https://github.com/brikdesigns/brikdesigns/pull/78))

Once 0.64.0 ships:
1. Update \`getServiceBySlug\` to include \`primary_badge_url\` in the \`service_lines\` join
2. Pass \`section.iconUrl: service.service_lines.primary_badge_url\` from the page

## Validation

- ✅ typecheck — clean
- ✅ canonical-check — 0 violations
- ✅ canonical-class-check — 0 violations
- ✅ validate:blueprints — registry valid (32 blueprints)
- ✅ build-storybook — successful
- ✅ Pre-push validate:full — all 8 checks passed

## Recommended release

Tag as **0.64.0** (minor — additive feature) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)