### PR TITLE
feat(input): AddressInput gold-standard — single Default with hook-driven autocomplete (#618 Batch A)

### DIFF
--- a/components/ui/AddressInput/AddressInput.mdx
+++ b/components/ui/AddressInput/AddressInput.mdx
@@ -8,28 +8,29 @@ import * as Stories from './AddressInput.stories';
 
 <ComponentLinks slug="address-input" />
 
-Location text input with a location icon and autocomplete suggestion dropdown. Designed for forms that require address or location entry.
+Location text input with a leading map-pin icon and an autocomplete suggestion dropdown. The component manages focus + dropdown visibility; the consumer owns the suggestions array and filtering logic. Visual treatment matches [`TextInput`](/?path=/docs/components-form-text-input--docs).
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Sizes and suggestion dropdown.
+AddressInput has no semantic-variant axis — all variation (size, label, placeholder, fullWidth) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-- **`md`** — standard size, default
-- **`sm`** — compact for dense layouts
+<Canvas of={Stories.Default} />
 
-<Canvas of={Stories.Variants} />
+- **`sm`** — 32px height, 14px body
+- **`md`** — 40px height, 16px body (default)
 
-## Patterns
-
-Interactive autocomplete with simulated suggestions. Type in the field to filter results.
-
-<Canvas of={Stories.Patterns} />
+AddressInput only ships two sizes today (no `lg`).
 
 ## Props
 
 <ArgTypes of={Stories} />
 
+## Notes
+
+> **Note** — AddressInput specialization is justified per [ADR-010 amendment §2](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) because the suggestion dropdown is unique interactive behavior beyond `<TextInput type="text" />`. The consumer provides the `suggestions` array and the filter logic; the component owns the open/close state, click-outside dismissal, and Escape key handling.
+
+> **Note** — The Default story embeds a controlled `useState` + filter hook in its `render` so the autocomplete flow is exercisable without leaving Storybook. Real consumers wire their own data source (Google Places API, internal address service, etc.) — the in-story hook is illustrative, not a recommended implementation.

--- a/components/ui/AddressInput/AddressInput.stories.tsx
+++ b/components/ui/AddressInput/AddressInput.stories.tsx
@@ -1,29 +1,10 @@
-import React from 'react';
+import { useState, useCallback, type ChangeEvent } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState, useCallback } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 import { Icon } from '@iconify/react';
 import { AddressInput, type AddressSuggestion } from './AddressInput';
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Mock Data ───────────────────────────────────────────────── */
+/* ─── Sample data ─────────────────────────────────────────────── */
 
 const mockSuggestions: AddressSuggestion[] = [
   { id: '1', label: '123 Main Street', description: 'Nashville, TN 37201', icon: <Icon icon="ph:house" /> },
@@ -42,14 +23,41 @@ const meta: Meta<typeof AddressInput> = {
   parameters: { layout: 'padded' },
   decorators: [
     (Story) => (
-      <div style={{ minHeight: 360, maxWidth: 520, padding: 'var(--padding-lg)' }}>
+      <div style={{ minHeight: 360, width: 420 }}>
         <Story />
       </div>
     ),
   ],
-  args: { placeholder: 'Enter address', size: 'md', fullWidth: true },
   argTypes: {
-    size: { control: 'select', options: ['sm', 'md'] },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Size token (sm=32px, md=40px). AddressInput only supports two sizes today. Default `md`.',
+    },
+    label: {
+      control: 'text',
+      description: 'Optional label rendered above the field. Auto-wires `htmlFor`/`id`.',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text shown when the field is empty.',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretch wrapper to its container width.',
+    },
+    suggestions: {
+      control: false,
+      description: 'Array of `AddressSuggestion` ({ id, label, description?, icon? }). Set in code — the Default story manages this via a hook in `render` to demonstrate the autocomplete flow.',
+    },
+    onSuggestionSelect: {
+      action: 'suggestion-selected',
+      description: 'Called when the user picks a suggestion from the dropdown. The component closes the dropdown automatically.',
+    },
+    onChange: {
+      action: 'changed',
+      description: 'Native change handler.',
+    },
   },
 };
 
@@ -57,76 +65,38 @@ export default meta;
 type Story = StoryObj<typeof AddressInput>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — single canonical story per ADR-010 §components without
+   a variant axis. The render function manages the suggestion-filter
+   hook internally because AddressInput's defining behavior (filter
+   suggestions as the user types) requires a controlled value + a
+   filtered suggestions array — args alone can't express it.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Location input with hook-driven autocomplete */
+export const Default: Story = {
   args: {
-    label: 'Address',
-    placeholder: 'Enter address',
+    label: 'Delivery address',
+    placeholder: 'Start typing an address...',
+    size: 'md',
+    fullWidth: true,
   },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Sizes, labels, static suggestions
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      {/* Sizes */}
-      <div>
-        <SectionLabel>Sizes</SectionLabel>
-        <Stack gap="var(--gap-lg)">
-          <AddressInput label="Medium (default)" placeholder="Enter address" fullWidth />
-          <AddressInput label="Small" size="sm" placeholder="Enter address" fullWidth />
-        </Stack>
-      </div>
-
-      {/* With suggestions visible */}
-      <div>
-        <SectionLabel>With suggestions dropdown</SectionLabel>
-        <AddressInput
-          label="Location"
-          defaultValue="Nash"
-          suggestions={mockSuggestions.slice(0, 3)}
-          onSuggestionSelect={(s) => console.log('Selected:', s)}
-          placeholder="Enter address"
-          fullWidth
-        />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Interactive autocomplete
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: function InteractivePattern() {
+  render: (args) => {
     const [value, setValue] = useState('');
     const [suggestions, setSuggestions] = useState<AddressSuggestion[]>([]);
 
-    const handleChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) => {
-        const query = e.target.value;
-        setValue(query);
-        setSuggestions(
-          query.length > 0
-            ? mockSuggestions.filter(
-                (s) =>
-                  s.label.toLowerCase().includes(query.toLowerCase()) ||
-                  s.description?.toLowerCase().includes(query.toLowerCase()),
-              )
-            : [],
-        );
-      },
-      [],
-    );
+    const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+      const query = e.target.value;
+      setValue(query);
+      setSuggestions(
+        query.length > 0
+          ? mockSuggestions.filter(
+              (s) =>
+                s.label.toLowerCase().includes(query.toLowerCase()) ||
+                s.description?.toLowerCase().includes(query.toLowerCase()),
+            )
+          : [],
+      );
+    }, []);
 
     const handleSelect = useCallback((suggestion: AddressSuggestion) => {
       setValue(suggestion.label);
@@ -134,20 +104,32 @@ export const Patterns: Story = {
     }, []);
 
     return (
-      <Stack>
-        <div>
-          <SectionLabel>Interactive autocomplete</SectionLabel>
-          <AddressInput
-            label="Delivery address"
-            value={value}
-            onChange={handleChange}
-            suggestions={suggestions}
-            onSuggestionSelect={handleSelect}
-            placeholder="Start typing an address..."
-            fullWidth
-          />
-        </div>
-      </Stack>
+      <AddressInput
+        {...args}
+        value={value}
+        onChange={handleChange}
+        suggestions={suggestions}
+        onSuggestionSelect={handleSelect}
+      />
     );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Delivery address') as HTMLInputElement;
+
+    await expect(input).toBeVisible();
+
+    // Type a partial query → suggestions filter live.
+    await userEvent.click(input);
+    await userEvent.type(input, 'Nash');
+    await expect(canvas.getByText('123 Main Street')).toBeVisible();
+
+    // Pick the first suggestion → input value updates, dropdown closes.
+    await userEvent.click(canvas.getByText('123 Main Street'));
+    await expect(input).toHaveValue('123 Main Street');
+
+    // Blur so the post-play canvas shows the canonical idle state
+    // (no focus ring, no open dropdown).
+    input.blur();
   },
 };


### PR DESCRIPTION
## Summary

Sixth component in Batch A of #618. Like PasswordInput (#630), lives in `Components/Input/` because the autocomplete behavior is unique per ADR-010 amendment §2.

**Before** — 3 exports (`Playground`, `Variants`, `Patterns`), with `Patterns` containing the only actually-useful demo (the hook-driven autocomplete).

**After** — 1 `Default` story that **promotes the autocomplete demo to canonical**. The hook-driven filter is the defining behavior of AddressInput; making it the Default removes the need for a separate Q4 story.

## Why the render hook is justified

AddressInput's defining behavior (filter suggestions as the user types) requires:

- Controlled `value` state
- Filtered `suggestions` array recomputed on each change

Args alone can't express this — it's a hook-driven state machine. Per ADR-010 Q4 (irreducible render), the render-mode demo is correct. But instead of being a separate `InteractiveAutocomplete` Q4 story alongside a static `Default`, we collapse to one story that IS the interactive demo — that's what consumers actually want to see, and what an MCP agent would reach for as a starting template.

## Framework alignment

- [x] One `Default` story per ADR-010 §components without a variant axis
- [x] No per-state stories
- [x] No show* booleans (Path A) — `suggestions` is a slot prop with `control: false`
- [x] `argTypes` with descriptions on every prop
- [x] `@summary` on Default
- [x] Single `surface-shared` tag
- [x] MDX recipe conformant: `## Playground` → `## Variants` → `## Props` → `## Notes`
- [x] No `## Patterns` (no separate Q4 — Default IS the interactive demo)
- [x] Play test exercises filter + selection + clean post-play state

## Verification

- `npm run typecheck` ✅
- `node scripts/lint-storybook-recipe.js` ✅ (72/72 conforming)
- `npm run storybook` starts cleanly
- All 9 pre-commit hooks pass

## Test plan

- [ ] Reviewer opens Storybook → Components → Input → address-input
- [ ] Default renders with "Delivery address" label, empty field
- [ ] Click into field + type "Nash" → 5 Nashville suggestions filter
- [ ] Click a suggestion → input value updates, dropdown closes
- [ ] Press Escape with dropdown open → dropdown dismisses
- [ ] Click outside the wrapper with dropdown open → dismisses
- [ ] Toggle `size: sm` Control → field shrinks to 32px
- [ ] Chromatic snapshot regression review

## Related

- Parent: #618 (Batch A umbrella)
- Framework: PR #619 + PR #621 (ADR-010 amendments §1 + §2)
- Siblings: #620 / #625 / #626 / #627 / #628 / #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)