### PR TITLE
fix(button): use --text-inverse for button-inverse variant text

### DIFF
--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -109,7 +109,7 @@
 
 .bds-button--inverse {
   background-color: var(--background-inverse);
-  color: var(--text-on-color-light);
+  color: var(--text-inverse);
 }
 
 .bds-button--on-color {
@@ -207,12 +207,12 @@
 /* ── Inverse ── */
 .bds-button--inverse:hover:not(:disabled):not(.bds-button--loading) {
   background-color: var(--background-secondary-pressed);
-  color: var(--text-on-color-dark);
+  color: var(--text-inverse);
 }
 
 .bds-button--inverse:active:not(:disabled) {
   background-color: var(--background-brand-primary-pressed);
-  color: var(--text-on-color-dark);
+  color: var(--text-inverse);
   transform: translateY(var(--button-active-translate-y)); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
 }
 


### PR DESCRIPTION
## Summary

- `.bds-button--inverse` base: `--text-on-color-light` → `--text-inverse`
- `.bds-button--inverse:hover` and `:active`: `--text-on-color-dark` → `--text-inverse`

**Why:** `--text-on-color-light` (always black) and `--text-on-color-dark` (always white) are static tokens that don't adapt to theme changes. `--background-inverse` flips between dark (light mode) and light (dark mode), so the text token must flip with it. `--text-inverse` does exactly that — white on dark in light mode, black on light in dark mode.

> **Note:** Button-inverse placed inside an inverse-surface context (e.g. `Footer variant="inverse"`) experiences double-inversion. That's a separate scoping issue tracked independently. This PR fixes the standalone inverse button case.

## Test plan

- [ ] Light mode: button-inverse renders white text on dark background ✓
- [ ] Dark mode: button-inverse renders black text on light background ✓
- [ ] Storybook: verify Button → Inverse story in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)