### PR TITLE
storybook: align top-level groups + theming order with docs site

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -310,7 +310,7 @@ const preview: Preview = {
             'Health',
             ['Health Dashboard', 'Token Coverage', 'Contrast Compliance'],
           ],
-          'Foundations',
+          'Foundation',
           [
             'Design Tokens',
             ['Overview', 'Color', 'Typography', 'Spacing', 'Border Radius', 'Border Width', 'Shadow', 'Size', 'Motion'],
@@ -322,7 +322,8 @@ const preview: Preview = {
             'Overview',
             'Client Themes',
             'Atmospheres',
-            'Navigation Archetypes',
+            'Modes',
+            'Layout Archetypes',
             'Blueprints',
             '*',
           ],
@@ -334,7 +335,7 @@ const preview: Preview = {
             'Vocabulary',
             '*',
           ],
-          'Content',
+          'Content System',
           [
             'Overview',
             'Industries',

--- a/stories/theming/NavigationArchetypes.stories.tsx
+++ b/stories/theming/NavigationArchetypes.stories.tsx
@@ -117,7 +117,7 @@ function ArchetypeStoryRender({ archetype }: ArchetypeStoryArgs) {
 }
 
 const meta: Meta<ArchetypeStoryArgs> = {
-  title: 'Theming/Navigation Archetypes',
+  title: 'Theming/Layout Archetypes',
   parameters: {
     layout: 'fullscreen',
     docs: {


### PR DESCRIPTION
## Summary

The Storybook sidebar's storySort order didn't match the docs-site IA after the docs sweep (#492, #513). Three renames + one addition to close the gap.

## Changes

In \`.storybook/preview.tsx\` storySort:
- \`Foundations\` → \`Foundation\` (matches docs Foundation section)
- \`Content\` → \`Content System\` (matches docs Content System section)
- \`Theming/Navigation Archetypes\` → \`Theming/Layout Archetypes\` (matches the nav+footer merge in #513)
- **Added** \`Theming/Modes\` between Atmospheres and Layout Archetypes — the existing \`Theming/Modes/Spacing\` story previously fell through \`'*'\`; now has a deliberate slot.

In \`stories/theming/NavigationArchetypes.stories.tsx\`:
- Story \`title\` changed from \`'Theming/Navigation Archetypes'\` → \`'Theming/Layout Archetypes'\`.

## Notes

- The three renamed top-level groups (\`Foundation\`, \`Content System\`, plus \`Motion\` which already matched) have **zero stories under them** today. They're aspirational slot placeholders for when token primitives / content-system content / motion content migrate to Storybook. Renaming now means future stories land correctly.
- File name \`NavigationArchetypes.stories.tsx\` left as-is — Storybook indexes by story title, not file path. Footer-archetype content will land in this story when blueprints-astro v0.2 ships (tracked in #520).
- No story content changes — pure label alignment.

## Test plan

- [x] \`npm run typecheck\` → clean
- [x] \`rg "Theming/Navigation Archetypes|'Foundations'|'Content',\$"\` → no other refs
- [ ] Visual confirm on storybook.brikdesigns.com after deploy: sidebar shows \"Theming → Layout Archetypes\"

## Context

Part of a Storybook ↔ docs alignment review:
- This PR — quick-win label alignment
- Follow-ups not in scope: neutralize Brik-specific content in default Blueprint Story args; add atmosphere-variant Stories per blueprint to demonstrate themability (separate work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)