### PR TITLE
refactor(chip)!: remove appearance axis — interactive components use variant only

### DIFF
--- a/components/ui/Chip/Chip.css
+++ b/components/ui/Chip/Chip.css
@@ -2,7 +2,7 @@
 /**
  * BDS Chip — Interactive pill for filtering, selection, or input
  *
- * Naming: .bds-chip, .bds-chip--{variant}-{appearance}, .bds-chip--{size}
+ * Naming: .bds-chip, .bds-chip--{variant}, .bds-chip--{size}
  */
 
 /* ─── Base ────────────────────────────────────────────────────── */
@@ -22,12 +22,10 @@
   text-transform: capitalize;
   cursor: pointer;
   user-select: none;
-  /* Reserve a transparent border on every Chip so solid + outline
-     variants share the same box dimensions. Toggling between
-     `primary-solid` (no visible border) and `secondary-outline` (2px
-     border) used to jump the layout by 2px on every edge. The outline
-     variants below override the border-color; solid variants keep it
-     transparent. brik-bds#414. */
+  /* Transparent border preserved at chip's intrinsic box for visual
+     parity with neighboring outlined pill components (FilterButton,
+     etc.) in the same row — keeps box dimensions stable across mixed
+     pill clusters. */
   border: var(--border-width-md) solid transparent;
   overflow: clip;
   transition: filter var(--duration-fast) var(--ease-out);
@@ -70,28 +68,16 @@
   height: 40px;
 }
 
-/* ─── Variant + Appearance ────────────────────────────────────── */
+/* ─── Variants (hierarchy only) ───────────────────────────────── */
 
-.bds-chip--primary-solid {
+.bds-chip--primary {
   background-color: var(--background-inverse);
   color: var(--text-inverse);
 }
 
-.bds-chip--primary-outline {
-  background-color: transparent;
-  color: var(--text-brand-primary);
-  border: var(--border-width-md) solid var(--border-brand-primary);
-}
-
-.bds-chip--secondary-solid {
+.bds-chip--secondary {
   background-color: var(--background-secondary);
   color: var(--text-primary);
-}
-
-.bds-chip--secondary-outline {
-  background-color: var(--background-primary);
-  color: var(--text-primary);
-  border: var(--border-width-md) solid var(--border-secondary);
 }
 
 /* ─── Disabled ────────────────────────────────────────────────── */

--- a/components/ui/Chip/Chip.mdx
+++ b/components/ui/Chip/Chip.mdx
@@ -16,16 +16,14 @@ Compact interactive pill for filtering, selection, and removable tokens. Use for
 
 ## Variants
 
-All variant, appearance, size, and state combinations.
+Single hierarchy axis — primary / secondary. Size and state combinations below.
 
 <Canvas of={Stories.Variants} />
 
-- **`secondary` + `solid`** — Default filter chip. High contrast fill.
-- **`secondary` + `outline`** — Softer filter chip. Transparent with neutral border.
-- **`primary` + `solid`** — Active/selected filter. Brand emphasis fill.
-- **`primary` + `outline`** — Active filter with lower-emphasis brand border.
+- **`secondary`** (default) — Neutral filter chip. The everyday filter pill.
+- **`primary`** — Emphasized chip. Active/selected filter, current state.
 
-**Appearance** is a shared axis across Badge/Chip/Tag — see [Vocabulary › Axes](https://design.brikdesigns.com/docs/primitives/naming-conventions).
+Chip is **interactive only** — appearance (`solid` / `outline`) was removed in v0.66 because it duplicated the hierarchy axis for an interactive component. Read-only fill variations live on [Badge](badge.mdx) and [Tag](tag.mdx).
 
 ## Patterns
 

--- a/components/ui/Chip/Chip.stories.tsx
+++ b/components/ui/Chip/Chip.stories.tsx
@@ -20,10 +20,6 @@ const meta: Meta<typeof Chip> = {
       control: 'select',
       options: ['primary', 'secondary'],
     },
-    appearance: {
-      control: 'select',
-      options: ['solid', 'outline'],
-    },
     showDropdown: { control: 'boolean' },
     disabled: { control: 'boolean' },
   },
@@ -77,12 +73,10 @@ export const Variants: Story = {
   render: () => (
     <Stack>
       <div>
-        <SectionLabel>Variant + Appearance</SectionLabel>
+        <SectionLabel>Variants</SectionLabel>
         <Row>
-          <Chip label="Secondary Solid" variant="secondary" appearance="solid" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Secondary Outline" variant="secondary" appearance="outline" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Primary Solid" variant="primary" appearance="solid" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Primary Outline" variant="primary" appearance="outline" icon={<Icon icon="ph:funnel" />} showDropdown />
+          <Chip label="Secondary" variant="secondary" icon={<Icon icon="ph:funnel" />} showDropdown />
+          <Chip label="Primary" variant="primary" icon={<Icon icon="ph:funnel" />} showDropdown />
         </Row>
       </div>
       <div>
@@ -117,7 +111,7 @@ export const Patterns: Story = {
       <div>
         <SectionLabel>Active filters</SectionLabel>
         <Row>
-          <Chip label="Status: Active" variant="primary" appearance="outline" onRemove={() => {}} />
+          <Chip label="Status: Active" variant="primary" onRemove={() => {}} />
           <Chip label="Category: Design" onRemove={() => {}} />
           <Chip label="Date: This week" onRemove={() => {}} />
         </Row>

--- a/components/ui/Chip/Chip.tsx
+++ b/components/ui/Chip/Chip.tsx
@@ -9,14 +9,6 @@ export type ChipSize = 'sm' | 'md' | 'lg';
 /** Chip hierarchy variant — how much attention the chip commands in a cluster. */
 export type ChipVariant = 'primary' | 'secondary';
 
-/**
- * Chip fill appearance — shared axis with Badge (`solid | subtle`) and
- * Tag (`solid | subtle`). Chip supports the two filled-vs-outlined values.
- * - `solid`   — filled background, no border.
- * - `outline` — transparent background with a border in the variant color.
- */
-export type ChipAppearance = 'solid' | 'outline';
-
 export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Chip label text */
   label: string;
@@ -24,8 +16,6 @@ export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childre
   size?: ChipSize;
   /** Hierarchy variant — primary (emphasized) or secondary (neutral). */
   variant?: ChipVariant;
-  /** Fill appearance — solid (filled) or outline (transparent + border). */
-  appearance?: ChipAppearance;
   /** Optional leading icon */
   icon?: ReactNode;
   /** Optional avatar element (rendered before label) */
@@ -43,8 +33,7 @@ export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childre
 /**
  * Chip — compact interactive pill for filtering, selection, or input.
  *
- * Pill-shaped with two variants (primary/secondary) and two appearances
- * (solid/outline).
+ * Pill-shaped with a single hierarchy axis (`primary` / `secondary`).
  *
  * **Action, not indicator.** Chip always represents user-initiated
  * state: filter toggles, selection chips, removable tokens, dropdown
@@ -58,7 +47,7 @@ export interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childre
  * ```tsx
  * <Chip label="All statuses" showDropdown onChipClick={openMenu} />
  * <Chip label="Status: Active" onRemove={() => removeFilter('status')} />
- * <Chip label="Selected" variant="primary" appearance="solid" onChipClick={toggle} />
+ * <Chip label="Selected" variant="primary" onChipClick={toggle} />
  * ```
  *
  * @summary Compact interactive pill for filtering or selection
@@ -67,7 +56,6 @@ export function Chip({
   label,
   size = 'md',
   variant = 'secondary',
-  appearance = 'solid',
   icon,
   avatar,
   showDropdown = false,
@@ -80,7 +68,7 @@ export function Chip({
 }: ChipProps) {
   const classes = bdsClass(
     'bds-chip',
-    `bds-chip--${variant}-${appearance}`,
+    `bds-chip--${variant}`,
     `bds-chip--${size}`,
     disabled && 'bds-chip--disabled',
     className

--- a/components/ui/Chip/index.ts
+++ b/components/ui/Chip/index.ts
@@ -1,1 +1,1 @@
-export { Chip, type ChipProps, type ChipSize, type ChipVariant, type ChipAppearance } from './Chip';
+export { Chip, type ChipProps, type ChipSize, type ChipVariant } from './Chip';

--- a/docs-site/content/docs/components/chip.mdx
+++ b/docs-site/content/docs/components/chip.mdx
@@ -48,17 +48,19 @@ import { Chip } from '@brikdesigns/bds';
 
 ## Variants
 
-Two variants × two appearances. Match the chip's role:
+Single hierarchy axis. Pick by role inside the cluster:
 
-- **`secondary` + `solid`** — Default filter chip. High contrast.
-- **`secondary` + `outline`** — Softer filter chip. Transparent + neutral border.
-- **`primary` + `solid`** — Active/selected filter. Brand emphasis.
-- **`primary` + `outline`** — Active filter with lower brand emphasis.
+- **`secondary`** (default) — Neutral filter chip. The everyday filter pill.
+- **`primary`** — Emphasized chip. Active/selected state, current filter.
 
 ```tsx
-<Chip label="Design" variant="secondary" appearance="solid" />
-<Chip label="Design" variant="primary" appearance="outline" />
+<Chip label="Design" variant="secondary" />
+<Chip label="Design" variant="primary" />
 ```
+
+<Callout type="info">
+  `appearance` (`solid` / `outline`) was removed in v0.66. Chip is interactive — its hierarchy axis (`variant`) is the only emphasis lever it needs. Fill variations on read-only pills live on [Badge](/docs/components/badge) and [Tag](/docs/components/tag), which keep the `appearance` axis.
+</Callout>
 
 ## Common shapes
 
@@ -113,7 +115,6 @@ Two variants × two appearances. Match the chip's role:
 | `label` | `string` *(required)* | — |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` |
 | `variant` | `'primary' \| 'secondary'` | `'secondary'` |
-| `appearance` | `'solid' \| 'outline'` | `'solid'` |
 | `icon` | `ReactNode` | — |
 | `avatar` | `ReactNode` | — |
 | `showDropdown` | `boolean` | `false` |

--- a/docs-site/content/docs/primitives/naming-conventions.mdx
+++ b/docs-site/content/docs/primitives/naming-conventions.mdx
@@ -202,11 +202,11 @@ Components with overlapping visual concerns share the same prop names and values
 | `size` | `xs` · `sm` · `md` · `lg` | Physical dimensions on a shared scale (e.g. Badge + Tag + Chip align by height at every tier). | Badge, Tag, Chip, BadgeGroup, TagGroup, Button, IconButton, Field, Sheet, most form controls |
 | `status` | `positive` · `warning` · `error` · `info` · `progress` · `brand` | Semantic value judgment — which system color tier applies. Indicator-only. | Badge, AlertBanner, Dot |
 | `variant` (hierarchy) | `primary` · `secondary` | How much attention the element commands inside a cluster. Not a fill style. | Chip, Button |
-| `appearance` (fill) | `solid` · `subtle` · `outline` | How the shape is filled vs. bordered. Each component supports the subset that has a real visual meaning. | Badge (`solid` / `subtle`), Chip (`solid` / `outline`), Tag (`solid` / `subtle`) |
+| `appearance` (fill) | `solid` · `subtle` · `outline` | How the shape is filled vs. bordered. Each component supports the subset that has a real visual meaning. Read-only/indicator components only. | Badge (`solid` / `subtle`), Tag (`solid` / `subtle`) |
 
 ### The rule
 
-> `variant` describes **hierarchy**. `appearance` describes **fill**. Never conflate them — a chip can be both `variant="primary"` and `appearance="outline"`, and the combination is meaningful.
+> `variant` describes **hierarchy**. `appearance` describes **fill**. Never conflate them. **Interactive components (Chip, Button) use `variant` only** — emphasis is one axis, picked at the hierarchy. **Read-only indicators (Badge, Tag) use `appearance`** — they don't have a hierarchy to express, so fill form is the only relevant lever.
 
 ### Why `solid | subtle | outline` (not `dark | light`)
 
@@ -222,7 +222,7 @@ The older `dark | light` vocabulary was ambiguous with dark-mode theming — `--
 |---|---|---|---|---|
 | Badge | — | `solid` (default) · `subtle` | required axis | Outline never made sense for status indicators — low contrast. |
 | Tag | — | `solid` (default) · `subtle` | — | Neutral categorization — no status axis. |
-| Chip | `primary` · `secondary` | `solid` (default) · `outline` | — | Two axes: hierarchy (variant) × fill (appearance). |
+| Chip | `primary` · `secondary` | — | — | Single hierarchy axis. `appearance` was removed in v0.66 — Chip is interactive, so emphasis lives on `variant`. |
 
 Adding a new pill component? Reuse the axis names above. Don't invent `kind`, `style`, `flavor`, etc. — the axes exist so a reader knows what to expect.
 


### PR DESCRIPTION
## Summary

**BREAKING**: Removes `Chip.appearance` prop and `ChipAppearance` type. Chip is interactive; its emphasis lives on `variant` only. The `appearance` axis (`solid` / `outline`) duplicated the hierarchy lever for an axis that only makes sense on read-only indicators (Badge, Tag — which keep it).

Pre-1.0 BDS, hard break per direction. No soft-deprecation cycle.

## Why this matters

This is the first concrete fix coming out of the canon-vs-code drift investigation. Canon documented an `appearance` axis for Chip; code shipped it; but neither answered "why does an interactive component need both a hierarchy axis AND a fill axis?" The answer is it doesn't — the two axes were saying the same thing. Removing one shrinks the system without losing expressiveness.

Pattern going forward:
- **Interactive components** (Chip, Button): `variant` for emphasis. No `appearance`.
- **Read-only indicators** (Badge, Tag): `appearance` for fill. No `variant`.

Documented in [naming-conventions.mdx](docs-site/content/docs/primitives/naming-conventions.mdx) — the rule callout in §Axes now explains this split.

## What changed

| File | Change |
|---|---|
| [Chip.tsx](components/ui/Chip/Chip.tsx) | Drop `ChipAppearance` type, `appearance?` prop, default. CSS class hook `bds-chip--{variant}-{appearance}` → `bds-chip--{variant}` |
| [Chip.css](components/ui/Chip/Chip.css) | Drop `.bds-chip--primary-outline` + `.bds-chip--secondary-outline`. Rename `--primary-solid` → `--primary`, `--secondary-solid` → `--secondary`. |
| [Chip.stories.tsx](components/ui/Chip/Chip.stories.tsx) | Drop `appearance` argType. Variants story: 4 chips → 2. Patterns: drop `appearance="outline"`. |
| [Chip.mdx](components/ui/Chip/Chip.mdx) | Variants section rewritten; v0.66 removal note. |
| [index.ts](components/ui/Chip/index.ts) | Drop `ChipAppearance` re-export. |
| [docs-site/.../chip.mdx](docs-site/content/docs/components/chip.mdx) | Variants + API table updated; removal callout. |
| [naming-conventions.mdx](docs-site/content/docs/primitives/naming-conventions.mdx) | Axis matrix: remove Chip from `appearance` row. Axis coverage: Chip row rewritten to single variant axis. Rule callout: explicit interactive-vs-indicator distinction. |

## Migration for consumers

- `<Chip appearance="solid">` → `<Chip>` (no other change — was the default)
- `<Chip appearance="outline">` → `<Chip variant="secondary">` if you wanted the lower-emphasis look; otherwise just `<Chip>`
- CSS selectors targeting `.bds-chip--primary-solid` → `.bds-chip--primary` (`grep` across this repo found zero consumer overrides today; only Chip.css itself referenced these)

Typecheck will fail loudly on any `<Chip appearance="...">` site after consumers bump the BDS dep. Forces fix-forward.

## Verification

- [x] `npx tsc --noEmit` — passes
- [x] `rg "ChipAppearance|<Chip[^>]*appearance="` against this worktree — 0 hits
- [x] Chromatic — to be reviewed; renames are symmetric across TSX/CSS so visual output should match `appearance="solid"` defaults

## Follow-ups (separate PRs, not blocked on this)

1. **Re-ingest RAG** after merge — `cd ~/Documents/Github/brik/brik-llm && python3 scripts/rag/ingest.py --source-type canon-components --slug chip --pgvector` (and the fumadocs source-type) so agents see the new vocabulary.
2. **Bump major** on next publish — semver signal for the breaking change.
3. **Reconcile remaining canon-vs-code drift** — Button's `ButtonVariant` ships 12 values; canon-components/button doc says 7; docs-site/button.mdx says 12. Both MDX files need to reflect the actual type union.
4. **Typegen ADR** — propose deriving canon-components/* MDX from TypeScript so this drift mechanism stops repeating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)