### PR TITLE
feat(form): DatePicker gold-standard — single Default + new MDX (refs #618 Batch C)

### DIFF
--- a/components/ui/DatePicker/DatePicker.mdx
+++ b/components/ui/DatePicker/DatePicker.mdx
@@ -1,0 +1,37 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './DatePicker.stories';
+
+<Meta of={Stories} />
+
+# Date picker
+
+<ComponentLinks slug="date-picker" />
+
+Themed date picker for forms — a trigger button that opens a calendar popover for single-date selection. Built on [Radix Popover](https://www.radix-ui.com/primitives/docs/components/popover) for portal + focus-management behavior; BDS owns the visual layer (trigger styling, day grid, hover / selected / today states). Fully controlled — the consumer manages the `value` externally and receives updates via `onChange`.
+
+## Playground
+
+<Canvas of={Stories.Default} />
+
+## Variants
+
+DatePicker has no semantic-variant axis — all variation (size, label, helper text, error, min/max constraints, disabled state) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
+
+<Canvas of={Stories.Default} />
+
+- **`sm`** — 32px trigger height, 14px body
+- **`md`** — 40px trigger height, 16px body (default)
+- **`lg`** — 48px trigger height, 18px body
+
+## Props
+
+<ArgTypes of={Stories} />
+
+## Notes
+
+> **Note** — DatePicker is fully controlled. Consumers track the selected `Date | null` externally (`useState`, form library, store, URL param) and pass `value` + `onChange` to receive update events. There is no internal value state.
+
+> **Note** — `minDate` / `maxDate` constrain which days are clickable in the grid. The constraint is inclusive at day-granularity (time-of-day on the boundary dates is ignored). Days outside the range render with `disabled` styling and ignore click events.
+
+> **Note** — The error state is announced via `role="alert"` on the helper text and `aria-invalid="true"` on the trigger. Setting `error` to a non-empty string also suppresses `helperText` so the two never co-render.

--- a/components/ui/DatePicker/DatePicker.stories.tsx
+++ b/components/ui/DatePicker/DatePicker.stories.tsx
@@ -1,30 +1,7 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { DatePicker } from './DatePicker';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-const Row = ({ children, gap = 'var(--padding-sm)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', gap, flexWrap: 'wrap', alignItems: 'flex-start' }}>{children}</div>
-);
 
 /* ─── Meta ────────────────────────────────────────────────────── */
 
@@ -34,13 +11,46 @@ const meta: Meta<typeof DatePicker> = {
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
-    size: { control: 'select', options: ['sm', 'md', 'lg'] },
-    label: { control: 'text' },
-    placeholder: { control: 'text' },
-    helperText: { control: 'text' },
-    error: { control: 'text' },
-    fullWidth: { control: 'boolean' },
-    disabled: { control: 'boolean' },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description:
+        'Trigger height — matches the BDS form-input scale (`sm`=32px, `md`=40px, `lg`=48px). Default `md`.',
+    },
+    label: {
+      control: 'text',
+      description:
+        'Optional label rendered above the trigger. Wired to the trigger via `htmlFor` so clicking the label focuses the trigger.',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Trigger placeholder when no date is selected. Default `Select a date`.',
+    },
+    helperText: {
+      control: 'text',
+      description: 'Helper text rendered below the trigger when no `error` is set.',
+    },
+    error: {
+      control: 'text',
+      description:
+        'Error message — non-empty value triggers error styling, announces via `role="alert"`, and suppresses `helperText`.',
+    },
+    minDate: {
+      control: 'date',
+      description: 'Earliest selectable date. Days before are disabled in the grid.',
+    },
+    maxDate: {
+      control: 'date',
+      description: 'Latest selectable date. Days after are disabled in the grid.',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretches the trigger to fill its container.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the trigger — non-interactive, muted appearance, popover does not open.',
+    },
   },
 };
 
@@ -48,21 +58,29 @@ export default meta;
 type Story = StoryObj<typeof DatePicker>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — single canonical story per ADR-010 §components without
+   a variant axis. Render wraps DatePicker in `useState` so the canvas
+   is fully interactive (DatePicker is controlled). The play function
+   exercises the Radix Popover portal mount + day-grid render timing.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
-  parameters: { chromatic: { disableSnapshot: true } },
+/** @summary Themed date picker with Radix Popover calendar */
+export const Default: Story = {
   args: {
-    placeholder: 'Select a date',
     size: 'md',
+    placeholder: 'Select a date',
   },
   render: (args) => {
     const [value, setValue] = useState<Date | null>(null);
     return (
       <div style={{ width: 280 }}>
-        <DatePicker {...args} value={value} onChange={setValue} />
+        <DatePicker
+          {...args}
+          minDate={args.minDate ? new Date(args.minDate as unknown as number) : undefined}
+          maxDate={args.maxDate ? new Date(args.maxDate as unknown as number) : undefined}
+          value={value}
+          onChange={setValue}
+        />
       </div>
     );
   },
@@ -79,253 +97,18 @@ export const Playground: Story = {
     const dialog = await body.findByRole('dialog', {}, { timeout: 3000 });
     await expect(dialog).toBeVisible();
 
-    // Wait for the day grid to mount (react-day-picker renders asynchronously
-    // after the dialog opens). Poll for a clickable cell instead of querying once.
-    const clickableDay = await waitFor(() => {
-      const cells = within(dialog).getAllByRole('gridcell');
-      const cell = cells.find((c) => !c.hasAttribute('disabled') && c.textContent?.trim());
-      if (!cell) throw new Error('No clickable day cell found yet');
-      return cell;
-    }, { timeout: 3000 });
+    // Wait for the day grid to mount; cells render asynchronously after the
+    // dialog opens. Poll for a clickable cell instead of querying once.
+    const clickableDay = await waitFor(
+      () => {
+        const cells = within(dialog).getAllByRole('gridcell');
+        const cell = cells.find((c) => !c.hasAttribute('disabled') && c.textContent?.trim());
+        if (!cell) throw new Error('No clickable day cell found yet');
+        return cell;
+      },
+      { timeout: 3000 },
+    );
 
     await userEvent.click(clickableDay);
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. DEFAULT — No label, clean trigger
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Default rendering */
-export const Default: Story = {
-  render: () => {
-    const [value, setValue] = useState<Date | null>(null);
-    return (
-      <div style={{ width: 280 }}>
-        <DatePicker
-          placeholder="Select a date"
-          value={value}
-          onChange={setValue}
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. WITH LABEL — Label + helper text
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary With label */
-export const WithLabel: Story = {
-  render: () => {
-    const [value, setValue] = useState<Date | null>(null);
-    return (
-      <div style={{ width: 280 }}>
-        <DatePicker
-          label="Appointment date"
-          placeholder="Select a date"
-          helperText="Choose your preferred appointment time"
-          value={value}
-          onChange={setValue}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   4. WITH ERROR — Error state
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary With error */
-export const WithError: Story = {
-  render: () => {
-    const [value, setValue] = useState<Date | null>(null);
-    return (
-      <div style={{ width: 280 }}>
-        <DatePicker
-          label="Due date"
-          placeholder="Select a date"
-          error="A due date is required"
-          value={value}
-          onChange={setValue}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   5. SMALL — sm size variant
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Small */
-export const Small: Story = {
-  render: () => {
-    const [value, setValue] = useState<Date | null>(null);
-    return (
-      <div style={{ width: 240 }}>
-        <DatePicker
-          size="sm"
-          label="Start date"
-          placeholder="Select a date"
-          value={value}
-          onChange={setValue}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   6. LARGE — lg size variant
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Large */
-export const Large: Story = {
-  render: () => {
-    const [value, setValue] = useState<Date | null>(null);
-    return (
-      <div style={{ width: 320 }}>
-        <DatePicker
-          size="lg"
-          label="End date"
-          placeholder="Select a date"
-          value={value}
-          onChange={setValue}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   7. MIN/MAX DATE — Constrained date range
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Min max date */
-export const MinMaxDate: Story = {
-  render: () => {
-    const [value, setValue] = useState<Date | null>(null);
-    const today = new Date();
-    const minDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-    const maxDate = new Date(today.getFullYear(), today.getMonth() + 1, today.getDate());
-
-    return (
-      <div style={{ width: 280 }}>
-        <DatePicker
-          label="Schedule date"
-          placeholder="Select a date"
-          helperText="Must be within the next 30 days"
-          minDate={minDate}
-          maxDate={maxDate}
-          value={value}
-          onChange={setValue}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   8. DISABLED — Disabled state
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Disabled state */
-export const Disabled: Story = {
-  render: () => (
-    <div style={{ width: 280 }}>
-      <DatePicker
-        label="Locked date"
-        placeholder="Not available"
-        disabled
-        fullWidth
-      />
-    </div>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   9. FULL WIDTH — Stretches to container
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Full width */
-export const FullWidth: Story = {
-  render: () => {
-    const [value, setValue] = useState<Date | null>(null);
-    return (
-      <div style={{ width: 480 }}>
-        <DatePicker
-          label="Project deadline"
-          placeholder="Select a date"
-          helperText="This date will be visible to all team members"
-          value={value}
-          onChange={setValue}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   10. VARIANTS — All sizes and states at a glance
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => {
-    const [sm, setSm] = useState<Date | null>(null);
-    const [md, setMd] = useState<Date | null>(null);
-    const [lg, setLg] = useState<Date | null>(null);
-    const [errVal, setErrVal] = useState<Date | null>(null);
-    const today = new Date();
-    const minDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-
-    return (
-      <div style={{ width: 480 }}>
-        <Stack>
-          {/* Sizes */}
-          <div>
-            <SectionLabel>Sizes</SectionLabel>
-            <Stack gap="var(--gap-lg)">
-              <DatePicker size="sm" label="Small (sm)" placeholder="Select a date" value={sm} onChange={setSm} fullWidth />
-              <DatePicker size="md" label="Medium (md)" placeholder="Select a date — default" value={md} onChange={setMd} fullWidth />
-              <DatePicker size="lg" label="Large (lg)" placeholder="Select a date" value={lg} onChange={setLg} fullWidth />
-            </Stack>
-          </div>
-
-          {/* States */}
-          <div>
-            <SectionLabel>States</SectionLabel>
-            <Stack gap="var(--gap-lg)">
-              <DatePicker label="Default" placeholder="Select a date" value={null} onChange={() => {}} fullWidth />
-              <DatePicker label="Helper text" placeholder="Select a date" helperText="Must be a future date" minDate={minDate} value={null} onChange={() => {}} fullWidth />
-              <DatePicker label="Error" placeholder="Select a date" error="A date is required" value={errVal} onChange={setErrVal} fullWidth />
-              <DatePicker label="Disabled" placeholder="Not available" disabled fullWidth />
-            </Stack>
-          </div>
-
-          {/* In a form context */}
-          <div>
-            <SectionLabel>Form context</SectionLabel>
-            <Row gap="var(--gap-lg)">
-              <div style={{ flex: 1 }}>
-                <DatePicker label="Start date" placeholder="Select" value={null} onChange={() => {}} fullWidth />
-              </div>
-              <div style={{ flex: 1 }}>
-                <DatePicker label="End date" placeholder="Select" value={null} onChange={() => {}} fullWidth />
-              </div>
-            </Row>
-          </div>
-        </Stack>
-      </div>
-    );
   },
 };


### PR DESCRIPTION
## Summary

Apply ADR-010 §components-without-a-variant-axis to **DatePicker**: collapse 10 story exports to a single hook-driven `Default` and add MDX docs from scratch (DatePicker was on #454's missing-MDX list).

### Story disposition — 10 → 1

| Old export | Disposition |
|---|---|
| `Playground`, `Default` | Merged into a single `Default` (hook-driven, all props exposed as Controls, play function preserved) |
| `WithLabel`, `WithError`, `Small`, `Large`, `Disabled`, `FullWidth`, `MinMaxDate` | Collapsed to Controls (boolean / select / text / date controls per framework) |
| `Variants` | Dropped (banned export name per ADR-006; duplicates Controls coverage) |

Play function preserved as-is — opens calendar, waits for Radix Popover portal mount (3s timeout absorbs parallel browser-vitest load), polls for a clickable day cell, clicks it. Real regression coverage for Popover + day-grid race conditions.

### New MDX (FilterToggle.mdx template)

`Title → ComponentLinks → Description → Playground → Variants (single Default + size bullets + no-semantic-axis note) → Props → Notes (controlled, min/max behavior, error a11y)`.

No `## Patterns` section (no compositions), no `## CSS Override API` section ([DatePicker.css](components/ui/DatePicker/DatePicker.css) exposes no `--date-picker-*` override variables).

## Files

- [components/ui/DatePicker/DatePicker.stories.tsx](components/ui/DatePicker/DatePicker.stories.tsx) — full rewrite (-180 net)
- [components/ui/DatePicker/DatePicker.mdx](components/ui/DatePicker/DatePicker.mdx) — new file (+37)

## Test plan

- [x] \`npm run validate:full\` — all 9 checks pass
- [x] \`npm run lint-storybook-recipe\` — 74/74 conforming (DatePicker added)
- [x] \`npm test -- --run components/ui/DatePicker\` — Default play fn passes (1/1)
- [x] \`npm run typegen:axes:check\` — manifest in sync
- [ ] Visual verification in Storybook (canvas + Controls panel + size variants)
- [ ] Confirm no consumer repos referenced removed story names

## Consumer sync plan

- [ ] Portal: \`npm update @brikdesigns/bds\` after merge + version publish
- [ ] renew-pms: submodule bump
- [ ] brikdesigns: \`./scripts/bds-sync.sh\`

## Follow-up

- TimePicker queued for next session (same template, same #618 batch).

Refs #618 (Batch C — Form category). Closes the DatePicker line item of #454 (missing MDX docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>