### PR TITLE
feat(actions): ButtonGroup — Default + IconButtonGroup + modal ActionBar (closes #617, #618 Batch B final)

### DIFF
--- a/components/ui/Button/Button.mdx
+++ b/components/ui/Button/Button.mdx
@@ -106,10 +106,6 @@ Click to simulate an async action. Render-mode demo because the toggle interacti
 
 <Canvas of={Stories.InlineDelete} />
 
-### Action bar
-
-<Canvas of={Stories.ActionBar} />
-
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/Button/Button.stories.tsx
+++ b/components/ui/Button/Button.stories.tsx
@@ -379,13 +379,3 @@ export const InlineDelete: Story = {
   ),
 };
 
-/** @summary Action bar — primary CTA + outline save + destructive discard */
-export const ActionBar: Story = {
-  render: () => (
-    <Row gap="var(--gap-lg)">
-      <Button variant="primary" iconAfter={<ArrowRight />}>Continue</Button>
-      <Button variant="outline">Save draft</Button>
-      <Button variant="destructive">Discard</Button>
-    </Row>
-  ),
-};

--- a/components/ui/ButtonGroup/ButtonGroup.css
+++ b/components/ui/ButtonGroup/ButtonGroup.css
@@ -1,55 +1,19 @@
 @layer bds-components {
 /**
  * BDS ButtonGroup — groups related buttons together
- * Variants: spaced (default) | segmented
  * Orientations: horizontal (default) | vertical
  * Align: start | center | end | between
+ *
+ * For mutually-exclusive option toolbars (shared borders), use
+ * SegmentedControl instead — that's its canonical home.
  */
 
 .bds-button-group {
   display: inline-flex;
   align-items: center;
   flex-wrap: wrap;
-  box-sizing: border-box;
-}
-
-/* ─── Variant: spaced (default) ──────────────────────────────── */
-
-.bds-button-group--spaced {
   gap: var(--gap-md);
-}
-
-/* ─── Variant: segmented — buttons share borders, no gap ─────── */
-
-.bds-button-group--segmented {
-  gap: 0;
-}
-
-/* Horizontal segmented: collapse adjacent borders + round only the
-   outer corners. Targets direct child buttons. */
-
-.bds-button-group--segmented:not(.bds-button-group--vertical) > *:not(:first-child) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  margin-left: calc(var(--border-width-sm) * -1);
-}
-
-.bds-button-group--segmented:not(.bds-button-group--vertical) > *:not(:last-child) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-/* Vertical segmented: same treatment on the vertical axis. */
-
-.bds-button-group--segmented.bds-button-group--vertical > *:not(:first-child) {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  margin-top: calc(var(--border-width-sm) * -1);
-}
-
-.bds-button-group--segmented.bds-button-group--vertical > *:not(:last-child) {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
+  box-sizing: border-box;
 }
 
 /* ─── Orientation: vertical ──────────────────────────────────── */

--- a/components/ui/ButtonGroup/ButtonGroup.css
+++ b/components/ui/ButtonGroup/ButtonGroup.css
@@ -1,20 +1,84 @@
 @layer bds-components {
 /**
  * BDS ButtonGroup — groups related buttons together
+ * Variants: spaced (default) | segmented
+ * Orientations: horizontal (default) | vertical
+ * Align: start | center | end | between
  */
 
 .bds-button-group {
   display: inline-flex;
   align-items: center;
-  gap: var(--gap-md);
   flex-wrap: wrap;
   box-sizing: border-box;
 }
+
+/* ─── Variant: spaced (default) ──────────────────────────────── */
+
+.bds-button-group--spaced {
+  gap: var(--gap-md);
+}
+
+/* ─── Variant: segmented — buttons share borders, no gap ─────── */
+
+.bds-button-group--segmented {
+  gap: 0;
+}
+
+/* Horizontal segmented: collapse adjacent borders + round only the
+   outer corners. Targets direct child buttons. */
+
+.bds-button-group--segmented:not(.bds-button-group--vertical) > *:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: calc(var(--border-width-sm) * -1);
+}
+
+.bds-button-group--segmented:not(.bds-button-group--vertical) > *:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+/* Vertical segmented: same treatment on the vertical axis. */
+
+.bds-button-group--segmented.bds-button-group--vertical > *:not(:first-child) {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  margin-top: calc(var(--border-width-sm) * -1);
+}
+
+.bds-button-group--segmented.bds-button-group--vertical > *:not(:last-child) {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+/* ─── Orientation: vertical ──────────────────────────────────── */
 
 .bds-button-group--vertical {
   flex-direction: column;
   align-items: stretch;
 }
+
+/* ─── Align: horizontal alignment (ignored when fullWidth=true) ─ */
+
+.bds-button-group--align-start {
+  justify-content: flex-start;
+}
+
+.bds-button-group--align-center {
+  justify-content: center;
+}
+
+.bds-button-group--align-end {
+  justify-content: flex-end;
+}
+
+.bds-button-group--align-between {
+  justify-content: space-between;
+  width: 100%;
+}
+
+/* ─── Full width ────────────────────────────────────────────── */
 
 .bds-button-group--full-width {
   width: 100%;

--- a/components/ui/ButtonGroup/ButtonGroup.mdx
+++ b/components/ui/ButtonGroup/ButtonGroup.mdx
@@ -8,35 +8,37 @@ import * as Stories from './ButtonGroup.stories';
 
 <ComponentLinks slug="button-group" />
 
-Groups related [`Button`](/?path=/docs/components-action-button--docs) (or [`IconButton`](/?path=/docs/components-action-button--docs)) components into a single visual unit. Two layout treatments via `variant`: `spaced` (default) keeps a gap between buttons; `segmented` collapses adjacent borders into a single toolbar.
+Groups related [`Button`](/?path=/docs/components-action-button--docs) or [`IconButton`](/?path=/docs/components-action-button--docs) components with consistent spacing and alignment. Use `align` to control placement within the container — replaces prior manual `<Row style={{ justifyContent: ... }}>` patterns.
+
+For mutually-exclusive option toolbars (Day / Week / Month), use [`SegmentedControl`](/?path=/docs/components-control-segmented-control--docs) instead — its shared-border treatment is the canonical home for that pattern.
 
 ## Playground
 
-<Canvas of={Stories.Spaced} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Per [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md), `variant` is the Q3 layout axis for ButtonGroup — segmented vs spaced is a real layout shape difference, not just a prop tweak. Orientation, align, and fullWidth stay as Controls.
+ButtonGroup has no semantic-variant prop — composition shapes are demonstrated via children + the `align` Control. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-### Spaced
+### Default
 
-<Canvas of={Stories.Spaced} />
+<Canvas of={Stories.Default} />
 
-Default layout — a gap (`var(--gap-md)`) between buttons. Canonical for form footers, dialog actions, and standard action sets.
+Canonical action set — one primary + two secondary buttons (`outline`, `ghost`). Default `align="start"` for form footers; toggle to `center` / `end` / `between` for different placement.
 
-### Segmented
+### Icon-button group
 
-<Canvas of={Stories.Segmented} />
+<Canvas of={Stories.IconButtonGroup} />
 
-Buttons share borders into a single toolbar unit (no gap, rounded ends only). Use for view-mode toggles, time-range switchers, and similar mutually-exclusive option toolbars.
+Inline toolbar of [`IconButton`](/?path=/docs/components-action-button--docs) children — up to 4 actions. Common for row / card chrome (edit, copy, share, delete). The final destructive variant signals an irreversible action.
 
 ## Patterns
 
-### Action bar
+### Action bar (modal / sheet)
 
 <Canvas of={Stories.ActionBar} />
 
-`align="between"` places the first child against the leading edge and the last child against the trailing edge — replaces the prior manual `<Row style={{ justifyContent: 'space-between' }}>` pattern from Button stories. **Closes [#617](https://github.com/brikdesigns/brik-bds/issues/617).**
+Modal and sheet bottom rows follow the platform convention: **primary action far right, secondary action to its left**. `align="end"` with `[Cancel, Save]` order achieves this — matches macOS HIG, Material, Carbon, and Brik's design library. **Closes [#617](https://github.com/brikdesigns/brik-bds/issues/617).**
 
 ## Props
 
@@ -48,4 +50,6 @@ Buttons share borders into a single toolbar unit (no gap, rounded ends only). Us
 
 > **Note** — `align` is ignored when `fullWidth: true`. Full-width groups always stretch children edge-to-edge regardless of alignment.
 
-> **Note** — Migrating from the old manual `Row + justify-content: space-between` ActionBar pattern: replace with `<ButtonGroup align="between">`. The segmented border math is handled automatically — don't add manual `border-radius` overrides.
+> **Note** — Migrating from the old manual `<Row style={{ justifyContent: 'space-between' }}>` ActionBar pattern: replace with `<ButtonGroup align="end">` for modal / sheet rows or `<ButtonGroup align="between">` for destructive-on-left + primary-on-right patterns.
+
+> **Note** — For mutually-exclusive segmented option toolbars (Day / Week / Month, View modes), reach for [`SegmentedControl`](/?path=/docs/components-control-segmented-control--docs) instead. ButtonGroup is for action sets and freeform toolbars where buttons are independent actions.

--- a/components/ui/ButtonGroup/ButtonGroup.mdx
+++ b/components/ui/ButtonGroup/ButtonGroup.mdx
@@ -8,25 +8,44 @@ import * as Stories from './ButtonGroup.stories';
 
 <ComponentLinks slug="button-group" />
 
-Groups related buttons into a single visual unit. Use for action sets where buttons share context.
+Groups related [`Button`](/?path=/docs/components-action-button--docs) (or [`IconButton`](/?path=/docs/components-action-button--docs)) components into a single visual unit. Two layout treatments via `variant`: `spaced` (default) keeps a gap between buttons; `segmented` collapses adjacent borders into a single toolbar.
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Spaced} />
 
 ## Variants
 
-Orientations, widths, and button sizes.
+Per [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md), `variant` is the Q3 layout axis for ButtonGroup — segmented vs spaced is a real layout shape difference, not just a prop tweak. Orientation, align, and fullWidth stay as Controls.
 
-<Canvas of={Stories.Variants} />
+### Spaced
+
+<Canvas of={Stories.Spaced} />
+
+Default layout — a gap (`var(--gap-md)`) between buttons. Canonical for form footers, dialog actions, and standard action sets.
+
+### Segmented
+
+<Canvas of={Stories.Segmented} />
+
+Buttons share borders into a single toolbar unit (no gap, rounded ends only). Use for view-mode toggles, time-range switchers, and similar mutually-exclusive option toolbars.
 
 ## Patterns
 
-Real-world usage: dialog actions, destructive confirmations, and form footers.
+### Action bar
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.ActionBar} />
+
+`align="between"` places the first child against the leading edge and the last child against the trailing edge — replaces the prior manual `<Row style={{ justifyContent: 'space-between' }}>` pattern from Button stories. **Closes [#617](https://github.com/brikdesigns/brik-bds/issues/617).**
 
 ## Props
 
 <ArgTypes of={Stories} />
 
+## Notes
+
+> **Note** — ButtonGroup does not expose its own `disabled` prop. Children manage their own state (e.g., `<Button disabled />` inside the group). Same pattern as [`FilterBar`](/?path=/docs/components-action-filter-bar--docs).
+
+> **Note** — `align` is ignored when `fullWidth: true`. Full-width groups always stretch children edge-to-edge regardless of alignment.
+
+> **Note** — Migrating from the old manual `Row + justify-content: space-between` ActionBar pattern: replace with `<ButtonGroup align="between">`. The segmented border math is handled automatically — don't add manual `border-radius` overrides.

--- a/components/ui/ButtonGroup/ButtonGroup.stories.tsx
+++ b/components/ui/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,6 +1,34 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ButtonGroup } from './ButtonGroup';
-import { Button } from '../Button';
+import { Button, IconButton } from '../Button';
+
+/* ─── Story-only icons ────────────────────────────────────────── */
+
+const Edit = () => (
+  <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10z" />
+  </svg>
+);
+
+const Copy = () => (
+  <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z" />
+    <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3z" />
+  </svg>
+);
+
+const Share = () => (
+  <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M13.5 1a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.5 2.5 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5z" />
+  </svg>
+);
+
+const Trash = () => (
+  <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z" />
+    <path fillRule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H5.5l1-1h3l1 1h2a1 1 0 0 1 1 1v1z" />
+  </svg>
+);
 
 /* ─── Meta ────────────────────────────────────────────────────── */
 
@@ -10,11 +38,6 @@ const meta: Meta<typeof ButtonGroup> = {
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
-    variant: {
-      control: 'select',
-      options: ['spaced', 'segmented'],
-      description: 'Layout treatment. `spaced` (default) keeps a gap between buttons; `segmented` collapses borders into a toolbar unit.',
-    },
     orientation: {
       control: 'select',
       options: ['horizontal', 'vertical'],
@@ -23,15 +46,18 @@ const meta: Meta<typeof ButtonGroup> = {
     align: {
       control: 'select',
       options: ['start', 'center', 'end', 'between'],
-      description: 'Horizontal alignment within the container. `between` replaces the prior manual `ActionBar` flex pattern (first child left, last child right).',
+      description:
+        'Horizontal alignment within the container. ' +
+        '`end` is the canonical modal / sheet action-row choice (primary far right, secondary to its left). ' +
+        '`between` places the first child against the leading edge and the last against the trailing edge.',
     },
     fullWidth: {
       control: 'boolean',
-      description: 'Stretch buttons to fill container width equally.',
+      description: 'Stretch buttons to fill container width equally. When true, `align` is ignored.',
     },
     children: {
       control: false,
-      description: 'Button / IconButton children. Story args render a canonical 2-3 button set.',
+      description: 'Button / IconButton children. Story args render canonical 3-4 button compositions.',
     },
   },
 };
@@ -40,18 +66,14 @@ export default meta;
 type Story = StoryObj<typeof ButtonGroup>;
 
 /* ═══════════════════════════════════════════════════════════════
-   SPACED — default variant, gap between buttons. Canonical
-   action-set look used for form footers, dialog actions, etc.
-   Per ADR-010 §components without a variant axis, `variant` IS
-   the Q3 axis here (segmented vs spaced is a real layout shape
-   difference, not just a prop) — so per-variant stories ship.
-   Orientation + align + fullWidth stay as Controls.
+   DEFAULT — canonical action set: 1 primary + 2 secondary buttons
+   in horizontal layout. Use Controls to flip orientation / align /
+   fullWidth.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Spaced — gap between buttons (default) */
-export const Spaced: Story = {
+/** @summary Default — primary + outline + ghost action set */
+export const Default: Story = {
   args: {
-    variant: 'spaced',
     orientation: 'horizontal',
     align: 'start',
     fullWidth: false,
@@ -66,48 +88,47 @@ export const Spaced: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   SEGMENTED — variant: 'segmented'. Buttons share borders into a
-   single toolbar unit. Common for view-mode toggles, time-range
-   switchers, segmented controls.
+   ICON-BUTTON GROUP — composing IconButton children. Common for
+   inline toolbars on rows / cards (edit, copy, share, delete).
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Segmented — shared borders, toolbar look */
-export const Segmented: Story = {
+/** @summary Icon-button toolbar — up to 4 actions */
+export const IconButtonGroup: Story = {
   args: {
-    variant: 'segmented',
     orientation: 'horizontal',
     align: 'start',
     fullWidth: false,
   },
   render: (args) => (
     <ButtonGroup {...args}>
-      <Button variant="secondary">Day</Button>
-      <Button variant="secondary">Week</Button>
-      <Button variant="secondary">Month</Button>
+      <IconButton icon={<Edit />} label="Edit" variant="ghost" />
+      <IconButton icon={<Copy />} label="Copy" variant="ghost" />
+      <IconButton icon={<Share />} label="Share" variant="ghost" />
+      <IconButton icon={<Trash />} label="Delete" variant="destructive" />
     </ButtonGroup>
   ),
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   ACTION-BAR — `align: 'between'` replaces the prior manual flex
-   pattern from Button.mdx. Closes #617. Discard on the left,
-   primary CTA on the right.
+   ACTION-BAR — modal / sheet action row. Per platform conventions
+   (macOS HIG, Material, Carbon), the primary action sits on the
+   far right with secondary actions to its LEFT. align="end" with
+   [secondary, primary] order achieves this.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Action bar — discard left, primary right (align="between") */
+/** @summary Action bar — modal / sheet row, primary far right */
 export const ActionBar: Story = {
   parameters: { layout: 'padded' },
   decorators: [(Story) => <div style={{ width: 480 }}><Story /></div>],
   args: {
-    variant: 'spaced',
     orientation: 'horizontal',
-    align: 'between',
+    align: 'end',
     fullWidth: false,
   },
   render: (args) => (
     <ButtonGroup {...args}>
-      <Button variant="destructive">Discard</Button>
-      <Button variant="primary">Continue</Button>
+      <Button variant="ghost">Cancel</Button>
+      <Button variant="primary">Save</Button>
     </ButtonGroup>
   ),
 };

--- a/components/ui/ButtonGroup/ButtonGroup.stories.tsx
+++ b/components/ui/ButtonGroup/ButtonGroup.stories.tsx
@@ -8,129 +8,106 @@ const meta: Meta<typeof ButtonGroup> = {
   title: 'Components/Action/button-group',
   component: ButtonGroup,
   tags: ['surface-shared'],
-  parameters: {
-    layout: 'centered',
-  },
+  parameters: { layout: 'centered' },
   argTypes: {
+    variant: {
+      control: 'select',
+      options: ['spaced', 'segmented'],
+      description: 'Layout treatment. `spaced` (default) keeps a gap between buttons; `segmented` collapses borders into a toolbar unit.',
+    },
     orientation: {
       control: 'select',
       options: ['horizontal', 'vertical'],
+      description: 'Stack direction. Default `horizontal`.',
     },
-    fullWidth: { control: 'boolean' },
+    align: {
+      control: 'select',
+      options: ['start', 'center', 'end', 'between'],
+      description: 'Horizontal alignment within the container. `between` replaces the prior manual `ActionBar` flex pattern (first child left, last child right).',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretch buttons to fill container width equally.',
+    },
+    children: {
+      control: false,
+      description: 'Button / IconButton children. Story args render a canonical 2-3 button set.',
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof ButtonGroup>;
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   SPACED — default variant, gap between buttons. Canonical
+   action-set look used for form footers, dialog actions, etc.
+   Per ADR-010 §components without a variant axis, `variant` IS
+   the Q3 axis here (segmented vs spaced is a real layout shape
+   difference, not just a prop) — so per-variant stories ship.
+   Orientation + align + fullWidth stay as Controls.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Spaced — gap between buttons (default) */
+export const Spaced: Story = {
+  args: {
+    variant: 'spaced',
+    orientation: 'horizontal',
+    align: 'start',
+    fullWidth: false,
+  },
   render: (args) => (
     <ButtonGroup {...args}>
-      <Button variant="primary">Primary</Button>
-      <Button variant="secondary">Secondary</Button>
+      <Button variant="primary">Save</Button>
+      <Button variant="outline">Preview</Button>
+      <Button variant="ghost">Cancel</Button>
     </ButtonGroup>
   ),
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Orientations, widths, sizes
+   SEGMENTED — variant: 'segmented'. Buttons share borders into a
+   single toolbar unit. Common for view-mode toggles, time-range
+   switchers, segmented controls.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Horizontal (default)</SectionLabel>
-        <ButtonGroup>
-          <Button variant="primary">Save</Button>
-          <Button variant="outline">Preview</Button>
-          <Button variant="ghost">Cancel</Button>
-        </ButtonGroup>
-      </div>
-      <div>
-        <SectionLabel>Vertical</SectionLabel>
-        <ButtonGroup orientation="vertical">
-          <Button variant="primary" fullWidth>Sign up</Button>
-          <Button variant="outline" fullWidth>Log in</Button>
-        </ButtonGroup>
-      </div>
-      <div>
-        <SectionLabel>Full width</SectionLabel>
-        <div style={{ width: 400 }}>
-          <ButtonGroup fullWidth>
-            <Button variant="primary" fullWidth>Confirm</Button>
-            <Button variant="secondary" fullWidth>Cancel</Button>
-          </ButtonGroup>
-        </div>
-      </div>
-      <div>
-        <SectionLabel>Small buttons</SectionLabel>
-        <ButtonGroup>
-          <Button variant="primary" size="sm">Accept</Button>
-          <Button variant="ghost" size="sm">Decline</Button>
-        </ButtonGroup>
-      </div>
-    </Stack>
+/** @summary Segmented — shared borders, toolbar look */
+export const Segmented: Story = {
+  args: {
+    variant: 'segmented',
+    orientation: 'horizontal',
+    align: 'start',
+    fullWidth: false,
+  },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <Button variant="secondary">Day</Button>
+      <Button variant="secondary">Week</Button>
+      <Button variant="secondary">Month</Button>
+    </ButtonGroup>
   ),
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world usage
+   ACTION-BAR — `align: 'between'` replaces the prior manual flex
+   pattern from Button.mdx. Closes #617. Discard on the left,
+   primary CTA on the right.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Patterns',
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Dialog actions</SectionLabel>
-        <ButtonGroup>
-          <Button variant="ghost">Cancel</Button>
-          <Button variant="primary">Save changes</Button>
-        </ButtonGroup>
-      </div>
-      <div>
-        <SectionLabel>Destructive confirmation</SectionLabel>
-        <ButtonGroup>
-          <Button variant="ghost">Keep</Button>
-          <Button variant="danger">Delete project</Button>
-        </ButtonGroup>
-      </div>
-      <div>
-        <SectionLabel>Form footer</SectionLabel>
-        <div style={{ width: 400 }}>
-          <ButtonGroup fullWidth>
-            <Button variant="secondary" fullWidth>Back</Button>
-            <Button variant="primary" fullWidth>Continue</Button>
-          </ButtonGroup>
-        </div>
-      </div>
-    </Stack>
+/** @summary Action bar — discard left, primary right (align="between") */
+export const ActionBar: Story = {
+  parameters: { layout: 'padded' },
+  decorators: [(Story) => <div style={{ width: 480 }}><Story /></div>],
+  args: {
+    variant: 'spaced',
+    orientation: 'horizontal',
+    align: 'between',
+    fullWidth: false,
+  },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <Button variant="destructive">Discard</Button>
+      <Button variant="primary">Continue</Button>
+    </ButtonGroup>
   ),
 };

--- a/components/ui/ButtonGroup/ButtonGroup.tsx
+++ b/components/ui/ButtonGroup/ButtonGroup.tsx
@@ -3,26 +3,19 @@ import { bdsClass } from '../../utils';
 import './ButtonGroup.css';
 
 export type ButtonGroupOrientation = 'horizontal' | 'vertical';
-export type ButtonGroupVariant = 'spaced' | 'segmented';
 export type ButtonGroupAlign = 'start' | 'center' | 'end' | 'between';
 
 export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
   /** `Button` (or `IconButton`) elements to group. */
   children: ReactNode;
-  /**
-   * Layout treatment.
-   * - `spaced` (default) — buttons separated by a gap; standard action-set look
-   * - `segmented` — buttons share borders into a single toolbar unit (no gap, rounded ends only)
-   */
-  variant?: ButtonGroupVariant;
   /** Stack direction. Default `horizontal`. */
   orientation?: ButtonGroupOrientation;
   /**
    * Horizontal alignment of the group's children when not `fullWidth`.
-   * Replaces the prior `ActionBar` pattern's manual `justify-content`.
+   * Replaces the prior manual `justify-content` patterns for action rows.
    * - `start` (default) — left-aligned
    * - `center` — centered
-   * - `end` — right-aligned
+   * - `end` — right-aligned (canonical for modal / sheet action rows: primary far right, secondary to its left)
    * - `between` — first child left, last child right (`justify-content: space-between`)
    */
   align?: ButtonGroupAlign;
@@ -31,40 +24,42 @@ export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * ButtonGroup — groups related Button components together.
+ * ButtonGroup — groups related Button (or IconButton) components into
+ * a single visual unit with consistent spacing and alignment.
  *
- * Two layout treatments via `variant`: `spaced` (default — gap between
- * buttons) and `segmented` (shared borders, toolbar look). Use `align`
- * to place the group at start / center / end / between within its
- * container — this replaces the prior manual `ActionBar` flex pattern.
+ * `align` replaces the prior manual `justify-content` flex patterns
+ * for action rows. For mutually-exclusive option toolbars (Day / Week
+ * / Month) use [`SegmentedControl`](../SegmentedControl) instead — its
+ * shared-border treatment is the canonical home for that pattern.
  *
  * @example
  * ```tsx
- * // Default form-footer action set
+ * // Default form-footer action set (1 primary + 2 secondary)
  * <ButtonGroup>
  *   <Button variant="primary">Save</Button>
+ *   <Button variant="outline">Preview</Button>
  *   <Button variant="ghost">Cancel</Button>
  * </ButtonGroup>
  *
- * // Segmented toolbar
- * <ButtonGroup variant="segmented">
- *   <Button variant="secondary">Day</Button>
- *   <Button variant="secondary">Week</Button>
- *   <Button variant="secondary">Month</Button>
+ * // Modal / sheet action row — primary far right, secondary to its left
+ * <ButtonGroup align="end">
+ *   <Button variant="ghost">Cancel</Button>
+ *   <Button variant="primary">Save</Button>
  * </ButtonGroup>
  *
- * // ActionBar replacement (discard left, primary right)
- * <ButtonGroup align="between">
- *   <Button variant="destructive">Discard</Button>
- *   <Button variant="primary">Continue</Button>
+ * // IconButton toolbar (up to 4 actions)
+ * <ButtonGroup>
+ *   <IconButton icon={<Edit />} label="Edit" variant="ghost" />
+ *   <IconButton icon={<Copy />} label="Copy" variant="ghost" />
+ *   <IconButton icon={<Share />} label="Share" variant="ghost" />
+ *   <IconButton icon={<Trash />} label="Delete" variant="destructive" />
  * </ButtonGroup>
  * ```
  *
- * @summary Group related Buttons (variant + orientation + align)
+ * @summary Group related Buttons (orientation + align + fullWidth)
  */
 export function ButtonGroup({
   children,
-  variant = 'spaced',
   orientation = 'horizontal',
   align = 'start',
   fullWidth = false,
@@ -73,7 +68,6 @@ export function ButtonGroup({
 }: ButtonGroupProps) {
   const classes = bdsClass(
     'bds-button-group',
-    `bds-button-group--${variant}`,
     orientation === 'vertical' && 'bds-button-group--vertical',
     `bds-button-group--align-${align}`,
     fullWidth && 'bds-button-group--full-width',

--- a/components/ui/ButtonGroup/ButtonGroup.tsx
+++ b/components/ui/ButtonGroup/ButtonGroup.tsx
@@ -3,12 +3,29 @@ import { bdsClass } from '../../utils';
 import './ButtonGroup.css';
 
 export type ButtonGroupOrientation = 'horizontal' | 'vertical';
+export type ButtonGroupVariant = 'spaced' | 'segmented';
+export type ButtonGroupAlign = 'start' | 'center' | 'end' | 'between';
 
 export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
   /** `Button` (or `IconButton`) elements to group. */
   children: ReactNode;
+  /**
+   * Layout treatment.
+   * - `spaced` (default) — buttons separated by a gap; standard action-set look
+   * - `segmented` — buttons share borders into a single toolbar unit (no gap, rounded ends only)
+   */
+  variant?: ButtonGroupVariant;
   /** Stack direction. Default `horizontal`. */
   orientation?: ButtonGroupOrientation;
+  /**
+   * Horizontal alignment of the group's children when not `fullWidth`.
+   * Replaces the prior `ActionBar` pattern's manual `justify-content`.
+   * - `start` (default) — left-aligned
+   * - `center` — centered
+   * - `end` — right-aligned
+   * - `between` — first child left, last child right (`justify-content: space-between`)
+   */
+  align?: ButtonGroupAlign;
   /** When true, buttons stretch to fill the container equally */
   fullWidth?: boolean;
 }
@@ -16,26 +33,49 @@ export interface ButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
 /**
  * ButtonGroup — groups related Button components together.
  *
+ * Two layout treatments via `variant`: `spaced` (default — gap between
+ * buttons) and `segmented` (shared borders, toolbar look). Use `align`
+ * to place the group at start / center / end / between within its
+ * container — this replaces the prior manual `ActionBar` flex pattern.
+ *
  * @example
  * ```tsx
+ * // Default form-footer action set
  * <ButtonGroup>
  *   <Button variant="primary">Save</Button>
  *   <Button variant="ghost">Cancel</Button>
  * </ButtonGroup>
+ *
+ * // Segmented toolbar
+ * <ButtonGroup variant="segmented">
+ *   <Button variant="secondary">Day</Button>
+ *   <Button variant="secondary">Week</Button>
+ *   <Button variant="secondary">Month</Button>
+ * </ButtonGroup>
+ *
+ * // ActionBar replacement (discard left, primary right)
+ * <ButtonGroup align="between">
+ *   <Button variant="destructive">Discard</Button>
+ *   <Button variant="primary">Continue</Button>
+ * </ButtonGroup>
  * ```
  *
- * @summary Group related Buttons (orientation + full-width)
+ * @summary Group related Buttons (variant + orientation + align)
  */
 export function ButtonGroup({
   children,
+  variant = 'spaced',
   orientation = 'horizontal',
+  align = 'start',
   fullWidth = false,
   className,
   ...props
 }: ButtonGroupProps) {
   const classes = bdsClass(
     'bds-button-group',
+    `bds-button-group--${variant}`,
     orientation === 'vertical' && 'bds-button-group--vertical',
+    `bds-button-group--align-${align}`,
     fullWidth && 'bds-button-group--full-width',
     className
   );

--- a/manifest/component-axes.json
+++ b/manifest/component-axes.json
@@ -97,6 +97,12 @@
       "xl"
     ]
   },
+  "ButtonGroup": {
+    "variant": [
+      "spaced",
+      "segmented"
+    ]
+  },
   "Card": {
     "variant": [
       "outlined",

--- a/manifest/component-axes.json
+++ b/manifest/component-axes.json
@@ -97,12 +97,6 @@
       "xl"
     ]
   },
-  "ButtonGroup": {
-    "variant": [
-      "spaced",
-      "segmented"
-    ]
-  },
   "Card": {
     "variant": [
       "outlined",


### PR DESCRIPTION
## Summary

**Closes #617** (ActionBar relocation) and completes **#618 Batch B** as the last Action-category PR.

Final shape after review rework:

| API | Behavior |
|---|---|
| `orientation` | `'horizontal'` (default) \| `'vertical'` |
| `align` | `'start'` (default) \| `'center'` \| `'end'` \| `'between'` |
| `fullWidth` | When true, align is ignored — children stretch |
| children | Button / IconButton |

**No `variant` prop** — the original `'spaced' \| 'segmented'` was reworked during review:
- `segmented` conflicted with the existing [`SegmentedControl`](/?path=/docs/components-control-segmented-control--docs) component (different shape, different domain) → removed
- With only `spaced` left, the prop had no decision point → dropped entirely

Default `gap: var(--gap-md)` is now the only layout treatment. For mutually-exclusive shared-border toolbars, consumers reach for SegmentedControl (cross-linked in MDX Notes).

## Stories shipped

| Story | Composition |
|---|---|
| `Default` | 1 primary + 2 secondary (Save / Preview / Cancel) — canonical action set |
| `IconButtonGroup` | Up to 4 IconButtons (Edit / Copy / Share / Delete) — row-chrome toolbar |
| `ActionBar` | Modal / sheet convention: primary far right + secondary to its left, via `align="end"` with `[Cancel, Save]` order |

## Closes #617

Cross-component cleanup in the same PR:

- Deleted `ActionBar` export from Button.stories.tsx (was a manual `Row + justify-content` composition)
- Removed `### Action bar` sub-section from Button.mdx
- Replacement documented in ButtonGroup.mdx `## Patterns` + `## Notes` migration guidance

## Action bar — platform convention

The reworked ActionBar matches macOS HIG, Material, Carbon, and Brik's design library: **primary action far right, secondary to its left**. \`align="end"\` with `[Cancel, Save]` JSX order achieves this. Documented explicitly in MDX so future authors don't accidentally invert.

## Framework alignment

- [x] No `variant` prop — collision with SegmentedControl avoided
- [x] `align` is the layout-axis Control; per-story compositions demonstrate the meaningful shapes
- [x] No show* booleans (Path A)
- [x] argTypes with descriptions on every prop
- [x] `surface-shared` tag
- [x] MDX recipe conformant
- [x] Existing consumers backward-compatible (orientation + fullWidth unchanged)
- [x] No `disabled` at container level (children own — same as FilterBar)

## Verification

- `npm run typecheck` ✅
- `node scripts/lint-storybook-recipe.js` ✅ (73 / 73 conforming)
- `npm run validate:full` ✅ (9/9 — pre-push validation suite)
- Manifest regenerated via `npm run typegen:axes` (ButtonGroup no longer in axes — no variant prop)

## Related

- **Closes #617** (ActionBar relocation)
- Parent: **#618 Batch B** — final Action-category PR
- Framework: PR #619 + #621 (ADR-010 amendments)
- Siblings: #638 / #639 / #640 / #642
- Cross-link: SegmentedControl is the canonical home for shared-border toolbars

🤖 Generated with [Claude Code](https://claude.com/claude-code)