### PR TITLE
feat(storybook): rename Layouts bucket — stack/cluster/grid/frame → Layouts/* (#629)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -356,6 +356,8 @@ const preview: Preview = {
             'Structure',
             '*',
           ],
+          'Layouts',
+          ['stack', 'cluster', 'grid', 'frame', '*'],
           'Navigation',
           ['Primary', 'Secondary', 'Stepper', '*'],
           'Displays',

--- a/components/ui/Cluster/Cluster.stories.tsx
+++ b/components/ui/Cluster/Cluster.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Cluster } from './Cluster';
 
 const meta: Meta<typeof Cluster> = {
-  title: 'Components/Layout/cluster',
+  title: 'Layouts/cluster',
   component: Cluster,
   tags: ['surface-shared'],
   parameters: {

--- a/components/ui/Frame/Frame.stories.tsx
+++ b/components/ui/Frame/Frame.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Frame } from './Frame';
 
 const meta: Meta<typeof Frame> = {
-  title: 'Components/Layout/frame',
+  title: 'Layouts/frame',
   component: Frame,
   tags: ['surface-shared'],
   parameters: {

--- a/components/ui/Grid/Grid.stories.tsx
+++ b/components/ui/Grid/Grid.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Grid } from './Grid';
 
 const meta: Meta<typeof Grid> = {
-  title: 'Components/Layout/grid',
+  title: 'Layouts/grid',
   component: Grid,
   tags: ['surface-shared'],
   parameters: {

--- a/components/ui/Stack/Stack.stories.tsx
+++ b/components/ui/Stack/Stack.stories.tsx
@@ -4,7 +4,7 @@ import { Stack } from './Stack';
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof Stack> = {
-  title: 'Components/Layout/stack',
+  title: 'Layouts/stack',
   component: Stack,
   tags: ['surface-shared'],
   parameters: {


### PR DESCRIPTION
## Summary

- Moves 4 layout primitives from `Components/Layout/*` (phantom subcategory not in `storySort.order`) to the new flat `Layouts/` top-level per ADR-006 amendment (PR #667)
- Adds `Layouts` to `storySort.order` in `preview.tsx` between `Components` and `Navigation` — `Navigation` and `Displays` remain in place until their own rename sweep PRs land

## Files changed

| File | Change |
| --- | --- |
| `Stack.stories.tsx` | `Components/Layout/stack` → `Layouts/stack` |
| `Cluster.stories.tsx` | `Components/Layout/cluster` → `Layouts/cluster` |
| `Grid.stories.tsx` | `Components/Layout/grid` → `Layouts/grid` |
| `Frame.stories.tsx` | `Components/Layout/frame` → `Layouts/frame` |
| `.storybook/preview.tsx` | Add `Layouts` + subcategory order to `storySort.order` |

## Why now (ahead of #618 wrap)

Layout primitives have no overlap with #618's active scope (Action + Input + Form atoms). Zero merge conflict risk.

## Test plan

- [x] 9/9 full validation suite passes
- [x] Storybook build clean — no undefined story title warnings
- [x] No MDX cross-links reference `Components/Layout/*` (grepped — confirmed)

Chromatic baseline re-approval needed after merge (4 story IDs change).

Part of #629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)