### PR TITLE
feat(forms): TextArea gold-standard — single Default story (#618 Batch A)

### DIFF
--- a/components/ui/TextArea/TextArea.mdx
+++ b/components/ui/TextArea/TextArea.mdx
@@ -8,17 +8,17 @@ import * as Stories from './TextArea.stories';
 
 <ComponentLinks slug="text-area" />
 
-Multi-line text input with configurable rows, resize behavior, and size variants. Use for longer-form text entry like comments, descriptions, and messages.
+Themed multi-line text input with optional label, helper text, error state, and configurable rows / resize. Uses BDS semantic tokens for color, border, and typography — same visual contract as `TextInput`.
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Sizes, states, and resize modes.
+TextArea has no semantic-variant axis — all variation (size, rows, resize mode, error, disabled, helper text) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 - **`sm`** — 14px text, compact forms
 - **`md`** — 16px text, default
@@ -31,13 +31,6 @@ Resize modes:
 - **`both`** — Width and height
 - **`horizontal`** — Width only
 
-## Patterns
-
-Real-world usage: feedback form and compact notes.
-
-<Canvas of={Stories.Patterns} />
-
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/TextArea/TextArea.stories.tsx
+++ b/components/ui/TextArea/TextArea.stories.tsx
@@ -1,144 +1,86 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
 import { TextArea } from './TextArea';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children, gap = 'var(--padding-sm)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', gap, flexWrap: 'wrap', alignItems: 'flex-start' }}>{children}</div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
 
 /* ─── Meta ────────────────────────────────────────────────────── */
 
-const meta = {
+const meta: Meta<typeof TextArea> = {
   title: 'Components/Form/text-area',
   component: TextArea,
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
+  decorators: [(Story) => <div style={{ width: 420 }}><Story /></div>],
   argTypes: {
-    size: { control: 'select', options: ['sm', 'md', 'lg'] },
-    label: { control: 'text' },
-    placeholder: { control: 'text' },
-    helperText: { control: 'text' },
-    error: { control: 'text' },
-    rows: { control: 'number' },
-    fullWidth: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    resize: { control: 'select', options: ['none', 'both', 'horizontal', 'vertical'] },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size token (sm=14px body, md=16px body, lg=18px body). Default `md`.',
+    },
+    label: {
+      control: 'text',
+      description: 'Optional label rendered above the field. Auto-wires `htmlFor`/`id`.',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text shown when the field is empty.',
+    },
+    helperText: {
+      control: 'text',
+      description: 'Hint text under the field. Hidden when `error` is present.',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message. Triggers `aria-invalid` and replaces `helperText`.',
+    },
+    rows: {
+      control: { type: 'number', min: 1, max: 20, step: 1 },
+      description: 'Number of visible text rows. Default `4`.',
+    },
+    resize: {
+      control: 'select',
+      options: ['none', 'both', 'horizontal', 'vertical'],
+      description: 'CSS resize behavior. Default `vertical`. `disabled` forces `none`.',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretch to fill container width.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the field — non-interactive, muted appearance, resize disabled.',
+    },
+    onChange: {
+      action: 'changed',
+      description: 'Native change handler.',
+    },
   },
-} satisfies Meta<typeof TextArea>;
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof TextArea>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — single canonical story per ADR-010 §components without
+   a variant axis. All variation (size, rows, resize, error,
+   disabled, helper text) is exposed via Controls.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Themed multi-line text input with label/helper/error */
+export const Default: Story = {
   args: {
-    label: 'Notes',
+    label: 'Description',
     placeholder: 'Enter your text here...',
     rows: 4,
     size: 'md',
     fullWidth: true,
   },
-};
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
 
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Sizes, states, resize modes
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <div style={{ width: 520 }}>
-      <Stack>
-        {/* Sizes */}
-        <div>
-          <SectionLabel>Sizes</SectionLabel>
-          <Row gap="var(--gap-lg)">
-            <div style={{ flex: 1 }}>
-              <TextArea size="sm" label="Small" placeholder="sm variant..." rows={3} fullWidth />
-            </div>
-            <div style={{ flex: 1 }}>
-              <TextArea size="md" label="Medium" placeholder="md variant..." rows={3} fullWidth />
-            </div>
-            <div style={{ flex: 1 }}>
-              <TextArea size="lg" label="Large" placeholder="lg variant..." rows={3} fullWidth />
-            </div>
-          </Row>
-        </div>
-
-        {/* States */}
-        <div>
-          <SectionLabel>States</SectionLabel>
-          <Stack gap="var(--gap-lg)">
-            <TextArea label="Default" placeholder="Enter your message..." rows={3} fullWidth />
-            <TextArea label="With value" defaultValue="This is some default text that appears in the textarea." rows={3} fullWidth />
-            <TextArea label="Helper text" placeholder="Describe your needs..." helperText="Maximum 500 characters" rows={3} fullWidth />
-            <TextArea label="Error" placeholder="Required field" error="This field is required" rows={3} fullWidth />
-            <TextArea label="Disabled" placeholder="This field is disabled" disabled rows={3} fullWidth />
-          </Stack>
-        </div>
-
-        {/* Resize modes */}
-        <div>
-          <SectionLabel>Resize modes</SectionLabel>
-          <Stack gap="var(--gap-lg)">
-            <TextArea label="Vertical (default)" placeholder="Resize vertically..." rows={3} resize="vertical" fullWidth />
-            <TextArea label="None" placeholder="Cannot be resized" rows={3} resize="none" fullWidth />
-            <TextArea label="Both" placeholder="Resize in any direction" rows={3} resize="both" fullWidth />
-          </Stack>
-        </div>
-      </Stack>
-    </div>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world form layouts
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Row gap="var(--padding-xl)">
-      {/* Feedback form */}
-      <div style={{ width: 400 }}>
-        <SectionLabel>Feedback form</SectionLabel>
-        <Stack gap="var(--gap-lg)">
-          <TextArea label="Description" placeholder="Describe your needs..." rows={4} fullWidth />
-          <TextArea label="Additional information" placeholder="Any other details..." rows={4} fullWidth />
-        </Stack>
-      </div>
-
-      {/* Compact notes */}
-      <div style={{ width: 300 }}>
-        <SectionLabel>Compact notes</SectionLabel>
-        <Stack gap="var(--gap-lg)">
-          <TextArea size="sm" label="Internal notes" placeholder="Add a note..." rows={3} resize="none" fullWidth />
-          <TextArea size="sm" label="Comments" placeholder="Share your feedback..." rows={6} fullWidth />
-        </Stack>
-      </div>
-    </Row>
-  ),
+    await expect(textarea).toBeVisible();
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, 'A short description.');
+    await expect(textarea).toHaveValue('A short description.');
+  },
 };


### PR DESCRIPTION
## Summary

Second component in Batch A of #618. Applies the framework + both merged ADR-010 amendments end-to-end.

**Before** — 3 exports (`Playground`, `Variants`, `Patterns`), render-mode galleries.

**After** — 1 `Default` story. No parked Q4 patterns. No `## Patterns` MDX section.

## What changed vs. TextInput's shape

TextArea ships even leaner than [#620 (TextInput)](https://github.com/brikdesigns/brik-bds/pull/620) — no parked Q4 stories. The old `FeedbackForm` + `CompactNotes` were single-primitive compositions (TextArea-only) that don't pass:

- **Q4 axis criteria** — not demonstrating orientation / layout / semantic-variant
- **Multi-primitive Patterns/Forms criteria** — single primitive per ADR-010 amendment §1

So they were inflation, not coverage. Deleted.

The Batch A wrap-up PR will author real multi-primitive `Patterns/Forms/*.stories.tsx` files combining TextArea + TextInput + Button + Checkbox etc. — that's where authentic form compositions belong.

## Framework alignment

- [x] One `Default` story per ADR-010 §components without a variant axis
- [x] No per-state stories (`error`, `disabled`, `withLabel` etc. → Controls)
- [x] `argTypes` with descriptions on every prop
- [x] `@summary` JSDoc on every story export
- [x] Single `surface-shared` tag in `meta.tags`
- [x] MDX recipe conformant: `## Playground` → `## Variants` → `## Props`
- [x] No `## Patterns` (conditional per ADR-007; no Q4 stories)
- [x] Meta annotation style `Meta<typeof TextArea>` (was `satisfies Meta<typeof TextArea>`) for consistency with Banner / Button gold-standard
- [x] Play test on `Default`

## Verification

- `npm run typecheck` ✅
- `node scripts/lint-storybook-recipe.js` ✅ (72/72 conforming)
- `npm run storybook` starts cleanly
- Pre-commit hooks all pass

## Test plan

- [ ] Reviewer opens Storybook → Components → Form → text-area
- [ ] Verify `Default` story renders with "Description" label + placeholder
- [ ] Toggle Controls — size / disabled / error / helperText / rows / resize all behave
- [ ] Chromatic snapshot regression review

## Related

- Parent: #618 (Batch A umbrella)
- Framework: PR #619 (ADR-010 amendment §1) + PR #621 (ADR-010 amendment §2)
- Sibling: PR #620 (TextInput) — same shape, slightly different parking decisions (TextInput shipped with parked Q4; TextArea ships clean per the merged amendment §1 strict reading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)