### PR TITLE
chore(release): 0.68.2 — HeroSplitImageCardOverlay imageRatio prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.67.0",
+  "version": "0.68.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.67.0",
+      "version": "0.68.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.68.1",
+  "version": "0.68.2",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

- Bumps `@brikdesigns/bds` from `0.68.1` → `0.68.2`
- Publishes the `imageRatio` prop added in #677

## What changed in this release

`HeroSplitImageCardOverlay` now accepts `imageRatio?: FrameRatio` (default `'landscape'`). Pass `imageRatio="square"` on the brikdesigns service detail page to fix 1:1 illustration clipping.

## After merging

Tag to trigger the publish workflow:
\`\`\`
git fetch origin
git tag v0.68.2 origin/main
git push origin v0.68.2
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)