### PR TITLE
fix(card): prevent Badge from stretching to full card width

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -281,4 +281,12 @@
    * regardless of description length. */
   margin-top: auto;
 }
+
+/* Prevent a direct Badge child from stretching to card width.
+ * preset-display uses absolute-positioned .bds-card__preset-display-badge
+ * and inline-flex .bds-card__preset-display-tag — both already sized correctly.
+ * This rule covers Badge placed directly inside a default or outlined Card. */
+.bds-card > .bds-badge {
+  align-self: flex-start;
+}
 }


### PR DESCRIPTION
## Summary

- Adds `.bds-card > .bds-badge { align-self: flex-start }` to Card.css

**Why:** `.bds-card` is a `flex-direction: column` container with the default `align-items: stretch`. A `<Badge>` placed directly as a child of a Card would expand to the card's full width. The new rule anchors it at natural inline width.

**Not affected:**
- `preset="display"` badge overlay — uses `position: absolute` inside the media slot, unaffected
- `preset="display"` tag slot — already uses `.bds-card__preset-display-tag { display: inline-flex; align-self: flex-start }`
- `preset="control"` badge — rendered inside its own row flex, not a direct card child

## Test plan

- [ ] Storybook: Card (default/outlined) with a `<Badge>` child — badge should render at natural width, not stretched
- [ ] `preset="display"` with `badge` prop — no visual change (still absolute-positioned top-right)

🤖 Generated with [Claude Code](https://claude.com/claude-code)