### PR TITLE
fix(devbar): stop inspector auto-activating from prior session + sync map

### DIFF
--- a/.storybook/public/brik-inspect.js
+++ b/.storybook/public/brik-inspect.js
@@ -10,9 +10,20 @@
  * font for visual consistency.
  *
  * Enable via:
- *   1. Query param:        ?inspect=1
- *   2. Script data-attr:   data-auto-enable="1"  (loads toolbar; doesn't activate hover)
- *   3. localStorage:       brik-inspect-enabled=1  (auto-activates from prior session)
+ *   1. Query param:        ?inspect=1  (loads toolbar AND activates hover)
+ *   2. Script data-attr:   data-auto-enable="1"  (loads toolbar; hover stays off
+ *                                                 until the user clicks Inspect
+ *                                                 in the DevBar or the toolbar
+ *                                                 fallback button)
+ *
+ * Inspect state is intentionally session-only: each page load starts inactive
+ * unless the URL explicitly requests it. The widget formerly auto-activated
+ * from `localStorage.brik-inspect-enabled` left over from a prior session,
+ * which surprised users — the DevBar pill could show "inactive" while the
+ * inspector was actually running because the DevBar shell hadn't yet hydrated
+ * at the time the localStorage check ran (race condition). The persistence
+ * was removed to keep the UI honest: pill state and runtime state are now
+ * always in sync.
  *
  * Inject alongside feedback-widget.js (same deploy pipeline):
  *   <script src="inspect-widget.js" data-auto-enable="1"></script>
@@ -32,10 +43,21 @@
   const script = document.currentScript;
   const AUTO_ENABLE = script?.getAttribute('data-auto-enable') === '1';
   const URL_ENABLED = /[?&]inspect=1\b/.test(location.search);
-  const LS_ENABLED = localStorage.getItem('brik-inspect-enabled') === '1';
-  const SHOULD_ENABLE = AUTO_ENABLE || URL_ENABLED || LS_ENABLED;
+  const SHOULD_ENABLE = AUTO_ENABLE || URL_ENABLED;
 
   if (!SHOULD_ENABLE) return;
+
+  // Clear any stale persistence from sessions before this widget stopped
+  // auto-activating from localStorage. Users who toggled inspect on in the
+  // past would otherwise still have `brik-inspect-enabled=1` lingering; this
+  // ensures their next session starts clean. Swallow access errors — older
+  // Safari throws on localStorage in private mode, and a missing key means
+  // there was nothing to clean up anyway.
+  try {
+    localStorage.removeItem('brik-inspect-enabled');
+  } catch (_err) {
+    /* private-mode storage unavailable — best-effort cleanup, safe to skip */
+  }
 
   // Token prefixes considered valid BDS tokens. Anything not starting with
   // one of these is treated as an unknown custom var (still surfaced, but
@@ -832,7 +854,6 @@
     if (window.BrikDevBar?.isRegistered?.('inspect')) {
       window.BrikDevBar.setActive('inspect', active);
     }
-    localStorage.setItem('brik-inspect-enabled', active ? '1' : '0');
     if (!active) {
       clearOutline();
       hidePill();
@@ -1201,7 +1222,9 @@
     document.addEventListener('keydown', onKey);
     window.addEventListener('scroll', onScrollOrResize, true);
     window.addEventListener('resize', onScrollOrResize);
-    if (LS_ENABLED) toggleActive();
+    // Activate on load only when the URL explicitly requested it (`?inspect=1`).
+    // Otherwise hover stays off until the user toggles via DevBar or shortcut.
+    if (URL_ENABLED) toggleActive();
   }
 
   if (document.readyState === 'loading') {

--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -10,9 +10,20 @@
  * font for visual consistency.
  *
  * Enable via:
- *   1. Query param:        ?inspect=1
- *   2. Script data-attr:   data-auto-enable="1"  (loads toolbar; doesn't activate hover)
- *   3. localStorage:       brik-inspect-enabled=1  (auto-activates from prior session)
+ *   1. Query param:        ?inspect=1  (loads toolbar AND activates hover)
+ *   2. Script data-attr:   data-auto-enable="1"  (loads toolbar; hover stays off
+ *                                                 until the user clicks Inspect
+ *                                                 in the DevBar or the toolbar
+ *                                                 fallback button)
+ *
+ * Inspect state is intentionally session-only: each page load starts inactive
+ * unless the URL explicitly requests it. The widget formerly auto-activated
+ * from `localStorage.brik-inspect-enabled` left over from a prior session,
+ * which surprised users — the DevBar pill could show "inactive" while the
+ * inspector was actually running because the DevBar shell hadn't yet hydrated
+ * at the time the localStorage check ran (race condition). The persistence
+ * was removed to keep the UI honest: pill state and runtime state are now
+ * always in sync.
  *
  * Inject alongside feedback-widget.js (same deploy pipeline):
  *   <script src="inspect-widget.js" data-auto-enable="1"></script>
@@ -32,10 +43,21 @@
   const script = document.currentScript;
   const AUTO_ENABLE = script?.getAttribute('data-auto-enable') === '1';
   const URL_ENABLED = /[?&]inspect=1\b/.test(location.search);
-  const LS_ENABLED = localStorage.getItem('brik-inspect-enabled') === '1';
-  const SHOULD_ENABLE = AUTO_ENABLE || URL_ENABLED || LS_ENABLED;
+  const SHOULD_ENABLE = AUTO_ENABLE || URL_ENABLED;
 
   if (!SHOULD_ENABLE) return;
+
+  // Clear any stale persistence from sessions before this widget stopped
+  // auto-activating from localStorage. Users who toggled inspect on in the
+  // past would otherwise still have `brik-inspect-enabled=1` lingering; this
+  // ensures their next session starts clean. Swallow access errors — older
+  // Safari throws on localStorage in private mode, and a missing key means
+  // there was nothing to clean up anyway.
+  try {
+    localStorage.removeItem('brik-inspect-enabled');
+  } catch (_err) {
+    /* private-mode storage unavailable — best-effort cleanup, safe to skip */
+  }
 
   // Token prefixes considered valid BDS tokens. Anything not starting with
   // one of these is treated as an unknown custom var (still surfaced, but
@@ -832,7 +854,6 @@
     if (window.BrikDevBar?.isRegistered?.('inspect')) {
       window.BrikDevBar.setActive('inspect', active);
     }
-    localStorage.setItem('brik-inspect-enabled', active ? '1' : '0');
     if (!active) {
       clearOutline();
       hidePill();
@@ -1201,7 +1222,9 @@
     document.addEventListener('keydown', onKey);
     window.addEventListener('scroll', onScrollOrResize, true);
     window.addEventListener('resize', onScrollOrResize);
-    if (LS_ENABLED) toggleActive();
+    // Activate on load only when the URL explicitly requested it (`?inspect=1`).
+    // Otherwise hover stays off until the user toggles via DevBar or shortcut.
+    if (URL_ENABLED) toggleActive();
   }
 
   if (document.readyState === 'loading') {

--- a/scripts/sync-devbar-widgets.sh
+++ b/scripts/sync-devbar-widgets.sh
@@ -8,6 +8,7 @@
 #   - brik-client-portal/public/                  (browser-served)
 #   - brik-client-portal/scripts/mockup-shared/   (mockup pipeline)
 #   - renew-pms/public/                            (browser-served)
+#   - brikdesigns/public/                          (browser-served, staging dev-tools)
 #   - brik-bds/.storybook/public/                  (Storybook iframe)
 #   - brik-llm/scripts/brik-dev-tool/widgets/     (Astro mockup pipeline cache)
 
@@ -67,6 +68,12 @@ sync_one "$WIDGETS/devbar.js"         "$RENEW_PUBLIC/brik-devbar.js"        "ren
 sync_one "$WIDGETS/inspect-widget.js" "$RENEW_PUBLIC/brik-inspect.js"       "renew-pms public/ brik-inspect.js"
 sync_one "$WIDGETS/events-widget.js"  "$RENEW_PUBLIC/brik-events-widget.js" "renew-pms public/ brik-events-widget.js"
 
+# brikdesigns public/ (browser-served, staging dev-tools)
+BRIKDESIGNS_PUBLIC="$GH_ROOT/web/brikdesigns/public"
+sync_one "$WIDGETS/devbar.js"          "$BRIKDESIGNS_PUBLIC/brik-devbar.js"           "brikdesigns public/ brik-devbar.js"
+sync_one "$WIDGETS/inspect-widget.js"  "$BRIKDESIGNS_PUBLIC/brik-inspect.js"          "brikdesigns public/ brik-inspect.js"
+sync_one "$WIDGETS/feedback-widget.js" "$BRIKDESIGNS_PUBLIC/brik-feedback-widget.js"  "brikdesigns public/ brik-feedback-widget.js"
+
 # BDS Storybook preview iframe — write to the *current* checkout (worktree or
 # primary) so commits from a task worktree capture these files. Previously this
 # wrote to BDS_PRIMARY, which left the worktree's tree clean and caused
@@ -89,9 +96,10 @@ sync_one "$WIDGETS/events-widget.js"   "$LLM_WIDGETS/events-widget.js"   "brik-l
 BDS_MANIFEST="$BDS_PRIMARY/dist/bds-manifest.json"
 if [[ -f "$BDS_MANIFEST" ]]; then
   echo ""
-  sync_one "$BDS_MANIFEST" "$PORTAL_PUBLIC/bds-manifest.json"      "portal public/    bds-manifest.json"
-  sync_one "$BDS_MANIFEST" "$RENEW_PUBLIC/bds-manifest.json"       "renew-pms public/ bds-manifest.json"
-  sync_one "$BDS_MANIFEST" "$BDS_STORYBOOK_PUBLIC/bds-manifest.json" "bds storybook     bds-manifest.json"
+  sync_one "$BDS_MANIFEST" "$PORTAL_PUBLIC/bds-manifest.json"        "portal public/      bds-manifest.json"
+  sync_one "$BDS_MANIFEST" "$RENEW_PUBLIC/bds-manifest.json"         "renew-pms public/   bds-manifest.json"
+  sync_one "$BDS_MANIFEST" "$BRIKDESIGNS_PUBLIC/bds-manifest.json"   "brikdesigns public/ bds-manifest.json"
+  sync_one "$BDS_MANIFEST" "$BDS_STORYBOOK_PUBLIC/bds-manifest.json" "bds storybook       bds-manifest.json"
 else
   echo ""
   echo -e "  ${YELLOW}-${NC} bds-manifest.json  (not built — run 'npm run build:inspector-manifest' first)"


### PR DESCRIPTION
## Summary

- Removes `localStorage.brik-inspect-enabled` auto-activation in `components/ui/BrikDevBar/widgets/inspect-widget.js`
- Inspect state now session-only: `?inspect=1` URL auto-activates; `data-auto-enable=\"1\"` loads toolbar but leaves hover off until the user clicks the Inspect slot
- One-time `removeItem('brik-inspect-enabled')` clears stale values from prior sessions (with justified catch for Safari private-mode)
- Adds `brikdesigns/public/` to `scripts/sync-devbar-widgets.sh` destinations so brikdesigns stops drifting from BDS canonical
- Storybook copy at `.storybook/public/brik-inspect.js` regenerated to match

## Why

Reviewers on the brikdesigns staging Netlify preview saw inspector outlines + tooltips active on every page load — but the DevBar pill displayed \"inactive.\" Root cause race condition:

1. `brik-inspect.js` loaded first, read `localStorage.brik-inspect-enabled='1'` (leftover from a prior session), called `toggleActive()` → `active=true`
2. `toggleActive()` tried to sync state to `window.BrikDevBar`, but the DevBar shell hadn't hydrated yet → sync was a no-op
3. DevBar shell hydrated with the slot's default state (inactive) → pill showed inactive
4. UI displayed inactive while runtime ran active. Reviewers had no obvious way to disable without finding `Cmd+Shift+I`

Session-only state keeps pill and runtime in sync by construction.

## Affects

Every consumer of `<BrikDevBar>` (React-side) and every page loading `brik-inspect.js` directly (Astro/static-side):
- brik-client-portal `/public/brik-inspect.js`
- renew-pms `/public/brik-inspect.js`
- brikdesigns `/public/brik-inspect.js` (folded into sync map by this PR)
- brik-llm scripts cache
- BDS Storybook iframe

After this merges, run `scripts/sync-devbar-widgets.sh` from a BDS checkout to propagate. The brikdesigns side has a parallel hotfix PR ([brikdesigns/brikdesigns#92](https://github.com/brikdesigns/brikdesigns/pull/92)) carrying the same change so its staging preview clears up immediately without waiting on the sync.

## Backwards compatibility

Fully compatible. `?inspect=1` users get a slight UX improvement (the URL param now also activates hover, matching long-standing documented intent). Anyone who actively relied on the localStorage persistence sees a one-time \"toggle once per session\" change.

## Test plan

- [ ] Storybook: load any story → inspector inactive, DevBar pill inactive
- [ ] Set `localStorage.brik-inspect-enabled = '1'` in DevTools, reload → still inactive (cleanup removes the key)
- [ ] `?inspect=1` URL → hover + outlines activate immediately on load
- [ ] `Cmd+Shift+I` shortcut toggles
- [ ] Click the Inspect slot in DevBar → activates; click again → deactivates; pill state always matches runtime
- [ ] `scripts/sync-devbar-widgets.sh` from a clean BDS checkout writes to all 6 destinations including brikdesigns

🤖 Generated with [Claude Code](https://claude.com/claude-code)