### PR TITLE
feat(displays): Form gold-standard + relocate FeedbackForm + SearchForm to Patterns/Forms/ (refs #618 Batch C)

### DIFF
--- a/components/ui/Form/Form.mdx
+++ b/components/ui/Form/Form.mdx
@@ -12,30 +12,24 @@ Structured form container with layout control, error/success messaging, and cons
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Error state, success state, and horizontal layout.
+Form has no semantic-variant axis — all variation (layout, gap, title, description, error, success) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
-- **`vertical`** — Fields stack vertically (default)
-- **`horizontal`** — Fields side by side for compact forms
-
-Gap sizes:
-
-- **`sm`** — `--gap-md` (8px)
-- **`md`** — `--gap-lg` (16px)
-- **`lg`** — `--gap-xl` (24px)
-
-## Patterns
-
-Real-world usage: interactive feedback form with validation and submission.
-
-<Canvas of={Stories.Patterns} />
+- **`layout`** — `vertical` (default) stacks fields; `horizontal` lays them out inline (use with the search-form pattern below).
+- **`gap`** — `sm` / `md` (default) / `lg`. Controls the vertical rhythm between fields.
+- **`title` / `description`** — optional header pair; the title renders as an `h3`, description as a `p` underneath.
+- **`error` / `success`** — inline form-level messaging announced via `role="alert"` / `role="status"`. Pass at most one.
+- **`footer`** — typically a submit `<Button>`; can hold a button group for submit + cancel.
 
 ## Props
 
 <ArgTypes of={Stories} />
 
+## Notes
+
+> **Note** — Multi-primitive compositions that *use* Form (feedback forms, search bars, login screens) live in [`Patterns/Forms/`](?path=/docs/patterns-forms-feedback-form--docs), not on this page. Per [#618](https://github.com/brikdesigns/brik-bds/issues/618) and the ADR-010 amendment, primitive story files demonstrate the primitive itself; multi-component compositions live alongside their siblings (ContactForm, LoginForm, SignUpForm, FeedbackForm, SearchForm).

--- a/components/ui/Form/Form.stories.tsx
+++ b/components/ui/Form/Form.stories.tsx
@@ -1,37 +1,13 @@
-import React from 'react';
-import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Form } from './Form';
 import { TextInput } from '../TextInput';
 import { TextArea } from '../TextArea';
-import { Select } from '../Select';
 import { Button } from '../Button';
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children, gap = 'var(--padding-sm)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', gap, flexWrap: 'wrap', alignItems: 'flex-start' }}>{children}</div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Meta ────────────────────────────────────────────────────── */
-
+/**
+ * Form — structured form container with layout, header, footer, and inline messaging.
+ * @summary Form container with layout and inline messaging
+ */
 const meta: Meta<typeof Form> = {
   title: 'Displays/Form/form',
   component: Form,
@@ -50,12 +26,13 @@ const meta: Meta<typeof Form> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Canonical Form — flip Controls to explore layout, gap, and inline messaging */
+export const Default: Story = {
+  args: {
+    title: 'Contact Us',
+    description: "We'll get back to you within 24 hours.",
+    footer: <Button type="submit">Send Message</Button>,
+  },
   render: (args) => (
     <div style={{ width: 400 }}>
       <Form {...args}>
@@ -65,137 +42,4 @@ export const Playground: Story = {
       </Form>
     </div>
   ),
-  args: {
-    title: 'Contact Us',
-    description: "We'll get back to you within 24 hours.",
-    footer: <Button type="submit">Send Message</Button>,
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Layouts, states, gap sizes
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Row gap="var(--padding-xl)">
-      <div style={{ width: 380 }}>
-        <Stack>
-          {/* Error state */}
-          <div>
-            <SectionLabel>With error</SectionLabel>
-            <Form
-              title="Sign Up"
-              error="Please fix the errors below and try again."
-              footer={<Button type="submit">Create Account</Button>}
-            >
-              <TextInput label="Email" type="email" placeholder="you@example.com" error="Email is already in use." fullWidth />
-              <TextInput label="Password" type="password" placeholder="Choose a password" fullWidth />
-            </Form>
-          </div>
-
-          {/* Success state */}
-          <div>
-            <SectionLabel>With success</SectionLabel>
-            <Form
-              title="Newsletter"
-              success="You've been subscribed successfully!"
-              footer={<Button type="submit" disabled>Subscribed</Button>}
-            >
-              <TextInput label="Email" type="email" value="user@example.com" readOnly fullWidth />
-            </Form>
-          </div>
-        </Stack>
-      </div>
-
-      <div style={{ width: 500 }}>
-        <Stack>
-          {/* Horizontal layout */}
-          <div>
-            <SectionLabel>Horizontal layout</SectionLabel>
-            <Form
-              title="Quick Search"
-              layout="horizontal"
-              gap="sm"
-              footer={<Button type="submit" size="sm">Search</Button>}
-            >
-              <div style={{ flex: '1 1 200px' }}>
-                <TextInput placeholder="Search..." fullWidth />
-              </div>
-              <div style={{ flex: '0 1 160px' }}>
-                <Select
-                  options={[
-                    { label: 'All', value: 'all' },
-                    { label: 'Products', value: 'products' },
-                    { label: 'Services', value: 'services' },
-                  ]}
-                  placeholder="Category"
-                />
-              </div>
-            </Form>
-          </div>
-        </Stack>
-      </div>
-    </Row>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Interactive form with validation
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => {
-    function FeedbackForm() {
-      const [submitted, setSubmitted] = useState(false);
-      const [error, setError] = useState('');
-      return (
-        <div style={{ width: 400 }}>
-          <SectionLabel>Interactive feedback form</SectionLabel>
-          <Form
-            title="Feedback"
-            description="Help us improve our product."
-            error={error}
-            success={submitted ? 'Thank you for your feedback!' : undefined}
-            onSubmit={(e) => {
-              e.preventDefault();
-              const data = new FormData(e.currentTarget);
-              if (!data.get('name')) {
-                setError('Name is required.');
-                setSubmitted(false);
-              } else {
-                setError('');
-                setSubmitted(true);
-              }
-            }}
-            footer={
-              <div style={{ display: 'flex', gap: 'var(--gap-md)' }}>
-                <Button type="submit">Submit</Button>
-                <Button variant="ghost" type="reset" onClick={() => { setError(''); setSubmitted(false); }}>Reset</Button>
-              </div>
-            }
-          >
-            <TextInput label="Name" name="name" placeholder="Your name" fullWidth />
-            <Select
-              label="Rating"
-              name="rating"
-              options={[
-                { label: 'Excellent', value: '5' },
-                { label: 'Good', value: '4' },
-                { label: 'Average', value: '3' },
-                { label: 'Poor', value: '2' },
-                { label: 'Terrible', value: '1' },
-              ]}
-              placeholder="Select a rating"
-            />
-            <TextArea label="Comments" name="comments" placeholder="Tell us more..." fullWidth />
-          </Form>
-        </div>
-      );
-    }
-
-    return <FeedbackForm />;
-  },
 };

--- a/stories/patterns/forms/FeedbackForm.stories.tsx
+++ b/stories/patterns/forms/FeedbackForm.stories.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import { Form } from '../../../components/ui/Form';
+import { TextInput } from '../../../components/ui/TextInput';
+import { TextArea } from '../../../components/ui/TextArea';
+import { Select } from '../../../components/ui/Select';
+import { Button } from '../../../components/ui/Button';
+
+const meta: Meta = {
+  title: 'Patterns/Forms/feedback-form',
+  tags: ['surface-shared'],
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj;
+
+/* ═══════════════════════════════════════════════════════════════
+   Multi-primitive form composition: Form composer × (TextInput +
+   Select + TextArea + Button) with interactive validation state.
+   Lives in Patterns/Forms/ per ADR-010 amendment §1 (compositions
+   combining multiple distinct primitives don't live on the
+   primitive's story file).
+   Relocated from Form.stories.tsx → Patterns in #618 Batch C.
+   ═══════════════════════════════════════════════════════════════ */
+
+function FeedbackForm({ onSubmit }: { onSubmit: (e: React.FormEvent) => void }) {
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
+
+  return (
+    <div style={{ width: 400 }}>
+      <Form
+        title="Feedback"
+        description="Help us improve our product."
+        error={error}
+        success={submitted ? 'Thank you for your feedback!' : undefined}
+        onSubmit={(e) => {
+          e.preventDefault();
+          const data = new FormData(e.currentTarget);
+          if (!data.get('name')) {
+            setError('Name is required.');
+            setSubmitted(false);
+          } else {
+            setError('');
+            setSubmitted(true);
+            onSubmit(e);
+          }
+        }}
+        footer={
+          <div style={{ display: 'flex', gap: 'var(--gap-md)' }}>
+            <Button type="submit">Submit</Button>
+            <Button
+              variant="ghost"
+              type="reset"
+              onClick={() => {
+                setError('');
+                setSubmitted(false);
+              }}
+            >
+              Reset
+            </Button>
+          </div>
+        }
+      >
+        <TextInput label="Name" name="name" placeholder="Your name" fullWidth />
+        <Select
+          label="Rating"
+          name="rating"
+          options={[
+            { label: 'Excellent', value: '5' },
+            { label: 'Good', value: '4' },
+            { label: 'Average', value: '3' },
+            { label: 'Poor', value: '2' },
+            { label: 'Terrible', value: '1' },
+          ]}
+          placeholder="Select a rating"
+        />
+        <TextArea label="Comments" name="comments" placeholder="Tell us more..." fullWidth />
+      </Form>
+    </div>
+  );
+}
+
+/** @summary Feedback form — name + rating + comments with inline validation */
+export const Default: Story = {
+  args: { onSubmit: fn() },
+  render: (args) => (
+    <FeedbackForm
+      onSubmit={(args as { onSubmit: (e: React.FormEvent) => void }).onSubmit}
+    />
+  ),
+};

--- a/stories/patterns/forms/SearchForm.stories.tsx
+++ b/stories/patterns/forms/SearchForm.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import { Form } from '../../../components/ui/Form';
+import { TextInput } from '../../../components/ui/TextInput';
+import { Select } from '../../../components/ui/Select';
+import { Button } from '../../../components/ui/Button';
+
+const meta: Meta = {
+  title: 'Patterns/Forms/search-form',
+  tags: ['surface-shared'],
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj;
+
+/* ═══════════════════════════════════════════════════════════════
+   Horizontal-layout Form composition: Form composer × (TextInput +
+   Select + Button) inline. Demonstrates `layout="horizontal"` with
+   a compact search bar pattern.
+   Relocated from Form.stories.tsx Variants → Patterns in #618 Batch C.
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Horizontal search form — query + category + submit, inline layout */
+export const Default: Story = {
+  args: { onSubmit: fn() },
+  render: (args) => (
+    <div style={{ width: 500 }}>
+      <Form
+        title="Quick Search"
+        layout="horizontal"
+        gap="sm"
+        onSubmit={(e) => {
+          e.preventDefault();
+          (args as { onSubmit?: (e: React.FormEvent) => void }).onSubmit?.(e);
+        }}
+        footer={<Button type="submit" size="sm">Search</Button>}
+      >
+        <div style={{ flex: '1 1 200px' }}>
+          <TextInput placeholder="Search..." fullWidth />
+        </div>
+        <div style={{ flex: '0 1 160px' }}>
+          <Select
+            options={[
+              { label: 'All', value: 'all' },
+              { label: 'Products', value: 'products' },
+              { label: 'Services', value: 'services' },
+            ]}
+            placeholder="Category"
+          />
+        </div>
+      </Form>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

Closes out [#618](https://github.com/brikdesigns/brik-bds/issues/618) Batch C Form-category cleanup. Migrates `Form` to single-`Default` shape per the Carbon precedent (matches Field #652 / FieldGrid #654 / DatePicker #646 / TimePicker #649) **and** relocates the two multi-primitive compositions that previously lived on `Form.stories.tsx` to `stories/patterns/forms/` per the ADR-010 amendment.

### Stories on Form.stories.tsx (3 → 1)

| Status | Story | Why |
|---|---|---|
| renamed | `Playground` → `Default` | Match Carbon-precedent canonical-story name |
| dropped | `Variants` | Q2 — `error` / `success` / `layout` sub-cases are all single-prop variations exposed via Controls. The horizontal-Select sub-case relocates to `SearchForm` pattern |
| dropped | `Patterns` (FeedbackForm) | Banned export — relocated to `Patterns/Forms/feedback-form` |

### New files — relocations to `stories/patterns/forms/`

| File | Title | Source |
|---|---|---|
| `FeedbackForm.stories.tsx` | `Patterns/Forms/feedback-form` | Was `Patterns` on Form.stories.tsx — interactive validation with FormData |
| `SearchForm.stories.tsx` | `Patterns/Forms/search-form` | Was the horizontal sub-case of `Variants` — inline TextInput + Select + Button via `layout="horizontal"` |

Both match the title convention used by existing `ContactForm` / `LoginForm` / `SignUpForm` patterns (from [#637](https://github.com/brikdesigns/brik-bds/pull/637)).

### MDX rewrite

- Drops `## Patterns` H2 — `Form.stories.tsx` no longer ships any Q4 story, so per ADR-007 the section is omitted (Banner is the gold-standard reference for the omit case).
- `## Playground` + `## Variants` both Canvas `Stories.Default` per ADR-010 §components-without-a-variant-axis.
- Adds `## Notes` callout linking readers to `Patterns/Forms/` for multi-primitive Form usage demos.

## Flagged for follow-up (composite-component cleanup, per recent in-session decision)

Existing `Patterns/Forms/` patterns from [#637](https://github.com/brikdesigns/brik-bds/pull/637) (`ContactForm` / `LoginForm` / `SignUpForm`) use raw `<form>` markup rather than the Form composer component. Different shape — they don't demonstrate the primitive they live next to. Should be audited (do we want them to use Form composer, or are they intentional "non-composer" patterns?). Separate concern; not in this PR.

## Test plan

- [x] `npm run lint-storybook-recipe` — 75/75 conforming
- [x] `npm run typecheck` — clean
- [ ] Visual review on Netlify deploy preview
- [ ] Confirm Form Controls panel exposes `layout` / `gap` / `title` / `description` / `error` / `success`
- [ ] Confirm `Displays / Form / form` houses just the primitive Default
- [ ] Confirm `Patterns / Forms / feedback-form` + `Patterns / Forms / search-form` render and are interactive

## Refs

- Tracking: [#618](https://github.com/brikdesigns/brik-bds/issues/618) Batch C — Form category (line 125) **— closes Form line**
- Framework: [ADR-010](docs/adrs/ADR-010-storybook-axes-of-information.md) §components-without-a-variant-axis + amendment §Patterns/Forms relocation
- Precedent: [#646](https://github.com/brikdesigns/brik-bds/pull/646), [#649](https://github.com/brikdesigns/brik-bds/pull/649), [#652](https://github.com/brikdesigns/brik-bds/pull/652), [#654](https://github.com/brikdesigns/brik-bds/pull/654)
- Taxonomy: relies on [#653](https://github.com/brikdesigns/brik-bds/pull/653) (Displays/ move)

🤖 Generated with [Claude Code](https://claude.com/claude-code)