### PR TITLE
docs(component-patterns): cross-reference naming canon + slot allowlist + ADR-008

### DIFF
--- a/docs/COMPONENT-PATTERNS.md
+++ b/docs/COMPONENT-PATTERNS.md
@@ -86,6 +86,22 @@ Inline `style` is only acceptable for:
 .bds-{component}__{child}--{mod}    child modifier
 ```
 
+The `__{child}` slot suffix is **not free-form** — it must come from the closed allowlist. See the next section.
+
+## Naming canon — single source of truth
+
+This page covers component CSS *structure*. The vocabulary the structure uses — every legitimate `__slot` name, every modifier rule, every `bds-` namespace decision — lives in dedicated canon:
+
+| What | Canon source |
+|---|---|
+| BEM rules, `bds-` namespace, structural-only modifier rule, id generation, axes | [Naming Conventions](../docs-site/content/docs/primitives/naming-conventions.mdx) (also at [design.brikdesigns.com/docs/primitives/naming-conventions](https://design.brikdesigns.com/docs/primitives/naming-conventions)) |
+| Closed allowlist of every `__slot` name (the only valid suffixes) | [`docs/SLOT-ALLOWLIST.md`](./SLOT-ALLOWLIST.md) |
+| Why the system runs on a closed allowlist instead of a banlist | [`docs/adrs/ADR-008`](./adrs/ADR-008-naming-canon-closed-allowlist.md) |
+| Token taxonomy (`--text-*`, `--surface-*`, `--background-*`, semantic `--border-*`) | [Color tokens](../docs-site/content/docs/primitives/color.mdx) + [Spacing](../docs-site/content/docs/primitives/spacing.mdx) — `dist/tokens.css` is the live allowlist |
+
+**The rule:** when this doc and the canon disagree, the canon wins. Open a PR to align this doc.
+
+**For consumers** (portal, renew-pms, brikdesigns, freedom, web sites): the same canon applies. Don't invent local class naming conventions; import BDS components or follow `bds-` BEM and the slot allowlist for any new CSS.
 
 ## Tokens only
 


### PR DESCRIPTION
## Summary

`COMPONENT-PATTERNS.md` lives in the **canon-coding-standards** RAG corpus. `naming-conventions.mdx` and `SLOT-ALLOWLIST.md` live in **canon-tokens** (and once #557 merges, the allowlist will too). Result: an agent querying *coding standards* for naming guidance hits this file's brief "## Class naming" stub and doesn't find the authoritative vocabulary.

Adds a "## Naming canon — single source of truth" section right after "## Class naming" with explicit pointers to:
- [naming-conventions.mdx](docs-site/content/docs/primitives/naming-conventions.mdx) — BEM, namespace, structural-modifier rule, id rules
- [`docs/SLOT-ALLOWLIST.md`](docs/SLOT-ALLOWLIST.md) — closed allowlist of legitimate `__slot` names
- [ADR-008](docs/adrs/ADR-008-naming-canon-closed-allowlist.md) — rationale
- Token canon

Explicit "canon wins" framing in the new section so future readers know which file is load-bearing if the per-section guidance here drifts.

## Why this matters

The user observation in this session: per-repo standards files (brik-llm 579 lines, brik-client-portal 362 lines) operate as **silos** — none of them cross-reference BDS canon on naming. Agents reading one of those don't learn that BDS owns the vocabulary. This PR is one of three closing that gap:

1. **This PR (brik-bds):** bridge through COMPONENT-PATTERNS.md → naming canon
2. **brik-llm (next PR):** expand canon-coding-standards corpus to ingest naming-conventions.mdx + SLOT-ALLOWLIST.md directly
3. **brik-client-portal (third PR):** add naming/CSS section to portal CODING-STANDARDS.md pointing at BDS canon

After all three land + a RAG re-ingest, any agent querying "how do I name a class" via any path will find the same authoritative answer.

## Test plan

- [x] `tsc --noEmit` passes (docs-only change)
- [x] Pre-commit hooks pass
- [ ] After merge: re-ingest `canon-coding-standards/brik-bds-component-patterns` slug so RAG serves the new section

## Strategic context

User direction this session: "Code = source of truth for agents. LLM/RAG with docs = source of truth for humans and agents. Both are living breathing entities." Today's per-repo standards files are 300–600 lines that silently restate canon and drift independently. Long-term, they should slim to ~50 lines of genuinely project-specific overrides + clear canon pointers. This PR doesn't slim those files yet — it adds the pointer architecture so the slimming can happen incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)