### PR TITLE
refactor(actions): Button slim-down — drop ConfirmationDialog + InlineDelete, hide LoadingToggle (closes #617)

### DIFF
--- a/components/ui/Button/Button.mdx
+++ b/components/ui/Button/Button.mdx
@@ -92,20 +92,6 @@ An icon-only button with a required `label` prop for accessibility.
 
 <Canvas of={Stories.IconButtonShowcase} />
 
-### Loading toggle
-
-Click to simulate an async action. Render-mode demo because the toggle interaction can't be expressed with args alone.
-
-<Canvas of={Stories.LoadingToggle} />
-
-### Confirmation dialog
-
-<Canvas of={Stories.ConfirmationDialog} />
-
-### Inline delete
-
-<Canvas of={Stories.InlineDelete} />
-
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/Button/Button.stories.tsx
+++ b/components/ui/Button/Button.stories.tsx
@@ -301,12 +301,14 @@ export const IconButtonShowcase: Story = {
 
 /**
  * Loading state wired up to local state — click to simulate an async
- * action. Spinner replaces text while preserving button width. Render-mode
- * is required because args alone can't express the click-to-toggle interaction.
+ * action. Spinner replaces text while preserving button width. Play-only
+ * regression demo; the canonical loading docs are the Playground `loading`
+ * control.
  *
- * @summary Loading toggle — interactive demo
+ * @summary Loading toggle — play-only interaction demo
  */
 export const LoadingToggle: Story = {
+  tags: ['!manifest'],
   render: () => {
     const [loading, setLoading] = useState(false);
     const handleClick = () => {
@@ -321,61 +323,5 @@ export const LoadingToggle: Story = {
       </Row>
     );
   },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   PATTERNS — real-world compositions
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Confirmation dialog — destructive primary + ghost cancel */
-export const ConfirmationDialog: Story = {
-  render: () => (
-    <div style={{
-      padding: 'var(--padding-lg)',
-      border: 'var(--border-width-sm) solid var(--border-secondary)',
-      borderRadius: 'var(--border-radius-md)',
-      maxWidth: '400px',
-    }}>
-      <div style={{
-        fontFamily: 'var(--font-family-heading)',
-        fontSize: 'var(--heading-sm)',
-        marginBottom: 'var(--gap-sm)',
-      }}>
-        Delete project?
-      </div>
-      <div style={{
-        fontFamily: 'var(--font-family-body)',
-        fontSize: 'var(--body-sm)',
-        color: 'var(--text-secondary)',
-        marginBottom: 'var(--gap-xl)',
-      }}>
-        This action cannot be undone. All data will be permanently removed.
-      </div>
-      <Row>
-        <Button variant="destructive">Delete project</Button>
-        <Button variant="ghost">Cancel</Button>
-      </Row>
-    </div>
-  ),
-};
-
-/** @summary Inline delete — file row with trailing destructive IconButton */
-export const InlineDelete: Story = {
-  render: () => (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      padding: 'var(--padding-md)',
-      border: 'var(--border-width-sm) solid var(--border-secondary)',
-      borderRadius: 'var(--border-radius-md)',
-      maxWidth: '400px',
-    }}>
-      <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)' }}>
-        document-final-v2.pdf
-      </span>
-      <IconButton icon={<Trash />} label="Delete file" variant="destructive" size="sm" />
-    </div>
-  ),
 };
 


### PR DESCRIPTION
## Summary

Continues #617 cleanup after #643 only completed the ActionBar → ButtonGroup relocation. The remaining two relocations called out in the reopen comment turned out not to have clean hosts; resolution per host-file investigation:

- **`ConfirmationDialog` — dropped.** [Dialog.stories.tsx:9](components/ui/Dialog/Dialog.stories.tsx#L9) marks Dialog deprecated (`!manifest` + use-Modal note). Modal already ships `Default confirm` + `Destructive confirm` preset stories using the real component with state. Moving the Button raw-markup version to Dialog would prop up a deprecated component and duplicate Modal coverage.
- **`InlineDelete` — dropped.** [InteractiveListItem.mdx:15](components/ui/InteractiveListItem/InteractiveListItem.mdx#L15) explicitly documents "row drills in AND interactive trailing slot" as a UX conflict — exactly the structure of `InlineDelete`. No primitive cleanly hosts the pattern today; removed rather than ported a docs-contradicting story.
- **`LoadingToggle` — `!manifest`-tagged, kept as play-only.** Canonical loading docs are the Playground `loading` control.

**Deferred** (per reopen comment): `LinkButtonShowcase` / `IconButtonShowcase` separation stays pending #616 (IconButton merge decision).

## Files

- `components/ui/Button/Button.stories.tsx` — drop `ConfirmationDialog` + `InlineDelete` exports, drop PATTERNS section header, add `!manifest` tag to `LoadingToggle`.
- `components/ui/Button/Button.mdx` — drop `### Loading toggle` / `### Confirmation dialog` / `### Inline delete` sub-headings. LinkButton + IconButton showcases retained.

## Test plan

- [x] \`npm run validate:full\` — all 9 checks pass (token / jsdoc / grid / theme / blueprint / canonical-tokens / component-axes / typescript / storybook-build)
- [x] \`npm run lint-storybook-recipe\` — 73/73 conforming
- [x] \`npm run typegen:axes:check\` — manifest in sync
- [ ] Visual verification of Button stories in Storybook
- [ ] Confirm no consumer repos still reference removed story names

## Consumer sync plan

- [ ] Portal: \`npm update @brikdesigns/bds\` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: \`./scripts/bds-sync.sh\`

Closes #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>