### PR TITLE
feat(blueprints): derive HeroSplitImageCardOverlay eyebrow from audience (closes #546)

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -95,7 +95,16 @@ const cta = section.cta;
         </nav>
       )}
 
-      {iconUrl && (
+      {/*
+        Eyebrow icon precedence (brik-bds#546):
+          1. iconUrl set → render raw <img> (legacy/decorative escape hatch)
+          2. audience set, no iconUrl → render canonical <ServiceTag variant="icon">
+             markup inline (Astro can't import the React component; it emits
+             the same `bds-service-tag*` classes so dist/styles.css renders
+             it identically)
+          3. neither → no eyebrow
+      */}
+      {iconUrl ? (
         <img
           src={iconUrl}
           alt={iconAlt ?? ''}
@@ -103,7 +112,13 @@ const cta = section.cta;
           loading="eager"
           decoding="async"
         />
-      )}
+      ) : audience ? (
+        <span
+          class={`bds-service-tag bds-service-tag--icon bds-service-tag--icon-lg bds-service-tag--${audience} bp-hero-img-card__icon`}
+          role="img"
+          aria-label={`${audience} category`}
+        />
+      ) : null}
 
       {eyebrow && <p class="bp-hero-img-card__eyebrow">{eyebrow}</p>}
 

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -125,12 +125,22 @@ export interface BlueprintSection {
    */
   readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
   /**
-   * Optional eyebrow icon URL — an audience or category badge SVG/PNG
-   * rendered between the breadcrumb and the h1 in interior-page hero
-   * blueprints. Sourced from a category/service-line CMS row's badge
-   * column (e.g. `service_lines.primary_badge_url`).
+   * Optional eyebrow icon URL — manual override for decorative, non-
+   * categorical images (campaign artwork, editorial illustrations).
    *
-   * Renders as a plain `<img>` sized via `--bp-hero-img-card-icon-size`.
+   * **Precedence (brik-bds#546):**
+   *   1. If `iconUrl` is set, render a raw `<img>` (this slot's legacy
+   *      contract — still respected for non-category eyebrows).
+   *   2. Otherwise, if `audience` is set, the blueprint renders a canonical
+   *      `<ServiceTag category={audience} variant="icon">` for the eyebrow
+   *      — the design-system path. Theme-aware, no consumer-side URL
+   *      computation needed.
+   *   3. Otherwise no eyebrow renders.
+   *
+   * Most service-detail pages can stop passing `iconUrl` entirely once
+   * `audience` is set. Keep `iconUrl` for cases where the visual is NOT a
+   * category indicator (e.g., a holiday campaign hero with a snowflake).
+   *
    * Pair with `iconAlt` for an informational alt; default empty (decorative).
    *
    * Additive, optional — blueprints without an eyebrow icon slot ignore it.

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -17,6 +17,7 @@
  */
 import { Breadcrumb } from '../../../components/ui/Breadcrumb/Breadcrumb';
 import { LinkButton } from '../../../components/ui/Button/LinkButton';
+import { ServiceTag } from '../../../components/ui/ServiceBadge/ServiceTag';
 import type { BlueprintProps } from '../astro/types';
 import './HeroSplitImageCardOverlay.css';
 
@@ -46,7 +47,18 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
             />
           )}
 
-          {iconUrl && (
+          {/*
+           * Eyebrow icon precedence (brik-bds#546):
+           *   1. If `iconUrl` is provided, render the raw `<img>` (legacy /
+           *      decorative-image escape hatch).
+           *   2. Otherwise, if `audience` is set, render the canonical
+           *      `<ServiceTag>` for that audience — the design-system path.
+           *      Consumers stop supplying `iconUrl` for category badges; the
+           *      blueprint resolves the icon via BDS's service-token system,
+           *      keeping theme awareness intact.
+           *   3. If neither is set, no eyebrow renders.
+           */}
+          {iconUrl ? (
             <img
               src={iconUrl}
               alt={iconAlt ?? ''}
@@ -54,7 +66,14 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
               loading="eager"
               decoding="async"
             />
-          )}
+          ) : audience ? (
+            <ServiceTag
+              category={audience}
+              variant="icon"
+              size="lg"
+              className="bp-hero-img-card__icon"
+            />
+          ) : null}
 
           {eyebrow && <p className="bp-hero-img-card__eyebrow">{eyebrow}</p>}
 


### PR DESCRIPTION
## Summary

- Adds audience-driven fallback for the hero eyebrow icon in `HeroSplitImageCardOverlay` (both React + Astro)
- Precedence: `iconUrl` (legacy override) → `audience` (canonical, renders `<ServiceTag>`) → none
- JSDoc on `BlueprintSection.iconUrl` documents the new behavior and recommends dropping `iconUrl` for category eyebrows

## Why

Closes #546. The blueprint forced consumers (brikdesigns, portal, client sites) to compute an eyebrow URL from a category enum that the blueprint already had — duplicating BDS's icon resolution in every consumer codebase.

## Backwards compatibility

Fully backwards compatible. Existing consumers passing `iconUrl` keep working unchanged. The new behavior kicks in only when `iconUrl` is null/undefined AND `audience` is set.

## Test plan

- [ ] Existing Storybook story for `HeroSplitImageCardOverlay` renders identically (still passes `iconUrl`)
- [ ] New Storybook story / story update demonstrating the audience-driven variant (no iconUrl, just audience)
- [ ] Astro renderer parity — `bds-service-tag*` class markup matches React's ServiceTag DOM shape
- [ ] brikdesigns consumes the new BDS version and drops its `SERVICE_LINE_ICON` 5-entry workaround map

🤖 Generated with [Claude Code](https://claude.com/claude-code)