### PR TITLE
refactor(stories): move Field/FieldGrid/Form to Displays/ + sync taxonomy standard

### DIFF
--- a/.claude/standards/storybook-story-shape.md
+++ b/.claude/standards/storybook-story-shape.md
@@ -5,7 +5,7 @@ type: reference
 scope: brik-bds
 applies-to: "**/components/ui/**/*.stories.tsx, **/content-system/blueprints/**/*.stories.tsx, **/stories/**/*.stories.tsx"
 retrieved-via: brik-rag query "storybook story shape standard"
-last-verified: 2026-05-13
+last-verified: 2026-05-15
 ---
 
 # Storybook story-shape standard (BDS)
@@ -184,34 +184,59 @@ Same tag applies to `InteractionTest…` stories (Q5 from the matrix) so they do
 
 Never combine two prop axes in one story. Write `Sizes` and `Variants` as separate stories — never `SizesAndVariants`. If a story name needs "and" to describe it, split it.
 
-## Sidebar taxonomy — four content top-levels
+## Sidebar taxonomy — preview.tsx is the source of truth
 
-`Foundations` / `Components` / `Patterns` / `Theming`, plus `Overview` (kept separate) and `Deprecated` (sorts last, tagged `!manifest`). `Components/` uses a single alphabetical subcategory layer:
+**Canon-on-paper has drifted from canon-in-fact.** ADR-006 and prior versions of this section described four content top-levels (`Foundations` / `Components` / `Patterns` / `Theming`); the live `.storybook/preview.tsx` `parameters.options.storySort.order` array is the actual sidebar order Storybook renders. Read it before authoring a `title:` — the two disagree today and `preview.tsx` wins.
+
+**Live storySort order** (see [`.storybook/preview.tsx`](../../.storybook/preview.tsx) `storySort.order`):
 
 ```
-Action  Addables  Card  Container  Control  Feedback
-Form  Indicator  List  Navigation  Overlay  Structure
+Overview → Foundation → Theming → Motion → Content System →
+Components → Navigation → Displays → * (catch-all) → Deprecated
 ```
 
-**Before writing `title:` in a story meta, read the sibling stories' titles in the same folder.** The sidebar tree is shared across all of Storybook — introducing a parallel top-level group (`Blueprints/...` instead of `Theming/Blueprints/...`) fragments it.
+Each top-level has an inner subcategory order. The key ones for component authors:
+
+| Top-level | Subcategories (in order) |
+|---|---|
+| `Components/` | `Action`, `Form`, `Input`, `Control`, `Indicator`, `Feedback`, `Structure` |
+| `Navigation/` | `Primary`, `Secondary`, `Stepper` |
+| `Displays/` | `Card`, `Accordion`, `Table`, `Sheet`, `Form`, `Overlay` |
+| `Displays/Sheet/` | `sheet`, `sheet-section`, `sheet-typography`, `field`, `field-grid`, `bullet-list`, `Read-Mode Sheet` |
+| `Displays/Form/` | `form`, `Read-Mode Page` |
+| `Theming/` | `Overview`, `Client Themes`, `Atmospheres`, `Modes`, `Layout Archetypes`, `Blueprints` |
+
+**Components vs Displays — the API-affordance line.** `Components/` holds atomic input primitives (the things a user types into / clicks on — `Button`, `Checkbox`, `TextInput`, `Select`). `Displays/` holds composition primitives that *render* data (the things that wrap, group, or read-mode display — `Card`, `Sheet`, `Field`, `Form` composer, `Table`). When in doubt, ask: "does this primitive accept input, or does it lay out something else?" Input → `Components/`; layout/read-mode → `Displays/`.
+
+**Phantom top-levels — slated for cleanup.** Two prefixes show up in the sidebar today that are *not* in `storySort.order` and fall into the `*` catch-all bucket:
+
+- `Patterns/` — created by [#637](https://github.com/brikdesigns/brik-bds/pull/637) (Patterns/Forms taxonomy). The compositions are correct work; the `Patterns/` top-level itself was added without amending `storySort.order` and reads as a phantom group. Cleanup is part of the planned top-level rationalization (post-#618 component cleanup).
+- `Dev Tools/` — used by some dashboard / interactive tooling stories. Same shape — phantom group, scheduled for cleanup.
+
+**Do not freelance a new top-level.** If your work needs one, surface the gap — adding a top-level requires updating `storySort.order` in `preview.tsx` and amending [ADR-006](../../docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md), not just a `title:` string.
 
 Canonical prefixes:
 
-| Folder | Title prefix |
+| Folder / file | Title prefix |
 |---|---|
-| `components/ui/<Component>` | `Components/<Group>/<component>` (e.g. `Components/Action/button`) |
+| `components/ui/<Component>` (input primitive) | `Components/<Subcategory>/<component>` (e.g. `Components/Action/button`) |
+| `components/ui/<Component>` (display / composer / read-mode) | `Displays/<Subcategory>/<component>` (e.g. `Displays/Sheet/field`, `Displays/Form/form`) |
 | `content-system/blueprints/react/<Blueprint>` | `Theming/Blueprints/<blueprint_key>` |
+| `stories/patterns/forms/<Pattern>` | `Patterns/Forms/<Pattern>` (phantom top-level — see note above) |
 | Storybook recipes / docs | `Recipes/<Topic>` |
 
 ```tsx
-/* Right — matches existing sidebar tree */
+/* Right — matches existing sidebar tree + preview.tsx storySort */
+title: 'Displays/Sheet/field'
+title: 'Components/Action/button'
 title: 'Theming/Blueprints/hero_split_image_card_overlay'
 
-/* Wrong — creates a parallel "Blueprints" top-level group */
+/* Wrong — creates a parallel top-level group not in storySort.order */
 title: 'Blueprints/hero_split_image_card_overlay'
+title: 'Form/field'
 ```
 
-Full member list per subcategory lives in [ADR-006 Part A](../../docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md). Query brik-rag (`storybook sidebar taxonomy`) or open the ADR.
+**Before writing `title:` in a story meta, read the sibling stories' titles in the same folder** AND verify the prefix appears in `.storybook/preview.tsx` `storySort.order`. The lint catches missing `<Canvas>` references but does not yet catch off-tree title prefixes.
 
 ## Args composition — blueprints + page stories
 

--- a/components/ui/Field/Field.stories.tsx
+++ b/components/ui/Field/Field.stories.tsx
@@ -8,7 +8,7 @@ import { EmptyState } from '../EmptyState';
  * @summary Read-mode label + value pair for Sheet body rows
  */
 const meta: Meta<typeof Field> = {
-  title: 'Components/Form/field',
+  title: 'Displays/Sheet/field',
   component: Field,
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },

--- a/components/ui/FieldGrid/FieldGrid.stories.tsx
+++ b/components/ui/FieldGrid/FieldGrid.stories.tsx
@@ -4,7 +4,7 @@ import { Field } from '../Field';
 import { Card } from '../Card';
 
 const meta: Meta<typeof FieldGrid> = {
-  title: 'Components/Form/field-grid',
+  title: 'Displays/Sheet/field-grid',
   component: FieldGrid,
   tags: ['surface-product'],
   parameters: { layout: 'padded' },

--- a/components/ui/Form/Form.stories.tsx
+++ b/components/ui/Form/Form.stories.tsx
@@ -33,7 +33,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof Form> = {
-  title: 'Components/Form/form',
+  title: 'Displays/Form/form',
   component: Form,
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },


### PR DESCRIPTION
## Summary

Aligns three composite/display primitives with the slots already provisioned in `.storybook/preview.tsx` `storySort.order`, and fixes the stale sidebar-taxonomy section of the `storybook-story-shape` standard so canon-on-paper matches canon-in-fact.

### Title moves

| Component | Old | New |
|---|---|---|
| Field | `Components/Form/field` | `Displays/Sheet/field` |
| FieldGrid | `Components/Form/field-grid` | `Displays/Sheet/field-grid` |
| Form | `Components/Form/form` | `Displays/Form/form` |

All three match slots already in `preview.tsx:367-383` — no `storySort.order` edits needed.

### Why move

`Components/` holds **input primitives** (Button, Checkbox, TextInput, Select — things the user interacts with). `Displays/` holds **composition / read-mode primitives** (Card, Sheet, Field, Form composer, Table — things that lay out or render data). The three subjects of this PR are all in the second bucket and were under the wrong top-level.

### Standards fix

`.claude/standards/storybook-story-shape.md` previously claimed four content top-levels (Foundations / Components / Patterns / Theming). That section was aspirational and out of sync with `preview.tsx`. Rewrite covers:

- Documents the live storySort order (8 content top-levels — Overview, Foundation, Theming, Motion, Content System, Components, Navigation, Displays — plus Deprecated)
- Subcategory tables for `Components/`, `Navigation/`, `Displays/` (including the inner orders for `Displays/Sheet/` and `Displays/Form/`)
- Defines the Components-vs-Displays line (input affordance vs layout/read-mode)
- Flags `Patterns/` + `Dev Tools/` as **phantom top-levels** — created by stories whose `title:` prefix isn't in `storySort.order`, so they render in the `*` catch-all. Scheduled for cleanup with the planned post-#618 top-level rationalization.
- Updates the canonical-prefixes table with the right/wrong examples
- Bumps `last-verified` to 2026-05-15
- Re-ingested into brik-rag via `scripts/ingest-storybook-story-shape-standard.sh`

## Out of scope

- No story / MDX body changes (those keep coming in the per-component gold-standard PRs).
- No `storySort.order` edits in `preview.tsx`.
- No cleanup of `Patterns/` or `Dev Tools/` phantom top-levels — that's the planned follow-up effort the user flagged.
- No ADR-006 amendment yet. The standards-file fix is the operational expression; ADR-006 Part A will be amended as part of the planned top-level cleanup.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint-storybook-recipe` — 75/75 conforming
- [x] `npm run validate:full` — all 9 checks pass
- [x] `grep -rE "Components/Form/(field|form)"` outside `node_modules`/`dist` — zero hits
- [ ] Visual confirm on Netlify deploy preview: Field/FieldGrid render under `Displays/Sheet/`, Form renders under `Displays/Form/`, and nothing falls into the `*` catch-all bucket

## Refs

- Follow-up to [#652](https://github.com/brikdesigns/brik-bds/pull/652) (Field gold-standard)
- Umbrella: [#618](https://github.com/brikdesigns/brik-bds/issues/618)
- Source of truth: [`.storybook/preview.tsx:305-385`](.storybook/preview.tsx#L305-L385)

🤖 Generated with [Claude Code](https://claude.com/claude-code)