### PR TITLE
chore(release): 0.65.0 → 0.66.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.65.0",
+      "version": "0.66.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

- Bumps `@brikdesigns/bds` from `0.65.0` → `0.66.0` (both `package.json` and `package-lock.json`)
- Publishes the work landed in #566 + #575 to consumers (portal, renew-pms, brikdesigns)

## What 0.66.0 ships (vs. published 0.65.0)

- **#575** — service-line taxonomy reconciliation
  - Adds tone variants (`-light`, `-dark`) and context variants (`-on-light`, `-on-dark`, `-inverse`) across `--surface-service-*`, `--background-service-*`, `--border-service-*`, `--text-service-*`
  - Renames the orange family `service-service` → `back-office`
  - Removes the legacy `--services--{hue}` palette and `*-secondary` modifiers (replaced by the tone/context naming)
- **#566** — composition-layer + token-name anatomy in `naming-conventions.mdx`

## Breaking changes for consumers

Removed names (consumers using them by raw string will need to migrate):
- `--services--{green,yellow,blue,purple,orange}` (+ `-dark`/`-light` modifiers)
- `--background-service-{family}-secondary`

Surface known to be affected:
- `brikdesigns` — `globals.css` + `lib/tokens.ts` shim `--background-service-*`/`--text-service-*` to `--services--*` (cleanup will land in a follow-up PR alongside brikdesigns#99)
- `brik-client-portal` — on `0.52.0`; not forced to bump. Has 45 refs to remove on its next bump.
- `renew-pms` — clean. Safe to bump.

## Release steps after merge

```
git -C $(git rev-parse --show-toplevel) checkout main
git pull --ff-only
git tag v0.66.0
git push origin v0.66.0
```

The `Release` workflow validates `package.json == tag` and publishes to GitHub Packages.

## Test plan

- [x] `node scripts/lint-tokens.js --errors-only` — 0 violations
- [x] `npm run lint-jsdoc` — clean
- [x] `npm run validate:blueprints` — 32 blueprints OK
- [x] `npm run typecheck` — clean
- [ ] After merge: tag v0.66.0 → `Release` workflow green → `0.66.0` listed on GitHub Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)