### PR TITLE
docs(button): reconcile Button.mdx with actual ButtonVariant type union

### DIFF
--- a/components/ui/Button/Button.mdx
+++ b/components/ui/Button/Button.mdx
@@ -16,7 +16,13 @@ Triggers an event or action. The button family includes three components for dif
 
 ## Variants
 
-Nine variants across two emphasis tiers — six **brand** variants (primary / outline / secondary / ghost / inverse / on-color) for general action hierarchy, and three **system** variants (selected / destructive / positive) for semantic action meaning. Plus state variants (disabled, loading) and composition variants (icon slots).
+`ButtonVariant` ships **12 values** — 9 actively documented + 3 legacy aliases.
+
+- **6 brand variants** — `primary` / `outline` / `secondary` / `ghost` / `inverse` / `on-color`. General action hierarchy.
+- **3 system variants** — `destructive` / `positive` / `selected`. Semantic action meaning.
+- **3 legacy aliases** — `danger` / `danger-outline` / `danger-ghost`. Still supported, but prefer `destructive` (and the system ladder generally). No Storybook story exists for these — see [Legacy aliases](#legacy-aliases) below.
+
+Plus state variants (disabled, loading) and composition variants (icon slots).
 
 ### Primary
 
@@ -93,6 +99,32 @@ An icon-only button with a required `label` prop for accessibility.
 Click to simulate an async action. Render-mode demo because the toggle interaction can't be expressed with args alone.
 
 <Canvas of={Stories.LoadingToggle} />
+
+### Legacy aliases
+
+Three values in `ButtonVariant` ship without a dedicated story because they're aliases of `destructive` retained for back-compat:
+
+- `danger` → use `destructive` (identical visual, system-red fill)
+- `danger-outline` → use `destructive` with `outline` if you need lower emphasis; the alias remains for code that hasn't migrated
+- `danger-ghost` → use a ghost button styled as destructive; the alias remains for inline-delete code
+
+New code should pick from the documented 9 above. The aliases are TypeScript-valid but won't render anything different from their canonical sibling.
+
+## Type union
+
+The full `ButtonVariant` and `ButtonSize` contracts — the authoritative list of valid values:
+
+```ts
+type ButtonVariant =
+  | 'primary' | 'outline' | 'secondary' | 'ghost'
+  | 'inverse' | 'on-color'
+  | 'destructive' | 'positive' | 'selected'
+  | 'danger' | 'danger-outline' | 'danger-ghost'; // legacy aliases
+
+type ButtonSize = 'tiny' | 'sm' | 'md' | 'lg' | 'xl';
+```
+
+This block mirrors `components/ui/Button/Button.tsx`. If it drifts from the source `.tsx`, the type is canonical — fix this doc.
 
 ## Patterns
 


### PR DESCRIPTION
## Summary

[Button.mdx](components/ui/Button/Button.mdx) claimed "Nine variants." [Button.tsx](components/ui/Button/Button.tsx#L26-L38) actually ships **twelve** — the three legacy aliases (`danger`, `danger-outline`, `danger-ghost`) were absent from the doc. An agent querying `canon-components/button` via RAG saw an incomplete contract and could reject `<Button variant="danger">` as invented.

Same canon-vs-code drift pattern that PR #554 (Chip) exposed. Surface-level fix here; the deeper fix (typegen from `.tsx`) tracked separately.

## What changed

- **Variants intro rewritten** to acknowledge all 12 type-union values, grouped as 6 brand + 3 system + 3 legacy aliases.
- **New `### Legacy aliases` subsection** inside Variants — calls out `danger` / `danger-outline` / `danger-ghost` as back-compat for `destructive`, with explicit guidance for new code.
- **New `## Type union` section** before Patterns — the full type union block, mirroring [Button.tsx:26-38](components/ui/Button/Button.tsx#L26-L38), with an explicit note that the `.tsx` is canonical if these drift.

## A deeper inconsistency I'm not fixing here (flagging for a decision)

[docs-site/.../button.mdx](docs-site/content/docs/components/button.mdx) already says "Twelve variants" and has the type union. But its `### Destructive ladder` uses `danger` / `danger-outline` / `danger-ghost` as the canonical destructive primitives. [Button.tsx:21-25](components/ui/Button/Button.tsx#L21-L25) JSDoc explicitly calls those "Legacy (still supported, prefer system variants)" and treats `destructive` as the canonical.

**docs-site and the type's JSDoc disagree about which is canonical.** Two interpretations:

1. JSDoc is right — `destructive` is canonical, `danger*` is back-compat. docs-site button.mdx's "Destructive ladder" should be rewritten to lead with `destructive` (with `destructive` + `outline` and `destructive` + `ghost` shapes — or just drop the ladder if it's not a real ladder anymore).
2. docs-site is right — `danger`/`danger-outline`/`danger-ghost` is the real destructive ladder, and `destructive` is just the single-shape alias. The JSDoc's "legacy" framing is wrong.

I don't have enough signal to make this call. It needs the user to decide, then a coordinated rewrite of the destructive section in docs-site button.mdx + possibly a JSDoc update on Button.tsx. Out of scope here.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run validate:blueprints` passes
- [ ] Reviewer reads the new Variants intro + Legacy aliases + Type union sections to sanity-check the framing
- [ ] After merge: re-ingest `canon-components/button` via `~/Documents/Github/brik/brik-llm/scripts/rag/ingest-with-secrets.sh --source-type canon-components --slug button --pgvector` so RAG serves the corrected variant list

## Follow-ups (separate PRs)

- Decide canonical destructive (see above) and reconcile docs-site button.mdx + Button.tsx JSDoc accordingly
- Apply the same audit to LinkButton, IconButton (they share `ButtonVariant`) — currently their MDX inherits from Button.mdx
- Typegen ADR — eliminate the rot mechanism at the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)