### PR TITLE
storybook(blueprints): neutralize Brik-branded content in default Story args

### DIFF
--- a/content-system/blueprints/react/AboutStorySplit.stories.tsx
+++ b/content-system/blueprints/react/AboutStorySplit.stories.tsx
@@ -11,7 +11,7 @@ const baseTheme: BlueprintProps['theme'] = {
 };
 
 const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
+  brandName: 'Acme',
   tagline: null,
   valueProposition: null,
   services: [],
@@ -27,9 +27,9 @@ const baseClientFacts: BlueprintProps['clientFacts'] = {
 const section: BlueprintProps['section'] = {
   sectionKey: 'about-story-default',
   sectionType: 'content_block',
-  heading: 'A studio that compounds your design budget.',
+  heading: 'A story-led section that introduces the brand.',
   subheading: 'Who we are',
-  body: 'Brik Designs is a Tennessee studio that pairs strategic thinking with execution speed. Our retainer clients see compounding returns because every quarter builds on the last — brand, marketing, and operations design treated as one system, not three vendors.',
+  body: 'A short paragraph of about-copy that sets context for the visitor — who you are, what you do, and the posture you bring to the work. Long enough to set the type rhythm but short enough that a visitor will actually read it.',
   cta: null,
   visualNotes: {
     blueprintKey: 'about_story_split',
@@ -41,9 +41,9 @@ const section: BlueprintProps['section'] = {
   },
   items: [
     {
-      title: 'Aaron Stanerson, Founder',
+      title: 'Sample Quote, Role',
       description:
-        'Brik isn’t a design vendor — it’s a long-term partner that lives inside the metrics it’s trying to move.',
+        'A short pull-quote that reinforces the section narrative — typically two sentences attributed to a leader or customer.',
     },
   ],
 };

--- a/content-system/blueprints/react/CtaDarkCentered.stories.tsx
+++ b/content-system/blueprints/react/CtaDarkCentered.stories.tsx
@@ -11,7 +11,7 @@ const baseTheme: BlueprintProps['theme'] = {
 };
 
 const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
+  brandName: 'Acme',
   tagline: null,
   valueProposition: null,
   services: [],
@@ -27,10 +27,10 @@ const baseClientFacts: BlueprintProps['clientFacts'] = {
 const section: BlueprintProps['section'] = {
   sectionKey: 'cta-dark-centered-default',
   sectionType: 'cta',
-  heading: 'Ready to make design a growth lever?',
+  heading: 'Ready to get started?',
   subheading: null,
-  body: 'Tell us about your business — we’ll send back a 24-hour assessment of where design is leaving value on the table.',
-  cta: { label: 'Start the conversation', url: '/contact' },
+  body: 'A closing prompt that earns the click — short, action-oriented, and specific to what the visitor gets after they tap the CTA.',
+  cta: { label: 'Get in touch', url: '#contact' },
   visualNotes: {
     blueprintKey: 'cta_dark_centered',
     moodKeywords: ['bold'],

--- a/content-system/blueprints/react/Features3ColBrandedDark.stories.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.stories.tsx
@@ -8,9 +8,9 @@ import { baseTheme, baseClientFacts } from './_fixtures';
  *
  * BDS ships the scope-binding pattern but not audience-specific values
  * — those live in each consumer's globals.css. Storybook needs the
- * binding present somewhere so cards visualize in the right brand
- * colors. This `<style>` block mirrors what brikdesigns.com would
- * declare for its five service-line audiences.
+ * binding present somewhere so cards visualize in distinct brand
+ * colors. This `<style>` block is a representative example of what
+ * a consumer site would declare for its audience verticals.
  *
  * Per the cascade rules (`docs/theming/client-themes`), we re-bind
  * `--background-brand-primary` and the related brand-* tokens inside
@@ -49,49 +49,50 @@ const audienceCascadeStyles = `
 const darkTheme: BlueprintProps['theme'] = { ...baseTheme, themeMode: 'dark' };
 
 /**
- * "Other Service Lines" fixture — the brikdesigns.com cross-sell
- * module shown at the bottom of each /services/{slug} page. Three
- * cards in service-line-distinct brand colors.
+ * Three cards in audience-distinct brand colors — the canonical
+ * fixture for the dark 3-column features blueprint. The shape (three
+ * scope-bound cards on a dark section) is what the blueprint
+ * documents; consumer sites supply their own card content.
  */
-const otherServiceLinesSection: BlueprintProps['section'] = {
+const featuresSection: BlueprintProps['section'] = {
   sectionKey: 'features-branded-dark-default',
   sectionType: 'features',
-  heading: 'Other Service Lines',
+  heading: 'Featured capabilities',
   subheading: null,
-  body: 'A complete operating system for visual communication — explore the parts you haven’t yet.',
+  body: 'A short section subheading that frames the cards below — typically a cross-sell or capability roll-up.',
   cta: null,
   visualNotes: {
     blueprintKey: 'features_3col_branded_dark',
     moodKeywords: ['bold', 'modern'],
     layoutBlueprint: 'features_3col_branded_dark',
-    imageOpportunity: '3D illustration per service line',
+    imageOpportunity: 'illustration per card',
     animationSuggestion: null,
-    illustrationOpportunity: 'service-line scene per card',
+    illustrationOpportunity: 'scene per card',
   },
   items: [
     {
-      title: 'Brand',
-      description: 'Logo, identity, and brand systems that scale.',
-      href: '/services/brand',
+      title: 'Capability one',
+      description: 'A two-line card description that sets the type rhythm without competing with the title.',
+      href: '#',
       audience: 'brand',
     },
     {
-      title: 'Marketing',
-      description: 'Web, email, and social design tied to growth metrics.',
-      href: '/services/marketing',
+      title: 'Capability two',
+      description: 'A two-line card description that sets the type rhythm without competing with the title.',
+      href: '#',
       audience: 'marketing',
     },
     {
-      title: 'Back Office',
-      description: 'Operations design — SOPs, automation, internal tooling.',
-      href: '/services/back-office',
+      title: 'Capability three',
+      description: 'A two-line card description that sets the type rhythm without competing with the title.',
+      href: '#',
       audience: 'service',
     },
   ],
 };
 
 const baseProps: BlueprintProps = {
-  section: otherServiceLinesSection,
+  section: featuresSection,
   clientFacts: baseClientFacts,
   theme: darkTheme,
 };
@@ -117,7 +118,7 @@ const meta: Meta<typeof Features3ColBrandedDark> = {
     docs: {
       description: {
         component:
-          'Dark section with a 3-column grid of brand-colored cards. Each card emits `data-audience` to re-bind `--background-brand-primary` for that subtree per the BDS scope-binding pattern (`docs/theming/client-themes`). Stories include a demo cascade block that mirrors the brikdesigns.com five service-line bindings; consumer sites must declare an equivalent block. Card title uses bold weight + 18px, description 16px regular — the AA-clearing posture for white-on-saturated-brand backgrounds (BDS contrast burndown #40).',
+          'Dark section with a 3-column grid of brand-colored cards. Each card emits `data-audience` to re-bind `--background-brand-primary` for that subtree per the BDS scope-binding pattern (`docs/theming/client-themes`). Stories include a representative cascade block showing how a consumer site would declare per-audience bindings. Card title uses bold weight + 18px, description 16px regular — the AA-clearing posture for white-on-saturated-brand backgrounds (BDS contrast burndown #40).',
       },
     },
   },
@@ -129,7 +130,7 @@ type Story = StoryObj<typeof Features3ColBrandedDark>;
 /* ─── Stories ──────────────────────────────────────────────────── */
 
 /**
- * @summary Three cards — brand / marketing / back-office. The brikdesigns "Other Service Lines" fixture.
+ * @summary Three cards — the canonical 3-column features fixture.
  */
 export const Playground: Story = {
   args: baseProps,
@@ -148,14 +149,14 @@ export const Wrapped: Story = {
   args: {
     ...baseProps,
     section: {
-      ...otherServiceLinesSection,
+      ...featuresSection,
       sectionKey: 'features-branded-dark-wrapped',
       items: [
-        ...otherServiceLinesSection.items,
+        ...featuresSection.items,
         {
-          title: 'Information',
-          description: 'Make complex information scannable and on-brand.',
-          href: '/services/information',
+          title: 'Capability four',
+          description: 'A two-line card description that sets the type rhythm without competing with the title.',
+          href: '#',
           audience: 'information',
         },
       ],

--- a/content-system/blueprints/react/HeroInteriorMinimal.stories.tsx
+++ b/content-system/blueprints/react/HeroInteriorMinimal.stories.tsx
@@ -11,7 +11,7 @@ const baseTheme: BlueprintProps['theme'] = {
 };
 
 const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
+  brandName: 'Acme',
   tagline: null,
   valueProposition: null,
   services: [],
@@ -27,9 +27,9 @@ const baseClientFacts: BlueprintProps['clientFacts'] = {
 const interiorSection: BlueprintProps['section'] = {
   sectionKey: 'hero-interior-default',
   sectionType: 'hero',
-  heading: 'Information Design',
-  subheading: 'Services',
-  body: 'Make complex information scannable, memorable, and beautifully on-brand.',
+  heading: 'Interior page headline.',
+  subheading: 'Section',
+  body: 'A short interior-page lead — one sentence of supporting copy that frames the page topic without competing with the headline.',
   cta: null,
   visualNotes: {
     blueprintKey: 'hero_interior_minimal',
@@ -63,7 +63,7 @@ export const WithCta: Story = {
     section: {
       ...interiorSection,
       sectionKey: 'hero-interior-with-cta',
-      cta: { label: 'See examples', url: '/work' },
+      cta: { label: 'See examples', url: '#' },
     },
     clientFacts: baseClientFacts,
     theme: baseTheme,

--- a/content-system/blueprints/react/HeroSplit6040.stories.tsx
+++ b/content-system/blueprints/react/HeroSplit6040.stories.tsx
@@ -11,7 +11,7 @@ const baseTheme: BlueprintProps['theme'] = {
 };
 
 const facts = (heroImageUrl: string | null): BlueprintProps['clientFacts'] => ({
-  brandName: 'Brik Designs',
+  brandName: 'Acme',
   tagline: null,
   valueProposition: null,
   services: [],
@@ -27,10 +27,10 @@ const facts = (heroImageUrl: string | null): BlueprintProps['clientFacts'] => ({
 const section: BlueprintProps['section'] = {
   sectionKey: 'hero-split-default',
   sectionType: 'hero',
-  heading: 'Strategic design that compounds.',
-  subheading: 'Brik Designs',
-  body: 'Brand systems, marketing, information design, and back-office tooling — under one roof.',
-  cta: { label: 'See our work', url: '/work' },
+  heading: 'A clear, compelling headline goes here.',
+  subheading: 'Acme',
+  body: 'One or two sentences of supporting copy — long enough to set the rhythm of body type next to the headline without overwhelming it.',
+  cta: { label: 'Learn more', url: '#' },
   visualNotes: {
     blueprintKey: 'hero_split_60_40',
     moodKeywords: ['professional', 'modern'],

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -44,7 +44,7 @@ const baseTheme: BlueprintProps['theme'] = {
 };
 
 const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
+  brandName: 'Acme',
   tagline: null,
   valueProposition: null,
   services: [],
@@ -58,29 +58,30 @@ const baseClientFacts: BlueprintProps['clientFacts'] = {
 };
 
 /**
- * "Layout Design" fixture — the brikdesigns.com `/service/layout-design`
- * interior hero, used to validate the canonical shape captured in the
- * blueprint coverage audit (2026-05-09).
+ * Canonical interior-hero fixture — service-detail page shape with
+ * breadcrumb trail, audience-tinted background, and a price-overlay
+ * card on the right. The shape (not the content) is what the blueprint
+ * documents; consumer sites supply their own copy.
  */
-const layoutDesignSection: BlueprintProps['section'] = {
+const interiorHeroSection: BlueprintProps['section'] = {
   sectionKey: 'hero-img-card-default',
   sectionType: 'hero',
-  heading: 'Layout Design',
-  subheading: 'INFORMATION',
-  body: 'From single-page flyers and one-pagers to multi-page brochures and booklets, we design marketing materials that are clear, compelling, and built to convert—whether for print or digital use.',
-  cta: { label: 'View Details', url: '/service/layout-design' },
+  heading: 'Service detail headline.',
+  subheading: 'CATEGORY',
+  body: 'A short interior-hero paragraph describing what this page covers — typically two or three sentences of supporting context before the visitor reaches the deliverable cards or pricing.',
+  cta: { label: 'View details', url: '#' },
   breadcrumb: [
-    { label: 'All Services', href: '/services' },
-    { label: 'Information Design', href: '/service-lines/information-design' },
-    { label: 'Layout Design' },
+    { label: 'All services', href: '#' },
+    { label: 'Category', href: '#' },
+    { label: 'Service detail' },
   ],
   audience: 'information',
   priceCard: {
-    imageUrl: 'https://placehold.co/640x480/eaf1fb/1f3d70?text=Trifold',
+    imageUrl: 'https://placehold.co/640x480/eaf1fb/1f3d70?text=Deliverable',
     imageAlt: '',
     priceLabel: 'Starting at',
     price: '$249',
-    cta: { label: "Let's Talk", url: '/contact' },
+    cta: { label: 'Get in touch', url: '#contact' },
   },
   visualNotes: {
     blueprintKey: 'hero_split_image_card_overlay',
@@ -94,7 +95,7 @@ const layoutDesignSection: BlueprintProps['section'] = {
 };
 
 const baseProps: BlueprintProps = {
-  section: layoutDesignSection,
+  section: interiorHeroSection,
   clientFacts: baseClientFacts,
   theme: baseTheme,
 };
@@ -132,7 +133,7 @@ type Story = StoryObj<typeof HeroSplitImageCardOverlay>;
 /* ─── Stories ──────────────────────────────────────────────────── */
 
 /**
- * @summary Canonical interior service-page hero — Layout Design fixture.
+ * @summary Canonical interior service-page hero.
  */
 export const Playground: Story = {
   args: baseProps,

--- a/content-system/blueprints/react/Services3ColCardGrid.stories.tsx
+++ b/content-system/blueprints/react/Services3ColCardGrid.stories.tsx
@@ -7,82 +7,82 @@ import { baseTheme, baseClientFacts } from './_fixtures';
 /* ─── Fixtures ─────────────────────────────────────────────────── */
 
 /**
- * "Information Design Services" fixture — six service cards modeled
- * on the brikdesigns.com `/services/information` page that drives this
- * blueprint. Image URLs are placeholder; the production CMS supplies
- * Webflow-hosted illustrations.
+ * Six service cards — the canonical fixture for the 3-column grid
+ * blueprint. The shape (six cards, optional category accent, optional
+ * "has options" pill) is what the blueprint documents; consumer sites
+ * supply their own service catalog.
  */
-const informationServicesSection: BlueprintProps['section'] = {
+const servicesGridSection: BlueprintProps['section'] = {
   sectionKey: 'services-grid-default',
   sectionType: 'services',
-  heading: 'Information Design Services',
-  subheading: 'Brik Designs',
-  body: 'Make complex information scannable, memorable, and beautifully on-brand.',
+  heading: 'Featured services',
+  subheading: 'Acme',
+  body: 'A one-line section subheading that frames the service catalog below.',
   cta: null,
   visualNotes: {
     blueprintKey: 'services_3col_card_grid',
     moodKeywords: ['approachable', 'modern'],
     layoutBlueprint: 'services_3col_card_grid',
-    imageOpportunity: 'service-line illustration per card',
+    imageOpportunity: 'illustration per card',
     animationSuggestion: null,
-    illustrationOpportunity: '3D persona scene per service',
+    illustrationOpportunity: 'scene per service',
   },
   items: [
     {
-      title: 'Information Design',
+      title: 'Service one',
       description:
-        'Turn dense data and dense reports into a clean visual story your audience will actually read.',
-      href: '/services/information/information-design',
-      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Information+Design',
+        'A two-line card description that sets the type rhythm without trying to tell the whole story.',
+      href: '#',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Service+One',
       category: 'information',
     },
     {
-      title: 'Infographics',
+      title: 'Service two',
       description:
-        'One-screen explanations of how something works — for proposals, decks, and on-page content.',
-      href: '/services/information/infographics',
-      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Infographics',
-      category: 'information',
-      hasOptions: true,
-    },
-    {
-      title: 'Patient Experience Mapping',
-      description:
-        'Visualize the patient journey end-to-end so every touchpoint can be improved with intent.',
-      href: '/services/information/patient-experience-mapping',
-      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Patient+Journey',
-      category: 'information',
-    },
-    {
-      title: 'Customer Journey Mapping',
-      description:
-        'A diagram of how customers find, evaluate, and stay with you — sized for a stakeholder readout.',
-      href: '/services/information/customer-journey-mapping',
-      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Customer+Journey',
-      category: 'information',
-    },
-    {
-      title: 'Process Documentation',
-      description:
-        'A repeatable visual SOP — the operations equivalent of a brand book — so handoffs survive growth.',
-      href: '/services/information/process-documentation',
-      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Process+Docs',
+        'A two-line card description that sets the type rhythm without trying to tell the whole story.',
+      href: '#',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Service+Two',
       category: 'information',
       hasOptions: true,
     },
     {
-      title: 'Wayfinding & Signage',
+      title: 'Service three',
       description:
-        'On-brand signage systems that get patients, customers, and staff to the right place every time.',
-      href: '/services/information/wayfinding',
-      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Wayfinding',
+        'A two-line card description that sets the type rhythm without trying to tell the whole story.',
+      href: '#',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Service+Three',
+      category: 'information',
+    },
+    {
+      title: 'Service four',
+      description:
+        'A two-line card description that sets the type rhythm without trying to tell the whole story.',
+      href: '#',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Service+Four',
+      category: 'information',
+    },
+    {
+      title: 'Service five',
+      description:
+        'A two-line card description that sets the type rhythm without trying to tell the whole story.',
+      href: '#',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Service+Five',
+      category: 'information',
+      hasOptions: true,
+    },
+    {
+      title: 'Service six',
+      description:
+        'A two-line card description that sets the type rhythm without trying to tell the whole story.',
+      href: '#',
+      imageUrl: 'https://placehold.co/480x320/eaf1fb/1f3d70?text=Service+Six',
       category: 'information',
     },
   ],
 };
 
 const baseProps: BlueprintProps = {
-  section: informationServicesSection,
+  section: servicesGridSection,
   clientFacts: baseClientFacts,
   theme: baseTheme,
 };
@@ -98,7 +98,7 @@ const meta: Meta<typeof Services3ColCardGrid> = {
     docs: {
       description: {
         component:
-          'Three-column service card grid blueprint. Drives the brikdesigns.com `/services/{slug}` index pages. Each card composes BDS primitives — Card frame, Frame for the 3:2 image, ServiceTag for the category badge, LinkButton for the "Learn more" CTA, and Badge for the optional "Has Options" pill. Description copy uses `--text-primary` to clear AA contrast at 14–16px (BDS contrast burndown #40).',
+          'Three-column service card grid blueprint. Each card composes BDS primitives — Card frame, Frame for the 3:2 image, ServiceTag for the category badge, LinkButton for the "Learn more" CTA, and Badge for the optional "Has Options" pill. Description copy uses `--text-primary` to clear AA contrast at 14–16px (BDS contrast burndown #40).',
       },
     },
   },
@@ -110,15 +110,15 @@ type Story = StoryObj<typeof Services3ColCardGrid>;
 /* ─── Stories ──────────────────────────────────────────────────── */
 
 /**
- * @summary Six "Information Design" service cards — the canonical fixture.
+ * @summary Six service cards — the canonical fixture.
  *
  * Single Playground story per ADR-006: shape-only blueprint stories
  * carry one canonical state, not a fan-out of content variations.
  * Per-card affordances (`hasOptions`, missing `imageUrl`, accent
  * `category`) are exercised by the leaf component stories
  * (`Card.stories.tsx`, `ServiceTag.stories.tsx`, `Frame.stories.tsx`).
- * Atmosphere variants are switched via the Theme Switcher addon —
- * not encoded as separate stories.
+ * Theme (light/dark/client-sim) is switched via the Theme Switcher
+ * toolbar; atmosphere variants are not encoded as separate stories.
  */
 export const Playground: Story = {
   args: baseProps,

--- a/content-system/blueprints/react/ServicesDetailTwoColumn.stories.tsx
+++ b/content-system/blueprints/react/ServicesDetailTwoColumn.stories.tsx
@@ -11,7 +11,7 @@ const baseTheme: BlueprintProps['theme'] = {
 };
 
 const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
+  brandName: 'Acme',
   tagline: null,
   valueProposition: null,
   services: [],
@@ -29,7 +29,7 @@ const section: BlueprintProps['section'] = {
   sectionType: 'services',
   heading: 'What we do',
   subheading: 'Services',
-  body: 'A complete operating system for visual communication — from brand to operations.',
+  body: 'A one-line section subheading that frames the service catalog below — short enough to scan, specific enough to set expectations.',
   cta: null,
   visualNotes: {
     blueprintKey: 'services_detail_two_column',
@@ -40,12 +40,12 @@ const section: BlueprintProps['section'] = {
     illustrationOpportunity: null,
   },
   items: [
-    { title: 'Brand', description: 'Identity systems that scale.' },
-    { title: 'Marketing', description: 'Web, email, and social that ties to growth.' },
-    { title: 'Information Design', description: 'Make complex data scannable and on-brand.' },
-    { title: 'Product', description: 'Interface design for the apps your business runs on.' },
-    { title: 'Back Office', description: 'Operations design — SOPs, automation, internal tools.' },
-    { title: 'Continuity Plans', description: 'Predictable monthly partnership for ongoing work.' },
+    { title: 'Service one', description: 'A one-line description of the first service offering.' },
+    { title: 'Service two', description: 'A one-line description of the second service offering.' },
+    { title: 'Service three', description: 'A one-line description of the third service offering.' },
+    { title: 'Service four', description: 'A one-line description of the fourth service offering.' },
+    { title: 'Service five', description: 'A one-line description of the fifth service offering.' },
+    { title: 'Service six', description: 'A one-line description of the sixth service offering.' },
   ],
 };
 

--- a/content-system/blueprints/react/SupportPlanCalloutSplit.stories.tsx
+++ b/content-system/blueprints/react/SupportPlanCalloutSplit.stories.tsx
@@ -7,19 +7,20 @@ import { baseTheme, baseClientFacts } from './_fixtures';
 /* ─── Fixtures ─────────────────────────────────────────────────── */
 
 /**
- * "Monthly support services" fixture — the brikdesigns.com cross-sell
- * section that drives this blueprint. Persona-cluster illustration on
- * the left, plan callout card on the right.
+ * Canonical fixture — persona-cluster illustration on the left, plan
+ * callout card on the right. The shape (split with named illustration
+ * variant + callout) is what the blueprint documents; consumer sites
+ * supply their own service offering and persona content.
  */
 const supportSection: BlueprintProps['section'] = {
   sectionKey: 'support-plan-default',
   sectionType: 'cta',
   heading: 'Monthly support services',
   subheading: null,
-  body: 'Keep momentum after launch — ongoing design partnership for the post-rollout work that compounds into growth.',
+  body: 'A short subheading that frames the support offering — what the visitor gets and why it matters to them.',
   cta: {
     label: 'Learn more',
-    url: '/services/monthly-support',
+    url: '#',
   },
   illustration: {
     variant: 'persona-cluster',
@@ -27,8 +28,8 @@ const supportSection: BlueprintProps['section'] = {
     tiles: [
       {
         kind: 'avatar',
-        src: 'https://placehold.co/240x240/eaf1fb/1f3d70?text=Sam',
-        alt: 'Strategist Sam',
+        src: 'https://placehold.co/240x240/eaf1fb/1f3d70?text=Persona+A',
+        alt: 'Persona A',
       },
       {
         kind: 'chat-bubble',
@@ -38,8 +39,8 @@ const supportSection: BlueprintProps['section'] = {
       { kind: 'message', accent: 'positive' },
       {
         kind: 'photo',
-        src: 'https://placehold.co/220x220/ffe1cc/663300?text=Olivia',
-        alt: 'Operations Olivia',
+        src: 'https://placehold.co/220x220/ffe1cc/663300?text=Persona+B',
+        alt: 'Persona B',
       },
       {
         kind: 'chat-bubble',
@@ -58,9 +59,9 @@ const supportSection: BlueprintProps['section'] = {
   },
   items: [
     {
-      title: 'Brik Continuity Plan',
+      title: 'Monthly Support Plan',
       description:
-        'A predictable monthly cadence — strategic check-ins, design execution, and a single point of contact who already knows your business.',
+        'A two- or three-sentence description of the plan offering — what the cadence covers, what the deliverables look like, and what the visitor walks away with after signing up.',
     },
   ],
 };
@@ -82,7 +83,7 @@ const meta: Meta<typeof SupportPlanCalloutSplit> = {
     docs: {
       description: {
         component:
-          'Section header + two-column split: persona-cluster illustration on the left, plan callout card on the right. Drives the brikdesigns.com `/services/{slug}` "Monthly support services" cross-sell. Uses the BDS `MarketingIllustration` primitive (PR #484) for the scene. Plan card text uses `--text-primary` to clear AA on `--surface-secondary`; CTA uses `LinkButton size="md"` to clear AA at the brand-poppy fill.',
+          'Section header + two-column split: persona-cluster illustration on the left, plan callout card on the right. Uses the BDS `MarketingIllustration` primitive (PR #484) for the scene. Plan card text uses `--text-primary` to clear AA on `--surface-secondary`; CTA uses `LinkButton size="md"` to clear AA at the brand-poppy fill.',
       },
     },
   },
@@ -108,7 +109,7 @@ export const Playground: Story = {
  * story because the visual rhythm changes substantially. The
  * "no header" / atmosphere variants are not separate stories —
  * they're trivial prop differences exercised at the leaf-component
- * stories or via the Theme Switcher addon.
+ * stories or via the Theme Switcher toolbar.
  */
 export const NoIllustration: Story = {
   args: {

--- a/content-system/blueprints/react/_fixtures.ts
+++ b/content-system/blueprints/react/_fixtures.ts
@@ -19,8 +19,14 @@ export const baseTheme: BlueprintProps['theme'] = {
   footerArchetype: 'four_col_directory',
 };
 
+/**
+ * Generic placeholder fixture. Blueprint stories are section-layout
+ * templates, not Brik content — the `Acme` brand name is the universal
+ * stand-in so a designer auditing a blueprint sees the template shape,
+ * not a specific client's voice.
+ */
 export const baseClientFacts: BlueprintProps['clientFacts'] = {
-  brandName: 'Brik Designs',
+  brandName: 'Acme',
   tagline: null,
   valueProposition: null,
   services: [],


### PR DESCRIPTION
## Summary

Blueprint stories are **section-layout templates** — the value is the shape, not the content. Every blueprint Story shipped hardcoded with Brik-specific copy (\"Strategic design that compounds.\", \"Brik Continuity Plan\", \"Aaron Stanerson, Founder\", brikdesigns.com URL paths, real Brik service-line names). A designer evaluating \"is \`hero_split_60_40\` a good template for my dental client?\" saw Brik's marketing pitch first instead of a neutral template.

This PR replaces default content with **generic placeholders that preserve type rhythm and section intent** while staying client-agnostic.

## What changed

| Story | Brik content → generic |
| --- | --- |
| \`_fixtures.ts\` | \`brandName: 'Brik Designs'\` → \`'Acme'\` (shared fixture) |
| \`HeroSplit6040\` | \"Strategic design that compounds.\" → \"A clear, compelling headline goes here.\" |
| \`HeroSplitImageCardOverlay\` | \"Layout Design\" / brikdesigns.com paths → \"Service detail headline.\" / \`#\` |
| \`HeroInteriorMinimal\` | \"Information Design\" → \"Interior page headline.\" |
| \`CtaDarkCentered\` | \"Ready to make design a growth lever?\" → \"Ready to get started?\" |
| \`AboutStorySplit\` | \"Aaron Stanerson, Founder\" + Tennessee studio narrative → \"Sample Quote, Role\" + generic story |
| \`ServicesDetailTwoColumn\` | 6 Brik service lines → \"Service one\" – \"Service six\" |
| \`Services3ColCardGrid\` | 6 Information Design services → 6 generic \"Service N\" cards |
| \`Features3ColBrandedDark\` | \"Other Service Lines\" / Brand/Marketing/Back Office → \"Featured capabilities\" / Capability one/two/three |
| \`SupportPlanCalloutSplit\` | \"Brik Continuity Plan\", \"Strategist Sam\", \"Operations Olivia\" → \"Monthly Support Plan\", \"Persona A\", \"Persona B\" |

Plus minor doc-comment touch-ups in 3 stories (\`Features3ColBrandedDark\`, \`Services3ColCardGrid\`, \`SupportPlanCalloutSplit\`): removed \"Drives the brikdesigns.com ...\" lines (blueprints are shared shapes, not single-consumer), and fixed the inaccurate \"Atmosphere variants are switched via the Theme Switcher addon\" comment — Theme Switcher only switches \`themeNumber\` today; atmosphere is a separate axis with no global control yet.

## Out of scope (separate work)

- **Demonstrating atmosphere variants on blueprints.** Pilot confirmed that blueprint components (e.g. \`HeroSplit6040.tsx\`) don't consume \`theme.atmosphere\` — making rethemability visible per blueprint would require story-side CSS loading + wrapper infrastructure or a global atmosphere control on the Storybook toolbar. Filing as a follow-up issue.
- **Refactoring inline \`baseClientFacts\` to import from \`_fixtures.ts\`.** 6 stories duplicate the fixture verbatim; DRY improvement but cosmetic. Separate PR.

## Test plan

- [x] \`npm run typecheck\` → clean
- [x] \`rg \"Brik\" content-system/blueprints/react/*.stories.tsx _fixtures.ts\` → only the intentional explanatory comment in \`_fixtures.ts\` (\"templates, not Brik content — the Acme brand name...\")
- [x] No story title / file structure changes — only content swaps
- [ ] Visual confirm on storybook.brikdesigns.com after deploy: blueprints render with Acme/generic content

🤖 Generated with [Claude Code](https://claude.com/claude-code)