### PR TITLE
ci: add cancel-in-progress concurrency to workflows

### DIFF
--- a/.github/workflows/build-tokens.yml
+++ b/.github/workflows/build-tokens.yml
@@ -10,6 +10,10 @@ on:
       - 'sd.config.tokens-studio.mjs'
   workflow_dispatch:
 
+concurrency:
+  group: build-tokens-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-tokens:
     runs-on: ubuntu-latest

--- a/.github/workflows/canonical-check.yml
+++ b/.github/workflows/canonical-check.yml
@@ -24,6 +24,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: canonical-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   canonical-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/canonical-class-check.yml
+++ b/.github/workflows/canonical-class-check.yml
@@ -32,6 +32,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: canonical-class-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   canonical-class-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,6 +10,10 @@ on:
       - 'design-tokens/**'
       - 'updates/**'
 
+concurrency:
+  group: chromatic-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/drift-alarm.yml
+++ b/.github/workflows/drift-alarm.yml
@@ -17,6 +17,10 @@ on:
     - cron: '0 13 * * 1'  # Monday 09:00 ET (13:00 UTC)
   workflow_dispatch:
 
+concurrency:
+  group: drift-alarm-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-drift:
     name: Check consumer drift

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,6 +6,10 @@ name: Secret scan
 on:
   pull_request:
 
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-recipe-check.yml
+++ b/.github/workflows/storybook-recipe-check.yml
@@ -23,6 +23,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: storybook-recipe-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   storybook-recipe-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds `concurrency: cancel-in-progress` to 7 workflows: `build-tokens`, `canonical-check`, `canonical-class-check`, `chromatic`, `drift-alarm`, `gitleaks`, `storybook-recipe-check`.

## Why
Stale runs on PR force-pushes were piling up — **chromatic alone runs visual diffs that can take 5+ minutes per run**, and rapid iteration on a PR multiplied that cost without producing signal. With `cancel-in-progress`, only the latest commit on a branch keeps its runner.

Part of a cross-repo Actions cost reduction — companion to brik-client-portal PR (uptime.yml removal + 5 workflow concurrency additions).

## Skipped (intentional)
- **`release.yml`** — author explicitly opted out in the workflow's header comment: *"half-published packages are worse than a queued duplicate."*
- **`sync-figma-variables.yml`** — writes commits to the repo; cancelling mid-run could lose work.
- **`sync-staging.yml`** — fast-forward push from main → staging; cancelling could leave staging behind main.

## Group scoping
PR/push-triggered workflows scope by `${{ github.ref }}` so different branches don't cancel each other.

## Test plan
- [x] All 7 workflows have well-formed YAML
- [x] Pre-push hooks pass (typecheck, anti-slop)
- [ ] Confirm gitleaks check runs on this PR (validates the gitleaks edit didn't break itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)