### PR TITLE
chore(release): 0.66.0 → 0.67.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

- Minor bump cutting a release for PR #585 (`bds-card-grid` + `Card preset="display"`), the only commit between `v0.66.0` and HEAD.
- Unblocks brikdesigns/brikdesigns#100 — the reference rebuild needs `<CardGrid>` + `<Card preset="display">` to dogfood the ADR-008 generic-primitive doctrine on `/services/marketing-design/web-design`.

## Why minor

Per [`docs/RELEASE.md`](docs/RELEASE.md): minor = new component or new prop on existing component. PR #585 ships both (CardGrid is new; Card gains the `display` preset discriminant).

## After merge

```bash
git -C ~/Documents/Github/brik/brik-bds pull --ff-only
git -C ~/Documents/Github/brik/brik-bds tag v0.67.0
git -C ~/Documents/Github/brik/brik-bds push origin v0.67.0
```

Then bump consumers: brikdesigns first (gates #100). Portal / renew / freedom can pick up at their own cadence — no breaking changes.

## Test plan

- [x] Local `npm install --package-lock-only` cleanly updates lockfile
- [x] Pre-commit hooks pass (gitleaks, typecheck, anti-slop)
- [ ] Release workflow validates + publishes to GitHub Packages on tag push
- [ ] `npm view @brikdesigns/bds@0.67.0` resolves post-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)