### PR TITLE
scripts(pr-task): add brik-rag remember prompt to PR body + success output

### DIFF
--- a/scripts/pr-task.sh
+++ b/scripts/pr-task.sh
@@ -173,6 +173,9 @@ ${COMMIT_BULLETS}
 - [ ] \`npm run lint-tokens\` passes
 - [ ] Dark mode checked (if applicable)
 
+## Knowledge capture
+- [ ] Non-obvious decisions / learnings captured: \`brik-rag remember "<key insight>"\`
+
 Generated with [Claude Code](https://claude.ai/code)
 EOF
 )
@@ -190,6 +193,9 @@ echo "  $PR_URL"
 echo ""
 echo "  Branch:  $BRANCH → ${BASE_BRANCH}"
 echo "  Commits: $COMMITS_AHEAD ahead of ${BASE_BRANCH}"
+echo ""
+echo -e "  ${YELLOW}Knowledge capture:${NC} did anything non-obvious come up?"
+echo "    brik-rag remember \"<key insight from this task>\""
 echo ""
 
 # ── Worktree cleanup hint ──


### PR DESCRIPTION
## Summary
- Add \`## Knowledge capture\` checklist item to the auto-generated PR body template
- Print a \`brik-rag remember\` reminder in the success banner after PR creation

## Why
Every PR close is a natural knowledge-capture moment. Without an explicit prompt, non-obvious decisions get lost. This closes the loop between the worktree workflow and brik-rag.

Follow-up from #594 (documentation-standards work).

## Consumer sync plan
- [ ] n/a — script-only change, no published package impact

## Test plan
- [ ] Run \`./scripts/pr-task.sh\` on a task branch and verify the new section appears in the generated PR body
- [ ] Verify the knowledge capture reminder prints in the success banner

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: \`brik-rag remember "<key insight>"\`

Generated with [Claude Code](https://claude.ai/code)