### PR TITLE
chore(release): 0.64.0 → 0.65.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.64.0",
+      "version": "0.65.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Releases the [audience cascade refactor](https://github.com/brikdesigns/brik-bds/pull/512) to consumers.

After merge: tag \`v0.65.0\` → Release workflow → publish to GitHub Packages.

## What ships in 0.65.0

\`HeroSplitImageCardOverlay\` (React + Astro) gains audience-aware cascade rules bound to canonical \`--background-service-{audience}\` and \`--text-service-{audience}\` tokens for all 5 audiences. Consumers no longer need to set inline overrides — passing \`section.audience\` is sufficient.

## Consumer impact

[brikdesigns#78](https://github.com/brikdesigns/brikdesigns/pull/78) will:
- Bump \`@brikdesigns/bds\` to \`^0.65.0\`
- Delete the inline \`--page-brand-primary\` / \`--text-brand-primary\` / \`--background-inverse\` / \`--text-on-color-light\` overrides in \`[serviceSlug]/page.tsx\`

## Changes

\`package.json\` + \`package-lock.json\` version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)