### PR TITLE
bds: 670 herosplit image ratio

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -52,9 +52,21 @@
  */
 import type { BlueprintProps } from './types';
 
-interface Props extends BlueprintProps {}
+type FrameRatio = 'square' | 'portrait' | 'landscape' | 'wide' | 'ultrawide';
 
-const { section } = Astro.props;
+const RATIO_ASPECT: Record<FrameRatio, string> = {
+  square: '1 / 1',
+  portrait: '3 / 4',
+  landscape: '4 / 3',
+  wide: '16 / 9',
+  ultrawide: '21 / 9',
+};
+
+interface Props extends BlueprintProps {
+  imageRatio?: FrameRatio;
+}
+
+const { section, imageRatio = 'landscape' } = Astro.props;
 
 const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
 const titleId = `${section.sectionKey}-title`;
@@ -135,7 +147,10 @@ const cta = section.cta;
 
     {priceCard ? (
       <aside class="bp-hero-img-card__media-card">
-        <div class="bp-hero-img-card__image-frame">
+        <div
+          class="bp-hero-img-card__image-frame"
+          style={imageRatio !== 'landscape' ? `--_bp-image-ratio: ${RATIO_ASPECT[imageRatio]}` : undefined}
+        >
           <img
             src={priceCard.imageUrl}
             alt={priceCard.imageAlt ?? ''}
@@ -165,6 +180,7 @@ const cta = section.cta;
         class="bp-hero-img-card__missing"
         data-content-needed="hero_image_url"
         role="presentation"
+        style={imageRatio !== 'landscape' ? `--_bp-image-ratio: ${RATIO_ASPECT[imageRatio]}` : undefined}
       >
         <p class="bp-hero-img-card__missing-label">
           Hero image card missing for this page.
@@ -299,7 +315,7 @@ const cta = section.cta;
   }
 
   .bp-hero-img-card__image-frame {
-    aspect-ratio: 4 / 3;
+    aspect-ratio: var(--_bp-image-ratio, 4 / 3);
     overflow: hidden;
     border-radius: var(--border-radius-md);
     background: var(--surface-secondary);
@@ -338,7 +354,7 @@ const cta = section.cta;
   }
 
   .bp-hero-img-card__missing {
-    aspect-ratio: 4 / 3;
+    aspect-ratio: var(--_bp-image-ratio, 4 / 3);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -18,13 +18,16 @@
 import { Breadcrumb } from '../../../components/ui/Breadcrumb/Breadcrumb';
 import { Button } from '../../../components/ui/Button';
 import { Frame } from '../../../components/ui/Frame/Frame';
+import type { FrameRatio } from '../../../components/ui/Frame/Frame';
 import { ServiceTag } from '../../../components/ui/ServiceBadge/ServiceTag';
 import type { BlueprintProps } from '../astro/types';
 import './HeroSplitImageCardOverlay.css';
 
-interface Props extends BlueprintProps {}
+interface Props extends BlueprintProps {
+  imageRatio?: FrameRatio;
+}
 
-export function HeroSplitImageCardOverlay({ section }: Props) {
+export function HeroSplitImageCardOverlay({ section, imageRatio = 'landscape' }: Props) {
   const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
   const titleId = `${section.sectionKey}-title`;
   const eyebrow = section.subheading;
@@ -93,7 +96,7 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
 
         {priceCard ? (
           <aside className="bp-hero-img-card__media-card">
-            <Frame ratio="landscape" className="bp-hero-img-card__image-frame">
+            <Frame ratio={imageRatio} className="bp-hero-img-card__image-frame">
               <img
                 src={priceCard.imageUrl}
                 alt={priceCard.imageAlt ?? ''}
@@ -122,7 +125,7 @@ export function HeroSplitImageCardOverlay({ section }: Props) {
           </aside>
         ) : (
           <Frame
-            ratio="landscape"
+            ratio={imageRatio}
             as="aside"
             className="bp-hero-img-card__missing"
             data-content-needed="hero_image_url"


### PR DESCRIPTION
## Summary
- feat(blueprint): add imageRatio prop to HeroSplitImageCardOverlay (#670)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)