### PR TITLE
docs(landing): strip root index + normalize all landing-page titles/descriptions

### DIFF
--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Building blocks. One job each, composable, themeable.
+title: Components
+description: React building blocks for product apps. One job each, composable, themeable.
 ---
 
 import { Cards, Card } from 'fumadocs-ui/components/card';

--- a/docs-site/content/docs/content-system/index.mdx
+++ b/docs-site/content/docs/content-system/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: The vocabulary peer to BDS — industries, voices, atmospheres, brand, compliance, and locked enums.
+title: Content System
+description: Industries, voices, brand, compliance, vocabularies — the content peer to tokens.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/docs-site/content/docs/contribution/index.mdx
+++ b/docs-site/content/docs/contribution/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Contribution
 description: How to add or change BDS components, tokens, content packs, and docs pages.
 ---
 

--- a/docs-site/content/docs/getting-started/index.mdx
+++ b/docs-site/content/docs/getting-started/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: How BDS is organized and what to expect from this site.
+title: Getting Started
+description: How BDS is organized and where to find each tenet.
 ---
 
 BDS ships three things on a single npm package: **tokens** (the design language), **components** (React building blocks), and **theming + content vocabulary** (atmospheres, layout archetypes, blueprints, industry packs, voices).

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -1,10 +1,9 @@
 ---
-title: Introduction
-description: Four tenets in one repository, published as a single versioned package.
+title: Brik Design System
+description: Tokens, components, theming, motion, and content vocabulary — one versioned package.
 ---
 
 import { Cards, Card } from 'fumadocs-ui/components/card';
-import { Callout } from 'fumadocs-ui/components/callout';
 
 BDS is four tenets in one repository, shipped as a single versioned package. Each tenet is an independent vocabulary the portal, mockup generators, and client sites consume to ship work that looks and reads like Brik without anyone having to re-decide the basics every project.
 
@@ -15,7 +14,7 @@ This site is the **guidance layer**. For live prop exploration and visual varian
 | Tenet | Answers | Ships |
 |---|---|---|
 | [**Foundation**](/docs/primitives) | *"What color, size, type?"* | Design tokens, scales, primitives |
-| [**Theming**](/docs/theming) | *"What brand, mood, shape?"* | Tokens + atmospheres + navigation archetypes + blueprints |
+| [**Theming**](/docs/theming) | *"What brand, mood, shape?"* | Tokens + atmospheres + layout archetypes + blueprints |
 | [**Motion**](/docs/motion) | *"How does it feel to move?"* | Three-tier animation system — CSS reveals → GSAP scroll → premium effects |
 | [**Content**](/docs/content-system) | *"What does it say, for whom?"* | Industry packs, voice patterns, locked vocabularies |
 
@@ -24,100 +23,12 @@ Each tenet evolves on its own cadence but cross-links at the edges. An industry 
 ## Where to start
 
 <Cards>
-  <Card title="Getting Started" href="/docs/getting-started" description="Install BDS, wire the cascade, and read the rules." />
-  <Card title="Primitives" href="/docs/primitives" description="Design tokens — color, type, spacing, the shared design language." />
+  <Card title="Getting Started" href="/docs/getting-started" description="Install BDS, wire the cascade, pick your framework." />
+  <Card title="Foundation" href="/docs/primitives" description="Design tokens — color, type, spacing, radius, shadow." />
   <Card title="Theming" href="/docs/theming" description="Atmospheres, archetypes, blueprints — the multi-tenant instrument." />
-  <Card title="Motion" href="/docs/motion" description="Three-tier animation system — Lightweight, GSAP, Premium." />
+  <Card title="Motion" href="/docs/motion" description="Three-tier system — Lightweight, GSAP, Premium." />
   <Card title="Content System" href="/docs/content-system" description="Industries, voices, vocabularies — the vocabulary peer to tokens." />
   <Card title="Components" href="/docs/components" description="React product surface. One job each, composable, themeable." />
   <Card title="Web Elements" href="/docs/web-elements" description="HTML/CSS components, sections, and email modules for websites." />
-  <Card title="Patterns" href="/docs/react-reference/patterns" description="Cross-component recipes for forms, empty states, page templates." />
+  <Card title="React Reference" href="/docs/react-reference/hooks" description="Hooks, patterns, and utilities for product apps." />
 </Cards>
-
-## Foundation — the visual atoms
-
-Design tokens are the atomic visual decisions that power BDS. Every component references tokens — never raw values.
-
-| Category | Page |
-|---|---|
-| Color | [Primitives → Color](/docs/primitives/color) |
-| Typography | [Primitives → Typography](/docs/primitives/typography) |
-| Spacing | [Primitives → Spacing](/docs/primitives/spacing) |
-| Motion | [Primitives → Motion](/docs/primitives/motion) |
-
-Border radius, border width, shadow, and size scales are documented in Storybook today and migrate here next.
-
-## Theming — the multi-tenant instrument
-
-Theming composes four orthogonal layers. Each is a decision a client can override independently of the rest.
-
-| Layer | Decides | Where it lives |
-|---|---|---|
-| Tokens | Color, type, spacing values per brand | [`theme-{client}.css`](/docs/theming/client-themes) in the consumer repo |
-| Atmospheres | Ambient mood — grain, glow, vignettes | [`@brikdesigns/bds/atmospheres/{slug}.css`](/docs/theming/atmospheres) |
-| Navigation Archetypes | Site-header shape + scroll/drawer behavior | [Industry pack → BDS `<SiteHeader>`](/docs/theming/navigation-archetypes) |
-| Blueprints | Section composition + mood tagging | [Authored in BDS, tagged per industry + mood](/docs/theming/blueprints) |
-
-## Motion — the three-tier system
-
-| Tier | Use for |
-|---|---|
-| **Lightweight** | Reveals, hovers, transitions — pure CSS, no JS |
-| **GSAP** | Scroll-driven sequences, complex orchestration |
-| **Premium** | Cinematic moments — typography flourishes, video overlays |
-
-See [Motion](/docs/motion) for the decision tree and per-tier specs.
-
-## Content — the vocabulary peer
-
-The content-vocabulary peer to the visual tokens. Paired with BDS to drive end-to-end mockup generation and structured strategy documents.
-
-| Category | Page |
-|---|---|
-| Overview | [Content System](/docs/content-system) |
-| Industries | [Content System → Industries](/docs/content-system/industries) |
-| Voices | [Content System → Voices](/docs/content-system/voices) |
-| Atmospheres | [Theming → Atmospheres](/docs/theming/atmospheres) |
-
-## Components
-
-| Group | Components |
-|---|---|
-| **Action** | Button, IconButton, LinkButton, ButtonGroup, FilterBar |
-| **Form** | Field, TextInput, Select, MultiSelect, DatePicker, Form, FieldGrid |
-| **Indicator** | Badge, Chip, Tag, Counter, Spinner, Skeleton |
-| **Feedback** | AlertBanner, Toast, Tooltip, EmptyState, ProgressBar |
-| **Control** | Switch, Slider, Stepper, Pagination, SegmentedControl, FileUploader |
-| **Addable** | AddableTagList, AddableEntryList, AddableFieldRowList |
-| **Structure** | Card, Divider, Accordion |
-
-See [Components](/docs/components) for the full index.
-
-## Token system — the naming contract
-
-Components use CSS custom properties from the Style Dictionary token pipeline:
-
-```text
---[category]-[type]-[variant]
-```
-
-**Primitives** — raw scale values, never used directly in components:
-
-```css
---space-400;             /* 16px */
---font-size-700;         /* 32px */
---color-grayscale-darkest; /* #333 */
-```
-
-**Semantic** — purpose-bound aliases, always use these in components:
-
-```css
---background-brand-primary; /* brand background color */
---font-family-heading;      /* heading font family */
---padding-lg;               /* large spacing value */
---border-radius-md;         /* button/card corner radius */
-```
-
-<Callout type="warn">
-  **Never write raw `var()` strings inline in app code.** Import from `@/lib/tokens` and `@/lib/styles` in consumer projects. The cascade is a contract — bypassing it leaks brand drift into components.
-</Callout>

--- a/docs-site/content/docs/motion/effects/index.mdx
+++ b/docs-site/content/docs/motion/effects/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Effect categories
-description: Implementation patterns by category — hover, scroll reveals, overlays, typography, video. Each category lives in a specific tier (Lightweight, GSAP, or Premium).
+title: Effects
+description: Hover, scroll reveals, overlays, typography, video — patterns by tier.
 ---
 
 import { Cards, Card } from 'fumadocs-ui/components/card';

--- a/docs-site/content/docs/motion/index.mdx
+++ b/docs-site/content/docs/motion/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: A three-tier motion system. Lightweight CSS reveals → GSAP scroll choreography → Premium cinematic effects. Every tier is additive — load only what your design calls for.
+title: Motion
+description: Three-tier motion system — lightweight CSS, GSAP scroll, premium effects.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/docs-site/content/docs/motion/tiers/index.mdx
+++ b/docs-site/content/docs/motion/tiers/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: When to escalate
-description: Three tiers, each additive. Tier comparison and the decision tree for picking the right tier per engagement.
+title: Tiers
+description: Lightweight, GSAP, Premium — and when to escalate.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/docs-site/content/docs/primitives/index.mdx
+++ b/docs-site/content/docs/primitives/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Foundation
-description: The single source of truth for every visual decision — color, type, spacing, radius, shadow, motion. Authored in Figma, exported via Tokens Studio, transformed by Style Dictionary, shipped as @brikdesigns/bds/tokens.css.
+description: Design tokens — color, typography, spacing, radius, shadow, size.
 ---
 
 import { Cards, Card } from 'fumadocs-ui/components/card';

--- a/docs-site/content/docs/theming/index.mdx
+++ b/docs-site/content/docs/theming/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Introduction
-description: How a single component library renders as a different brand for every client — composed across four orthogonal layers.
+title: Theming
+description: Compose per-client brand identity across four orthogonal layers.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/docs-site/content/docs/web-elements/index.mdx
+++ b/docs-site/content/docs/web-elements/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Framework-agnostic HTML/CSS components, repeatable section blueprints, and email modules — built once in BDS, retheme per client, render via Astro/Webflow/email pipelines.
+title: Web Elements
+description: HTML/CSS components, section blueprints, and email modules for non-React consumers.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';


### PR DESCRIPTION
## Summary

Two related cleanups on the docs site's front-door surface.

**1. Strip \`/docs/index.mdx\` to traffic-cop** — was 123 lines duplicating Foundation, Theming, Motion, Content, Components per-tenet recap sections (each duplicated the sibling overview page). Now 33 lines: intro + four-tenet table + 8-card grid matching the IA's top-level groups.

**2. Normalize all 11 landing-page H1 titles + descriptions** — every \`index.mdx\` H1 now matches its section's meta.json group title (consistent "you are here" signal). Descriptions capped at ~80 chars; written as nav aids, not marketing copy.

## Title changes

| File | Before | After |
| --- | --- | --- |
| \`/docs/index.mdx\` | Introduction | Brik Design System |
| \`getting-started/index.mdx\` | Overview | Getting Started |
| \`theming/index.mdx\` | Introduction | Theming |
| \`motion/index.mdx\` | Overview | Motion |
| \`motion/effects/index.mdx\` | Effect categories | Effects |
| \`motion/tiers/index.mdx\` | When to escalate | Tiers |
| \`content-system/index.mdx\` | Overview | Content System |
| \`components/index.mdx\` | Overview | Components |
| \`web-elements/index.mdx\` | Overview | Web Elements |
| \`contribution/index.mdx\` | Overview | Contribution |
| \`primitives/index.mdx\` | Foundation (kept — set in #492) | Foundation |

## Description normalization

Worst offender was \`primitives/index.mdx\` at **222 chars** ("Authored in Figma, exported via Tokens Studio, transformed by Style Dictionary…") → "Design tokens — color, typography, spacing, radius, shadow, size." (65 chars).

All 11 descriptions now ≤ 85 chars.

## Diff

11 files changed, +25 / −114 (net −89).

## Test plan

- [x] \`npm run build\` in docs-site → 138 static pages, no errors
- [x] \`npm run validate\` (BDS) → all 8 checks pass
- [x] No internal cross-link breakage (no URLs changed)

## Context

Part of the docs IA + content cleanup sweep:
- #492 — IA restructure
- #494 — framework-guides rewrite
- #509 — react-helpers dedup
- #510 — cascade dedup
- **#this** — landing normalization
- Next queued: nav + footer archetype merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)