### PR TITLE
feat(form): Field gold-standard — Default + 2 Q4 stories (refs #618 Batch C)

### DIFF
--- a/components/ui/Field/Field.mdx
+++ b/components/ui/Field/Field.mdx
@@ -8,47 +8,34 @@ import * as Stories from './Field.stories';
 
 <ComponentLinks slug="field" />
 
-Label + value pair for read-mode display inside a Sheet. One API covers text, tags, URLs, bullet lists, and empty states.
+Read-mode label + value pair for Sheet body rows. One API covers text, tags, URLs, bullet lists, and empty states.
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Stacked layout — label above value — is the default. Use for sheet body rows where the value needs full width.
+Field has no semantic-variant axis — all variation (label, value content, layout, empty fallback) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
-### Inline layout
-
-Label on the left, value right-aligned. Use for compact stat rows ("Status · Active", "Scraped · 8").
-
-<Canvas of={Stories.InlineLayout} />
-
-### Empty states
-
-When `children` is null, undefined, or empty string, `Field` renders an inline muted "Not set" string by default. Pass `empty="..."` to customize the message per-field.
-
-<Canvas of={Stories.EmptyStates} />
-
-### Section-level empty
-
-When an entire section has no data (vs. one missing field), pass an `<EmptyState>` into `empty`. Use the full bordered treatment sparingly — one per section at most.
-
-<Canvas of={Stories.SectionLevelEmpty} />
-
-### Value types
-
-`children` accepts any ReactNode — text, `<TagGroup>` / `<Tag>` groups, `<a>` links, `<BulletList>`, or compound content.
-
-<Canvas of={Stories.ValueTypes} />
+- **`stacked`** — label above value (default). Full-width value content; use for sheet body rows.
+- **`inline`** — label / value on one row. Use for compact stat rows ("Status · Active", "Scraped · 8").
 
 ## Patterns
 
-Typical sheet-body field stack with mixed filled and empty values.
+### Composite empty
 
-<Canvas of={Stories.Patterns} />
+When an entire section has no data (vs. one missing field), pass an `<EmptyState>` into `empty`. Use the full bordered treatment sparingly — one per section at most.
+
+<Canvas of={Stories.WithCompositeEmpty} />
+
+### Rich value composition
+
+`children` accepts any ReactNode — text, `<Tag>` groups, `<a>` links, bullet lists, or compound content.
+
+<Canvas of={Stories.WithRichValue} />
 
 ## Props
 

--- a/components/ui/Field/Field.stories.tsx
+++ b/components/ui/Field/Field.stories.tsx
@@ -3,6 +3,10 @@ import { Field } from './Field';
 import { Tag } from '../Tag';
 import { EmptyState } from '../EmptyState';
 
+/**
+ * Field — read-mode label + value pair for Sheet body rows.
+ * @summary Read-mode label + value pair for Sheet body rows
+ */
 const meta: Meta<typeof Field> = {
   title: 'Components/Form/field',
   component: Field,
@@ -10,6 +14,7 @@ const meta: Meta<typeof Field> = {
   parameters: { layout: 'padded' },
   argTypes: {
     label: { control: 'text' },
+    children: { control: 'text' },
     layout: { control: 'select', options: ['stacked', 'inline'] },
     empty: { control: 'text' },
   },
@@ -18,22 +23,14 @@ const meta: Meta<typeof Field> = {
 export default meta;
 type Story = StoryObj<typeof Field>;
 
-/* ─── Story helpers ──────────────────────────────────────────── */
-
 const Frame = ({ width = '360px', children }: { width?: string; children: React.ReactNode }) => (
   <div style={{ width, padding: 'var(--padding-lg)', background: 'var(--surface-primary)' }}>
     {children}
   </div>
 );
 
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>{children}</div>
-);
-
-/* ─── 1. Playground ──────────────────────────────────────────── */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Canonical Field — flip Controls to explore layout + empty fallbacks */
+export const Default: Story = {
   args: {
     label: 'Status',
     children: 'Active',
@@ -46,58 +43,8 @@ export const Playground: Story = {
   ),
 };
 
-/* ─── 2. Variants ────────────────────────────────────────────── */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Frame>
-      <Stack>
-        <Field label="Status">Active</Field>
-        <Field label="Owner">Nick Stanerson</Field>
-        <Field label="Industry">Design & Engineering</Field>
-        <Field label="Last updated">2 days ago</Field>
-      </Stack>
-    </Frame>
-  ),
-};
-
-/* ─── 3. Inline layout ──────────────────────────────────────── */
-
-/** @summary Inline layout */
-export const InlineLayout: Story = {
-  render: () => (
-    <Frame>
-      <Stack>
-        <Field layout="inline" label="Status">Active</Field>
-        <Field layout="inline" label="Scraped">8</Field>
-        <Field layout="inline" label="Failed">12</Field>
-        <Field layout="inline" label="Last updated">2 days ago</Field>
-      </Stack>
-    </Frame>
-  ),
-};
-
-/* ─── 4. Empty states ────────────────────────────────────────── */
-
-/** @summary Empty states */
-export const EmptyStates: Story = {
-  render: () => (
-    <Frame>
-      <Stack>
-        <Field label="Status">Active</Field>
-        <Field label="Notes" />
-        <Field label="Tags">{null}</Field>
-        <Field label="Custom empty" empty="No owner assigned" />
-      </Stack>
-    </Frame>
-  ),
-};
-
-/* ─── 5. Section-level empty override ────────────────────────── */
-
-/** @summary Section level empty */
-export const SectionLevelEmpty: Story = {
+/** @summary EmptyState composed into the `empty` slot for section-level empties */
+export const WithCompositeEmpty: Story = {
   render: () => (
     <Frame width="480px">
       <Field
@@ -113,13 +60,11 @@ export const SectionLevelEmpty: Story = {
   ),
 };
 
-/* ─── 6. Value types — text, tags, URL, list ────────────────── */
-
-/** @summary Value types */
-export const ValueTypes: Story = {
+/** @summary `children` accepts text, Tag groups, anchors, or bullet lists */
+export const WithRichValue: Story = {
   render: () => (
     <Frame>
-      <Stack>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
         <Field label="Name">Birdwell & Mutlak Dentistry</Field>
 
         <Field label="Services">
@@ -131,8 +76,12 @@ export const ValueTypes: Story = {
         </Field>
 
         <Field label="Website">
-          <a href="https://birdwelldentist.com" target="_blank" rel="noreferrer"
-             style={{ color: 'var(--text-brand-primary)', textDecoration: 'none' }}>
+          <a
+            href="https://birdwelldentist.com"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: 'var(--text-brand-primary)', textDecoration: 'none' }}
+          >
             birdwelldentist.com ↗
           </a>
         </Field>
@@ -144,24 +93,7 @@ export const ValueTypes: Story = {
             <li>Avoid dental-industry jargon</li>
           </ul>
         </Field>
-      </Stack>
-    </Frame>
-  ),
-};
-
-/* ─── 7. Patterns — multi-field row ─────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Frame width="480px">
-      <Stack>
-        <Field label="Entity name">Birdwell & Mutlak, LLC</Field>
-        <Field label="Owner">Nick Stanerson</Field>
-        <Field label="Practice location">Thompson Station, TN</Field>
-        <Field label="Insurance accepted" />
-        <Field label="Parent organization" empty="Independent" />
-      </Stack>
+      </div>
     </Frame>
   ),
 };


### PR DESCRIPTION
## Summary

Migrates `Field` to the single-`Default` gold-standard shape per [#618](https://github.com/brikdesigns/brik-bds/issues/618) framework (Carbon precedent), matching DatePicker (#646) / TimePicker (#649) cadence in Batch C.

**Stories: 7 → 3**

| Status | Story | Why |
|---|---|---|
| renamed | `Playground` → `Default` | Match Carbon-precedent canonical-story name |
| dropped | `Variants` | Banned export — 4-Field side-by-side gallery duplicates the sidebar |
| dropped | `InlineLayout` | Q2 — `layout` axis (`stacked`/`inline`) is already a Control |
| dropped | `EmptyStates` | Q2 — `empty` + `children` are already Controls |
| kept | `WithCompositeEmpty` (was `SectionLevelEmpty`) | Q4 irreducible — `<EmptyState>` composed into `empty` slot |
| kept | `WithRichValue` (was `ValueTypes`) | Q4 irreducible — Tag groups, anchors, bullet lists in `children` |
| dropped | `Patterns` | Banned export — 5-Field stack is documentation gallery |

**MDX rewrite**: `## Playground` + `## Variants` both Canvas `Stories.Default` per ADR-010 §components-without-a-variant-axis (matches DatePicker/TimePicker). `## Patterns` retained — content-bearing via `WithCompositeEmpty` + `WithRichValue`, not contrived to satisfy lint.

## Test plan

- [x] `npm run lint-storybook-recipe` — 75/75 conforming
- [x] `npm run typecheck` — clean
- [x] `npm run validate:full` — all 9 checks pass (token/jsdoc/grid/theme/blueprint/canonical/axes/tsc/storybook-build)
- [ ] Visual review on Netlify deploy preview
- [ ] Confirm Controls panel exposes `label` / `children` / `layout` / `empty`

## Refs

- Tracking: [#618](https://github.com/brikdesigns/brik-bds/issues/618) Batch C — Form category
- Framework: [ADR-010](docs/adrs/ADR-010-storybook-axes-of-information.md) §components-without-a-variant-axis
- Precedent: [#646](https://github.com/brikdesigns/brik-bds/pull/646) (DatePicker), [#649](https://github.com/brikdesigns/brik-bds/pull/649) (TimePicker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)