### PR TITLE
docs(standards): Fumadocs content standard + thin-retriever skill (brik-llm#436 PR A)

### DIFF
--- a/.claude/skills/fumadocs-content-standard/SKILL.md
+++ b/.claude/skills/fumadocs-content-standard/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: fumadocs-content-standard
+description: Retrieve the canonical Fumadocs writing standard from brik-rag before authoring or editing MDX in docs-site/content/docs. Covers frontmatter shape, IA decision tree (page vs section vs callout vs cross-link), heading depth, voice pointer, and anti-patterns. Source of truth lives at brik-bds/.claude/standards/fumadocs-content-standard.md; this skill fetches the ingested copy from brik-rag so guidance loads at edit time without re-reading the markdown.
+triggers:
+  - About to create a new .mdx file under docs-site/content/docs/
+  - About to edit an existing .mdx file under docs-site/content/docs/
+  - User asks "how should this docs page be structured" / "fumadocs frontmatter" / "docs IA"
+  - About to add a new Fumadocs component (Callout, Cards, etc.) to an MDX page
+  - About to introduce a new top-level dir under content/docs/ (also needs meta.json update)
+last-verified: 2026-05-11
+---
+
+# fumadocs-content-standard — Retrieve the docs-site writing standard via brik-rag
+
+The canonical rules for `docs-site/content/docs/**/*.mdx` live in `brik-bds/.claude/standards/fumadocs-content-standard.md` and are ingested into brik-rag. Auto-retrieve before authoring or editing MDX so the standard loads into context at edit time.
+
+## When to invoke
+
+Auto-invoke (don't wait for the user) when any of:
+
+- A `.mdx` file under `docs-site/content/docs/` is in the edit path
+- A new MDX page is being scaffolded
+- A user prompt mentions Fumadocs structure, MDX frontmatter, docs IA, callout/card usage, or `meta.json` nav
+
+Skip when:
+
+- The edit is a pure typo fix or punctuation tweak (the standard does not bear on it)
+- You already retrieved on this topic in this session and the chunks are still in context
+- The work is in `docs-site/app/`, `docs-site/components/`, or other non-content paths (this skill is content-only)
+
+## How to invoke
+
+```bash
+brik-rag query "fumadocs writing standard" \
+  --workflow-type fumadocs-standard \
+  --top-k 5
+```
+
+Optional follow-ups (use only if the top result didn't answer):
+
+```bash
+brik-rag query "fumadocs frontmatter fields" --workflow-type fumadocs-standard --top-k 3
+brik-rag query "fumadocs IA decision tree page section callout" --workflow-type fumadocs-standard --top-k 3
+brik-rag query "fumadocs anti-patterns" --workflow-type fumadocs-standard --top-k 3
+```
+
+Parse the JSON output, apply the relevant rules to the MDX edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/ingest-fumadocs-standard.sh` once, then retry.
+
+## If you get a conflict between the standard and existing content
+
+The standard is canon. Existing MDX that violates it is legacy — flag the inconsistency in your PR description but do not refactor unrelated files in the same PR (surgical-changes rule).
+
+## How to update the standard itself
+
+Edit `brik-bds/.claude/standards/fumadocs-content-standard.md`, bump `last-verified`, re-run `scripts/ingest-fumadocs-standard.sh`. The skill picks up the new content on the next retrieval — no skill file change needed.

--- a/.claude/standards/fumadocs-content-standard.md
+++ b/.claude/standards/fumadocs-content-standard.md
@@ -1,0 +1,103 @@
+---
+name: Fumadocs content standard (BDS docs-site)
+description: Canonical rules for authoring MDX in docs-site/content/docs. Frontmatter shape, IA decision tree, voice pointer, length caps, anti-patterns.
+type: reference
+scope: brik-bds
+applies-to: "**/docs-site/content/docs/**/*.mdx"
+retrieved-via: brik-rag query "fumadocs writing standard"
+last-verified: 2026-05-11
+---
+
+# Fumadocs content standard
+
+Rules for `brik-bds/docs-site/content/docs/**/*.mdx`. Source of truth lives in this file (git-tracked); agents retrieve via `brik-rag query "fumadocs writing standard"`.
+
+## Frontmatter — only two fields
+
+```yaml
+---
+title: <Concept>
+description: <One sentence. Action-oriented. Tells the reader what they leave with.>
+---
+```
+
+Do not add `tags`, `keywords`, `author`, `date`, `category`, `sidebar_position`, or other fields. Fumadocs uses `meta.json` for nav ordering — not frontmatter. Adding bespoke fields creates parallel taxonomies that diverge.
+
+`description` is required; it surfaces in nav previews and search. Treat it as the elevator pitch.
+
+## IA decision tree — page / section / callout / cross-link
+
+Ask in this order; first YES wins:
+
+| Question | YES → |
+|---|---|
+| Is this its own discoverable concept someone would search for? | New `*.mdx` page |
+| Is this a facet of an existing page that deserves a heading? | New `##` section in that page |
+| Is this a 1-3 sentence warning, caveat, or "did you know"? | `<Callout type="info\|warn\|error">` |
+| Does this fact already live on another page? | Cross-link with `[label](/docs/path)` — do not duplicate |
+
+If you add a new top-level dir under `content/docs/`, update `meta.json`. Do not rely on alphabetical fallback.
+
+## Heading depth — `##` and `###` only
+
+`#` is reserved for the page title (rendered from frontmatter `title`). Use `##` for sections, `###` for subsections. Do not use `####` or deeper — Fumadocs nav UI does not surface them and readers lose orientation.
+
+If you need a fourth level, split into a new page.
+
+## Section length cap — soft 400 words, hard 800
+
+A section (`##` to the next `##`) over 800 words is almost always two sections. Over 1500 words is a new page.
+
+Exception: code-block-heavy sections (API references, full snippets). Count prose lines, not code lines.
+
+## Voice — point, don't redefine
+
+The canonical Brik voice corpus is `brik-bds/source=brand-voice`. Retrieve via `brik-rag query "brik brand voice" --workflow-type fumadocs-standard`. Do not re-articulate voice rules inside this file or in MDX pages.
+
+Concrete shorthand: terse, opinionated, knowledge-dense. "Patterns are recipes, not new components." Match the existing `react-reference/patterns.mdx` register.
+
+## Code blocks — always language-tagged
+
+````markdown
+```tsx
+<Component prop="value" />
+```
+````
+
+Never bare triple-backticks. Tags in use: `tsx`, `ts`, `js`, `bash`, `css`, `json`, `yaml`, `mdx`, `tree` (for ascii dir layouts).
+
+## Cross-link pattern
+
+Internal links use absolute docs paths: `[Foundation](/docs/primitives)`. Never `./` or `../`. Storybook lives at `https://storybook.brikdesigns.com` — link out explicitly when referencing visual playground.
+
+When referencing a token, component, or atmosphere, link to the canon page (`/docs/primitives/color`, `/docs/components/button`, `/docs/theming/atmospheres`) rather than restating it inline.
+
+## Allowed Fumadocs components
+
+Use only those already in active use across docs-site:
+
+- `<Callout type="info|warn|error">` from `fumadocs-ui/components/callout`
+- `<Cards>` / `<Card title href description>` from `fumadocs-ui/components/card`
+- Standard markdown tables for comparisons
+
+Adding a new Fumadocs UI component (tabs, accordions, custom MDX components) is a docs-site infrastructure change — open an issue first. Do not introduce ad-hoc components in a content PR.
+
+## Anti-patterns — do not ship
+
+- New frontmatter fields beyond `title` + `description`
+- `####`+ heading depth
+- Inline restatement of brand voice rules (point to corpus instead)
+- Inline restatement of token names / component props (link to canon page)
+- "TODO", "WIP", or "Coming soon" callouts as page-body content — use `<Callout type="warn">Status: roadmap.</Callout>` at the top of the page, then write content as if it exists
+- Bare triple-backtick code blocks
+- Mixing tenets on one page (Foundation / Theming / Motion / Content stay separate per the `index.mdx` four-tenets split)
+- Marketing copy ("powerful", "delightful", "seamless"). Match the docs-site register: state what the thing is, what it does, when to reach for it.
+
+## When this standard updates
+
+1. Edit this file (the source of truth)
+2. Re-run `scripts/ingest-fumadocs-standard.sh` to push to brik-rag
+3. Bump `last-verified` in frontmatter
+4. Note the change in the PR description
+
+The skill auto-retrieves on `.mdx` edits — no other propagation needed.

--- a/scripts/ingest-fumadocs-standard.sh
+++ b/scripts/ingest-fumadocs-standard.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# ingest-fumadocs-standard.sh — push the Fumadocs writing standard into brik-rag.
+#
+# Source of truth: .claude/standards/fumadocs-content-standard.md
+# Destination: brik-rag memory corpus (type=reference, project=brik-bds)
+#
+# Re-runnable: each invocation re-ingests the latest content. Run after editing
+# the standard markdown so the brik-rag copy stays current.
+#
+# Why memory corpus (not a dedicated canon source_type): holding pattern for
+# brik-llm#436 PR A. If usage warrants, promote to a first-class canon source
+# via a new module in brik-llm/scripts/rag/corpora/ in a follow-up.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+STANDARD_FILE="$REPO_ROOT/.claude/standards/fumadocs-content-standard.md"
+
+if [[ ! -f "$STANDARD_FILE" ]]; then
+  echo "error: standard markdown not found at $STANDARD_FILE" >&2
+  exit 1
+fi
+
+if ! command -v brik-rag >/dev/null 2>&1; then
+  echo "error: brik-rag CLI not on PATH. Expected at ~/.local/bin/claude-tools/brik-rag" >&2
+  exit 1
+fi
+
+# Strip YAML frontmatter (everything from first --- to second ---).
+BODY="$(awk 'BEGIN{c=0} /^---$/{c++; next} c>=2' "$STANDARD_FILE")"
+
+if [[ -z "$BODY" ]]; then
+  echo "error: standard body is empty after frontmatter strip" >&2
+  exit 1
+fi
+
+echo "▸ Ingesting fumadocs-writing-standard ($(echo "$BODY" | wc -l | tr -d ' ') lines)..."
+
+brik-rag remember \
+  --name "fumadocs-writing-standard" \
+  --description "Canonical Fumadocs MDX writing standard for brik-bds docs-site — frontmatter shape, IA decision tree (page/section/callout/cross-link), heading depth cap, voice pointer, anti-patterns. Source: brik-bds/.claude/standards/fumadocs-content-standard.md" \
+  --type reference \
+  --project brik-bds \
+  --human \
+  - <<< "$BODY"
+
+echo "✓ Ingested. Verify with: brik-rag query \"fumadocs writing standard\" --top-k 3 --human"


### PR DESCRIPTION
## Summary

PR A of three for [brik-llm#436](https://github.com/brikdesigns/brik-llm/issues/436) — establishes the canonical writing standard for `docs-site/content/docs/**/*.mdx`, with the standard ingested into `brik-rag` and a project-scoped skill that auto-retrieves it at `.mdx` edit time.

**Pattern (RAG-as-canon, single source of truth):**
- Source markdown lives in git (reviewable on PRs)
- Standard ingested into `brik-rag` (consumed by agents)
- Thin skill triggers on `.mdx` edits, queries brik-rag for guidance — no per-session re-read of the markdown
- Editing the standard = edit the .md + re-run `scripts/ingest-fumadocs-standard.sh`

## Files

| Path | Purpose |
|---|---|
| `.claude/standards/fumadocs-content-standard.md` | Canonical rules — frontmatter shape (title + description only), IA decision tree (page / section / callout / cross-link), heading depth cap (`##`/`###` only), section length caps, voice pointer (no re-definition), Fumadocs component allow-list, anti-patterns |
| `.claude/skills/fumadocs-content-standard/SKILL.md` | Thin retriever (~60 lines). Triggers: any `.mdx` edit in `docs-site/content/docs/`, new MDX page scaffolding, user prompts referencing Fumadocs structure. Invokes `brik-rag query "fumadocs writing standard" --workflow-type fumadocs-standard --top-k 5` |
| `scripts/ingest-fumadocs-standard.sh` | Re-runnable. Strips frontmatter, pushes body via `brik-rag remember --type reference --project brik-bds` |

## Verification

Initial ingest verified — retrieval cosine **0.615** for `"fumadocs writing standard"` and **0.580** for `"fumadocs frontmatter fields"`, both returning this standard as the top hit (above existing canon corpora).

```
1. [0.615] memory/per-machine-memory/brik-bds  ·  memory.reference.fumadocs-writing-standard
```

## Out of scope (covered by PR B / C of #436)

- **PR B** — Docs content ingest pipeline at `brik-llm/operations/mcp/brik-rag/ingest/fumadocs.py` (per-heading chunking of all 130+ BDS docs MDX files, new `source=fumadocs, source_type=bds-docs`)
- **PR C** — End-to-end enforcement hook verification + PR-time MDX shape lint (deferred follow-up issue)

## Design notes

- **Why memory corpus (not a dedicated canon source_type)?** Holding pattern. The `brik-rag remember` CLI writes to the memory corpus today; a first-class canon source_type for this would require adding a new module under `brik-llm/scripts/rag/corpora/`, which would split PR A across two repos. If usage warrants, promote in a follow-up.
- **Why `.claude/skills/` in this repo (not `~/.claude/skills/`)?** `~/.claude/skills/` is not git-tracked on the Brik workstations — files there aren't durable artifacts. Project-scoped skills are.
- **Why the standard does NOT redefine brand voice?** The `brik-bds/source=brand-voice` corpus is already in brik-rag with 12+ chunks. Re-articulating voice in this standard would create a parallel taxonomy (the failure pattern documented in `feedback_documentation_standards_layer.md`).

## Test plan
- [x] `brik-rag query "fumadocs writing standard"` returns this standard as top hit
- [x] `brik-rag query "fumadocs frontmatter fields"` returns this standard as top hit
- [x] Pre-commit hooks pass (gitleaks, typecheck, anti-slop)
- [ ] Reviewer sanity check: open the standard markdown and confirm rules match observed BDS docs conventions (sample: `react-reference/patterns.mdx`, `react-reference/hooks.mdx`, `web-elements/sections.mdx`)

## Consumer sync plan

N/A — this PR adds `.claude/` and `scripts/` only. No `components/`, `tokens/`, or `dist/` changes. No package version bump needed; no portal / renew-pms / brikdesigns sync required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)