### PR TITLE
docs(standards): @deprecated component retirement rule (closes #607)

### DIFF
--- a/.claude/standards/component-build.md
+++ b/.claude/standards/component-build.md
@@ -5,7 +5,7 @@ type: reference
 scope: brik-bds
 applies-to: "**/components/ui/**/*.{tsx,css}"
 retrieved-via: brik-rag query "component build standard"
-last-verified: 2026-05-13
+last-verified: 2026-05-14
 ---
 
 # Component build standard (BDS)
@@ -332,6 +332,46 @@ style={text.body}  // family + size + lineHeight matched correctly
 // ~/Documents/GitHub/brik/brik-bds/
 // Then: ./scripts/bds-sync.sh in each consuming project
 ```
+
+## Retiring a `@deprecated` component
+
+A `@deprecated` JSDoc tag is a *promise to remove the component*, not a permanent label. Without a retirement schedule, deprecated components ship banned-shape stories indefinitely — the AlertBanner case ([#605](https://github.com/brikdesigns/brik-bds/issues/605)) is the prototype: a `Variants` + `Patterns` story file lingered after the component was superseded by `<Banner tone="warning|error|information" />`, hidden from MCP via `tags: ['!manifest']` but still visible to humans in Storybook.
+
+Every deprecation moves through three stages:
+
+| Stage | When | What happens | What stays |
+|---|---|---|---|
+| **1. Deprecation lands** | A `@deprecated` JSDoc tag is added to the exported component | Story file gets `tags: ['!manifest']`; MDX `## Notes` adds *"Deprecated — use `<X>` instead. Stories will be retired in `vN.M`."*; file a retirement-tracker issue with the target version | Component continues to ship; consumers keep working |
+| **2. Stories retired** | **Two minor releases after Stage 1** (default; override via the JSDoc sentinel below) | Delete `Component.stories.tsx` + `Component.mdx`; PR references the tracker issue | `Component.tsx` + `Component.css` + `index.ts` export remain — consumers on the old API don't break |
+| **3. Component removed** | At the next **major** release | Delete the component directory; remove `index.ts` export; confirm consumer audit (portal / renew / web/{slug}) before merge | Tracker issue closes |
+
+### `@deprecated` JSDoc shape
+
+Every `@deprecated` tag must name the replacement and (optionally) override the default retirement schedule:
+
+```tsx
+/**
+ * @deprecated Use `<Banner tone="warning" />` instead.
+ *   Slated for retirement in v0.70 (current: v0.67).
+ */
+export function AlertBanner(...) { ... }
+```
+
+The sentinel `Slated for retirement in vN.M` parses cleanly for future linting (deferred — see #607). Omit it to accept the default (two minors after the tag was added).
+
+### Default schedule (N=2 minors)
+
+Two minor releases is the Carbon-aligned default — long enough for downstream consumers to migrate at a comfortable cadence, short enough that drift doesn't accumulate. Override with the JSDoc sentinel when:
+
+- A consumer has explicitly asked for more time (rare; capture the ask in the tracker issue)
+- The replacement isn't shipped yet (the deprecation is aspirational; pick a target after replacement lands)
+- The deprecation is part of a coordinated multi-component sweep (use one shared target across the sweep)
+
+### What this rule does NOT cover
+
+- Cross-repo deprecation policy for `content-system/blueprints/**` or BCS resolvers — separate concern.
+- Retroactive audit of currently-`@deprecated` components in `components/ui/**` — file individual retirement-tracker issues; this rule applies forward-only to new deprecations.
+- Enforcement (`lint-jsdoc.js` extension) — deferred; today the rule is enforced by review.
 
 ## Migration checklist — updating an existing component
 


### PR DESCRIPTION
## Summary

Closes [#607](https://github.com/brikdesigns/brik-bds/issues/607). Adds a three-stage rule for retiring `@deprecated` components to [`.claude/standards/component-build.md`](.claude/standards/component-build.md). Motivated by the AlertBanner drift mode that surfaced during [#605](https://github.com/brikdesigns/brik-bds/issues/605) — a `@deprecated` component shipped banned-shape `Variants` + `Patterns` stories indefinitely until the gold-standard Banner migration cleaned them up opportunistically.

Per #607 scoping (this PR is minimal-rule-first):

- **In:** the three-stage rule + the JSDoc shape with `Slated for retirement in vN.M` sentinel
- **Out:** `lint-jsdoc.js` extension to enforce the sentinel (deferred; grammar is captured here so it's ready to lint when needed)
- **Out:** retroactive audit of existing `@deprecated` components in `components/ui/**` (rule applies forward-only — separate task to file individual retirement-tracker issues)

## The rule

| Stage | When | What happens | What stays |
|---|---|---|---|
| **1. Deprecation lands** | `@deprecated` JSDoc tag added | Story file gets `tags: ['!manifest']`; MDX `## Notes` adds *"Deprecated — use `<X>` instead. Stories will be retired in vN.M."*; file retirement-tracker issue | Component continues to ship |
| **2. Stories retired** | **Two minor releases after Stage 1** (default; override via JSDoc sentinel) | Delete `Component.stories.tsx` + `Component.mdx` | `Component.tsx` + `Component.css` + `index.ts` export remain |
| **3. Component removed** | At the next major release | Delete the component directory; remove `index.ts` export; confirm consumer audit | — |

N=2 is the Carbon-aligned default. Components with consumer constraints override via the JSDoc sentinel:

```tsx
/**
 * @deprecated Use `<Banner tone="warning" />` instead.
 *   Slated for retirement in v0.70 (current: v0.67).
 */
export function AlertBanner(...) { ... }
```

## Files changed

- `.claude/standards/component-build.md` — new section "Retiring a `@deprecated` component", placed before the existing "Migration checklist" section. `last-verified` bumped to 2026-05-14.

## brik-rag re-ingest

Re-ran `scripts/ingest-component-build-standard.sh`:

```
corpus_id: dbb0c44b-207e-442d-88ac-42e72d0e1036
chunk_id:  memory/brik-bds/component-build-standard
char_count: 16910
status:    written
```

## Test plan

- [x] Pre-commit hooks (gitleaks, typecheck) pass
- [x] Pre-push validation (all 9 checks) pass
- [x] brik-rag re-ingest succeeded
- [ ] Reviewer: `brik-rag query "@deprecated retirement"` should surface the new section in top results

## References

- Parent umbrella: [#587](https://github.com/brikdesigns/brik-bds/issues/587)
- Proximate motivator: [#605](https://github.com/brikdesigns/brik-bds/issues/605) (AlertBanner retirement)
- Banned-export ADRs: [ADR-006](docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md), [ADR-010](docs/adrs/ADR-010-storybook-axes-of-information.md)
- Future Phase 4 lint: [#569](https://github.com/brikdesigns/brik-bds/issues/569)

🤖 Generated with [Claude Code](https://claude.com/claude-code)