### PR TITLE
feat(displays): FieldGrid gold-standard — Default + StatTiles (refs #618 Batch C)

### DIFF
--- a/components/ui/FieldGrid/FieldGrid.mdx
+++ b/components/ui/FieldGrid/FieldGrid.mdx
@@ -12,27 +12,24 @@ Equal-column grid for laying out `Field` components side by side. Accepts any ch
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-### Columns
+FieldGrid has no semantic-variant axis — all variation (column count, gap size) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-`columns` locks to `2`, `3`, or `4`. No custom column templates — if you need something else, you're composing the wrong primitive.
+<Canvas of={Stories.Default} />
 
-<Canvas of={Stories.Columns} />
-
-### Stat tiles
-
-Wrapping each grid cell in a `<Card variant="outlined">` produces the stat-tile pattern.
-
-<Canvas of={Stories.StatTiles} />
+- **`columns`** — `2` (default), `3`, or `4`. No custom column templates; if you need something else, you're composing the wrong primitive.
+- **`gap`** — `md` / `lg` / `xl` (default). Matches the inter-cell spacing scale used across portal sheets.
 
 ## Patterns
 
-Typical 2-column entity detail grid.
+### Stat tiles
 
-<Canvas of={Stories.Patterns} />
+Wrapping each grid cell in a `<Card variant="outlined">` produces the stat-tile pattern — typical for source/scraped/failed dashboards inside a sheet.
+
+<Canvas of={Stories.StatTiles} />
 
 ## Props
 

--- a/components/ui/FieldGrid/FieldGrid.stories.tsx
+++ b/components/ui/FieldGrid/FieldGrid.stories.tsx
@@ -3,6 +3,10 @@ import { FieldGrid } from './FieldGrid';
 import { Field } from '../Field';
 import { Card } from '../Card';
 
+/**
+ * FieldGrid — equal-column grid for laying out Fields side by side.
+ * @summary Equal-column grid for laying out Fields side by side
+ */
 const meta: Meta<typeof FieldGrid> = {
   title: 'Displays/Sheet/field-grid',
   component: FieldGrid,
@@ -23,10 +27,8 @@ const Frame = ({ width = '540px', children }: { width?: string; children: React.
   </div>
 );
 
-/* ─── 1. Playground ──────────────────────────────────────────── */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Canonical FieldGrid — flip Controls to change columns + gap */
+export const Default: Story = {
   args: {
     columns: 2,
     gap: 'xl',
@@ -43,38 +45,7 @@ export const Playground: Story = {
   ),
 };
 
-/* ─── 2. Columns ─────────────────────────────────────────────── */
-
-/** @summary Columns */
-export const Columns: Story = {
-  render: () => (
-    <Frame>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)' }}>
-        <FieldGrid columns={2}>
-          <Field label="Owner">Nick Stanerson</Field>
-          <Field label="Status">Active</Field>
-        </FieldGrid>
-
-        <FieldGrid columns={3}>
-          <Field label="Source" layout="inline">birdwelldentist.com</Field>
-          <Field label="Scraped" layout="inline">8</Field>
-          <Field label="Failed" layout="inline">12</Field>
-        </FieldGrid>
-
-        <FieldGrid columns={4}>
-          <Field label="Gold">#c49a2f</Field>
-          <Field label="Gray">#b0b0b0</Field>
-          <Field label="White">#ffffff</Field>
-          <Field label="Black">#000000</Field>
-        </FieldGrid>
-      </div>
-    </Frame>
-  ),
-};
-
-/* ─── 3. Stat tiles — Cards in a FieldGrid ───────────────────── */
-
-/** @summary Stat tiles */
+/** @summary Card-wrapped cells produce the stat-tile pattern */
 export const StatTiles: Story = {
   render: () => (
     <Frame>
@@ -88,24 +59,6 @@ export const StatTiles: Story = {
         <Card variant="outlined">
           <Field label="Failed">12</Field>
         </Card>
-      </FieldGrid>
-    </Frame>
-  ),
-};
-
-/* ─── 4. Patterns — mixed with SheetSection ─────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Frame width="520px">
-      <FieldGrid columns={2}>
-        <Field label="Entity name">Birdwell & Mutlak, LLC</Field>
-        <Field label="Founded">2014</Field>
-        <Field label="Owner">Nick Stanerson</Field>
-        <Field label="Parent" empty="Independent" />
-        <Field label="Primary location">Thompson Station, TN</Field>
-        <Field label="Locations">3</Field>
       </FieldGrid>
     </Frame>
   ),


### PR DESCRIPTION
## Summary

Migrates `FieldGrid` to the single-`Default` gold-standard shape per [#618](https://github.com/brikdesigns/brik-bds/issues/618) framework (Carbon precedent), matching Field (#652) / DatePicker (#646) / TimePicker (#649) cadence in Batch C.

**Stories: 4 → 2**

| Status | Story | Why |
|---|---|---|
| renamed | `Playground` → `Default` | Match Carbon-precedent canonical-story name |
| dropped | `Columns` | Q2 — `columns` is already a select Control (2/3/4); 3-grid side-by-side gallery isn't Q4 |
| kept | `StatTiles` | Q4 irreducible — Card-wrapped Field cells, multi-component composition |
| dropped | `Patterns` | Banned export — entity-detail gallery duplicated the sidebar |

**MDX rewrite**: `## Playground` + `## Variants` both Canvas `Stories.Default` per ADR-010 §components-without-a-variant-axis. `## Patterns` retained — content-bearing via `StatTiles`, not contrived. `columns` + `gap` values enumerated as bullets under `## Variants`.

## Test plan

- [x] `npm run lint-storybook-recipe` — 75/75 conforming
- [x] `npm run typecheck` — clean
- [ ] Visual review on Netlify deploy preview
- [ ] Confirm Controls panel exposes `columns` (2/3/4) + `gap` (md/lg/xl)
- [ ] Confirm new title appears under **Displays / Sheet / field-grid** (per [#653](https://github.com/brikdesigns/brik-bds/pull/653))

## Refs

- Tracking: [#618](https://github.com/brikdesigns/brik-bds/issues/618) Batch C — Form category (line 124)
- Framework: [ADR-010](docs/adrs/ADR-010-storybook-axes-of-information.md) §components-without-a-variant-axis
- Precedent: [#646](https://github.com/brikdesigns/brik-bds/pull/646), [#649](https://github.com/brikdesigns/brik-bds/pull/649), [#652](https://github.com/brikdesigns/brik-bds/pull/652)
- Taxonomy: relies on [#653](https://github.com/brikdesigns/brik-bds/pull/653) (Displays/ move)

🤖 Generated with [Claude Code](https://claude.com/claude-code)