### PR TITLE
feat(form): TimePicker gold-standard — single Default + new MDX (refs #618 Batch C)

### DIFF
--- a/components/ui/TimePicker/TimePicker.mdx
+++ b/components/ui/TimePicker/TimePicker.mdx
@@ -1,0 +1,41 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './TimePicker.stories';
+
+<Meta of={Stories} />
+
+# Time picker
+
+<ComponentLinks slug="time-picker" />
+
+Themed time picker for forms — a trigger button that opens a popover with hour / minute / period scroll columns. Built on [Radix Popover](https://www.radix-ui.com/primitives/docs/components/popover) for portal + focus-management behavior; BDS owns the visual layer (trigger styling, scroll columns, selected-cell state). Fully controlled — the consumer manages the `value` externally and receives updates via `onChange`.
+
+Values are exchanged in **24-hour `HH:mm` format** (e.g. `"14:30"`) regardless of whether the picker displays 12-hour or 24-hour. The `use24Hour` prop only changes the display + column rendering.
+
+## Playground
+
+<Canvas of={Stories.Default} />
+
+## Variants
+
+TimePicker has no semantic-variant axis — all variation (size, label, helper text, error, minute step, 12h/24h, disabled state) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
+
+<Canvas of={Stories.Default} />
+
+- **`sm`** — 32px trigger height, 14px body
+- **`md`** — 40px trigger height, 16px body (default)
+- **`lg`** — 48px trigger height, 18px body
+
+## Props
+
+<ArgTypes of={Stories} />
+
+## Notes
+
+> **Note** — TimePicker is fully controlled. Consumers track the selected time string externally (`useState`, form library, store, URL param) and pass `value` + `onChange` to receive update events. There is no internal value state.
+
+> **Note** — `value` and `onChange` always use 24-hour `HH:mm` format. The `use24Hour` prop controls display only; storing the value as 24h means the underlying data shape stays consistent whether the user has 12h or 24h preference.
+
+> **Note** — `minuteStep` constrains the minute column to multiples of the given value. Common choices: `5` for 5-minute intervals, `15` for quarter-hour blocks, `30` for half-hour appointments. The default `1` allows every minute.
+
+> **Note** — The error state is announced via `role="alert"` on the helper text and `aria-invalid="true"` on the trigger. Setting `error` to a non-empty string also suppresses `helperText` so the two never co-render.

--- a/components/ui/TimePicker/TimePicker.stories.tsx
+++ b/components/ui/TimePicker/TimePicker.stories.tsx
@@ -1,30 +1,7 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, within } from 'storybook/test';
 import { TimePicker } from './TimePicker';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-const Row = ({ children, gap = 'var(--padding-sm)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', gap, flexWrap: 'wrap', alignItems: 'flex-start' }}>{children}</div>
-);
 
 /* ─── Meta ────────────────────────────────────────────────────── */
 
@@ -34,15 +11,48 @@ const meta: Meta<typeof TimePicker> = {
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
-    size: { control: 'select', options: ['sm', 'md', 'lg'] },
-    label: { control: 'text' },
-    placeholder: { control: 'text' },
-    helperText: { control: 'text' },
-    error: { control: 'text' },
-    fullWidth: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    minuteStep: { control: 'number' },
-    use24Hour: { control: 'boolean' },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description:
+        'Trigger height — matches the BDS form-input scale (`sm`=32px, `md`=40px, `lg`=48px). Default `md`.',
+    },
+    label: {
+      control: 'text',
+      description:
+        'Optional label rendered above the trigger. Wired to the trigger via `htmlFor` so clicking the label focuses the trigger.',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Trigger placeholder when no time is selected. Default `Select time`.',
+    },
+    helperText: {
+      control: 'text',
+      description: 'Helper text rendered below the trigger when no `error` is set.',
+    },
+    error: {
+      control: 'text',
+      description:
+        'Error message — non-empty value triggers error styling, announces via `role="alert"`, and suppresses `helperText`.',
+    },
+    minuteStep: {
+      control: 'number',
+      description:
+        'Minute increment for the minute column. Use `5` for 5-minute, `15` for quarter-hour, `30` for half-hour blocks. Default `1`.',
+    },
+    use24Hour: {
+      control: 'boolean',
+      description:
+        'Render the picker in 24-hour mode (hours 00–23, no AM/PM column). Default `false` (12-hour with AM/PM).',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretches the trigger to fill its container.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the trigger — non-interactive, muted appearance, popover does not open.',
+    },
   },
 };
 
@@ -50,19 +60,22 @@ export default meta;
 type Story = StoryObj<typeof TimePicker>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — single canonical story per ADR-010 §components without
+   a variant axis. Render wraps TimePicker in `useState` so the canvas
+   is fully interactive (TimePicker is controlled). The play function
+   exercises the Radix Popover portal mount.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
-  parameters: { chromatic: { disableSnapshot: true } },
+/** @summary Themed time picker with Radix Popover scroll columns */
+export const Default: Story = {
   args: {
-    placeholder: 'Select time',
     size: 'md',
-    value: '09:00',
+    placeholder: 'Select time',
+    minuteStep: 1,
+    use24Hour: false,
   },
   render: (args) => {
-    const [value, setValue] = useState(args.value ?? '09:00');
+    const [value, setValue] = useState('09:00');
     return (
       <div style={{ width: 280 }}>
         <TimePicker {...args} value={value} onChange={setValue} />
@@ -81,224 +94,5 @@ export const Playground: Story = {
     const body = within(document.body);
     const dialog = await body.findByRole('dialog', {}, { timeout: 3000 });
     await expect(dialog).toBeVisible();
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. DEFAULT — 12-hour format
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Default rendering */
-export const Default: Story = {
-  render: () => {
-    const [value, setValue] = useState('09:00');
-    return (
-      <div style={{ width: 280 }}>
-        <TimePicker
-          placeholder="Select time"
-          value={value}
-          onChange={setValue}
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. WITH LABEL — Label + helper text
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary With label */
-export const WithLabel: Story = {
-  render: () => {
-    const [value, setValue] = useState('09:00');
-    return (
-      <div style={{ width: 280 }}>
-        <TimePicker
-          label="Start Time"
-          placeholder="Select time"
-          helperText="Appointment will be scheduled at this time"
-          value={value}
-          onChange={setValue}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   4. WITH ERROR — Error state
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary With error */
-export const WithError: Story = {
-  render: () => {
-    const [value, setValue] = useState('09:00');
-    return (
-      <div style={{ width: 280 }}>
-        <TimePicker
-          label="End Time"
-          placeholder="Select time"
-          error="End time must be after start time"
-          value={value}
-          onChange={setValue}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   5. 24-HOUR FORMAT
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Twenty four hour */
-export const TwentyFourHour: Story = {
-  render: () => {
-    const [value, setValue] = useState('14:30');
-    return (
-      <div style={{ width: 280 }}>
-        <TimePicker
-          label="Time (24h)"
-          value={value}
-          onChange={setValue}
-          use24Hour
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   6. MINUTE STEP — 5-minute intervals
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Minute step */
-export const MinuteStep: Story = {
-  render: () => {
-    const [value, setValue] = useState('09:00');
-    return (
-      <div style={{ width: 280 }}>
-        <TimePicker
-          label="Appointment Time"
-          helperText="Available in 5-minute intervals"
-          value={value}
-          onChange={setValue}
-          minuteStep={5}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   7. MINUTE STEP 15 — Quarter-hour intervals
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Quarter hour */
-export const QuarterHour: Story = {
-  render: () => {
-    const [value, setValue] = useState('09:00');
-    return (
-      <div style={{ width: 280 }}>
-        <TimePicker
-          label="Meeting Time"
-          helperText="15-minute blocks"
-          value={value}
-          onChange={setValue}
-          minuteStep={15}
-          fullWidth
-        />
-      </div>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   8. DISABLED
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Disabled state */
-export const Disabled: Story = {
-  render: () => (
-    <div style={{ width: 280 }}>
-      <TimePicker
-        label="Locked Time"
-        value="08:00"
-        disabled
-        fullWidth
-      />
-    </div>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   9. VARIANTS — All sizes and states at a glance
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => {
-    const [sm, setSm] = useState('09:00');
-    const [md, setMd] = useState('14:30');
-    const [lg, setLg] = useState('17:00');
-    const [errVal, setErrVal] = useState('09:00');
-
-    return (
-      <div style={{ width: 480 }}>
-        <Stack>
-          {/* Sizes */}
-          <div>
-            <SectionLabel>Sizes</SectionLabel>
-            <Stack gap="var(--gap-lg)">
-              <TimePicker size="sm" label="Small (sm)" value={sm} onChange={setSm} fullWidth />
-              <TimePicker size="md" label="Medium (md) — default" value={md} onChange={setMd} fullWidth />
-              <TimePicker size="lg" label="Large (lg)" value={lg} onChange={setLg} fullWidth />
-            </Stack>
-          </div>
-
-          {/* States */}
-          <div>
-            <SectionLabel>States</SectionLabel>
-            <Stack gap="var(--gap-lg)">
-              <TimePicker label="Default" value="09:00" onChange={() => {}} fullWidth />
-              <TimePicker label="Helper text" value="09:00" helperText="Pick the best time" onChange={() => {}} fullWidth />
-              <TimePicker label="Error" error="Time is required" value={errVal} onChange={setErrVal} fullWidth />
-              <TimePicker label="Disabled" value="08:00" disabled fullWidth />
-            </Stack>
-          </div>
-
-          {/* Format */}
-          <div>
-            <SectionLabel>Format</SectionLabel>
-            <Row gap="var(--gap-lg)">
-              <div style={{ flex: 1 }}>
-                <TimePicker label="12-hour" value="14:30" onChange={() => {}} fullWidth />
-              </div>
-              <div style={{ flex: 1 }}>
-                <TimePicker label="24-hour" value="14:30" onChange={() => {}} use24Hour fullWidth />
-              </div>
-            </Row>
-          </div>
-
-          {/* Form context — Start/End pair */}
-          <div>
-            <SectionLabel>Form context — Start / End pair</SectionLabel>
-            <Row gap="var(--gap-lg)">
-              <div style={{ flex: 1 }}>
-                <TimePicker size="sm" label="Start Time" value="09:00" onChange={() => {}} fullWidth />
-              </div>
-              <div style={{ flex: 1 }}>
-                <TimePicker size="sm" label="End Time" value="10:00" onChange={() => {}} fullWidth />
-              </div>
-            </Row>
-          </div>
-        </Stack>
-      </div>
-    );
   },
 };


### PR DESCRIPTION
## Summary

Apply ADR-010 §components-without-a-variant-axis to **TimePicker**: collapse 9 story exports to a single hook-driven `Default` and add MDX docs from scratch (TimePicker was on #454's missing-MDX list). Mirrors the DatePicker gold-standard shape shipped in #646.

### Story disposition — 9 → 1

| Old export | Disposition |
|---|---|
| `Playground`, `Default` | Merged into a single `Default` (hook-driven, all props exposed as Controls, play function preserved) |
| `WithLabel`, `WithError`, `Disabled` | Collapsed to Controls |
| `TwentyFourHour` | Collapsed to Control (`use24Hour` boolean prop) |
| `MinuteStep`, `QuarterHour` | Collapsed to Control (`minuteStep` number prop) |
| `Variants` | Dropped (banned export name per ADR-006; duplicates Controls coverage) |

Play function preserved — opens popover, asserts Radix dialog is visible (3s timeout absorbs parallel browser-vitest portal mount).

### New MDX (DatePicker template)

`Title → ComponentLinks → Description → Playground → Variants (single Default + size bullets + no-semantic-axis note) → Props → Notes (controlled, HH:mm 24h value format, minute-step intervals, error a11y)`.

No `## Patterns` section, no `## CSS Override API` section ([TimePicker.css](components/ui/TimePicker/TimePicker.css) exposes no `--time-picker-*` override variables).

## Files

- [components/ui/TimePicker/TimePicker.stories.tsx](components/ui/TimePicker/TimePicker.stories.tsx) — full rewrite (-218 net)
- [components/ui/TimePicker/TimePicker.mdx](components/ui/TimePicker/TimePicker.mdx) — new file (+41)

## Test plan

- [x] \`npm run validate:full\` — all 9 checks pass
- [x] \`npm run lint-storybook-recipe\` — 75/75 conforming (TimePicker added)
- [x] \`npm test -- --run components/ui/TimePicker\` — Default play fn passes (1/1)
- [x] \`npm run typegen:axes:check\` — manifest in sync
- [ ] Visual verification in Storybook (canvas + Controls panel + 12h/24h toggle + minute steps)
- [ ] Confirm no consumer repos referenced removed story names

## Consumer sync plan

- [ ] Portal: \`npm update @brikdesigns/bds\` after merge + version publish
- [ ] renew-pms: submodule bump
- [ ] brikdesigns: \`./scripts/bds-sync.sh\`

Refs #618 (Batch C — Form category). Closes the TimePicker line item of #454 (missing MDX docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>