### PR TITLE
feat(storybook): rename Sections bucket — Navigation/* → Sections/* (#629)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -358,8 +358,10 @@ const preview: Preview = {
           ],
           'Layouts',
           ['stack', 'cluster', 'grid', 'frame', '*'],
+          'Sections',
+          ['nav-bar', 'footer', 'sidebar-navigation', 'breadcrumb', 'page-header', 'tab-bar', 'progress-stepper', '*'],
           'Navigation',
-          ['Primary', 'Secondary', 'Stepper', '*'],
+          ['Menu', '*'],
           'Displays',
           [
             'Card',

--- a/components/ui/Breadcrumb/Breadcrumb.stories.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.stories.tsx
@@ -24,7 +24,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof Breadcrumb> = {
-  title: 'Navigation/Secondary/breadcrumb',
+  title: 'Sections/breadcrumb',
   component: Breadcrumb,
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },

--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -73,7 +73,7 @@ const socialLinks = (
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof Footer> = {
-  title: 'Navigation/Primary/footer',
+  title: 'Sections/footer',
   component: Footer,
   tags: ['surface-web'],
   parameters: { layout: 'fullscreen' },

--- a/components/ui/NavBar/NavBar.stories.tsx
+++ b/components/ui/NavBar/NavBar.stories.tsx
@@ -46,7 +46,7 @@ const LogoPlaceholder = () => (
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof NavBar> = {
-  title: 'Navigation/Primary/nav-bar',
+  title: 'Sections/nav-bar',
   component: NavBar,
   tags: ['surface-web'],
   parameters: { layout: 'fullscreen' },

--- a/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/components/ui/PageHeader/PageHeader.stories.tsx
@@ -46,7 +46,7 @@ const sampleBreadcrumbs = [
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof PageHeader> = {
-  title: 'Navigation/Secondary/page-header',
+  title: 'Sections/page-header',
   component: PageHeader,
   tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },

--- a/components/ui/ProgressStepper/ProgressStepper.stories.tsx
+++ b/components/ui/ProgressStepper/ProgressStepper.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { ProgressStepper, type ProgressStep } from './ProgressStepper';
 
 const meta: Meta<typeof ProgressStepper> = {
-  title: 'Navigation/Stepper/progress-stepper',
+  title: 'Sections/progress-stepper',
   component: ProgressStepper,
   tags: ['surface-product'],
   parameters: {

--- a/components/ui/SidebarNavigation/SidebarNavigation.stories.tsx
+++ b/components/ui/SidebarNavigation/SidebarNavigation.stories.tsx
@@ -71,7 +71,7 @@ const userSection = (
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof SidebarNavigation> = {
-  title: 'Navigation/Primary/sidebar-navigation',
+  title: 'Sections/sidebar-navigation',
   component: SidebarNavigation,
   tags: ['surface-product'],
   parameters: { layout: 'fullscreen' },

--- a/components/ui/TabBar/TabBar.stories.tsx
+++ b/components/ui/TabBar/TabBar.stories.tsx
@@ -59,7 +59,7 @@ function InteractiveTabBar({
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof TabBar> = {
-  title: 'Navigation/Secondary/tab-bar',
+  title: 'Sections/tab-bar',
   component: TabBar,
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },

--- a/docs-site/content/docs/components/breadcrumb.mdx
+++ b/docs-site/content/docs/components/breadcrumb.mdx
@@ -99,4 +99,4 @@ interface BreadcrumbItem {
 - [TabBar](/docs/components/tab-bar) — sibling-section navigation
 - [NavBar](/docs/components/nav-bar) — top-level primary nav
 - [SidebarNavigation](/docs/components/sidebar-navigation) — vertical primary nav
-- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-secondary-breadcrumb--overview)**
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/sections-breadcrumb--overview)**

--- a/docs-site/content/docs/components/footer.mdx
+++ b/docs-site/content/docs/components/footer.mdx
@@ -177,4 +177,4 @@ interface FooterColumn {
 
 - [NavBar](/docs/components/nav-bar) — top-of-page partner
 - [TextLink](/docs/components/text-link) — alternative to FooterColumn for inline link lists
-- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-primary-footer--overview)**
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/sections-footer--overview)**

--- a/docs-site/content/docs/components/nav-bar.mdx
+++ b/docs-site/content/docs/components/nav-bar.mdx
@@ -113,4 +113,4 @@ interface NavBarLink {
 - [SidebarNavigation](/docs/components/sidebar-navigation) — vertical app-shell alternative
 - [TabBar](/docs/components/tab-bar) — section nav within the main content area
 - [Breadcrumb](/docs/components/breadcrumb) — hierarchical position
-- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-primary-nav-bar--overview)**
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/sections-nav-bar--overview)**

--- a/docs-site/content/docs/components/page-header.mdx
+++ b/docs-site/content/docs/components/page-header.mdx
@@ -222,4 +222,4 @@ interface MetadataItem {
 - [ServiceBadge](/docs/components/service-badge) — common badge prop content
 - [DataSection](/docs/components/data-section) — for body sections below the header
 - [Sheet](/docs/components/sheet) — has its own header for in-Sheet contexts
-- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-secondary-page-header--overview)**
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/sections-page-header--overview)**

--- a/docs-site/content/docs/components/sidebar-navigation.mdx
+++ b/docs-site/content/docs/components/sidebar-navigation.mdx
@@ -132,4 +132,4 @@ interface SidebarNavItem {
 - [NavBar](/docs/components/nav-bar) — top-bar alternative for marketing sites
 - [TabBar](/docs/components/tab-bar) — secondary section navigation inside the main content area
 - [Breadcrumb](/docs/components/breadcrumb) — hierarchical position within a section
-- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-primary-sidebar-navigation--overview)**
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/sections-sidebar-navigation--overview)**

--- a/docs-site/content/docs/components/tab-bar.mdx
+++ b/docs-site/content/docs/components/tab-bar.mdx
@@ -133,4 +133,4 @@ interface TabItem {
 - [SegmentedControl](/docs/components/segmented-control) — in-panel content switcher
 - [Breadcrumb](/docs/components/breadcrumb) — hierarchical position
 - [SidebarNavigation](/docs/components/sidebar-navigation) — vertical nav for many items
-- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/navigation-secondary-tab-bar--overview)**
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/sections-tab-bar--overview)**


### PR DESCRIPTION
## Summary

Moves 7 page-level region components to the new flat `Sections/` top-level per ADR-006 amendment (PR #667).

## Story title changes

| Component | Old | New |
| --- | --- | --- |
| NavBar | `Navigation/Primary/nav-bar` | `Sections/nav-bar` |
| Footer | `Navigation/Primary/footer` | `Sections/footer` |
| SidebarNavigation | `Navigation/Primary/sidebar-navigation` | `Sections/sidebar-navigation` |
| Breadcrumb | `Navigation/Secondary/breadcrumb` | `Sections/breadcrumb` |
| PageHeader | `Navigation/Secondary/page-header` | `Sections/page-header` |
| TabBar | `Navigation/Secondary/tab-bar` | `Sections/tab-bar` |
| ProgressStepper | `Navigation/Stepper/progress-stepper` | `Sections/progress-stepper` |

## Other changes

- `preview.tsx` — add `Sections` to `storySort.order`; trim `Navigation` to `['Menu', '*']` (Menu deferred to Containers PR)
- 6 docs-site MDX files — update Storybook playground links from `navigation-primary/secondary/stepper-*` → `sections-*`

## Not in this PR

- `Menu` (`Navigation/Menu/menu`) → `Containers/menu` — moves with the Containers rename PR

## Test plan

- [x] 9/9 full validation suite passes
- [x] Storybook build clean
- [x] Verified all 6 MDX playground links updated

Part of #629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)