### PR TITLE
docs(naming): ADR-008 — closed allowlist + single bds- namespace + structural modifiers

### DIFF
--- a/docs-site/content/docs/primitives/naming-conventions.mdx
+++ b/docs-site/content/docs/primitives/naming-conventions.mdx
@@ -13,6 +13,27 @@ Every word below describes a **role** or a **slot**. It does not dictate the vis
 
 This distinction is especially load-bearing for titles and headings (below) — get it wrong and you render outline-invisible content that looks correct visually.
 
+## Closed allowlist — single source of truth
+
+Per [ADR-008](../../../../docs/adrs/ADR-008-naming-canon-closed-allowlist.md), the system runs on a **closed allowlist** of slot names. The allowlist lives in [`docs/SLOT-ALLOWLIST.md`](../../../../docs/SLOT-ALLOWLIST.md) — a single file, organized by category, that enumerates every legitimate `__slot` suffix.
+
+### The rule
+
+> Every `bds-{block}__{slot}` class uses a slot name that appears in `SLOT-ALLOWLIST.md`. Anything else fails the lint.
+
+The sections below (Title, Subtitle, Description, the label family, …) explain *what each canonical slot means and when to use it*. They are reference; the allowlist is the contract. If the allowlist and these sections disagree, the allowlist wins — open a PR to align the prose.
+
+### Why closed
+
+The old open-banlist canon enumerated *banned* terms; agents invented new ones (`__lead`, `__quote-text`, `__plan-name`, `__hamburger-bar`) faster than the banlist grew. Closing the canon inverts the burden: the default is reject, new vocabulary requires a deliberate PR. See ADR-008 for the full reasoning and the 2026-05-11 inventory data that prompted the change.
+
+### Adding a slot
+
+1. Identify the role the slot expresses; pick the most generic word that fits.
+2. Grep the codebase for existing allowlist slots that already cover the role — **reuse before invent**.
+3. If no existing slot fits, PR an entry into `SLOT-ALLOWLIST.md` with justification.
+4. Reviewer checks: would this slot work on more than one block? Is it generic (not layout-specific)? Is it structural (not visual)?
+
 ## Title vs heading
 
 `title` and `heading` refer to the same typographic role at different layers. They are **not** substitutes for each other.
@@ -144,26 +165,28 @@ Don't reach for a `Card` when a `DataSection` is right. Cards are self-contained
 
 ## Blueprints — composition, not redefinition
 
-Blueprints (`content-system/blueprints/*`) are page-level layouts assembled from BDS primitives. The `bp-{layout-name}` namespace exists to distinguish layout-owned CSS from primitive CSS — it does **not** open a parallel naming vocabulary.
+Blueprints (`content-system/blueprints/*`) are page-level layouts assembled from BDS primitives. Per [ADR-008](../../../../docs/adrs/ADR-008-naming-canon-closed-allowlist.md), **blueprints use the same `bds-` namespace as primitives** — the `bp-` prefix is deprecated.
 
 ### The rules
 
-1. **Slot suffixes follow the canon.** `bp-about-story-split__title`, `bp-hero-split-6040__subtitle`, `bp-cta-dark-centered__description`. Never `__heading`, `__headline`, `__eyebrow`, `__body`, `__quote` (use `CardTestimonial`), `__callout` (use `Banner`).
-2. **Compose, don't reimplement.** If a blueprint draws raw `<blockquote>` / `<img>` / `<aside>` markup that duplicates a primitive, import the primitive instead. A blueprint `.tsx` that imports zero from `components/ui/*` is almost always drift.
-3. **Use `Frame` for any aspect-locked image.** Never hardcode `aspect-ratio` in blueprint CSS — pass the ratio to `<Frame customRatio="..." />` or use a named preset (`square`, `portrait`, `landscape`, `wide`, `ultrawide`).
-4. **Variant + appearance values come from the component's declared type.** Pass values that exist on the component's prop union (e.g. `ButtonVariant`, `ServiceTagVariant`). The hierarchy axis in [Axes](#axes--shared-prop-vocabulary-across-components) — `variant ∈ {primary, secondary}` — applies where canon explicitly enumerates it (Chip, Button base case); individual components legitimately extend their variant union beyond hierarchy (Button has `outline`, `ghost`, `inverse`, `danger`, etc.; ServiceTag has `text`, `icon`, `icon-text`). Don't invent values the component doesn't declare — `variant="persona-cluster"` is wrong because no component has it; `variant="ghost"` on Button is fine because the Button type ships it. TypeScript is the authoritative gate; the lint stays out of this until the canon axis matrix grows to cover every component.
+1. **Single namespace.** Every class uses `bds-`. The `bp-` prefix is deprecated; no new `bp-*` classes ship after ADR-008. Existing `bp-*` classes migrate during Phase D blueprint consolidation (one family per PR).
+2. **One block per blueprint family.** `bds-hero`, `bds-cta`, `bds-services`, `bds-features`, `bds-about`, `bds-support-plan`. Each family is **one block** with structural modifiers (`bds-hero--split-image`), not N separate blueprints.
+3. **Slot names come from the closed allowlist.** Every `bds-{block}__{slot}` must use a slot listed in [`docs/SLOT-ALLOWLIST.md`](../../../../docs/SLOT-ALLOWLIST.md). Anything else fails the lint (Phase C). To add a new slot, edit the allowlist file in its own PR.
+4. **Structural-only modifiers.** Modifier names describe *structure* (`--split-image`, `--two-column`, `--with-pricing-card`) — never appearance (`--dark`, `--centered`) or theme (`--inverse`, `--light`). A "dark centered" CTA themed light makes the name a lie; that's the failure mode the rule prevents.
+5. **Compose, don't reimplement.** If a blueprint draws raw `<blockquote>` / `<img>` / `<aside>` markup that duplicates a primitive, import the primitive instead. A blueprint `.tsx` that imports zero from `components/ui/*` is almost always drift.
+6. **Use `Frame` for any aspect-locked image.** Never hardcode `aspect-ratio` in blueprint CSS — pass the ratio to `<Frame customRatio="..." />` or use a named preset (`square`, `portrait`, `landscape`, `wide`, `ultrawide`).
+7. **Variant + appearance values come from the component's declared type.** Pass values that exist on the component's prop union (e.g. `ButtonVariant`, `ServiceTagVariant`). The hierarchy axis in [Axes](#axes--shared-prop-vocabulary-across-components) — `variant ∈ {primary, secondary}` — applies where canon explicitly enumerates it (Chip base case); individual components legitimately extend their variant union beyond hierarchy (Button has `outline`, `ghost`, `inverse`, `danger`, etc.; ServiceTag has `text`, `icon`, `icon-text`). Don't invent values the component doesn't declare; TypeScript is the authoritative gate.
 
-### What `bp-` prefixes are for
+### Migration status
 
-- Layout-specific CSS that doesn't belong on the primitive (e.g. `bp-services-grid` setting its own grid template).
-- Container slots specific to the layout (`bp-hero-split-6040__media-column`).
-- Custom property overrides scoped to the layout (`--bp-about-story-split-bg`).
-
-What `bp-` prefixes are **not** for: renaming primitive roles. A title is a title.
-
-### Enforcement
-
-`scripts/lint-blueprint-naming.mjs` greps blueprint `.tsx` / `.astro` / `.css` for banned roles, banned axis values, hand-rolled markup that duplicates BDS primitives, and unstable `aria-labelledby` ids. Runs in `npm run validate` and pre-commit when blueprint files are staged.
+| Status | What |
+|---|---|
+| Locked in canon | Rules 1–7 above (this section) |
+| Allowlist | [`docs/SLOT-ALLOWLIST.md`](../../../../docs/SLOT-ALLOWLIST.md) — canonical slot list |
+| Lint | `scripts/lint-blueprint-naming.mjs` runs in pre-commit on staged blueprint files. **Phase C** flips it to allowlist mode (fails on any slot not in the allowlist). |
+| Code | Existing blueprints still ship `bp-*` classes — being migrated **Phase D**, one family per PR (hero → cta → services → features → about → support-plan). |
+| Consumers | `bp-*` overrides in consumer repos audited + migrated **Phase E**, coordinated with Phase D rollout. |
+| `bp-` deletion | After all consumers migrate, the deprecated prefix is dropped — **Phase F**. Until then, both prefixes coexist in the codebase. |
 
 ## Stable ids and `aria-labelledby`
 

--- a/docs/SLOT-ALLOWLIST.md
+++ b/docs/SLOT-ALLOWLIST.md
@@ -1,0 +1,248 @@
+# BDS Slot Allowlist
+
+**Status:** Canon source of truth — ADR-008
+**Format:** Each `## Category` heading owns a fenced `slots` code block. The lint reads these blocks; one slot per line, comments start with `#`. Anything in a `slots` code block is *allowed*. Anything not in any `slots` block is *banned* and fails the lint.
+
+This file is the only allowlist. Don't enumerate slots elsewhere. To add a slot, edit this file, justify in the PR description, get review.
+
+## How to read this file
+
+Each slot below is the BEM `__suffix` part — what appears after `__` in a class like `bds-card__title`. The block name (`bds-card`) is allowed; the slot (`__title`) is what's governed here.
+
+A slot may have **modifiers** declared inline as `--mod` suffixes (e.g. `__label--error`). The modifier suffix is part of the allowlist entry; `__label--error` ≠ `__label`. If a slot supports modifiers, list each modifier separately.
+
+For *blueprint* blocks (`bds-hero`, `bds-cta`, …), the BEM modifier syntax governs *layout variants* (`bds-hero--split-image`). Layout modifiers are not slots and are not governed by this file — they're governed by the structural-only modifier rule in ADR-008.
+
+## Text + content slots
+
+```slots
+__title
+__subtitle
+__description
+__label
+__label--error
+__label--sm
+__label--md
+__label--lg
+__value
+__text
+__heading           # legacy — Sheet section only; new code uses __title
+__body              # legacy — being phased out per PR #552; new code uses __description
+__name
+__inner
+__content
+__helper
+__helper--error
+__error
+__strict-hint
+__hint
+__cite              # source attribution on quotes / testimonials
+```
+
+## Layout + container slots
+
+```slots
+__container
+__header
+__footer
+__content           # also appears under text/content for distinct roles — same word, different role
+__inner
+__row
+__rows
+__column
+__columns
+__grid
+__top
+__bottom
+__media             # any aspect-locked media frame; pairs with Frame primitive
+__media-column      # column-shaped media region
+__sidebar
+__main
+```
+
+## Interaction slots
+
+```slots
+__actions
+__action
+__cta
+__button
+__close
+__toggle
+__remove
+__trigger
+__trigger--open
+__trigger--error
+__trigger--disabled
+__caret
+__dropdown
+__option
+__option--active
+__placeholder
+__link
+```
+
+## Visual + icon slots
+
+```slots
+__icon
+__avatar
+__image
+__image-fallback
+__photo
+__illustration
+__badge
+__dot
+__track
+__fill
+__indicator
+__indicator--active
+__shape
+__tile
+__progress
+__progress--error
+__status
+__spinner
+__logo
+__brand             # logo + brand-text grouping
+```
+
+## List + item slots
+
+```slots
+__list
+__item
+__items
+__item--active
+__item--disabled
+__item--pending
+__item--in-progress
+__item--completed
+__item--failed
+__item-content      # legacy compound — flag for review (should be __item__content?)
+__item-label        # legacy compound — flag for review
+__input-row
+```
+
+## Form slots
+
+```slots
+__input
+__field
+__fieldset
+__legend
+__group
+__checkbox
+__radio
+__switch
+```
+
+## Navigation slots
+
+```slots
+__nav
+__nav-link
+__breadcrumb
+__hamburger
+__menu
+__menu-item
+__menu-item--active
+__menu-item--disabled
+```
+
+## Modal + popover + tooltip slots
+
+```slots
+__modal
+__dialog
+__sheet
+__popover
+__bubble
+__bubble--top
+__bubble--right
+__bubble--bottom
+__bubble--left
+__bubble--visible
+__bubble--portal
+__arrow
+__arrow--top
+__arrow--right
+__arrow--bottom
+__arrow--left
+```
+
+## Drawer / mobile-nav slots
+
+```slots
+__drawer
+__drawer-nav
+__drawer-list
+__drawer-item
+__drawer-link
+__drawer-actions
+__drawer-phone
+__drawer-cta
+```
+
+## Specialized slots
+
+These are domain-specific slots that belong to one block but are too useful to forbid outright. Each entry must reference the block that owns it.
+
+```slots
+__category-pill         # filter chip / category indicator (FilterBar, CardList)
+__category-row          # row of category chips
+__cell                  # cell in TimePicker / Calendar tables
+__cell--selected
+__not-found             # empty state / 404 illustration
+__has-options           # combo-list state class
+```
+
+## Banned slots (explicit — for clarity, fail the lint)
+
+These are common drift inventions. Listed here so an agent reading the canon sees the wrong word *and* the right one in the same place.
+
+| Banned | Use instead | Reason |
+|---|---|---|
+| `__eyebrow` | `__subtitle` | Marketing-design term; not BDS vocabulary |
+| `__kicker` | `__subtitle` | Same as eyebrow |
+| `__overline` | `__subtitle` | Same |
+| `__pre-title` | `__subtitle` | Same |
+| `__headline` | `__title` | `heading` is a token scale, not a BEM role |
+| `__lead` | `__description` | Newspaper-print term; BDS uses `__description` for prose |
+| `__quote` | use `CardTestimonial` component | Don't hand-roll blockquote markup |
+| `__quote-text` | use `CardTestimonial` | Same |
+| `__quote-cite` | use `CardTestimonial`'s `__cite` | Same |
+| `__callout` | use `Banner` or `AlertBanner` | Don't hand-roll callout markup |
+| `__plan-name` | `__title` | Layout-specific noun for a generic role |
+| `__plan-description` | `__description` | Same |
+| `__support-title` | `__title` | Same |
+| `__statistic` | `__value` | Same |
+| `__statistic-value` | `__value` | Same |
+| `__method` | `__label` (for the label) + `__value` (for the value) | Domain-specific term for `__label`+`__value` pair |
+| `__method-label` | `__label` | Same |
+| `__method-value` | `__value` | Same |
+| `__role` | `__label` (it labels a name) | Same |
+| `__separator` | `Divider` component | Don't hand-roll separator divs |
+| `__underline` | CSS, not a slot | Visual treatment, not a role |
+| `__hero-title`, `__page-heading` | `__title` | The parent block already says "hero" or "page" |
+| `__hero-cta`, `__page-actions` | `__cta` / `__actions` | Same |
+
+## How to add a slot
+
+1. Identify the **role** the slot expresses (text content? container? interaction? icon?). Pick the most generic word that fits.
+2. Grep the codebase to see whether an existing allowlist slot already covers the role. **Reuse before invent.**
+3. If no existing slot fits, open a PR that:
+   - Adds the new slot to the relevant `## Category` block above
+   - Justifies in the PR description why no existing slot worked
+   - References the block(s) that will use the new slot
+4. Reviewer checks that the new slot is generic (would work on more than one block), not layout-specific (`__hero-image` no, `__image` yes), not visual-descriptive (`__dark-cta` no, `__cta` yes).
+
+## How to remove a slot
+
+Three conditions must hold:
+
+1. Zero current uses across BDS + every consumer repo (grep verified)
+2. PR description explains why the slot is no longer needed
+3. Removal lands in the same PR (or just before) the last code that used it
+
+Removing a slot from the allowlist immediately fails the lint on any consumer code still using it — so the removal PR must coordinate with consumer-repo migrations.

--- a/docs/adrs/ADR-008-naming-canon-closed-allowlist.md
+++ b/docs/adrs/ADR-008-naming-canon-closed-allowlist.md
@@ -1,0 +1,105 @@
+# ADR-008 — Naming canon: closed allowlist, single namespace, structural-only modifiers
+
+**Status:** Accepted (2026-05-11)
+**Supersedes:** parts of [naming-conventions.mdx](../../docs-site/content/docs/primitives/naming-conventions.mdx) before this date
+**Related:** ADR-004 (component bloat), PR #550 (canon doc patches), PR #552 (blueprint BEM rename), PR #554 (Chip appearance removal)
+
+## Context
+
+The naming-conventions doc has been an *open banlist*: it enumerates terms agents must not use (`__eyebrow`, `__heading`, `__headline`, `__body`). Anything not on the banlist passes through. Result, observed repeatedly in 2026-04/05:
+
+- Agents invent new slot names that don't appear on the banlist (`__lead`, `__quote-text`, `__cta-arrow`, `__plan-name`, `__statistic`, `__hamburger-bar`, …). The lint can't catch what canon never named.
+- Blueprints use a separate `bp-*` namespace that creates an arbitrary distinction between "primitive component" and "page layout" — the distinction adds no value but ships its own parallel vocabulary that drifts.
+- Class names bake in *layout-specific* and *visual-specific* descriptors (`bp-cta-dark-centered__title`, `bp-hero-img-card__lead`). These names lie when a layout is themed differently or restructured.
+- Identifier strings (`id="cta-dark-centered-default-title"`) bake the layout name into a11y plumbing; same problem.
+
+A read-only inventory on 2026-05-11 found **675 BEM slot occurrences across 473 unique slot names** in the BDS repo. Of those, **75 are singletons** (used exactly once — high drift signal) and **45 exist only on blueprints** (not on any primitive — pure inventions). The system has been accepting drift faster than the lint catches it.
+
+The pattern is structural, not behavioral. Open canon + open vocabulary = drift forever.
+
+## Decision
+
+Four interlocking changes to the canon. Each was decided with explicit user direction on 2026-05-11.
+
+### 1. Single namespace — `bds-` everywhere
+
+- Every class in the design system uses the `bds-` prefix, including blueprints.
+- The `bp-` prefix is **deprecated**. No new `bp-*` classes ship after this ADR.
+- Blueprints become high-level components in the same vocabulary as primitives. The "primitive vs layout" distinction is real but is *not* a naming concern — it's a directory concern (`components/ui/*` vs `content-system/blueprints/*`).
+
+**Rationale:** the namespace split added no value but cost two parallel vocabularies that drifted. Single namespace = single source of truth for what a class name means.
+
+### 2. Closed allowlist for slot names
+
+- Canon enumerates **every** allowed slot name (the BEM `__suffix`). Anything not on the allowlist fails the lint.
+- The allowlist lives in `docs/SLOT-ALLOWLIST.md` — single file, machine-readable, the lint's source of truth.
+- New slot names require a PR that updates the allowlist. The PR forces a deliberate decision before a new word enters the system.
+
+**Rationale:** open banlists fail by design — agents invent words faster than humans add bans. A closed allowlist inverts the burden: the default is *reject*, and new vocabulary requires explicit approval.
+
+### 3. Structural-only modifiers, no layout name in slot class
+
+- A blueprint *family* gets one block name (`bds-hero`, `bds-cta`, `bds-services`, `bds-features`, `bds-about`, `bds-support-plan`).
+- Variations within a family use BEM **modifiers**: `bds-hero--split-image`, `bds-hero--interior-minimal`. The modifier names the **structural** difference, never the visual / theme / alignment.
+- Slot classes drop the layout segment entirely: `bds-hero__title`, not `bds-hero-split-image__title`.
+- Banned modifier patterns: anything that describes appearance (`--dark`, `--centered`, `--branded`, `--minimal-aesthetic`) or theme (`--inverse`, `--light`, `--dark-mode`). These all lie when the layout is themed differently.
+- Acceptable modifier patterns: structural (`--split-image`, `--two-column`, `--with-pricing-card`), positional (`--narrow`, `--full-width`), variant-by-purpose (`--testimonial`, `--feature-grid`).
+
+**Rationale:** the today-state has every blueprint living as its own block. That forces every CSS rule to repeat the layout name and prevents shared styling. Consolidation to one block per family with modifiers (a) shrinks the library (b) makes the rules portable (c) survives theme + layout changes.
+
+This decision implies that blueprint *components* also consolidate — 4 hero blueprints become one parameterized `Hero` React component with a `layout` prop. That work happens in Phase D (see Migration below); ADR-008 establishes the rule, not the implementation.
+
+### 4. BEM `__` separator for elements
+
+- `bds-{block}__{slot}` for elements.
+- `bds-{block}--{modifier}` for modifiers.
+- `bds-{block}__{slot}--{modifier}` when an element has its own modifier.
+- No single underscores. No other separators. No layout name in `__slot`.
+
+**Rationale:** BEM is industry standard, well-documented, and ~500 existing classes already use it. Changing the separator would ripple through every primitive + every consumer. The cost of switching outweighs the readability benefit.
+
+## Consequences
+
+### What ships immediately (this ADR + companion PR)
+
+1. ADR-008 (this file).
+2. `docs/SLOT-ALLOWLIST.md` — initial allowlist derived from the 2026-05-11 inventory, intersected with the rules above.
+3. Updates to [`naming-conventions.mdx`](../../docs-site/content/docs/primitives/naming-conventions.mdx):
+   - Replace the open banlist framing with the closed allowlist + link to `SLOT-ALLOWLIST.md`
+   - Document the single-namespace rule
+   - Document the structural-only modifier rule
+   - Document the id-generation rule (already specified for React in PR #552; add Astro-specific guidance)
+
+### What does NOT ship immediately
+
+- The lint is **not** flipped to allowlist mode in this PR. That's Phase C — a separate PR that updates `scripts/lint-blueprint-naming.mjs` to read the allowlist file and fail on any `bds-*__*` whose slot isn't in the list.
+- No blueprint code is renamed in this PR. That's Phase D — multi-PR consolidation, one family at a time (hero first, then cta, services, features, about, support-plan).
+- No consumer-repo migration yet. That's Phase E, coordinated with Phase D rollout.
+
+### Migration plan
+
+| Phase | Output | Status |
+|---|---|---|
+| A | ADR-008 + canon update + allowlist file | **this PR** |
+| B | Inventory of consumer-repo slot usage (BDS already inventoried) | next session |
+| C | Lint flipped to allowlist mode | follows B |
+| D | Blueprint family consolidation, one family per PR (hero → cta → services → features → about → support-plan). Each PR: collapse N blueprints into 1 parameterized, rename classes to allowlist vocabulary, drop `bp-` prefix. | multi-session |
+| E | Consumer-repo CSS rename (any `bp-*` or non-allowlist slot used in consumer code) | coordinated with D |
+| F | Deprecation cleanup — drop the `bp-` prefix support after all consumers migrated | last |
+
+Phases C–F are post-ADR; they each get their own ADR if scope is non-trivial.
+
+### Breaking-change semantics
+
+This ADR doesn't break anything by itself — it's pure documentation. Phase D + E ship breaking class renames. BDS is pre-1.0 (`0.65.0`), so each blueprint-family PR bumps minor; the full migration warrants a major bump after Phase F.
+
+### What this ADR refuses
+
+- It refuses to enumerate per-component variant unions (Button, ServiceTag, etc.) here. Those live in each component's `.tsx` type union and that component's MDX. ADR-008 is about the *shared vocabulary* — slot names that span the system. Per-component variant unions are tracked by the typegen ADR (future).
+- It refuses to specify *exactly* which blueprints survive after Phase D consolidation. The structural-vs-visual modifier rule is the test; each family's consolidation PR makes the call with the rule applied.
+
+## Open questions tracked separately
+
+- **Consumer-repo extension policy.** Can a consumer repo invent a slot name not on the allowlist? Initial answer: no — they import the lint guard from BDS. Final answer pending consumer-repo inventory (Phase B).
+- **Component vs blueprint allowlist split.** Today's allowlist proposal is one list shared by both. We may discover slots that belong only on blueprints (`__media-column`, `__hero-image`) — those will get a separate "blueprint slots" section in the allowlist file rather than mixing with primitive vocabulary.
+- **Singleton review.** The 75 singletons from the inventory need a per-block decision: keep + add to allowlist, or rename to an existing allowlist term, or delete. Tracked as a pre-Phase-C cleanup.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -39,6 +39,7 @@ These compose: ADR-006 governs *story files* (where stories live, what shape); A
 |---|---|---|
 | [ADR-001](./ADR-001-bds-find.md) | **Accepted** (2026-05-08) | `bds-find` CLI + semantic manifest fields so consumer agents can discover BDS components instead of building local clones |
 | [ADR-002](./ADR-002-accessibility-overlays.md) | **Accepted** | Ban third-party accessibility overlay widgets — they harm the users they claim to help and increase ADA legal exposure |
+| [ADR-008](./ADR-008-naming-canon-closed-allowlist.md) | **Accepted** (2026-05-11) | Naming canon flips from open banlist to closed allowlist — single `bds-` namespace, structural-only modifiers, slot vocabulary enumerated in `docs/SLOT-ALLOWLIST.md`. Stops the `__lead` / `__plan-name` drift mechanism at the source. |
 
 ## Status field — what each value means
 


### PR DESCRIPTION
## Summary

**Phase A of the naming canon overhaul.** Establishes the contract; subsequent phases enforce it (Phase C: lint flip) and migrate to it (Phase D: blueprint family consolidation).

This PR is **documentation only** — no code is renamed yet. The decisions below are authorized by user direction on 2026-05-11 in response to a concrete review of in-storybook blueprint class names (`bp-hero-img-card__lead`, `cta-dark-centered-default-title`, etc.).

## What this fixes

Canon was an **open banlist** of forbidden slot names. Agents kept inventing words the banlist hadn't named:

- `__lead` (5 blueprints) — not banned, not approved, just invented
- `__quote-text`, `__quote-cite` — hand-rolled blockquote markup
- `__plan-name`, `__plan-description`, `__statistic`, `__statistic-value`, `__support-title` — layout-specific nouns for generic roles
- `__hamburger-bar`, `__brand-text`, `__cta-arrow`, `__cta-row` — micro-variants that bloat the system

The 2026-05-11 inventory found **675 BEM slot occurrences across 473 unique slot names** in BDS, of which **75 are singletons** (used once) and **45 exist only on blueprints**. Banlists fail by design when inventors move faster than banners.

**Closed allowlist** inverts the burden: default is REJECT, new vocabulary requires a deliberate PR.

## Four decisions (each with explicit user direction)

1. **Single `bds-` namespace.** Drop the `bp-` prefix. Blueprints become high-level components in the same vocabulary as primitives.
2. **Closed allowlist.** Every legitimate `__slot` is enumerated in [`docs/SLOT-ALLOWLIST.md`](docs/SLOT-ALLOWLIST.md). Default for unknown slots: reject.
3. **Structural-only modifiers.** Blueprint families collapse to one block (`bds-hero`, `bds-cta`, …) with BEM modifiers for variants. Modifiers describe structure (`--split-image`), never appearance (`--dark`) or theme (`--inverse`). A "dark centered" CTA themed light is the failure mode this rule prevents.
4. **BEM `__` separator stays.** ~500 existing classes use it; switching would ripple through every primitive + consumer.

## Files

- **New:** [`docs/adrs/ADR-008-naming-canon-closed-allowlist.md`](docs/adrs/ADR-008-naming-canon-closed-allowlist.md) — decisions, rationale, consequences, phased migration plan
- **New:** [`docs/SLOT-ALLOWLIST.md`](docs/SLOT-ALLOWLIST.md) — canonical slot vocabulary by category, machine-parseable for Phase C lint, includes an explicit "banned → canon translation" table at the end
- **Modified:** [`docs-site/content/docs/primitives/naming-conventions.mdx`](docs-site/content/docs/primitives/naming-conventions.mdx) — adds top-level "Closed allowlist" section; rewrites the "Blueprints" section with the new namespace + modifier rules
- **Modified:** [`docs/adrs/README.md`](docs/adrs/README.md) — index entry for ADR-008

## Phased migration plan (in the ADR)

| Phase | What | Status |
|---|---|---|
| **A** | ADR + canon + allowlist | **this PR** |
| B | Consumer-repo slot inventory | next session |
| C | Lint flipped to allowlist mode | follows B |
| D | Blueprint family consolidation, one per PR (hero → cta → services → features → about → support-plan) | multi-session |
| E | Consumer-repo CSS rename, coordinated with D | as D lands |
| F | Delete `bp-` prefix after all consumers migrated | last |

## What this PR explicitly does NOT do

- Flip the lint to allowlist mode — Phase C
- Rename any blueprint code — Phase D
- Consolidate the 4 hero blueprints into one `Hero` — Phase D
- Touch any consumer repo — Phase E
- Delete `bp-` prefix support — Phase F

## Test plan

- [x] Typecheck passes (no code changes)
- [x] Pre-commit hooks pass (gitleaks + completeness + anti-slop all skip — docs only)
- [ ] Reviewer reads ADR-008 + SLOT-ALLOWLIST.md end-to-end and either ratifies the 4 decisions or pushes back on specific allowlist entries
- [ ] After merge: re-ingest `canon-tokens/naming-conventions` so RAG serves the new framing

## Open questions deliberately deferred to follow-ups

- Consumer-repo extension policy (can consumer code add slots? initial answer: no)
- Component vs blueprint allowlist split (today: shared list; may need to split later)
- The 75 singleton slots from the inventory — per-block decision needed before Phase C

🤖 Generated with [Claude Code](https://claude.com/claude-code)