### PR TITLE
feat(actions): TextLink gold-standard — Default + InParagraph (#618 Batch B)

### DIFF
--- a/components/ui/TextLink/TextLink.mdx
+++ b/components/ui/TextLink/TextLink.mdx
@@ -4,40 +4,39 @@ import * as Stories from './TextLink.stories';
 
 <Meta of={Stories} />
 
-# TextLink
+# Text link
 
 <ComponentLinks slug="text-link" />
 
-Inline navigation link styled to match BDS typography. Two sizes (`default`, `small`); supports external-link semantics via `target` and `rel`.
+Themed inline anchor link styled to match BDS body typography. Muted text color that transitions to brand color on hover. Two sizes (`default`, `small`); accepts standard `<a>` attributes (`href`, `target`, `rel`) and optional leading / trailing icon slots.
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Default and small sizes side by side.
+TextLink has no semantic-variant axis on the component — size is the only Q3-candidate prop (2 values) and is exposed via Controls. External-link behavior is set via standard anchor Controls (`target`, `rel`), not a separate story. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
-### External
-
-External-link target opens in a new tab. Pair with `rel="noopener noreferrer"`.
-
-<Canvas of={Stories.External} />
-
-### In paragraph
-
-Inline link rendering inside body copy.
-
-<Canvas of={Stories.InParagraph} />
+- **`default`** — body-md (16px)
+- **`small`** — body-sm (14px), for footnotes / captions
 
 ## Patterns
 
-Navigation row with multiple links.
+### In paragraph
 
-<Canvas of={Stories.Patterns} />
+Demonstrates how the link visually integrates with flowing paragraph text. Surrounding body text is structural composition, not a component prop, so this case is irreducible (Q4) per [ADR-010](../../../docs/adrs/ADR-010-storybook-axes-of-information.md).
+
+<Canvas of={Stories.InParagraph} />
 
 ## Props
 
 <ArgTypes of={Stories} />
+
+## Notes
+
+> **Note** — For external links, set `target="_blank"` **and** `rel="noopener noreferrer"` together. The component doesn't add these automatically — the security pair is the consumer's responsibility. The Storybook Controls expose both for inline testing.
+
+> **Note** — **No `disabled` state today.** TextLink is an `<a>` element; HTML `disabled` doesn't apply to anchors. The accessible pattern is `aria-disabled="true"` + remove `href` + muted styling — not currently implemented. Tracked separately; consumers needing a disabled link should render plain text (or a [`Button variant="ghost"`](/?path=/docs/components-action-button--docs)) instead.

--- a/components/ui/TextLink/TextLink.stories.tsx
+++ b/components/ui/TextLink/TextLink.stories.tsx
@@ -1,22 +1,46 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { TextLink } from './TextLink';
 
+/* ─── Meta ────────────────────────────────────────────────────── */
+
 const meta: Meta<typeof TextLink> = {
   title: 'Components/Action/text-link',
   component: TextLink,
   tags: ['surface-shared'],
-  parameters: {
-    layout: 'centered',
-  },
+  parameters: { layout: 'centered' },
   argTypes: {
     size: {
       control: 'select',
       options: ['default', 'small'],
-      description: 'Size variant',
+      description: 'Size variant. `default` is body-md; `small` is body-sm for tight contexts (footnotes, captions).',
     },
     href: {
       control: 'text',
-      description: 'Link destination',
+      description: 'Link destination. Any standard URL or anchor.',
+    },
+    children: {
+      control: 'text',
+      description: 'Link text. Accepts ReactNode for inline composition (e.g., inline icons).',
+    },
+    target: {
+      control: 'select',
+      options: ['_self', '_blank', '_parent', '_top'],
+      description:
+        'Anchor target. Pair `target="_blank"` with `rel="noopener noreferrer"` for security on external links.',
+    },
+    rel: {
+      control: 'text',
+      description:
+        'Anchor relationship. For external links, use `"noopener noreferrer"` to prevent tab-nabbing.',
+    },
+    iconBefore: {
+      control: false,
+      description: 'Optional leading icon node (e.g. `<Icon icon="ph:arrow-left" />`).',
+    },
+    iconAfter: {
+      control: false,
+      description:
+        'Optional trailing icon node. Common pattern for external links: `<Icon icon="ph:arrow-square-out" />`.',
     },
   },
 };
@@ -24,98 +48,47 @@ const meta: Meta<typeof TextLink> = {
 export default meta;
 type Story = StoryObj<typeof TextLink>;
 
-// Basic link
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/* ═══════════════════════════════════════════════════════════════
+   DEFAULT — single canonical story per ADR-010 §components without
+   a variant axis. Size is the only Q3-candidate prop (2 values:
+   default / small), exposed via Controls. External-link behavior
+   (target=_blank + rel) is set via standard anchor attribute Controls,
+   not a separate story — the component has no "external" variant.
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Themed inline anchor link */
+export const Default: Story = {
   args: {
     href: '#',
-    children: 'Learn More',
+    size: 'default',
+    children: 'Learn more',
   },
 };
 
-// Small link
-/** @summary Small */
-export const Small: Story = {
-  args: {
-    href: '#',
-    size: 'small',
-    children: 'View Details',
-  },
-};
+/* ═══════════════════════════════════════════════════════════════
+   IN-PARAGRAPH — Q4 irreducible per ADR-010. Demonstrates how the
+   link visually integrates with flowing paragraph text (baseline
+   alignment, color contrast against body text, underline behavior).
+   Surrounding text is structural, not a component prop, so this
+   case can't be expressed via args alone.
+   ═══════════════════════════════════════════════════════════════ */
 
-// External link
-/** @summary External */
-export const External: Story = {
-  args: {
-    href: 'https://example.com',
-    target: '_blank',
-    rel: 'noopener noreferrer',
-    children: 'Visit Website',
-  },
-};
-
-// Link in context
-/** @summary In paragraph */
+/** @summary Link integrated with flowing paragraph text */
 export const InParagraph: Story = {
-  parameters: {
-    docs: {
-      source: {
-        code: `<p>
-  Our team specializes in web design and development.{' '}
-  <TextLink href="#">Learn more about our services</TextLink> or{' '}
-  <TextLink href="#">contact us</TextLink> to get started.
-</p>`,
-      },
-    },
-  },
+  parameters: { layout: 'padded' },
   render: () => (
     <p
       style={{
         fontFamily: 'var(--font-family-body)',
+        fontSize: 'var(--body-md)',
         color: 'var(--text-primary)',
-        maxWidth: '400px',
-        lineHeight: '1.6',
+        maxWidth: 480,
+        lineHeight: 'var(--font-line-height-normal)',
       }}
     >
       Our team specializes in web design and development.{' '}
       <TextLink href="#">Learn more about our services</TextLink> or{' '}
       <TextLink href="#">contact us</TextLink> to get started.
     </p>
-  ),
-};
-
-// Navigation links
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  parameters: {
-    docs: {
-      source: {
-        code: `<nav>
-  <TextLink href="#">Home</TextLink>
-  <TextLink href="#">About</TextLink>
-  <TextLink href="#">Services</TextLink>
-  <TextLink href="#">Contact</TextLink>
-</nav>`,
-      },
-    },
-  },
-  render: () => (
-    <nav style={{ display: 'flex', gap: 'var(--gap-xl)' }}>
-      <TextLink href="#">Home</TextLink>
-      <TextLink href="#">About</TextLink>
-      <TextLink href="#">Services</TextLink>
-      <TextLink href="#">Contact</TextLink>
-    </nav>
-  ),
-};
-
-// All variants in one view
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <div style={{ display: 'flex', gap: 'var(--gap-xl)', alignItems: 'center' }}>
-      <TextLink href="#">Default Link</TextLink>
-      <TextLink href="#" size="small">Small Link</TextLink>
-    </div>
   ),
 };


### PR DESCRIPTION
## Summary

Fourth Batch B component. Completes the Action category gold-standard sweep (sans ButtonGroup — deferred to its own batch for #617 absorption).

**Before** — 6 exports (`Playground`, `Small`, `External`, `InParagraph`, `Patterns`, `Variants`-equivalent).

**After** — 2 stories along the Q3 disposition: `Default` (args-driven) + `InParagraph` (Q4 irreducible).

## Q3 disposition reasoning

| Old export | Disposition | Why |
|---|---|---|
| `Playground` | Renamed to `Default` | Canonical sandbox |
| `Small` | **Delete** | `size` is a 2-value union with no semantic difference — pure Q2 Control |
| `External` | **Delete** | No component-level "external" variant exists. `target` + `rel` are standard anchor attributes → Q2 Controls |
| `InParagraph` | **Keep** | Q4 irreducible — paragraph wrapping behavior requires surrounding body text composition; can't be expressed via args |
| `Patterns` (nav row) | **Delete** | Single-primitive composition, doesn't pass amendment §1 multi-primitive criteria |

This is the **first Batch B component to ship with a Q4 `## Patterns` MDX section** because InParagraph genuinely qualifies (text-composition irreducibility).

## Framework alignment

- [x] Q3 matrix applied per ADR-010 amendment §1
- [x] No show* booleans (Path A)
- [x] `argTypes` with descriptions on every prop (size, href, target, rel, children, iconBefore, iconAfter)
- [x] `target` Control includes security note pairing with `rel`
- [x] `surface-shared` tag
- [x] MDX recipe conformant with `### In paragraph` sub-heading under `## Patterns`

## The disabled question

TextLink has **no disabled state today**. Documented in `## Notes` rather than implemented in this PR:

- TextLink is `<a>` (anchor), not `<button>` — native HTML `disabled` doesn't apply
- Correct pattern: `aria-disabled="true"` + remove `href` + muted styling
- Different design surface than the button-shaped FilterButton/FilterToggle (#638/#639 added disabled to those in their PRs)
- Consumer workaround: render plain text or `Button variant="ghost"` instead

Recommend tracking as a follow-up if/when consumer demand surfaces. **Open question for review — implement here or defer?**

## Verification

- `npm run typecheck` ✅
- `node scripts/lint-storybook-recipe.js` ✅ (73/73 conforming)
- All 9 pre-commit hooks pass

## Test plan

- [ ] Reviewer opens Storybook → Components → Action → text-link
- [ ] Default renders "Learn more" link with muted color + hover transition
- [ ] Toggle `size: small` → typography shifts to body-sm
- [ ] Set `target: _blank` + add `rel: noopener noreferrer` → anchor opens in new tab safely
- [ ] InParagraph renders link inline with body text, baseline-aligned
- [ ] Chromatic snapshot regression review

## Related

- Parent: #618 (Batch B)
- Framework: PR #619 + #621 (ADR-010 amendments)
- Siblings: #638 (FilterButton, merged), #639 (FilterToggle, merged), #640 (FilterBar, open)
- Deferred: ButtonGroup (own batch — #617 absorption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)