### PR TITLE
feat(components): Button gold-standard migration + refine ADR-010 risk metric (#587 Phase 3 Batch 1, refs #613)

### DIFF
--- a/components/ui/Button/Button.mdx
+++ b/components/ui/Button/Button.mdx
@@ -20,9 +20,9 @@ Triggers an event or action. The button family includes three components for dif
 
 - **6 brand variants** — `primary` / `outline` / `secondary` / `ghost` / `inverse` / `on-color`. General action hierarchy.
 - **3 system variants** — `destructive` / `positive` / `selected`. Semantic action meaning.
-- **3 legacy aliases** — `danger` / `danger-outline` / `danger-ghost`. Still supported, but prefer `destructive` (and the system ladder generally). No Storybook story exists for these — see [Legacy aliases](#legacy-aliases) below.
+- **3 legacy aliases** — `danger` / `danger-outline` / `danger-ghost`. Still supported, but prefer `destructive`. No Storybook story exists for these — see [Legacy aliases](#legacy-aliases) below.
 
-Plus state variants (disabled, loading) and composition variants (icon slots).
+State props (`disabled`, `loading`, `fullWidth`) and composition slots (`iconBefore`, `iconAfter`) are Controls in the Playground, not standalone stories — per ADR-010 Q2.
 
 ### Primary
 
@@ -60,27 +60,25 @@ Plus state variants (disabled, loading) and composition variants (icon slots).
 
 <Canvas of={Stories.Positive} />
 
-### Disabled
-
-<Canvas of={Stories.Disabled} />
-
-### Loading
-
-<Canvas of={Stories.Loading} />
-
-### With leading icon
-
-<Canvas of={Stories.WithIconBefore} />
-
-### With trailing icon
-
-<Canvas of={Stories.WithIconAfter} />
-
 ### Sizes
 
 Side-by-side comparison of the five size tokens — qualifies as the ADR-006 axis-only gallery exception (one variant, size axis varied).
 
 <Canvas of={Stories.Sizes} />
+
+### Legacy aliases
+
+Three values in `ButtonVariant` ship without a dedicated story because they're aliases of `destructive` retained for back-compat:
+
+- `danger` → use `destructive` (identical visual, system-red fill)
+- `danger-outline` → use `destructive` with `outline` if you need lower emphasis; the alias remains for code that hasn't migrated
+- `danger-ghost` → use a ghost button styled as destructive; the alias remains for inline-delete code
+
+New code should pick from the documented 9 above. The aliases are TypeScript-valid but won't render anything different from their canonical sibling.
+
+## Patterns
+
+Multi-component compositions and sibling-component showcases. Each is a Q4 irreducible render-mode story per ADR-010 — args alone can't express the composition or hook-driven state.
 
 ### LinkButton
 
@@ -99,36 +97,6 @@ An icon-only button with a required `label` prop for accessibility.
 Click to simulate an async action. Render-mode demo because the toggle interaction can't be expressed with args alone.
 
 <Canvas of={Stories.LoadingToggle} />
-
-### Legacy aliases
-
-Three values in `ButtonVariant` ship without a dedicated story because they're aliases of `destructive` retained for back-compat:
-
-- `danger` → use `destructive` (identical visual, system-red fill)
-- `danger-outline` → use `destructive` with `outline` if you need lower emphasis; the alias remains for code that hasn't migrated
-- `danger-ghost` → use a ghost button styled as destructive; the alias remains for inline-delete code
-
-New code should pick from the documented 9 above. The aliases are TypeScript-valid but won't render anything different from their canonical sibling.
-
-## Type union
-
-The full `ButtonVariant` and `ButtonSize` contracts — the authoritative list of valid values:
-
-```ts
-type ButtonVariant =
-  | 'primary' | 'outline' | 'secondary' | 'ghost'
-  | 'inverse' | 'on-color'
-  | 'destructive' | 'positive' | 'selected'
-  | 'danger' | 'danger-outline' | 'danger-ghost'; // legacy aliases
-
-type ButtonSize = 'tiny' | 'sm' | 'md' | 'lg' | 'xl';
-```
-
-This block mirrors `components/ui/Button/Button.tsx`. If it drifts from the source `.tsx`, the type is canonical — fix this doc.
-
-## Patterns
-
-Three canonical compositions where Button does multi-component work alongside its siblings.
 
 ### Confirmation dialog
 

--- a/components/ui/Button/Button.stories.tsx
+++ b/components/ui/Button/Button.stories.tsx
@@ -16,17 +16,48 @@ const meta: Meta<typeof Button> = {
     layout: 'centered',
   },
   argTypes: {
+    children: {
+      control: 'text',
+      description: 'Button label. Accepts ReactNode for inline composition.',
+    },
     variant: {
       control: 'select',
       options: ['primary', 'outline', 'secondary', 'ghost', 'inverse', 'on-color', 'destructive', 'positive', 'selected'],
+      description:
+        'Brand hierarchy: `primary` → `outline` → `secondary` → `ghost`. ' +
+        '`inverse` for inverse surfaces; `on-color` for brand-primary surfaces. ' +
+        'System: `destructive`, `positive`, `selected`. ' +
+        'Legacy aliases (`danger`, `danger-outline`, `danger-ghost`) are TS-valid but prefer `destructive`.',
     },
     size: {
       control: 'select',
       options: ['tiny', 'sm', 'md', 'lg', 'xl'],
+      description: 'Size token on the 4-point grid. Default `md`.',
     },
-    fullWidth: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    loading: { control: 'boolean' },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretch to fill the container width.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the button — non-interactive, muted appearance, blocks `onClick`.',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Async-pending state — spinner replaces label, width preserved, click blocked.',
+    },
+    iconBefore: {
+      control: false,
+      description: 'Optional leading icon node. Common for actions like Add / Download.',
+    },
+    iconAfter: {
+      control: false,
+      description: 'Optional trailing icon node. Common for forward-motion CTAs.',
+    },
+    onClick: {
+      action: 'clicked',
+      description: 'Click handler. Not invoked when `disabled` or `loading`.',
+    },
   },
 };
 
@@ -113,7 +144,8 @@ export const Playground: Story = {
 };
 
 /** @summary Interaction test — disabled blocks click */
-export const InteractionTest: Story = {
+export const InteractionTestDisabled: Story = {
+  tags: ['!manifest'],
   args: { variant: 'primary', size: 'md', children: 'Submit', disabled: true, onClick: fn() },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
@@ -181,28 +213,10 @@ export const Positive: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   VARIANTS — states + composition
+   AXIS-ONLY GALLERY (ADR-006 exception)
+   `disabled` / `loading` / `iconBefore` / `iconAfter` / `fullWidth`
+   collapsed to Controls per ADR-010 Q2.
    ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Disabled — locked, non-interactive, muted appearance */
-export const Disabled: Story = {
-  args: { variant: 'primary', size: 'md', children: 'Submit', disabled: true },
-};
-
-/** @summary Loading — async-pending state, spinner replaces text, width preserved */
-export const Loading: Story = {
-  args: { variant: 'primary', size: 'md', children: 'Save Changes', loading: true },
-};
-
-/** @summary With leading icon — icon precedes the label */
-export const WithIconBefore: Story = {
-  args: { variant: 'outline', size: 'md', children: 'Add item', iconBefore: <Plus /> },
-};
-
-/** @summary With trailing icon — icon follows the label, common for forward-motion CTAs */
-export const WithIconAfter: Story = {
-  args: { variant: 'primary', size: 'md', children: 'Get started', iconAfter: <ArrowRight /> },
-};
 
 /**
  * Sizes axis — qualifies as the ADR-006 §"axis-only gallery" exception:

--- a/scripts/extract-component-inventory.mjs
+++ b/scripts/extract-component-inventory.mjs
@@ -14,10 +14,22 @@
  *   - Component path    — components/ui/Button/Button.tsx
  *   - Story title       — meta.title literal (e.g. Components/Action/button)
  *   - Surface           — derived from meta.tags surface-* (shared/web/product/unknown)
- *   - Story exports     — count of `export const X (: Story)?` (excludes default meta)
+ *   - Story exports     — raw count of `export const X (: Story)?` (excludes default meta)
  *   - Deprecated        — meta.tags includes `!manifest`
- *   - ADR-010 risk      — computed: Story exports > 13 (Q2 collapse signal)
+ *   - ADR-010 risk      — computed: Q3-relevant export count > 13 (see below)
  *   - Last sync         — today (ISO date)
+ *
+ * ADR-010 risk metric (refined #613):
+ *   The raw export count over-counts Q4 (irreducible render-mode) and Q5
+ *   (`!manifest`-tagged interaction tests). Those are legitimate per the
+ *   matrix and don't represent Q2/Q3 inflation. We compute risk against
+ *   the *Q3-relevant* count instead:
+ *
+ *     q3RelevantExports = totalExports − renderModeExports − manifestHiddenExports
+ *
+ *   This makes the threshold a Q2/Q3 inflation gauge as ADR-010 intended:
+ *   "after migration: Playground + ~12 semantic variants + 1 axis-only = ~14
+ *   args-driven exports, with Q4 patterns layered on top per matrix."
  *
  * Coverage % fields (argTypes / @summary) deferred to a follow-up PR
  * because they need full TypeChecker prop-counting on the paired *.tsx
@@ -121,24 +133,60 @@ function extractMeta(sourceFile) {
 }
 
 /**
- * Counts exported story constants. Excludes the default export (meta).
- * A "story export" is any `export const X = …` at the top level.
+ * Walks exported story constants and classifies each by ADR-010 axis.
+ *
+ * Returns three counts:
+ *   - total            — every `export const X` (excludes default meta)
+ *   - renderMode       — story object has a `render:` property (Q4 irreducible
+ *                        OR ADR-006 axis-only gallery exception)
+ *   - manifestHidden   — story object has `tags: [..., '!manifest', ...]`
+ *                        (Q5 interaction test OR explicitly hidden from MCP)
+ *
+ * Q3-relevant count (used for risk) = total − renderMode − manifestHidden.
+ * Stories may match both renderMode and manifestHidden — they're counted in
+ * both buckets but only subtracted once (set semantics on the export name).
  */
-function countStoryExports(sourceFile) {
-  let count = 0;
+function analyzeStoryExports(sourceFile) {
+  const renderModeNames = new Set();
+  const manifestHiddenNames = new Set();
+  const allNames = new Set();
+
   ts.forEachChild(sourceFile, (node) => {
     if (!ts.isVariableStatement(node)) return;
     const isExported = (node.modifiers ?? []).some(
       (m) => m.kind === ts.SyntaxKind.ExportKeyword,
     );
     if (!isExported) return;
+
     for (const decl of node.declarationList.declarations) {
-      if (ts.isIdentifier(decl.name) && decl.name.text !== 'meta') {
-        count += 1;
+      if (!ts.isIdentifier(decl.name) || decl.name.text === 'meta') continue;
+      const exportName = decl.name.text;
+      allNames.add(exportName);
+
+      const initializer = unwrapAssertions(decl.initializer);
+      if (!initializer || !ts.isObjectLiteralExpression(initializer)) continue;
+
+      for (const prop of initializer.properties) {
+        if (!ts.isPropertyAssignment(prop) && !ts.isShorthandPropertyAssignment(prop)) continue;
+        if (!ts.isIdentifier(prop.name)) continue;
+
+        if (prop.name.text === 'render') {
+          renderModeNames.add(exportName);
+        } else if (prop.name.text === 'tags' && ts.isPropertyAssignment(prop)) {
+          const tags = getArrayStringLiterals(prop.initializer) ?? [];
+          if (tags.includes('!manifest')) manifestHiddenNames.add(exportName);
+        }
       }
     }
   });
-  return count;
+
+  const excluded = new Set([...renderModeNames, ...manifestHiddenNames]);
+  return {
+    total: allNames.size,
+    renderMode: renderModeNames.size,
+    manifestHidden: manifestHiddenNames.size,
+    q3Relevant: allNames.size - excluded.size,
+  };
 }
 
 function parseStoryFile(filePath) {
@@ -152,7 +200,7 @@ function parseStoryFile(filePath) {
   );
 
   const meta = extractMeta(sourceFile);
-  const storyExports = countStoryExports(sourceFile);
+  const exports = analyzeStoryExports(sourceFile);
 
   const surfaceTag = meta.tags.find((t) => SURFACE_TAGS.has(t));
   const surface = surfaceTag ? surfaceTag.replace('surface-', '') : 'unknown';
@@ -162,8 +210,11 @@ function parseStoryFile(filePath) {
     storyTitle: meta.title,
     surface,
     deprecated,
-    storyExports,
-    risk: storyExports > ADR_010_RISK_THRESHOLD,
+    storyExports: exports.total,
+    q3RelevantExports: exports.q3Relevant,
+    renderModeExports: exports.renderMode,
+    manifestHiddenExports: exports.manifestHidden,
+    risk: exports.q3Relevant > ADR_010_RISK_THRESHOLD,
     tags: meta.tags,
   };
 }
@@ -263,11 +314,12 @@ async function upsertRow(notion, row, existingId, today) {
 // ── Main ───────────────────────────────────────────────────────────────
 
 function logRowsTable(rows) {
-  const header = ['Name', 'Surface', 'Exports', 'Risk', 'Deprecated', 'Story title'];
+  const header = ['Name', 'Surface', 'Exports', 'Q3', 'Risk', 'Deprecated', 'Story title'];
   const cols = [header, ...rows.map((r) => [
     r.name,
     r.surface,
     String(r.storyExports),
+    String(r.q3RelevantExports),
     r.risk ? '⚠️ ' : '  ',
     r.deprecated ? 'yes' : '   ',
     r.storyTitle ?? '(no meta.title)',


### PR DESCRIPTION
## Summary

Mirrors PR #610 (Banner gold-standard) for **Button** — first component of [#613 Phase 3 Batch 1](https://github.com/brikdesigns/brik-bds/issues/613). Bundles a metric-side fix that the migration surfaced as necessary.

## Button — ADR-010 conformance

Applied the [ADR-010](docs/adrs/ADR-010-storybook-axes-of-information.md) story-vs-control matrix to all 22 existing exports:

| Q | Outcome | Stories |
|---|---|---|
| Q2 (collapse to Control) | **removed** | `Disabled`, `Loading`, `WithIconBefore`, `WithIconAfter` |
| Q3 (semantic starting points, keep) | kept | Playground + 9 variants (Primary, Outline, Secondary, Ghost, Inverse, OnColor, Selected, Destructive, Positive) + Sizes (axis-only gallery exception) |
| Q4 (irreducible, keep) | kept | LinkButtonShowcase, IconButtonShowcase, LoadingToggle, ConfirmationDialog, InlineDelete, ActionBar |
| Q5 (interaction test, keep + hide) | kept + tagged \`!manifest\` | InteractionTestDisabled (renamed from \`InteractionTest\` for clarity) |

**22 → 18 exports.** Every remaining export passes Q1–Q5 cleanly.

**\`argTypes\` expanded** 5 → 9 props with description on every entry (feeds MCP \`get-documentation\`, the \`<ArgTypes>\` table, and the Controls panel — all three at once per ADR-010 §\"argTypes is load-bearing\"). Added: \`children\`, \`iconBefore\`, \`iconAfter\`, \`onClick\`.

### Button.mdx cleanup

- Removed 4 \`### subsections\` for collapsed Q2 stories
- Moved \`### LinkButton\` / \`### IconButton\` / \`### Loading toggle\` from \`## Variants\` → \`## Patterns\` (correct ADR-010 placement — they're Q4 compositions, not variant axes)
- Removed \`## Type union\` (banned narrative section per [recipe acceptance criterion #6](.claude/standards/storybook-mdx-recipe.md) — duplicates \`<ArgTypes>\` content)

## Metric refinement — \`scripts/extract-component-inventory.mjs\`

The script's risk gate was \`total exports > 13\`. That raw count over-counts legitimate Q4 (irreducible render-mode) and Q5 (\`!manifest\`-tagged) exports — Button's matrix-conformant 18 would still trip the gate. Refined:

\`\`\`
q3RelevantExports = total − renderModeExports − manifestHiddenExports
risk = q3RelevantExports > 13
\`\`\`

The threshold is now the **Q3-inflation gauge** ADR-010 intended, not a raw-count proxy. Dry-run table grows a \`Q3\` column to surface the breakdown.

## Re-scope finding for #613

Inventory dry-run with the refined metric over the four #613 components:

| Component | Total exports | Q3-relevant | Verdict |
|---|---|---|---|
| **Button** | 18 | **10** | clears (this PR) |
| **Meter** | 18 | **14** | still flags — true Q3 inflation, valid migration target |
| **AddableEntryList** | 16 | **0** | clears — but all-render-mode (different problem) |
| **AddableComboList** | 14 | **0** | clears — same shape as AddableEntryList |

Two of the original four components turn out to have **all-render-mode galleries**, not Q3 inflation. The [story-shape standard §\"render is for irreducible cases only\"](.claude/standards/storybook-story-shape.md) bans documentation galleries dressed up as Q4, but the cleanup is structurally different from this PR's matrix migration.

**Recommend:** narrow #613 to Button + Meter (Q3 inflation), and file a separate issue for the Addable-family render-mode-gallery cleanup.

## Verification

- ✅ \`npx tsc --noEmit\` — clean
- ✅ \`npm run lint-storybook-recipe\` — 72/72 conforming
- ✅ \`npm test\` — 116/116 files, 694/694 tests pass
- ✅ \`node scripts/extract-component-inventory.mjs --dry-run\` — Button clears (Q3=10); Banner unchanged (Q3=5); Meter correctly still flags (Q3=14)
- ✅ Pre-commit suite: gitleaks, BDS token lint, JSDoc lint, recipe lint, typecheck, anti-slop CRITICAL — all clean
- ✅ Full validation suite (\`npm run validate\`): 9/9 checks pass including Storybook build
- ✅ Chromatic build #465 uploaded: https://www.chromatic.com/build?appId=69b8918cac3056b39424d5d3&number=465

### Friction surfaced — Chromatic quota

The Chromatic account is **out of snapshots for the month**. The Storybook build uploaded cleanly (295 files, 12.74 MB, 110 components / 508 stories) but no visual diffs were generated. Removed-story diffs aren't visual changes; remaining stories were unchanged in args. If a visual baseline is required before merge, billing needs a refill.

## Consumer sync plan

Button is in \`surface-shared\`. No \`@brikdesigns/bds\` API surface changed — only story shapes + docs + an internal script. After publish:

- [ ] Portal: \`npm update @brikdesigns/bds\` (no code changes needed)
- [ ] renew-pms: submodule bump
- [ ] brikdesigns: \`./scripts/bds-sync.sh\`

## References

- Parent umbrella: [#587](https://github.com/brikdesigns/brik-bds/issues/587) (Rearchitect Storybook standards)
- Phase 3 batch: [#613](https://github.com/brikdesigns/brik-bds/issues/613)
- Gold-standard reference: [PR #610](https://github.com/brikdesigns/brik-bds/pull/610) (Banner)
- Inventory DB foundation: [PR #611](https://github.com/brikdesigns/brik-bds/pull/611) (extract-component-inventory + Notion sync, closes #603)
- [ADR-010](docs/adrs/ADR-010-storybook-axes-of-information.md) — story-vs-control matrix
- [story-shape standard](.claude/standards/storybook-story-shape.md)
- [storybook-mdx-recipe standard](.claude/standards/storybook-mdx-recipe.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Follow-up issues filed

Architectural questions surfaced during review that don't belong in this PR's scope:

- [#615](https://github.com/brikdesigns/brik-bds/issues/615) — Model `selected` as a state prop, not a `ButtonVariant` member (breaking API change, needs consumer audit + migration plan)
- [#616](https://github.com/brikdesigns/brik-bds/issues/616) — Extract IconButton to own stories file + MDX page (`Components/Action/icon-button`)
- [#617](https://github.com/brikdesigns/brik-bds/issues/617) — Relocate Button.mdx `## Patterns` stories: ConfirmationDialog → Dialog, InlineDelete → InteractiveListItem, ActionBar → ButtonGroup or drop

This PR ships the matrix migration as scoped; the follow-ups will further reduce Button's sidebar footprint and clean up cross-component pattern placement.