### PR TITLE
feat(forms): CompletionToggle gold-standard — Single + Vertical + Horizontal (#618 Batch A — final)

### DIFF
--- a/components/ui/CompletionToggle/CompletionToggle.mdx
+++ b/components/ui/CompletionToggle/CompletionToggle.mdx
@@ -4,36 +4,42 @@ import * as Stories from './CompletionToggle.stories';
 
 <Meta of={Stories} />
 
-# CompletionToggle
+# Completion toggle
 
 <ComponentLinks slug="completion-toggle" />
 
-Circular completion control. The atomic primitive for representing the **complete / not complete** state on a discrete unit of work — a task, a checklist item, a clinical step. Renders as a `<button>` so it can stand alone as a click target in card chrome.
+Circular icon-only toggle for marking a discrete unit of work complete or incomplete. Renders as a `<button>` so it's a self-contained click target with native keyboard support (`Space` / `Enter`).
 
-**Distinct from `Checkbox`.** Checkbox is rectangular and intended for form selections (multi-select filter, "I agree to terms"). CompletionToggle is circular and intended for completion-state on units of work. The visual difference matches the semantic difference; reach for the right one based on what the box represents — a *selection* (square) vs. a *completion* (circle).
-
-For row-style use where the entire row is the click target (label + circle, like a sub-task row inside a sheet), use `Checklist` — it pairs this control's visual with a native `<label>` + `<input>` for proper form semantics and full-row click target.
+Use for task cards, completion lists, board-card chrome — anywhere a binary "complete / not complete" state lives on its own. For row-style use where an adjacent label is also the click target, use [`Checklist`](/?path=/docs/components-list-checklist--docs).
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Single} />
 
 ## Variants
 
-<Canvas of={Stories.Variants} />
+CompletionToggle varies along the **orientation** axis when grouped. Boolean state (`checked`, `disabled`) is exposed via Controls on the `Single` canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-- **Unchecked** — Empty circle with neutral border
-- **Checked** — Brand-primary fill with white checkmark
-- **Disabled** — Reduced opacity, no interaction (use during async save or for read-only items)
+### Single
 
-## Patterns
+<Canvas of={Stories.Single} />
 
-<Canvas of={Stories.Patterns} />
+### Vertical
 
-- **Card chrome** — Used as a self-contained toggle on a task card. The toggle is the click target; the rest of the card is something else (e.g. opens the task sheet).
-- **Inline list** — Stand-alone toggles next to label text. For full-row click targets, use `Checklist` instead of composing manually.
+<Canvas of={Stories.Vertical} />
+
+### Horizontal
+
+<Canvas of={Stories.Horizontal} />
 
 ## Props
 
 <ArgTypes of={Stories} />
 
+## Notes
+
+> **Note** — CompletionToggle is icon-only by design. For row-style use with an adjacent label as the click target, use [`Checklist`](/?path=/docs/components-list-checklist--docs) — same visual, paired with a native `<label>` + `<input>`.
+
+> **Note** — CompletionToggle is fully controlled. Consumers manage the `checked` state externally (typically in a task store or row state) and pass `onCheckedChange` to receive updates. The Storybook canvas wraps it with `useState` for interactive demo purposes.
+
+> **Note** — Sidebar title corrected to `Components/Form/completion-toggle` (kebab-case) to match the rest of the Form category. Previously `Components/Form/CompletionToggle` (CamelCase).

--- a/components/ui/CompletionToggle/CompletionToggle.stories.tsx
+++ b/components/ui/CompletionToggle/CompletionToggle.stories.tsx
@@ -1,52 +1,28 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
 import { CompletionToggle } from './CompletionToggle';
 
-/* ─── Layout helpers (story-only) ────────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div
-    style={{
-      fontFamily: 'var(--font-family-label)',
-      fontSize: 'var(--body-xs)', // bds-lint-ignore
-      textTransform: 'uppercase' as const,
-      letterSpacing: '0.05em',
-      marginBottom: 'var(--gap-md)',
-      color: 'var(--text-muted)',
-    }}
-  >
-    {children}
-  </div>
-);
-
-const Stack = ({
-  children,
-  gap = 'var(--gap-xl)',
-}: {
-  children: React.ReactNode;
-  gap?: string;
-}) => <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>;
-
-const Row = ({
-  children,
-  gap = 'var(--gap-lg)',
-}: {
-  children: React.ReactNode;
-  gap?: string;
-}) => (
-  <div style={{ display: 'flex', gap, flexWrap: 'wrap', alignItems: 'center' }}>{children}</div>
-);
-
-/* ─── Meta ───────────────────────────────────────────────────────── */
+/* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof CompletionToggle> = {
-  title: 'Components/Form/CompletionToggle',
+  title: 'Components/Form/completion-toggle',
   component: CompletionToggle,
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
-    checked: { control: 'boolean' },
-    disabled: { control: 'boolean' },
+    checked: {
+      control: 'boolean',
+      description: 'Current completion state. Seeds the in-story `useState` on initial render; click the toggle in the canvas to flip it interactively.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the toggle — non-interactive, muted appearance.',
+    },
+    onCheckedChange: {
+      action: 'checked-changed',
+      description: 'Called with the new boolean state when the toggle is clicked.',
+    },
   },
 };
 
@@ -54,11 +30,14 @@ export default meta;
 type Story = StoryObj<typeof CompletionToggle>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND
+   SINGLE — args-driven canonical instance. CompletionToggle is fully
+   controlled (no internal state), so the render wraps it with a
+   useState hook seeded from `args.checked`. Click the toggle in the
+   canvas to flip; the `disabled` Control locks it.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Circular completion toggle for task / item state */
+export const Single: Story = {
   args: {
     checked: false,
     disabled: false,
@@ -67,114 +46,74 @@ export const Playground: Story = {
     const [checked, setChecked] = useState(args.checked);
     return <CompletionToggle {...args} checked={checked} onCheckedChange={setChecked} />;
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Mark complete' });
+
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    // Round-trip the state: not-complete → complete → not-complete.
+    // aria-label flips to "Mark incomplete" while checked so the next
+    // canvas.getByRole query has to match the new accessible name.
+    await userEvent.click(toggle);
+    await expect(canvas.getByRole('button', { name: 'Mark incomplete' })).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Mark incomplete' }));
+    await expect(canvas.getByRole('button', { name: 'Mark complete' })).toHaveAttribute('aria-pressed', 'false');
+
+    // Blur so the post-play canvas matches the canonical idle state.
+    (canvas.getByRole('button', { name: 'Mark complete' }) as HTMLElement).blur();
+  },
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS
+   ORIENTATION axis — Vertical / Horizontal group layouts per ADR-010
+   §components without a variant axis. CompletionToggle is icon-only
+   (no built-in label); consumers compose adjacent text via Checklist
+   for row-style use or wrap their own card chrome. The orientation
+   stories here show toggles in isolation so the spacing rhythm and
+   interactive behavior are clear without composition noise.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All states side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>States</SectionLabel>
-        <Row gap="var(--gap-xl)">
-          <CompletionToggle checked={false} onCheckedChange={() => {}} />
-          <CompletionToggle checked={true} onCheckedChange={() => {}} />
-          <CompletionToggle checked={false} onCheckedChange={() => {}} disabled />
-          <CompletionToggle checked={true} onCheckedChange={() => {}} disabled />
-        </Row>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Used as a standalone toggle on a card or as the click target inside a row composition */
-export const Patterns: Story = {
+/** @summary Vertical group — toggles stacked top-to-bottom */
+export const Vertical: Story = {
+  parameters: { layout: 'padded' },
   render: () => {
     const [items, setItems] = useState<Record<string, boolean>>({
       a: false,
       b: true,
       c: false,
+      d: false,
     });
     const toggle = (id: string) => setItems((prev) => ({ ...prev, [id]: !prev[id] }));
-
     return (
-      <Stack gap="var(--gap-huge)">
-        <div>
-          <SectionLabel>Card chrome (BoardCard pattern)</SectionLabel>
-          <div
-            style={{
-              maxWidth: '320px',
-              padding: 'var(--padding-lg)',
-              border: 'var(--border-width-md) solid var(--border-secondary)',
-              borderRadius: 'var(--border-radius-lg)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: 'var(--gap-md)',
-            }}
-          >
-            <span
-              style={{
-                fontFamily: 'var(--font-family-body)',
-                fontSize: 'var(--body-md)',
-                color: 'var(--text-primary)',
-              }}
-            >
-              Patient check-in processing
-            </span>
-            <CompletionToggle checked={items.a} onCheckedChange={() => toggle('a')} />
-          </div>
-        </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
+        {(['a', 'b', 'c', 'd'] as const).map((id) => (
+          <CompletionToggle key={id} checked={items[id]} onCheckedChange={() => toggle(id)} />
+        ))}
+      </div>
+    );
+  },
+};
 
-        <div>
-          <SectionLabel>Inline list of toggleable units</SectionLabel>
-          <Stack gap="var(--gap-md)">
-            <Row>
-              <CompletionToggle checked={items.b} onCheckedChange={() => toggle('b')} />
-              <span
-                style={{
-                  fontFamily: 'var(--font-family-body)',
-                  fontSize: 'var(--body-md)',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                Restock surgical gloves
-              </span>
-            </Row>
-            <Row>
-              <CompletionToggle checked={items.c} onCheckedChange={() => toggle('c')} />
-              <span
-                style={{
-                  fontFamily: 'var(--font-family-body)',
-                  fontSize: 'var(--body-md)',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                Sanitize workstations
-              </span>
-            </Row>
-          </Stack>
-          <p
-            style={{
-              fontFamily: 'var(--font-family-body)',
-              fontSize: 'var(--body-xs)',
-              color: 'var(--text-muted)',
-              marginTop: 'var(--gap-md)',
-            }}
-          >
-            For row-wide click targets with completion state, prefer{' '}
-            <code>{'<Checklist>'}</code> — it pairs this control with a native{' '}
-            <code>{'<label>'}</code> + <code>{'<input>'}</code>.
-          </p>
-        </div>
-      </Stack>
+/** @summary Horizontal group — toggles inline */
+export const Horizontal: Story = {
+  parameters: { layout: 'padded' },
+  render: () => {
+    const [items, setItems] = useState<Record<string, boolean>>({
+      a: true,
+      b: false,
+      c: false,
+      d: false,
+    });
+    const toggle = (id: string) => setItems((prev) => ({ ...prev, [id]: !prev[id] }));
+    return (
+      <div style={{ display: 'flex', flexDirection: 'row', gap: 'var(--gap-xl)', alignItems: 'center' }}>
+        {(['a', 'b', 'c', 'd'] as const).map((id) => (
+          <CompletionToggle key={id} checked={items[id]} onCheckedChange={() => toggle(id)} />
+        ))}
+      </div>
     );
   },
 };


### PR DESCRIPTION
## Summary

**Final Batch A primitive.** Matches the orientation pattern Checkbox (#632) and Radio (#633) ship with.

**Before** — 3 exports (`Playground`, `Variants`, `Patterns`), render-mode galleries including BoardCardChrome (CompletionToggle + card row) and InlineList (CompletionToggle + adjacent label).

**After** — 3 stories along the orientation axis: `Single` + `Vertical` + `Horizontal`. Old multi-primitive compositions deleted per ADR-010 amendment §1.

## Key changes

- **Title kebab-cased**: `Components/Form/CompletionToggle` → `Components/Form/completion-toggle`. Previously the only CamelCase outlier in the Form category.
- **`Single`** — args-driven with useState hook (CompletionToggle is fully controlled). Play test round-trips state + verifies the dynamic aria-label flips (`Mark complete` ↔ `Mark incomplete`).
- **`Vertical` / `Horizontal`** — pure icon-only orientation demos. Per-id state map so each toggle is independently interactive.
- **DELETED `BoardCardChrome`** — single-primitive composition (CompletionToggle + card chrome + text). Belongs in Board's stories, not CompletionToggle's. **Follow-up issue coming separately.**
- **DELETED `InlineList`** — single-primitive composition (CompletionToggle + adjacent text spans). Effectively a manual Checklist; consumers should use `Checklist` for row-style use.

## Framework alignment

- [x] Orientation Q3 axis per ADR-010 §components without a variant axis
- [x] Title kebab-case to match Form category convention
- [x] Boolean state (`checked`, `disabled`) → Controls
- [x] No show* booleans (Path A)
- [x] `argTypes` with descriptions
- [x] `@summary` on every story
- [x] Single `surface-shared` tag
- [x] MDX recipe conformant with three `### {Orientation}` sub-headings
- [x] No `## Patterns` (no Q4 stories)
- [x] Play test on `Single` verifies aria-pressed + dynamic aria-label

## Verification

- `npm run typecheck` ✅
- `node scripts/lint-storybook-recipe.js` ✅ (72/72 conforming)
- All 9 pre-commit hooks pass

## Test plan

- [ ] Reviewer opens Storybook → Components → Form → completion-toggle
- [ ] `Single` renders unchecked circle; click → fills with check; click → empties
- [ ] `Vertical` renders 4 toggles stacked, 2nd pre-checked
- [ ] `Horizontal` renders 4 toggles inline, 1st pre-checked
- [ ] Each toggle in groups is independently interactive
- [ ] `disabled` Control on Single locks the toggle
- [ ] Chromatic snapshot regression review

## Related

- Parent: #618 (Batch A umbrella — **all 9 primitives now have open PRs**)
- Framework: PR #619 + PR #621 (ADR-010 amendments §1 + §2)
- Orientation pattern precedents: #632 (Checkbox), #633 (Radio)
- Siblings: #620 / #625 / #626 / #627 / #628 / #630 / #631 / #632 / #633

## Follow-up issues to be filed

- BoardCard pattern relocation to Board's stories (the deleted BoardCardChrome demo)
- CompletionToggle + Checklist + Checkbox API alignment investigation (raised by reviewer — Checklist already has required `label`, but the visual/API overlap with CompletionToggle is worth a design call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)