### PR TITLE
docs(color): split portal-generator content out of color.mdx

### DIFF
--- a/docs-site/content/docs/content-system/vocabularies/color-primitive-tier.mdx
+++ b/docs-site/content/docs/content-system/vocabularies/color-primitive-tier.mdx
@@ -52,6 +52,50 @@ Walk this top-down for each primitive in a brand:
 
 The default answer is **no tier**. Only tag a primitive when it has a canonical slot it must drive.
 
+## Tonal scale emission
+
+Two orthogonal axes pair with the tier vocabulary above. Don't mix them.
+
+**Primitives carry tone.** Every primitive emits the Figma 6-stop scale: `lightest`, `lighter`, `light`, `dark`, `darker`, `darkest`. The unsuffixed variable (`--{slug}-{color}`) aliases the `light` step.
+
+```css
+/* Per-client primitive emission, one row per Figma stop */
+--vale-partners-navy:            #95afd4;  /* base = light */
+--vale-partners-navy-lightest:   #e7effb;
+--vale-partners-navy-lighter:    #d1dff4;
+--vale-partners-navy-light:      #95afd4;
+--vale-partners-navy-dark:       #5f7697;
+--vale-partners-navy-darker:     #1c3252;
+--vale-partners-navy-darkest:    #111720;
+```
+
+**Semantic aliases carry state.** Interaction-state names (`-hover`, `-pressed`, `-active`, `-disabled`) live on canonical aliases like `--background-brand-primary-hover` — never on primitives. Each state alias **references** a tonal stop:
+
+```css
+--background-brand-primary:         var(--vale-partners-olive);          /* base */
+--background-brand-primary-hover:   var(--vale-partners-olive-lighter);  /* one stop up */
+--background-brand-primary-pressed: var(--vale-partners-olive-dark);     /* one stop down */
+```
+
+<Callout type="warn">
+  **Figma is source of truth for primitive naming.** When a CSS suffix doesn't match a Figma stop name, the system has drifted. Primitives never carry interaction-state names (`-hover`, `-pressed`); those belong on canonical aliases that *reference* a tonal stop.
+</Callout>
+
+### Deprecated suffix aliases
+
+Pre-2026-Q2, the portal token generator emitted state-named suffixes on primitives — `--{slug}-{color}-subtle/-hover/-pressed/-deep/-deepest`. These are now **deprecation aliases** that point at their Figma-named counterparts via `var()`:
+
+```css
+/* Deprecated — emitted only for backward compatibility */
+--vale-partners-navy-subtle:   var(--vale-partners-navy-lightest);
+--vale-partners-navy-hover:    var(--vale-partners-navy-lighter);
+--vale-partners-navy-pressed:  var(--vale-partners-navy-dark);
+--vale-partners-navy-deep:     var(--vale-partners-navy-darker);
+--vale-partners-navy-deepest:  var(--vale-partners-navy-darkest);
+```
+
+**Targeted retirement: ≥ 2026-Q3.** New consumer code MUST use the Figma-named tonal stops. Existing references migrate at consumer-repo pace; track via cross-repo grep.
+
 ## Programmatic access
 
 ```ts

--- a/docs-site/content/docs/primitives/color.mdx
+++ b/docs-site/content/docs/primitives/color.mdx
@@ -143,54 +143,6 @@ Online/offline indicator tokens used by Avatar and Dot components.
   columns={4}
 />
 
-## Tonal scale + interaction state
-
-Two orthogonal axes. Don't mix them.
-
-**Primitives carry tone.** Every primitive emits the Figma 6-stop scale: `lightest`, `lighter`, `light`, `dark`, `darker`, `darkest`. The unsuffixed variable (`--{slug}-{color}`) aliases the `light` step.
-
-```css
-/* Per-client primitive emission, one row per Figma stop */
---vale-partners-navy:            #95afd4;  /* base = light */
---vale-partners-navy-lightest:   #e7effb;
---vale-partners-navy-lighter:    #d1dff4;
---vale-partners-navy-light:      #95afd4;
---vale-partners-navy-dark:       #5f7697;
---vale-partners-navy-darker:     #1c3252;
---vale-partners-navy-darkest:    #111720;
-```
-
-**Semantic aliases carry state.** Interaction-state names (`-hover`, `-pressed`, `-active`, `-disabled`) live on canonical aliases like `--background-brand-primary-hover` — never on primitives. Each state alias **references** a tonal stop:
-
-```css
---background-brand-primary:         var(--vale-partners-olive);          /* base */
---background-brand-primary-hover:   var(--vale-partners-olive-lighter);  /* one stop up */
---background-brand-primary-pressed: var(--vale-partners-olive-dark);     /* one stop down */
-```
-
-<Callout type="warn">
-  **Figma is source of truth for primitive naming.** When a CSS suffix doesn't match a Figma stop name, the system has drifted. Primitives never carry interaction-state names (`-hover`, `-pressed`); those belong on canonical aliases that *reference* a tonal stop.
-</Callout>
-
-### Re-binding canonical brand tokens per audience or service line
-
-When a client site needs multiple brand colors visible at the same time (Vale's three audience verticals, brikdesigns' service lines), don't add audience-specific names to canonical. Re-bind the same `--background-brand-primary` / `--text-brand-primary` / `--border-brand-primary` tokens inside `[data-audience=X]` (or `data-service`, `data-department`) scopes. Components keep referencing the canonical token; CSS custom-property scoping resolves the right value per subtree. Full pattern + Vale + brikdesigns examples: [Client Themes → Per-audience scope binding](/docs/theming/client-themes#per-audience-or-service-line-scope-binding).
-
-### Deprecated suffix aliases
-
-Pre-2026-Q2, the portal token generator emitted state-named suffixes on primitives — `--{slug}-{color}-subtle/-hover/-pressed/-deep/-deepest`. These are now **deprecation aliases** that point at their Figma-named counterparts via `var()`:
-
-```css
-/* Deprecated — emitted only for backward compatibility */
---vale-partners-navy-subtle:   var(--vale-partners-navy-lightest);
---vale-partners-navy-hover:    var(--vale-partners-navy-lighter);
---vale-partners-navy-pressed:  var(--vale-partners-navy-dark);
---vale-partners-navy-deep:     var(--vale-partners-navy-darker);
---vale-partners-navy-deepest:  var(--vale-partners-navy-darkest);
-```
-
-**Targeted retirement: ≥ 2026-Q3.** New consumer code MUST use the Figma-named tonal stops. Existing references migrate at consumer-repo pace; track via cross-repo grep.
-
 ## Primitives
 
 Raw color scales from the Figma Brand Kit. **Components reference these via semantic tokens — never directly.** The primitives change rarely; the semantic mappings change per theme.
@@ -207,7 +159,8 @@ Raw color scales from the Figma Brand Kit. **Components reference these via sema
 
 ## Related
 
-- [Color primitive tier](/docs/content-system/vocabularies/color-primitive-tier) — the closed `tier` vocabulary that decides which canonical slots a brand primitive resolves into
+- [Color primitive tier](/docs/content-system/vocabularies/color-primitive-tier) — the closed `tier` vocabulary, tonal-scale emission rules, and the deprecated suffix-alias migration
+- [Client Themes → Per-audience scope binding](/docs/theming/client-themes#per-audience-or-service-line-scope-binding) — multi-brand scope-based token re-binding for sites like Vale Partners and brikdesigns.com
 - [Cascade rules](/docs/getting-started/cascade) — the three-layer architecture every consumer follows
 - [Atmospheres](/docs/content-system/atmospheres) — the mood overlay layer that sits on top of theme tokens
 - [Storybook → Color contrast compliance](https://storybook.brikdesigns.com/?path=/docs/overview-health-contrast-compliance--docs)


### PR DESCRIPTION
## Summary

\`primitives/color.mdx\` was mixing three audiences on one page:
- Designers (swatches, palettes)
- Consumers (semantic vocabulary, interaction states, status, presence)
- Portal developers (tonal-scale emission rules, deprecated suffix-alias migration)

Portal-developer specialist content moves to \`content-system/vocabularies/color-primitive-tier.mdx\`, which already documents the closed \`tier\` vocabulary the portal theme generator reads. Tonal scale + deprecated suffix aliases are part of the same generator concern — they belong together.

## Changes

| File | Action |
| --- | --- |
| \`primitives/color.mdx\` | −51 lines. Stripped "Tonal scale + interaction state", "Re-binding canonical brand tokens" stub, and "Deprecated suffix aliases" sections. Related links updated. |
| \`content-system/vocabularies/color-primitive-tier.mdx\` | +44 lines. Added "Tonal scale emission" section + sub-section for "Deprecated suffix aliases". |

**Net −5 lines.** The bigger win is shape: \`color.mdx\` is now a focused designer + consumer surface; \`color-primitive-tier.mdx\` is the focused portal-developer reference.

## Test plan

- [x] \`npm run build\` in docs-site → 137 static pages, no errors
- [x] \`npm run validate\` (BDS) → all 8 checks pass
- [x] No stale cross-references

## Context — sweep complete

This is the final PR in the docs IA + content cleanup sweep:
- #492 — IA restructure (12 → 9 groups)
- #494 — framework-guides rewrite (real Next.js + Astro scaffolds)
- #509 — react-helpers dedup
- #510 — cascade dedup
- #511 — landing-page normalization
- #513 — nav + footer archetype merge
- **#this** — color page split

🤖 Generated with [Claude Code](https://claude.com/claude-code)