### PR TITLE
fix: blueprints mdx vocab and docs ci

### DIFF
--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -1,0 +1,57 @@
+name: Docs Site Build
+
+# Runs `next build` against docs-site/ on every PR that touches docs-site/**
+# and on every push to main. Catches MDX parse errors, broken imports, and
+# prerender failures before they land — replicating the gap that let the
+# ADR-008 MDX bug (nested backticks) reach main undetected in May 2026.
+#
+# Trigger path is docs-site/** only; changes outside that path don't need
+# a full Next.js build.
+#
+# Issue: brikdesigns/brik-bds#567
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs-site/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs-site/**'
+
+concurrency:
+  group: docs-site-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-site-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # BDS lib must be built before docs-site prebuild runs (ensure-bds-dist.mjs
+      # checks for dist/content-system/index.js). Building it here avoids a
+      # redundant check + subprocess spawn inside the prebuild hook.
+      - name: Install BDS root dependencies
+        run: npm ci
+
+      - name: Build BDS lib
+        run: npm run build:lib
+
+      - name: Install docs-site dependencies
+        working-directory: docs-site
+        run: npm ci
+
+      - name: Build docs-site
+        working-directory: docs-site
+        run: npm run build

--- a/docs-site/content/docs/theming/blueprints.mdx
+++ b/docs-site/content/docs/theming/blueprints.mdx
@@ -15,25 +15,39 @@ Authors hand-write match tags (`moods`, `industries`). Client-axis projections (
 
 ### Mood → Personality
 
+Derived by `MOOD_TO_PERSONALITY` in `content-system/blueprints/bridges.ts` — never hand-authored on blueprints.
+
 | Mood | Personality projection |
 |---|---|
-| `editorial` | Sophisticated · Refined · Composed |
-| `clinical` | Trustworthy · Precise · Reliable |
-| `warm` | Approachable · Empathetic · Welcoming |
-| `bold` | Confident · Energetic · Direct |
-| `quiet` | Calm · Considered · Restrained |
-| `playful` | Friendly · Optimistic · Light |
+| `bold` | Bold |
+| `minimal` | Minimal |
+| `warm` | Warm |
+| `corporate` | Corporate |
+| `playful` | Playful |
+| `luxury` | Luxury · Refined |
+| `trustworthy` | Trustworthy |
+| `energetic` | Energetic |
+| `professional` | Professional |
+| `modern` | Modern |
+| `approachable` | Approachable |
 
 ### Mood → Visual Style
 
+Derived by `MOOD_TO_VISUAL_STYLE` in `content-system/blueprints/bridges.ts`. Moods with no visual correlate (`warm`, `trustworthy`, `professional`, `approachable`) project to an empty set — explicit, not a gap.
+
 | Mood | Visual Style projection |
 |---|---|
-| `editorial` | Refined · Spacious |
-| `clinical` | Minimal · Geometric |
-| `warm` | Soft · Organic |
-| `bold` | Dark · High-contrast |
-| `quiet` | Soft · Minimal |
-| `playful` | (no visual-style constraint) |
+| `bold` | Bold |
+| `minimal` | Minimal |
+| `warm` | — |
+| `corporate` | Classic |
+| `playful` | Playful |
+| `luxury` | Luxurious |
+| `trustworthy` | — |
+| `energetic` | Colorful |
+| `professional` | — |
+| `modern` | Modern |
+| `approachable` | — |
 
 ### Industry tag → Industry pack slug
 


### PR DESCRIPTION
## Summary
- fix(docs): correct blueprints.mdx mood tables + gate docs-site build in CI (closes #533, closes #567)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)