### PR TITLE
feat(forms): Select gold-standard — single Default story (#618 Batch A)

### DIFF
--- a/components/ui/Select/Select.mdx
+++ b/components/ui/Select/Select.mdx
@@ -8,33 +8,33 @@ import * as Stories from './Select.stories';
 
 <ComponentLinks slug="select" />
 
-Dropdown selection control with options, placeholder, optional leading icon, and size variants. Fills its container by default.
+Themed native `<select>` dropdown with optional label, helper text, error state, and leading icon. Accepts either a flat `SelectOption[]` or a mixed array containing `SelectOptionGroup` entries that render as `<optgroup>`.
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Sizes, icons, states, option groups, and width modes.
+Select has no semantic-variant axis — all variation (size, icon, options shape, error, disabled, helper text, fullWidth) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
-- **Default** — Light border (`--border-input`)
-- **Hover** — Darker border (`--border-primary`)
-- **Focus** — Brand border + ring (`--border-brand-primary`)
-- **Error** — Red border + ring (`--color-system-red`)
-- **Disabled** — 50% opacity
+- **`sm`** — 32px height, 14px body
+- **`md`** — 40px height, 16px body (default)
+- **`lg`** — 48px height, 18px body
 
-## Patterns
+States exposed via Controls:
 
-Real-world usage: form layouts and constrained containers.
-
-<Canvas of={Stories.Patterns} />
+- **Default** — light input border
+- **Hover** — darker border via `--border-primary`
+- **Focus** — brand border + focus ring
+- **Error** — red border + ring (set `error` Control)
+- **Disabled** — 50% opacity, non-interactive
 
 ## Props
 
-<ArgTypes of={Stories} />
+<ArgTypes of={Stories} exclude={['showLeadingIcon', 'showOptionGroups']} />
 
 ## CSS Override API
 
@@ -52,4 +52,3 @@ Component-scoped CSS variables exposed on `.bds-select`. Set on a wrapping eleme
   --select-icon-color: var(--text-brand-primary);
 }
 ```
-

--- a/components/ui/Select/Select.stories.tsx
+++ b/components/ui/Select/Select.stories.tsx
@@ -1,37 +1,17 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, within, fn } from 'storybook/test';
 import { Icon } from '@iconify/react';
-import { Select } from './Select';
+import { Select, type SelectProps, type SelectOption, type SelectOptionGroup } from './Select';
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
+/* ─── Sample data ─────────────────────────────────────────────── */
 
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Sample Data ─────────────────────────────────────────────── */
-
-const basicOptions = [
+const flatOptions: SelectOption[] = [
   { label: 'First choice', value: 'first' },
   { label: 'Second choice', value: 'second' },
   { label: 'Third choice', value: 'third' },
 ];
 
-const groupedOptions = [
+const groupedOptions: SelectOptionGroup[] = [
   {
     label: 'United States',
     options: [
@@ -50,179 +30,117 @@ const groupedOptions = [
   },
 ];
 
+/* ─── Story-only args ─────────────────────────────────────────── */
+
+/**
+ * Default story extends SelectProps with two story-only flags so the
+ * Controls panel can swap the leading icon and the options shape
+ * (flat vs grouped) without requiring the viewer to edit JSON arrays.
+ * Excluded from the MDX `<ArgTypes>` block.
+ */
+type DefaultArgs = SelectProps & {
+  showLeadingIcon?: boolean;
+  showOptionGroups?: boolean;
+};
+
 /* ─── Meta ────────────────────────────────────────────────────── */
 
-const meta: Meta<typeof Select> = {
+const meta: Meta<DefaultArgs> = {
   title: 'Components/Form/select',
   component: Select,
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
+  decorators: [(Story) => <div style={{ width: 360 }}><Story /></div>],
   argTypes: {
-    placeholder: { control: 'text' },
-    disabled: { control: 'boolean' },
-    size: { control: 'select', options: ['sm', 'md', 'lg'] },
-    fullWidth: { control: 'boolean' },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size token (sm=32px, md=40px, lg=48px). Default `md`.',
+    },
+    label: {
+      control: 'text',
+      description: 'Optional label rendered above the select. Auto-wires `htmlFor`/`id`.',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Empty-value option text shown when no selection has been made.',
+    },
+    helperText: {
+      control: 'text',
+      description: 'Hint text under the select. Hidden when `error` is present.',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message. Triggers `aria-invalid` and replaces `helperText`.',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretch wrapper to its container width. Default `true`.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the select — non-interactive, muted appearance.',
+    },
+    icon: {
+      control: false,
+      description: 'Optional leading icon node. Use `showLeadingIcon` Control in Storybook to toggle a sample tag icon.',
+    },
+    options: {
+      control: false,
+      description: 'Array of `SelectOption` (flat) or `SelectOptionGroup` (renders as `<optgroup>`). Mix freely. Use `showOptionGroups` Control in Storybook to swap sample data.',
+    },
+    onChange: {
+      action: 'changed',
+      description: 'Native change handler — receives the change event.',
+    },
+    showLeadingIcon: {
+      control: 'boolean',
+      description: 'Story-only — toggle a sample tag icon as `icon`.',
+      table: { category: 'Story-only' },
+    },
+    showOptionGroups: {
+      control: 'boolean',
+      description: 'Story-only — swap `options` between a flat list and `<optgroup>`-rendered groups.',
+      table: { category: 'Story-only' },
+    },
   },
 };
 
 export default meta;
-type Story = StoryObj<typeof Select>;
+type Story = StoryObj<DefaultArgs>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — single canonical story per ADR-010 §components without
+   a variant axis. All variation (size, icon, options shape, error,
+   disabled, helper text) is exposed via Controls.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Themed native select with label/helper/error */
+export const Default: Story = {
   args: {
-    placeholder: 'Select one...',
-    options: basicOptions,
     label: 'Choice',
+    placeholder: 'Select one...',
     size: 'md',
+    fullWidth: true,
+    options: flatOptions,
+    showLeadingIcon: false,
+    showOptionGroups: false,
     onChange: fn(),
   },
+  render: ({ showLeadingIcon, showOptionGroups, options, ...args }) => (
+    <Select
+      {...args}
+      icon={showLeadingIcon ? <Icon icon="ph:tag" /> : undefined}
+      options={showOptionGroups ? groupedOptions : options}
+    />
+  ),
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const select = canvas.getByRole('combobox');
 
     await expect(select).toBeVisible();
     await userEvent.selectOptions(select, 'second');
-    await expect(args.onChange).toHaveBeenCalled();
     await expect(select).toHaveValue('second');
+    await expect(args.onChange).toHaveBeenCalled();
   },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Sizes, icons, states, groups
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack gap="var(--gap-huge)">
-      <div>
-        <SectionLabel>Sizes</SectionLabel>
-        <Stack gap="var(--gap-lg)">
-          <Select size="sm" placeholder="Small" options={basicOptions} icon={<Icon icon="ph:tag" />} />
-          <Select size="md" placeholder="Medium" options={basicOptions} icon={<Icon icon="ph:tag" />} />
-          <Select size="lg" placeholder="Large" options={basicOptions} icon={<Icon icon="ph:tag" />} />
-        </Stack>
-      </div>
-
-      <div>
-        <SectionLabel>With icon and label</SectionLabel>
-        <Select
-          label="Company"
-          placeholder="Select company..."
-          options={[
-            { label: 'Acme Corp', value: 'acme' },
-            { label: 'Globex Inc', value: 'globex' },
-            { label: 'Initech', value: 'initech' },
-          ]}
-          icon={<Icon icon="ph:buildings" />}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>With default value</SectionLabel>
-        <Select placeholder="Select one..." options={basicOptions} defaultValue="second" />
-      </div>
-
-      <div>
-        <SectionLabel>Disabled</SectionLabel>
-        <Select placeholder="Select one..." options={basicOptions} disabled />
-      </div>
-
-      <div>
-        <SectionLabel>Error state</SectionLabel>
-        <Select
-          label="Region"
-          placeholder="Select region..."
-          options={[
-            { label: 'North America', value: 'na' },
-            { label: 'Europe', value: 'eu' },
-            { label: 'Asia Pacific', value: 'apac' },
-          ]}
-          error="Please select a region"
-          icon={<Icon icon="ph:globe" />}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Option groups</SectionLabel>
-        <Select
-          label="Location"
-          placeholder="Select a city..."
-          options={groupedOptions}
-          icon={<Icon icon="ph:globe" />}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Compact (fullWidth=false)</SectionLabel>
-        <Select placeholder="Compact..." options={basicOptions} fullWidth={false} />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world compositions
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Stack gap="var(--gap-huge)">
-      {/* Form layout */}
-      <div>
-        <SectionLabel>Form layout</SectionLabel>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--padding-lg)' }}>
-          <div style={{ flex: '1 1 240px', minWidth: 0 }}>
-            <Select
-              label="Country"
-              placeholder="Select country..."
-              options={[
-                { label: 'United States', value: 'us' },
-                { label: 'Canada', value: 'ca' },
-                { label: 'United Kingdom', value: 'uk' },
-                { label: 'Australia', value: 'au' },
-              ]}
-              icon={<Icon icon="ph:globe" />}
-            />
-          </div>
-          <div style={{ flex: '1 1 240px', minWidth: 0 }}>
-            <Select
-              label="Industry"
-              placeholder="Select industry..."
-              options={[
-                { label: 'Technology', value: 'tech' },
-                { label: 'Healthcare', value: 'healthcare' },
-                { label: 'Finance', value: 'finance' },
-                { label: 'Education', value: 'education' },
-              ]}
-              icon={<Icon icon="ph:buildings" />}
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Constrained width */}
-      <div>
-        <SectionLabel>Constrained container</SectionLabel>
-        <div style={{ maxWidth: '320px' }}>
-          <Select
-            label="Role"
-            placeholder="Select role..."
-            options={[
-              { label: 'Admin', value: 'admin' },
-              { label: 'Editor', value: 'editor' },
-              { label: 'Viewer', value: 'viewer' },
-            ]}
-            helperText="Choose the permission level for this user"
-          />
-        </div>
-      </div>
-    </Stack>
-  ),
 };


### PR DESCRIPTION
## Summary

Third component in Batch A of #618. Same shape as TextArea (#625) + the icon-Control pattern from TextInput (#620), with one new wrinkle: a story-only Control for the flat-vs-grouped `options` shape.

**Before** — 3 exports (`Playground`, `Variants`, `Patterns`), render-mode galleries with hard-coded option lists and icon variants.

**After** — 1 `Default` story with three Storybook-only Controls under a "Story-only" category:

- `showLeadingIcon` — toggles a sample `ph:tag` icon (mirrors TextInput #620)
- `showOptionGroups` — swaps between `flatOptions` (3 simple choices) and `groupedOptions` (US / Europe cities under `<optgroup>`s)
- `options` itself is `control: false` — stays in the props table but avoids the awkward array editor

## What's deleted vs. the merged amendment §1

- Old `FormLayout` (2 Selects) — single-primitive, no Q4 axis → not in scope for Patterns/Forms either. Deleted.
- Old `ConstrainedContainer` (1 Select inside a 320px div) — single-primitive layout demo, covered by `fullWidth: false` Control. Deleted.

## Framework alignment

- [x] One `Default` story per ADR-010 §components without a variant axis
- [x] No per-state stories
- [x] `argTypes` with descriptions on every prop (including `options`, `icon`, `onChange`)
- [x] `@summary` JSDoc on Default
- [x] Single `surface-shared` tag
- [x] MDX recipe conformant: `## Playground` → `## Variants` → `## Props` → `## CSS Override API`
- [x] No `## Patterns` (no Q4 stories)
- [x] Story-only args excluded from `<ArgTypes>` via `exclude` prop
- [x] Play test on `Default` selects "second", verifies value + onChange call

## Verification

- `npm run typecheck` ✅
- `node scripts/lint-storybook-recipe.js` ✅ (72/72 conforming)
- `npm run storybook` starts cleanly
- All 9 pre-commit hooks pass

## Test plan

- [ ] Reviewer opens Storybook → Components → Form → select
- [ ] Default renders with flat 3-option choice, no icon
- [ ] Toggle `showLeadingIcon` → `ph:tag` appears as leading icon
- [ ] Toggle `showOptionGroups` → options swap to US/Europe cities with `<optgroup>` separators
- [ ] Toggle `error` Control to populate an error message
- [ ] Chromatic snapshot regression review

## Related

- Parent: #618 (Batch A umbrella)
- Framework: PR #619 + PR #621 (ADR-010 amendments §1 + §2)
- Siblings: PR #620 (TextInput), PR #625 (TextArea)

🤖 Generated with [Claude Code](https://claude.com/claude-code)