### PR TITLE
feat(actions): FilterBar gold-standard — single hook-driven Default (#618 Batch B)

### DIFF
--- a/components/ui/FilterBar/FilterBar.mdx
+++ b/components/ui/FilterBar/FilterBar.mdx
@@ -39,3 +39,5 @@ State behavior to exercise:
 > **Note** — The Default story embeds a `useState` + `useMemo` filter pipeline because FilterBar's defining behavior (filter → recount → clear-button-appears) requires real state. Consumers wire their own data source; the in-story hook is illustrative.
 
 > **Note** — FilterBar does not expose a `disabled` prop. Filter children manage their own disabled state (e.g., `<FilterButton disabled />` greys out an individual filter). When the entire bar should be locked, gate at the consumer level (omit the bar entirely or render a read-only summary instead).
+
+> **Note** — FilterBar is fluid (`width: 100%`) — it fills its container. The Default story constrains the canvas to 1200px to match a typical desktop list/table viewport. Consumers control width via their layout. **Responsive collapse for narrow viewports (mobile: overflow filter children into a "Filters" sheet/drawer) is a known future improvement, not currently implemented** — tracked separately.

--- a/components/ui/FilterBar/FilterBar.mdx
+++ b/components/ui/FilterBar/FilterBar.mdx
@@ -4,42 +4,38 @@ import * as Stories from './FilterBar.stories';
 
 <Meta of={Stories} />
 
-# FilterBar
+# Filter bar
 
 <ComponentLinks slug="filter-bar" />
 
-Toolbar that pairs a result counter with one or more `FilterButton`s. Use above tables and lists to expose filtering controls plus a clear-all affordance.
+Toolbar that pairs a result counter with one or more filter controls ([`FilterButton`](/?path=/docs/components-action-filter-button--docs), [`FilterToggle`](/?path=/docs/components-action-filter-toggle--docs), or any compatible child). Use above tables and lists to expose filtering plus a clear-all affordance.
+
+Layout: `[title] [counter] ... [filter children] [clear?]`
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-### Filtered state
+FilterBar has no semantic-variant axis — all variation (title presence, counter status, clear-button visibility, filter children) is exposed via Controls + the hook-driven Default story. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-Counter shifts to the filtered result count when filters narrow the data.
+<Canvas of={Stories.Default} />
 
-<Canvas of={Stories.Filtered} />
+State behavior to exercise:
 
-### No title
-
-Drop the title for compact toolbars where the surrounding context is enough.
-
-<Canvas of={Stories.NoTitle} />
-
-### Clear callback omitted
-
-When `onClear` is not supplied, the clear-all affordance is suppressed.
-
-<Canvas of={Stories.NoClear} />
-
-## Patterns
-
-Full table + filter wiring with state, filter changes, and the clear-all flow.
-
-<Canvas of={Stories.Patterns} />
+- **Filtered** — pick an Industry or toggle "Active only" → counter switches to `activeStatus` color and reflects the filtered count
+- **No title** — clear the `title` Control → bar collapses to counter + children
+- **Clear button visibility** — automatic: appears when `filtered < total` AND `onClear` is provided; suppressed otherwise
 
 ## Props
 
 <ArgTypes of={Stories} />
+
+## Notes
+
+> **Note** — FilterBar is the canonical host for compositions of [`FilterButton`](/?path=/docs/components-action-filter-button--docs) and [`FilterToggle`](/?path=/docs/components-action-filter-toggle--docs). Don't reach for a manual flex row in consumer code; use FilterBar so the counter, clear-button placement, and aria-label all stay consistent.
+
+> **Note** — The Default story embeds a `useState` + `useMemo` filter pipeline because FilterBar's defining behavior (filter → recount → clear-button-appears) requires real state. Consumers wire their own data source; the in-story hook is illustrative.
+
+> **Note** — FilterBar does not expose a `disabled` prop. Filter children manage their own disabled state (e.g., `<FilterButton disabled />` greys out an individual filter). When the entire bar should be locked, gate at the consumer level (omit the bar entirely or render a read-only summary instead).

--- a/components/ui/FilterBar/FilterBar.stories.tsx
+++ b/components/ui/FilterBar/FilterBar.stories.tsx
@@ -35,7 +35,13 @@ const meta: Meta<typeof FilterBar> = {
   component: FilterBar,
   tags: ['surface-product'],
   parameters: { layout: 'padded' },
-  decorators: [(Story) => <div style={{ minHeight: 280 }}><Story /></div>],
+  decorators: [
+    // 1200px container matches a typical desktop list/table viewport — Table
+    // ships fluid (`width: 100%`) and FilterBar sits above it. The constraint
+    // is only on the story canvas, not the component itself; consumers
+    // control the width via their layout.
+    (Story) => <div style={{ width: '100%', maxWidth: 1200, minHeight: 280 }}><Story /></div>,
+  ],
   argTypes: {
     title: {
       control: 'text',

--- a/components/ui/FilterBar/FilterBar.stories.tsx
+++ b/components/ui/FilterBar/FilterBar.stories.tsx
@@ -4,6 +4,20 @@ import { fn } from 'storybook/test';
 import { FilterBar } from './FilterBar';
 import { FilterButton } from '../FilterButton';
 import { FilterToggle } from '../FilterToggle';
+import type { CounterStatus } from '../Counter';
+
+/* ─── Counter status options for the activeStatus Control ───────
+   Mirrors `CounterStatus` from ../Counter exactly. The `satisfies`
+   cast catches drift if Counter adds / renames statuses.
+   ─────────────────────────────────────────────────────────────── */
+const counterStatusOptions = [
+  'brand',
+  'success',
+  'error',
+  'warning',
+  'progress',
+  'neutral',
+] satisfies CounterStatus[];
 
 /* ─── Sample data ─────────────────────────────────────────────── */
 
@@ -57,8 +71,11 @@ const meta: Meta<typeof FilterBar> = {
     },
     activeStatus: {
       control: 'select',
-      options: ['brand', 'positive', 'warning', 'negative', 'neutral'],
-      description: 'Counter status when a filter is active. Default `brand` — gives the count a brand-color pill while filtered.',
+      options: counterStatusOptions,
+      description:
+        'Counter status when a filter is active. Default `brand` — gives the count a brand-color pill while filtered. ' +
+        '`success` / `error` / `warning` / `progress` convey semantic meaning about the filtered set (e.g. error status when filtering to error rows). ' +
+        '**`neutral` defeats the active-state visual** — the counter becomes indistinguishable from the inactive state, so it\'s rarely the right choice but supported for API completeness.',
     },
     total: {
       control: false,

--- a/components/ui/FilterBar/FilterBar.stories.tsx
+++ b/components/ui/FilterBar/FilterBar.stories.tsx
@@ -1,11 +1,11 @@
 import { useState, useMemo } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { fn, expect } from 'storybook/test';
+import { fn } from 'storybook/test';
 import { FilterBar } from './FilterBar';
 import { FilterButton } from '../FilterButton';
 import { FilterToggle } from '../FilterToggle';
 
-/* ─── Shared Fixtures ─────────────────────────────────── */
+/* ─── Sample data ─────────────────────────────────────────────── */
 
 type Row = { id: string; name: string; industry: string; status: 'active' | 'inactive' };
 
@@ -28,194 +28,111 @@ const industryOptions = [
   { id: 'creative', label: 'Creative' },
 ];
 
-const statusOptions = [
-  { id: 'active', label: 'Active' },
-  { id: 'inactive', label: 'Inactive' },
-];
+/* ─── Meta ────────────────────────────────────────────────────── */
 
-/* ─── Meta ────────────────────────────────────────────── */
-
-const meta = {
+const meta: Meta<typeof FilterBar> = {
   title: 'Components/Action/filter-bar',
   component: FilterBar,
   tags: ['surface-product'],
   parameters: { layout: 'padded' },
-  decorators: [
-    (Story) => (
-      <div style={{ width: '100%', minHeight: 200, padding: 'var(--padding-lg)' }}>
-        <Story />
-      </div>
-    ),
-  ],
-} satisfies Meta<typeof FilterBar>;
+  decorators: [(Story) => <div style={{ minHeight: 280 }}><Story /></div>],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Optional section heading rendered at heading-sm inline with the counter.',
+    },
+    label: {
+      control: 'text',
+      description: 'Plural entity label used in the aria-label fallback (e.g. "companies", "tasks").',
+    },
+    clearLabel: {
+      control: 'text',
+      description: 'Label for the clear button. Default `"Clear filters"`.',
+    },
+    activeStatus: {
+      control: 'select',
+      options: ['brand', 'positive', 'warning', 'negative', 'neutral'],
+      description: 'Counter status when a filter is active. Default `brand` — gives the count a brand-color pill while filtered.',
+    },
+    total: {
+      control: false,
+      description: 'Total count before filtering. Story drives this from `rows.length`.',
+    },
+    filtered: {
+      control: false,
+      description: 'Count after filtering. Story computes this from the hook-filtered subset.',
+    },
+    children: {
+      control: false,
+      description: 'FilterButton / FilterToggle children rendered to the right of the title + counter. Story injects industry + active-only filters.',
+    },
+    onClear: {
+      action: 'cleared',
+      description: 'Callback to clear all filters. When provided, a ghost "Clear filters" button appears while filtered < total.',
+    },
+  },
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof FilterBar>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, no filter applied; counter neutral
+   DEFAULT — full composition (bar + FilterButton + FilterToggle +
+   clear-all). Hook-driven because FilterBar's defining behavior is
+   interactive filtering with live counter updates. This is Q4
+   irreducible per ADR-010 — args alone can't express the filter →
+   recount → clear-button-appears cycle. The Default story IS the
+   canonical use case; no separate Patterns story needed.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Heading + counter + filter children + clear-all */
+export const Default: Story = {
   args: {
-    title: 'Companies',
-    total: rows.length,
-    filtered: rows.length,
-    label: 'companies',
-    children: (
-      <>
-        <FilterButton label="Industry" options={industryOptions} />
-        <FilterButton label="Status" options={statusOptions} />
-      </>
-    ),
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. FILTERED — Filter active; counter switches to brand + Clear button
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Filtered */
-export const Filtered: Story = {
-  args: {
-    title: 'Companies',
-    total: rows.length,
-    filtered: 3,
-    label: 'companies',
+    title: 'Engagements',
+    label: 'engagements',
+    clearLabel: 'Clear filters',
+    activeStatus: 'brand',
     onClear: fn(),
-    children: (
-      <>
-        <FilterButton label="Industry" options={industryOptions} value="saas" />
-        <FilterButton label="Status" options={statusOptions} />
-      </>
-    ),
   },
-  play: async ({ canvas, args }) => {
-    const clearBtn = await canvas.findByRole('button', { name: /clear filters/i });
-    await clearBtn.click();
-    await expect(args.onClear).toHaveBeenCalled();
-  },
-};
+  render: (args) => {
+    const [industry, setIndustry] = useState<string | undefined>(undefined);
+    const [activeOnly, setActiveOnly] = useState(false);
 
-/* ═══════════════════════════════════════════════════════════════
-   3. NO TITLE — Counter leads when title is omitted
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary No title */
-export const NoTitle: Story = {
-  args: {
-    total: rows.length,
-    filtered: rows.length,
-    label: 'companies',
-    children: (
-      <>
-        <FilterButton label="Industry" options={industryOptions} />
-        <FilterButton label="Status" options={statusOptions} />
-      </>
-    ),
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   4. NO CLEAR — onClear omitted so no button appears when filtered
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary No clear */
-export const NoClear: Story = {
-  args: {
-    title: 'Companies',
-    total: rows.length,
-    filtered: 2,
-    label: 'companies',
-    children: (
-      <>
-        <FilterButton label="Industry" options={industryOptions} value="legal" />
-      </>
-    ),
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   5. PATTERNS — Full table + filter wiring (real-world composition)
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  args: {
-    title: 'Companies',
-    total: rows.length,
-    filtered: rows.length,
-    label: 'companies',
-    children: null,
-  },
-  render: () => {
-    function Demo() {
-      const [industry, setIndustry] = useState<string | undefined>();
-      const [status, setStatus] = useState<string | undefined>();
-
-      const filtered = useMemo(() => {
-        return rows.filter((r) => {
+    const filteredRows = useMemo(
+      () =>
+        rows.filter((r) => {
           if (industry && r.industry !== industry) return false;
-          if (status && r.status !== status) return false;
+          if (activeOnly && r.status !== 'active') return false;
           return true;
-        });
-      }, [industry, status]);
+        }),
+      [industry, activeOnly],
+    );
 
-      const clearFilters = () => {
-        setIndustry(undefined);
-        setStatus(undefined);
-      };
+    const handleClear = () => {
+      setIndustry(undefined);
+      setActiveOnly(false);
+      args.onClear?.();
+    };
 
-      return (
-        <div>
-          <FilterBar
-            title="Companies"
-            total={rows.length}
-            filtered={filtered.length}
-            label="companies"
-            onClear={clearFilters}
-          >
-            <FilterButton
-              label="Industry"
-              options={industryOptions}
-              value={industry}
-              onChange={setIndustry}
-            />
-            <FilterButton
-              label="Status"
-              options={statusOptions}
-              value={status}
-              onChange={setStatus}
-            />
-            <FilterToggle
-              label="Active only"
-              active={status === 'active'}
-              onToggle={() => setStatus(status === 'active' ? undefined : 'active')}
-            />
-          </FilterBar>
-
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-            <thead>
-              <tr>
-                <th style={{ textAlign: 'left', padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)' }}>Name</th>
-                <th style={{ textAlign: 'left', padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)' }}>Industry</th>
-                <th style={{ textAlign: 'left', padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)' }}>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((r) => (
-                <tr key={r.id}>
-                  <td style={{ padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)' }}>{r.name}</td>
-                  <td style={{ padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)', textTransform: 'capitalize' }}>{r.industry}</td>
-                  <td style={{ padding: 'var(--padding-sm)', borderBottom: '1px solid var(--border-muted)', textTransform: 'capitalize' }}>{r.status}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      );
-    }
-    return <Demo />;
+    return (
+      <FilterBar
+        {...args}
+        total={rows.length}
+        filtered={filteredRows.length}
+        onClear={handleClear}
+      >
+        <FilterButton
+          label="Industry"
+          options={industryOptions}
+          value={industry}
+          onChange={setIndustry}
+        />
+        <FilterToggle
+          label="Active only"
+          active={activeOnly}
+          onToggle={() => setActiveOnly((prev) => !prev)}
+        />
+      </FilterBar>
+    );
   },
 };


### PR DESCRIPTION
## Summary

Third Batch B component. FilterBar is the **composite host** for filter compositions — per ADR-010 amendment §1, multi-primitive compositions live with the dominant host. So the canonical filter-row composition lands here as `Default`, not as a separate Patterns story.

**Before** — 5 exports (`Playground`, `Filtered`, `NoTitle`, `NoClear`, `Patterns`), render-mode galleries demonstrating prop-combination states.

**After** — 1 hook-driven `Default` that exercises every state via real filtering on a sample 8-row dataset.

## Framework alignment

- [x] One `Default` per ADR-010 §components without a variant axis
- [x] Q4 irreducible (filter → recount → clear-button-appears can't be expressed via args alone)
- [x] **The Q4 composition IS the canonical use case** — so no separate Patterns story (host = primary)
- [x] All prop-combination states reachable via Controls
- [x] No show* booleans (Path A)
- [x] `argTypes` with descriptions on every prop
- [x] `surface-product` tag preserved
- [x] MDX recipe conformant: Playground → Variants → Props → Notes
- [x] No `## Patterns` section
- [x] `## Notes` callout on **no `disabled` prop at the bar level** — children own their disabled state

## What the Default canvas demonstrates

- Industry FilterButton dropdown (5 options)
- Active-only FilterToggle
- Live counter that switches to `activeStatus` color when filtered
- Clear-all button that appears when `filtered < total`, disappears when all filters reset
- onClear resets all internal state

Try toggling Controls: clearing `title` → bar collapses; changing `activeStatus` → counter color when filtered changes; etc.

## Verification

- `npm run typecheck` ✅
- `node scripts/lint-storybook-recipe.js` ✅ (73 / 73 conforming)
- All 9 pre-commit hooks pass

## Test plan

- [ ] Reviewer opens Storybook → Components → Action → filter-bar
- [ ] Default renders title "Engagements" + counter (8) + two filters + no clear button
- [ ] Pick an Industry → counter recounts, color shifts to brand, clear button appears
- [ ] Toggle "Active only" → further filters, counter updates
- [ ] Click clear button → all filters reset, counter returns to 8, clear button hides
- [ ] Toggle `title` Control to empty → title disappears, layout collapses
- [ ] Change `activeStatus` to `positive` → filtered counter renders in positive color
- [ ] Chromatic snapshot regression review

## Related

- Parent: #618 (Batch B)
- Framework: PR #619 + #621 (ADR-010 amendments)
- Siblings (merged): #638 (FilterButton) + #639 (FilterToggle, both with disabled state wired in same PRs)
- Up next: TextLink (last Batch B sweep before ButtonGroup's own batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)