### PR TITLE
chore(release): 0.63.0 → 0.64.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.63.0",
+      "version": "0.64.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Releases the [eyebrow iconUrl slot](https://github.com/brikdesigns/brik-bds/pull/506) to consumers.

After merge: tag \`v0.64.0\` → Release workflow → publish to GitHub Packages.

## What ships

- New optional \`section.iconUrl\` + \`section.iconAlt\` on \`BlueprintSection\`
- \`hero_split_image_card_overlay\` renders an \`<img>\` in the eyebrow position when present
- Sized via per-blueprint \`--bp-hero-img-card-icon-size\` (default \`2.5rem\`)

## Consumer impact

[brikdesigns/brikdesigns#78](https://github.com/brikdesigns/brikdesigns/pull/78) will:
- Bump \`@brikdesigns/bds\` to \`^0.64.0\`
- Update \`getServiceBySlug\` to include \`primary_badge_url\` in the \`service_lines\` join
- Pass \`section.iconUrl: service.service_lines.primary_badge_url\`

## Changes

\`package.json\` + \`package-lock.json\` version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)