### PR TITLE
feat(storybook): rename Tools bucket — Dev Tools/* → Tools/* (#629)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -381,6 +381,8 @@ const preview: Preview = {
             'Overlay',
             '*',
           ],
+          'Tools',
+          ['brik-dev-bar', 'dev-feedback-widget', 'widgets', '*'],
           '*',
           'Deprecated',
         ],

--- a/components/ui/BrikDevBar/BrikDevBar.stories.tsx
+++ b/components/ui/BrikDevBar/BrikDevBar.stories.tsx
@@ -4,7 +4,7 @@ import { BrikDevBar, useDevBarSlot, useDevBarApi } from './BrikDevBar';
 import type { DevBarSlotDef } from './BrikDevBar';
 
 const meta: Meta<typeof BrikDevBar> = {
-  title: 'Dev Tools/BrikDevBar',
+  title: 'Tools/brik-dev-bar',
   component: BrikDevBar,
   tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },

--- a/components/ui/BrikDevBar/widgets/EventsWidget.stories.tsx
+++ b/components/ui/BrikDevBar/widgets/EventsWidget.stories.tsx
@@ -19,7 +19,7 @@ import { BrikDevBar } from '../BrikDevBar';
  * has something to display.
  */
 const meta: Meta = {
-  title: 'Dev Tools/widgets/Events',
+  title: 'Tools/widgets/events',
   tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },
 };

--- a/components/ui/BrikDevBar/widgets/FeedbackWidget.stories.tsx
+++ b/components/ui/BrikDevBar/widgets/FeedbackWidget.stories.tsx
@@ -22,7 +22,7 @@ import { BrikDevBar } from '../BrikDevBar';
  *   - **user** (Phase 2) — form-mode only; cookies for auth.
  */
 const meta: Meta = {
-  title: 'Dev Tools/widgets/Feedback',
+  title: 'Tools/widgets/feedback',
   tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },
 };

--- a/components/ui/BrikDevBar/widgets/InspectWidget.stories.tsx
+++ b/components/ui/BrikDevBar/widgets/InspectWidget.stories.tsx
@@ -22,7 +22,7 @@ import { BrikDevBar } from '../BrikDevBar';
  *   4. localStorage `brik-inspect-enabled=1` persists across sessions.
  */
 const meta: Meta = {
-  title: 'Dev Tools/widgets/Inspect',
+  title: 'Tools/widgets/inspect',
   tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },
 };

--- a/components/ui/BrikDevBar/widgets/README.md
+++ b/components/ui/BrikDevBar/widgets/README.md
@@ -17,7 +17,7 @@ Edit here, run `npm run sync:devbar-widgets`, commit the diffs in each affected 
 
 ## Storybook
 
-Each widget has a story under `Dev Tools/widgets/*` exercising its bootstrap path. The `BrikDevBar` shell story (one level up) shows two slots registered via `useDevBarSlot` — that pattern is the React side.
+Each widget has a story under `Tools/widgets/*` exercising its bootstrap path. The `Tools/brik-dev-bar` shell story shows two slots registered via `useDevBarSlot` — that pattern is the React side.
 
 ## Adding a new widget
 

--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.stories.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.stories.tsx
@@ -21,7 +21,7 @@ const Frame = ({ children }: { children: React.ReactNode }) => (
 /* ─── Meta ────────────────────────────────────────────── */
 
 const meta: Meta<typeof DevFeedbackWidget> = {
-  title: 'Dev Tools/DevFeedbackWidget',
+  title: 'Tools/dev-feedback-widget',
   component: DevFeedbackWidget,
   tags: ['surface-product', 'surface-shared'],
   parameters: { layout: 'fullscreen' },


### PR DESCRIPTION
## Summary

Moves 5 stories from the phantom `Dev Tools/` top-level (not in `storySort.order`) to the new flat `Tools/` bucket per ADR-006 amendment (PR #667).

## Files changed

| File | Change |
| --- | --- |
| `BrikDevBar.stories.tsx` | `Dev Tools/BrikDevBar` → `Tools/brik-dev-bar` |
| `DevFeedbackWidget.stories.tsx` | `Dev Tools/DevFeedbackWidget` → `Tools/dev-feedback-widget` |
| `widgets/EventsWidget.stories.tsx` | `Dev Tools/widgets/Events` → `Tools/widgets/events` |
| `widgets/InspectWidget.stories.tsx` | `Dev Tools/widgets/Inspect` → `Tools/widgets/inspect` |
| `widgets/FeedbackWidget.stories.tsx` | `Dev Tools/widgets/Feedback` → `Tools/widgets/feedback` |
| `widgets/README.md` | Update one storybook path reference |
| `.storybook/preview.tsx` | Add `Tools` to `storySort.order` after `Displays` |

## Why now (ahead of #618 wrap)

`Dev Tools/` stories have zero overlap with #618's active scope (Action + Input + Form atoms). Same zero-conflict logic as the Layouts rename (PR #668).

## Test plan

- [x] 9/9 full validation suite passes
- [x] Storybook build clean
- [x] No other files reference `Dev Tools/` paths

Chromatic baseline re-approval needed after merge (5 story IDs change).

Part of #629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)