### PR TITLE
feat(tooling): extract-component-inventory script + Notion code-mirror DB (#587 Phase 1 PR-C, closes #603)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ FIGMA_FILE_KEYS=Rkdc3SIWJUdgoAkeadgZZe,GLi4Xm9q783AniSTY009p5,XEXnuAmnklNKw55kxj
 # Get your token from: https://www.notion.so/profile/integrations
 # 1. Create a new internal integration
 # 2. Copy the "Internal Integration Secret"
-# 3. Share your Design Tokens and Modes databases with the integration
+# 3. Share Design Tokens, Modes, and Component Inventory databases with the integration
+# Used by: npm run populate-notion, npm run extract:component-inventory
 NOTION_TOKEN=secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Chromatic project token (for `npm run chromatic` — visual regression upload)

--- a/package.json
+++ b/package.json
@@ -151,6 +151,8 @@
     "sync:figma-mcp": "node scripts/sync-figma-mcp.js",
     "sync:figma-mcp:build": "node scripts/sync-figma-mcp.js --build",
     "populate-notion": "node scripts/populate-notion-tokens.js",
+    "extract:component-inventory": "node scripts/extract-component-inventory.mjs",
+    "extract:component-inventory:dry": "node scripts/extract-component-inventory.mjs --dry-run",
     "propagate": "bash scripts/propagate.sh",
     "propagate:dry": "bash scripts/propagate.sh --dry-run",
     "sync:devbar-widgets": "bash scripts/sync-devbar-widgets.sh",

--- a/scripts/extract-component-inventory.mjs
+++ b/scripts/extract-component-inventory.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+/**
+ * extract-component-inventory.mjs — Code-mirror of components/ui/ → Notion.
+ *
+ * Walks `components/ui/*\/*.stories.tsx`, parses each with the TypeScript
+ * compiler API to extract story-shape signal, and upserts a row per
+ * component into the "Component Inventory" Notion DB (see #603 / #587
+ * Phase 1 PR-C). The DB is a sibling of "UI Elements" under the
+ * Components parent page; design-curated rows live in UI Elements and
+ * are NOT touched by this script.
+ *
+ * v1 fields (minimal-core per #603 scoping):
+ *   - Name              — component dir name (e.g. Button)
+ *   - Component path    — components/ui/Button/Button.tsx
+ *   - Story title       — meta.title literal (e.g. Components/Action/button)
+ *   - Surface           — derived from meta.tags surface-* (shared/web/product/unknown)
+ *   - Story exports     — count of `export const X (: Story)?` (excludes default meta)
+ *   - Deprecated        — meta.tags includes `!manifest`
+ *   - ADR-010 risk      — computed: Story exports > 13 (Q2 collapse signal)
+ *   - Last sync         — today (ISO date)
+ *
+ * Coverage % fields (argTypes / @summary) deferred to a follow-up PR
+ * because they need full TypeChecker prop-counting on the paired *.tsx
+ * file; v1 is the cheap-but-actionable signal that orders Phase 3 batches.
+ *
+ * Auth:
+ *   Reads NOTION_TOKEN from .env (matches populate-notion-tokens.js).
+ *
+ * Usage:
+ *   node scripts/extract-component-inventory.mjs            # live sync
+ *   node scripts/extract-component-inventory.mjs --dry-run  # parse + log, no Notion writes
+ *
+ * See ADR-010 + #603.
+ */
+
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+const { Client } = require('@notionhq/client');
+require('dotenv').config();
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const COMPONENTS_DIR = path.join(REPO_ROOT, 'components', 'ui');
+
+const COMPONENT_INVENTORY_DB_ID = 'b838bbf1-d682-4687-a3eb-8f94ef2b9536';
+
+const SURFACE_TAGS = new Set(['surface-shared', 'surface-web', 'surface-product']);
+const DEPRECATED_TAG = '!manifest';
+const ADR_010_RISK_THRESHOLD = 13;
+
+const dryRun = process.argv.includes('--dry-run');
+
+// ── AST helpers ─────────────────────────────────────────────────────────
+
+function getStringLiteralValue(node) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  return null;
+}
+
+function getArrayStringLiterals(node) {
+  if (!ts.isArrayLiteralExpression(node)) return null;
+  return node.elements
+    .map(getStringLiteralValue)
+    .filter((v) => v !== null);
+}
+
+/**
+ * Unwraps `satisfies` and `as` clauses so callers see the underlying
+ * literal. `const meta: Meta<…> = { … } satisfies Meta<…>` is the
+ * Footer/Tooltip/etc. pattern; without this, the initializer node is a
+ * SatisfiesExpression and the object-literal walk silently fails.
+ */
+function unwrapAssertions(node) {
+  while (
+    node &&
+    (ts.isSatisfiesExpression(node) ||
+      ts.isAsExpression(node) ||
+      ts.isParenthesizedExpression(node) ||
+      ts.isTypeAssertionExpression?.(node))
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+/**
+ * Finds the `const meta` declaration and pulls out title + tags.
+ * Pattern: `const meta: Meta<typeof X> = { title: '...', tags: [...] }`.
+ */
+function extractMeta(sourceFile) {
+  let meta = { title: null, tags: [] };
+
+  ts.forEachChild(sourceFile, (node) => {
+    if (!ts.isVariableStatement(node)) return;
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.name.text !== 'meta') continue;
+      const initializer = unwrapAssertions(decl.initializer);
+      if (!initializer || !ts.isObjectLiteralExpression(initializer)) continue;
+
+      for (const prop of initializer.properties) {
+        if (!ts.isPropertyAssignment(prop)) continue;
+        if (!ts.isIdentifier(prop.name)) continue;
+
+        if (prop.name.text === 'title') {
+          meta.title = getStringLiteralValue(prop.initializer);
+        } else if (prop.name.text === 'tags') {
+          meta.tags = getArrayStringLiterals(prop.initializer) ?? [];
+        }
+      }
+    }
+  });
+
+  return meta;
+}
+
+/**
+ * Counts exported story constants. Excludes the default export (meta).
+ * A "story export" is any `export const X = …` at the top level.
+ */
+function countStoryExports(sourceFile) {
+  let count = 0;
+  ts.forEachChild(sourceFile, (node) => {
+    if (!ts.isVariableStatement(node)) return;
+    const isExported = (node.modifiers ?? []).some(
+      (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+    );
+    if (!isExported) return;
+    for (const decl of node.declarationList.declarations) {
+      if (ts.isIdentifier(decl.name) && decl.name.text !== 'meta') {
+        count += 1;
+      }
+    }
+  });
+  return count;
+}
+
+function parseStoryFile(filePath) {
+  const sourceText = fs.readFileSync(filePath, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX,
+  );
+
+  const meta = extractMeta(sourceFile);
+  const storyExports = countStoryExports(sourceFile);
+
+  const surfaceTag = meta.tags.find((t) => SURFACE_TAGS.has(t));
+  const surface = surfaceTag ? surfaceTag.replace('surface-', '') : 'unknown';
+  const deprecated = meta.tags.includes(DEPRECATED_TAG);
+
+  return {
+    storyTitle: meta.title,
+    surface,
+    deprecated,
+    storyExports,
+    risk: storyExports > ADR_010_RISK_THRESHOLD,
+    tags: meta.tags,
+  };
+}
+
+// ── Walk components/ui/ ────────────────────────────────────────────────
+
+function findInventoryRows() {
+  const rows = [];
+  const componentDirs = fs
+    .readdirSync(COMPONENTS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+
+  for (const componentName of componentDirs) {
+    const componentDir = path.join(COMPONENTS_DIR, componentName);
+    const storyFiles = fs
+      .readdirSync(componentDir)
+      .filter((f) => f.endsWith('.stories.tsx'));
+
+    if (storyFiles.length === 0) continue;
+
+    // Convention: one stories file per directory, named ComponentName.stories.tsx.
+    // If multiple, prefer the one matching the dir name; otherwise take the first.
+    const preferred =
+      storyFiles.find((f) => f === `${componentName}.stories.tsx`) ?? storyFiles[0];
+    const storyPath = path.join(componentDir, preferred);
+    const tsxName = preferred.replace(/\.stories\.tsx$/, '');
+    const componentPath = path
+      .join('components', 'ui', componentName, `${tsxName}.tsx`)
+      .replaceAll(path.sep, '/');
+
+    const parsed = parseStoryFile(storyPath);
+    rows.push({
+      name: componentName,
+      componentPath,
+      ...parsed,
+    });
+  }
+
+  return rows;
+}
+
+// ── Notion upsert ──────────────────────────────────────────────────────
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const RATE_LIMIT_MS = 350; // 3 req/s ceiling per populate-notion-tokens.js
+
+function buildProperties(row, today) {
+  return {
+    Name: { title: [{ text: { content: row.name } }] },
+    'Component path': {
+      rich_text: [{ text: { content: row.componentPath } }],
+    },
+    'Story title': {
+      rich_text: [{ text: { content: row.storyTitle ?? '' } }],
+    },
+    Surface: { select: { name: row.surface } },
+    'Story exports': { number: row.storyExports },
+    Deprecated: { checkbox: row.deprecated },
+    'ADR-010 risk': { checkbox: row.risk },
+    'Last sync': { date: { start: today } },
+  };
+}
+
+async function fetchExistingPages(notion) {
+  const byName = new Map();
+  let cursor = undefined;
+  do {
+    const response = await notion.databases.query({
+      database_id: COMPONENT_INVENTORY_DB_ID,
+      page_size: 100,
+      start_cursor: cursor,
+    });
+    for (const page of response.results) {
+      const name = page.properties?.Name?.title?.[0]?.plain_text;
+      if (name) byName.set(name, page.id);
+    }
+    cursor = response.has_more ? response.next_cursor : undefined;
+  } while (cursor);
+  return byName;
+}
+
+async function upsertRow(notion, row, existingId, today) {
+  const properties = buildProperties(row, today);
+  if (existingId) {
+    await notion.pages.update({ page_id: existingId, properties });
+    return 'updated';
+  }
+  await notion.pages.create({
+    parent: { database_id: COMPONENT_INVENTORY_DB_ID },
+    properties,
+  });
+  return 'created';
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+function logRowsTable(rows) {
+  const header = ['Name', 'Surface', 'Exports', 'Risk', 'Deprecated', 'Story title'];
+  const cols = [header, ...rows.map((r) => [
+    r.name,
+    r.surface,
+    String(r.storyExports),
+    r.risk ? '⚠️ ' : '  ',
+    r.deprecated ? 'yes' : '   ',
+    r.storyTitle ?? '(no meta.title)',
+  ])];
+  const widths = header.map((_, i) => Math.max(...cols.map((row) => row[i].length)));
+  for (const row of cols) {
+    console.log(row.map((cell, i) => cell.padEnd(widths[i])).join('  '));
+  }
+}
+
+async function main() {
+  const rows = findInventoryRows();
+  const today = new Date().toISOString().slice(0, 10);
+
+  console.log(`Parsed ${rows.length} components from ${COMPONENTS_DIR}\n`);
+  logRowsTable(rows);
+
+  const riskCount = rows.filter((r) => r.risk).length;
+  const deprecatedCount = rows.filter((r) => r.deprecated).length;
+  const unknownSurfaceCount = rows.filter((r) => r.surface === 'unknown').length;
+  console.log(
+    `\nSummary: ${rows.length} total · ${riskCount} ADR-010 risk · ` +
+    `${deprecatedCount} deprecated · ${unknownSurfaceCount} unknown surface`,
+  );
+
+  if (dryRun) {
+    console.log('\n(dry-run: no Notion writes)');
+    return;
+  }
+
+  if (!process.env.NOTION_TOKEN) {
+    console.error('ERROR: NOTION_TOKEN missing. Set it in .env (see .env.example).');
+    process.exit(1);
+  }
+
+  const notion = new Client({ auth: process.env.NOTION_TOKEN });
+  console.log(`\nFetching existing pages from Component Inventory DB...`);
+  const existing = await fetchExistingPages(notion);
+  console.log(`  ${existing.size} existing rows.\n`);
+
+  let created = 0;
+  let updated = 0;
+  let failed = 0;
+  for (const row of rows) {
+    try {
+      const result = await upsertRow(notion, row, existing.get(row.name), today);
+      if (result === 'created') {
+        created += 1;
+        console.log(`  \x1b[32m+\x1b[0m ${row.name}`);
+      } else {
+        updated += 1;
+        console.log(`  \x1b[34m~\x1b[0m ${row.name}`);
+      }
+    } catch (err) {
+      failed += 1;
+      console.error(`  \x1b[31mx\x1b[0m ${row.name}: ${err.message}`);
+    }
+    await delay(RATE_LIMIT_MS);
+  }
+
+  console.log(`\nDone. ${created} created · ${updated} updated · ${failed} failed.`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

PR-C of [#587](https://github.com/brikdesigns/brik-bds/issues/587) Phase 1 — closes [#603](https://github.com/brikdesigns/brik-bds/issues/603). Adds the last missing piece of the Phase 1 standards-reorg work that PR [#601](https://github.com/brikdesigns/brik-bds/pull/601) (PR-A) and [#604](https://github.com/brikdesigns/brik-bds/pull/604) (PR-B) shipped.

`scripts/extract-component-inventory.mjs` walks `components/ui/*/*.stories.tsx`, parses each via the TypeScript compiler API, and upserts a row per component into a new **Component Inventory** Notion DB. v1 surfaces the ADR-010 Phase 3 batch-ordering signal — which components have story-export inflation, which are deprecated, which surface they target.

## What's in

- `scripts/extract-component-inventory.mjs` — walker + parser + Notion upserter. Mirrors `scripts/generate-component-axes.mjs` patterns (`createRequire(import.meta.url)` for the `typescript` lib, `fs.readdirSync` walk, `--check` / `--dry-run` flag conventions).
- `package.json` — two npm scripts:
  - `npm run extract:component-inventory` — live sync
  - `npm run extract:component-inventory:dry` — parse + log, no Notion writes
- `.env.example` — `NOTION_TOKEN` block updated to list `extract:component-inventory` as a consumer; documents the third DB the integration needs share access to.

## What changed in Notion

New database **Component Inventory** created under the existing "Components" parent page (sibling of "UI Elements"). DB ID `b838bbf1-d682-4687-a3eb-8f94ef2b9536`. Schema:

| Column | Type | Source |
|---|---|---|
| Name | Title | component dir name |
| Component path | Text | `components/ui/Button/Button.tsx` |
| Story title | Text | `meta.title` literal |
| Surface | Select (shared/web/product/unknown) | `meta.tags` `surface-*` tag |
| Story exports | Number | count of `export const X` excluding default meta |
| Deprecated | Checkbox | `meta.tags` includes `!manifest` |
| ADR-010 risk | Checkbox | computed: Story exports > 13 |
| UI Element | Relation → UI Elements | manual link from designers (script doesn't set) |
| Last sync | Date | set by script |

**Initial run results: 89 components, all surfaces resolved.**

- **4 ADR-010 risk** (export count > 13): Button (22), Meter (18), AddableEntryList (16), AddableComboList (14)
- **1 deprecated**: Dialog
- **0 unknown surface** after fixing the parser to unwrap `satisfies Meta<…>` clauses (15 components use that pattern — Footer, Tooltip, FilterBar, etc.)

Button matches the issue body's example exactly ("today's `Button.stories.tsx` at 22 exports") — primary acceptance signal.

## Why a new DB instead of writing into UI Elements

UI Elements (141 rows) is design-curated and spans 6 Types (Content / Asset / Element / Page / Section / Display) — most rows aren't React components. Adding code-extracted columns to it would:

1. Force the script to filter to `Type=Element` rows only, leaving design-curated rows un-mirrored
2. Overlap with the existing curated `Status` field (which already uses "Needs Refactored" — semantically the same as ADR-010 risk)
3. Mix design-side curation with code-extracted data in the same table

The new sibling DB keeps the separation clean: design-curated stays curated; code-extracted lives in Component Inventory; designers can manually link rows via the `UI Element` relation when one exists.

This deviates from the literal #603 body, which assumed UI Elements would receive the columns. The deviation is captured in a comment on #603 / this PR.

## Scope deferred from #603

The issue lists `argTypes coverage %` and `@summary coverage %`. Both need a full `ts.createProgram` + `TypeChecker` pass to enumerate props on the paired `*.tsx` and compare against the `meta.argTypes` keys. That's a meaningful jump in complexity. The v1 signal (export count alone) already orders Phase 3 batches; coverage % is incremental, not gating. Will follow up as a separate PR if Phase 3 batch ordering needs more granular signal than what the risk flag provides.

## Deviations from issue body

- File extension: issue says `.ts`; PR ships `.mjs` to match the existing `generate-component-axes.mjs` pattern (the repo has no `.ts` scripts and no `tsx` runner in deps). The TypeScript compiler API loads fine from `.mjs` via `createRequire`.
- DB: see "Why a new DB" above.

## Test plan

- [x] `npm run extract:component-inventory:dry` — 89 components parsed, 0 unknown surfaces
- [x] First live run — 89 created / 0 failed
- [x] Re-run idempotence check — 0 created / 89 updated / 0 failed
- [x] Pre-commit hooks (gitleaks, typecheck, anti-slop) pass
- [x] Pre-push validation (all 9 checks) pass
- [ ] Reviewer: open https://www.notion.so/b838bbf1d6824687a3eb8f94ef2b9536 — confirm Button has Story exports=22, ADR-010 risk=✓, Surface=shared

## Out of scope (separate PRs)

- argTypes / @summary coverage % fields (follow-up if needed)
- Cron / CI integration — manual `npm run extract:component-inventory` is enough until adoption proves the need
- Inventory of non-`components/ui/` stories (blueprints, foundation pages, dev tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)