### PR TITLE
fix(tokens): repair Figma → tokens-studio pipeline (3 shape mismatches + dev-relay autostart)

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
+    "dev": "bash scripts/start-figma-relay.sh && npm run storybook",
     "prestorybook": "node scripts/build-health-data.js",
     "storybook": "storybook dev -p 6006",
     "prebuild-storybook": "node scripts/build-health-data.js",

--- a/scripts/figma-pull-tokens.sh
+++ b/scripts/figma-pull-tokens.sh
@@ -120,8 +120,15 @@ while [[ $ATTEMPT -lt $MAX_RETRIES ]]; do
   ATTEMPT=$((ATTEMPT + 1))
 
   if bun "$PULL_SCRIPT" "$CHANNEL" > "$OUTPUT_FILE" 2>/tmp/figma-pull-err.log; then
-    # Validate output is real JSON with variables
-    VAR_COUNT=$(node -e "const d=require('$OUTPUT_FILE'); console.log(d.totalVariables || d.variables?.length || 0)" 2>/dev/null || echo "0")
+    # Validate output is real JSON with variables. Plugin's `get_variables`
+    # returns variables nested per collection (`collections[].variables[]`),
+    # so count from there as well as the legacy top-level `variables[]`.
+    VAR_COUNT=$(node -e "
+      const d = require('$OUTPUT_FILE');
+      const flat = d.totalVariables || d.variables?.length;
+      const nested = d.collections?.reduce((sum, c) => sum + (c.variables?.length || 0), 0);
+      console.log(flat || nested || 0);
+    " 2>/dev/null || echo "0")
     if [[ "$VAR_COUNT" -gt 0 ]]; then
       ok "Pulled $VAR_COUNT variables → $OUTPUT_FILE"
       break
@@ -150,45 +157,16 @@ while [[ $ATTEMPT -lt $MAX_RETRIES ]]; do
   fi
 done
 
-# ── 5. Transform to sync-figma-mcp format ────────────────────
-# The pull-variables.js output has { variables: [...] } with valuesByMode
-# The sync-figma-mcp.js expects flat { "path/key": "value" } format
-# Transform here.
+# ── 5. Sync to tokens-studio.json + rebuild ───────────────────
+# `sync-figma-mcp.js` natively handles the plugin's nested-collections
+# response shape (with VARIABLE_ALIAS objects and RGBA color values), so
+# pipe the raw pull output directly — no flatten step needed.
 
-log "Transforming to token format..."
-
-FLAT_FILE="/tmp/figma-vars-flat-$(date +%Y%m%d-%H%M%S).json"
-
-node -e "
-const data = require('$OUTPUT_FILE');
-const flat = {};
-
-for (const v of (data.variables || [])) {
-  // Use the variable name path (e.g., 'color/system/green-light')
-  const key = v.name.replace(/\\//g, '/');
-
-  // Use first mode value (usually 'Value' for primitives, 'Light' for semantics)
-  const modes = v.valuesByMode || {};
-  const modeNames = Object.keys(modes);
-  const val = modes[modeNames[0]];
-
-  if (val !== undefined && val !== null) {
-    flat[key] = typeof val === 'object' ? JSON.stringify(val) : String(val);
-  }
-}
-
-require('fs').writeFileSync('$FLAT_FILE', JSON.stringify(flat, null, 2));
-console.log(Object.keys(flat).length + ' tokens flattened');
-" || fail "Transform failed"
-
-ok "Flattened → $FLAT_FILE"
-
-# ── 6. Sync to tokens-studio.json + rebuild ───────────────────
 log "Syncing to tokens-studio.json and rebuilding..."
 
 cd "$BDS_ROOT"
 
-if node "$SYNC_SCRIPT" "$FLAT_FILE" --build 2>&1; then
+if node "$SYNC_SCRIPT" "$OUTPUT_FILE" --build 2>&1; then
   ok "Token sync + build complete"
 else
   warn "Sync completed with warnings (check output above)"

--- a/scripts/start-figma-relay.sh
+++ b/scripts/start-figma-relay.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────
+# start-figma-relay.sh — Idempotent start for the Figma plugin
+# WebSocket relay on port 3055.
+#
+# - Exits 0 immediately if the relay is already listening.
+# - Otherwise starts it in the background (detached) and returns
+#   once the relay confirms `/status` is reachable.
+#
+# The relay survives the foreground process exiting — Ctrl-C on
+# `npm run dev` will not kill it. That's deliberate so consecutive
+# dev sessions don't need to re-pay the relay startup cost.
+#
+# Stop the relay manually with:
+#   kill $(lsof -ti :3055 -sTCP:LISTEN)
+#
+# Usage:
+#   ./scripts/start-figma-relay.sh
+# ──────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+PORT="${FIGMA_RELAY_PORT:-3055}"
+
+# ── Resolve relay source dir ────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BDS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ -n "${BRIK_TOOLS_DIR:-}" ]]; then
+  TOOLS_DIR="$BRIK_TOOLS_DIR"
+elif [[ -d "$BDS_ROOT/../_vendor/claude-talk-to-figma-mcp" ]]; then
+  TOOLS_DIR="$(cd "$BDS_ROOT/../_vendor/claude-talk-to-figma-mcp" && pwd)"
+elif [[ -d "$BDS_ROOT/../../_vendor/claude-talk-to-figma-mcp" ]]; then
+  TOOLS_DIR="$(cd "$BDS_ROOT/../../_vendor/claude-talk-to-figma-mcp" && pwd)"
+else
+  echo "[figma-relay] WARN: cannot locate _vendor/claude-talk-to-figma-mcp from $BDS_ROOT" >&2
+  echo "[figma-relay]       set BRIK_TOOLS_DIR or skip this preflight" >&2
+  exit 0  # Soft-fail — don't block `npm run dev` if the relay tool isn't installed
+fi
+
+RELAY_SCRIPT="$TOOLS_DIR/src/socket.ts"
+
+# ── Short-circuit if already running ─────────────────────────
+if lsof -i ":$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "[figma-relay] already running on :$PORT"
+  exit 0
+fi
+
+# ── Check bun ───────────────────────────────────────────────
+if ! command -v bun >/dev/null 2>&1; then
+  echo "[figma-relay] WARN: bun not installed — skipping relay autostart" >&2
+  exit 0
+fi
+
+# ── Start detached ───────────────────────────────────────────
+echo "[figma-relay] starting on :$PORT..."
+(cd "$TOOLS_DIR" && nohup bun run "$RELAY_SCRIPT" >/dev/null 2>&1 &)
+
+# ── Wait up to 5s for /status to respond ────────────────────
+for i in {1..10}; do
+  if curl -s "http://localhost:$PORT/status" >/dev/null 2>&1; then
+    echo "[figma-relay] ✓ ready on :$PORT"
+    exit 0
+  fi
+  sleep 0.5
+done
+
+echo "[figma-relay] WARN: started but /status not reachable after 5s" >&2
+exit 0  # Soft-fail — let the foreground process try anyway

--- a/scripts/sync-figma-mcp.js
+++ b/scripts/sync-figma-mcp.js
@@ -65,6 +65,47 @@ if (!inputFile) {
 const rawData = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
 const tokensStudio = JSON.parse(fs.readFileSync(TOKENS_FILE, 'utf8'));
 
+// ─── Normalize: handle the current plugin output shape ─────────────
+// The Claude-Talk-to-Figma plugin's `get_variables` returns variables nested
+// per-collection (`collections[].variables[]`) and uses modeId-keyed values.
+// Older versions of this script expected a flat top-level `variables[]` with
+// each variable carrying its `collection` name and modeName-keyed values.
+// Normalize the nested shape to the flat shape so the downstream patch
+// routine doesn't have to know which version produced the dump.
+if (
+  !Array.isArray(rawData.variables) &&
+  Array.isArray(rawData.collections) &&
+  rawData.collections.some((c) => Array.isArray(c.variables))
+) {
+  const flatVariables = [];
+  for (const col of rawData.collections) {
+    if (!Array.isArray(col.variables)) continue;
+    // Build a modeId → modeName lookup once per collection so we can rekey
+    // each variable's valuesByMode to the human-readable mode name (which is
+    // what tokens-studio.json sets are keyed by, e.g. `color/light`).
+    const modeIdToName = new Map((col.modes || []).map((m) => [m.modeId, m.name]));
+    for (const v of col.variables) {
+      const valuesByModeName = {};
+      for (const [modeId, modeValue] of Object.entries(v.valuesByMode || {})) {
+        const modeName = modeIdToName.get(modeId) || modeId;
+        valuesByModeName[modeName] = modeValue;
+      }
+      flatVariables.push({
+        id: v.id,
+        name: v.name,
+        resolvedType: v.resolvedType,
+        collection: col.name,
+        valuesByMode: valuesByModeName,
+        description: v.description || '',
+        scopes: v.scopes || [],
+      });
+    }
+  }
+  rawData.variables = flatVariables;
+  rawData.totalCollections = rawData.collections.length;
+  rawData.totalVariables = flatVariables.length;
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────
 
 function inferTypeFromResolved(resolvedType, varName) {
@@ -112,18 +153,51 @@ function toTokenRef(varName) {
   return `{${varName.replace(/\//g, '.')}}`;
 }
 
+// Convert Figma's normalized RGBA (0-1 floats) into a CSS hex string.
+// Alpha is included only when < 1 (8-char hex); fully opaque colors stay 6-char.
+function rgbaToHex({ r, g, b, a }) {
+  const to255 = (x) => Math.round(Math.max(0, Math.min(1, x)) * 255);
+  const hex = [to255(r), to255(g), to255(b)]
+    .map((n) => n.toString(16).padStart(2, '0'))
+    .join('');
+  if (typeof a === 'number' && a < 1) {
+    return '#' + hex + to255(a).toString(16).padStart(2, '0');
+  }
+  return '#' + hex;
+}
+
 // Resolve a single mode value into its tokens-studio.json $value.
 //   - Direct primitive (string | number) → as-is.
-//   - Alias object { alias: "VariableID:..." } → "{a.b.c}".
+//   - RGBA color object { r, g, b, a } → hex string (#rrggbb or #rrggbbaa).
+//   - Alias object → "{a.b.c}". Two shapes accepted, in this order:
+//       (a) Current plugin: { type: 'VARIABLE_ALIAS', id: 'VariableID:...' }
+//       (b) Legacy:         { alias: 'VariableID:...' }
 //   - Anything else → null (caller decides to skip).
 function resolveValue(modeValue, idToName) {
   if (typeof modeValue === 'string' || typeof modeValue === 'number') {
     return modeValue;
   }
-  if (modeValue && typeof modeValue === 'object' && typeof modeValue.alias === 'string') {
-    const targetName = idToName.get(modeValue.alias);
-    if (!targetName) return null; // dangling alias
-    return toTokenRef(targetName);
+  if (modeValue && typeof modeValue === 'object') {
+    // Alias — current plugin shape ({ type, id }) takes precedence
+    if (modeValue.type === 'VARIABLE_ALIAS' && typeof modeValue.id === 'string') {
+      const targetName = idToName.get(modeValue.id);
+      if (!targetName) return null; // dangling alias
+      return toTokenRef(targetName);
+    }
+    // Alias — legacy shape ({ alias: 'VariableID:...' })
+    if (typeof modeValue.alias === 'string') {
+      const targetName = idToName.get(modeValue.alias);
+      if (!targetName) return null;
+      return toTokenRef(targetName);
+    }
+    // RGBA color from Figma Variables API
+    if (
+      typeof modeValue.r === 'number' &&
+      typeof modeValue.g === 'number' &&
+      typeof modeValue.b === 'number'
+    ) {
+      return rgbaToHex(modeValue);
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Why

The Figma-Variables-via-WebSocket-relay pipeline has been silently broken since the plugin moved to a nested-collections response shape. `design-tokens/metadata.json` shows the last successful tokens update was **2026-03-18 from a Webflow CSS export** — the Figma path has never landed a sync.

This PR fixes only the pipeline. **No token values change.** The actual alignment (which will produce a large diff) is queued as a set of sequential follow-up PRs grouped by surface — primitives, semantic colors, `[base]` rename, spacing/border RGBA fix.

## Three shape mismatches fixed in `sync-figma-mcp.js`

| Issue | Plugin returns | Script expected | Fix |
|---|---|---|---|
| Nested collections | `{ collections: [{ variables: [] }] }` with modeId-keyed values | Top-level `variables[]` with modeName-keyed values | Normalize at input — walk nested, rekey by modeName, populate legacy flat array |
| Aliases | `{ type: 'VARIABLE_ALIAS', id: 'VariableID:...' }` | `{ alias: 'VariableID:...' }` | Both shapes resolve; current shape takes precedence |
| Colors | `{ r, g, b, a }` 0-1 floats | hex string | Convert to `#rrggbb` (or `#rrggbbaa` when alpha < 1) |

## Wrapper script (`figma-pull-tokens.sh`) cleanup

- **Validator** now counts variables from both nested and flat shapes — previously only checked `d.totalVariables || d.variables?.length` and missed actual plugin output (returned 0, marked as failure).
- **Dropped redundant flatten step** — `sync-figma-mcp.js` now accepts raw pull output natively. The wrapper's manual flatten was wrong anyway (stringified RGBA, broke alias resolution).

## New: `scripts/start-figma-relay.sh` + `npm run dev`

Per request to reduce relay-start friction:

- **`scripts/start-figma-relay.sh`** — idempotent preflight. Exits 0 if relay is already listening on port 3055; otherwise starts it detached and waits up to 5s for `/status`. Soft-fails when the relay tool or `bun` isn't installed, so it never blocks dev.
- **`npm run dev`** — relay preflight → `npm run storybook`. Relay survives Storybook restarts (deliberately detached) so consecutive dev sessions don't pay startup cost.

## Verification

- [x] \`npm run validate:full\` — all 9 checks pass
- [x] \`bash scripts/start-figma-relay.sh\` — short-circuits when relay is up
- [x] \`node scripts/sync-figma-mcp.js <raw-pull.json> --dry-run\` produces **54 updates + 183 adds** against the Brand Kit (previous pipeline produced **1 add + 345 skips**)

## Follow-up PRs queued

1. **PR 2** — \`primitives/value\` sync (grayscale value shifts + new color base primitives). Visual-regression risk → needs Chromatic review.
2. **PR 3** — \`color/light\` + \`color/dark\` semantic tokens (50 updates + 176 adds).
3. **Figma side** — rename \`color/poppy/light [base]\` etc. to remove spaces + brackets (CSS-unsafe), then re-pull.
4. **PR 5** — spacing/border non-COLOR RGBA-shape bug (sync currently skips 37 of these — separate issue from this PR's scope).
5. **Phase 2 state-shift** — hover → darker, pressed → darkest after alignment lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>