### PR TITLE
bds: atmosphere strip overrides

### DIFF
--- a/content-system/atmospheres/cinematic-dramatic.css
+++ b/content-system/atmospheres/cinematic-dramatic.css
@@ -1,18 +1,23 @@
 /**
  * cinematic-dramatic atmosphere
  *
- * Dark-theatrical treatment. Deeper navy-black base than editorial-luxury,
- * with an aurora-drift gradient at the top of the viewport and a conic
- * rotating spotlight behind hero sections. Leans theatrical rather than
- * quiet — fit for legal/agency/finance/dark-mode SaaS verticals where
- * the brand moment matters more than hushed editorial restraint.
+ * Dark-theatrical decoration layer. Deeper navy-black than editorial-
+ * luxury, with an aurora-drift gradient at the top of the viewport and
+ * a conic rotating spotlight behind hero sections. Leans theatrical
+ * rather than quiet — fit for legal/agency/finance/dark-mode SaaS
+ * verticals where the brand moment matters more than hushed editorial
+ * restraint.
  *
  * Differences from editorial-luxury:
- *   - Darker base (#060612 vs #08080a) with a violet-black tint
+ *   - Deeper violet-black theme posture vs editorial's near-black
  *   - Aurora-drift gradient (cool/warm dual-tone) instead of gold orbs
  *   - Conic rotating spotlight (38s period) behind hero
  *   - No film grain (heavier atmosphere is already doing the work)
  *   - Section-edge vignettes kept for "page-turn" continuity
+ *
+ * Surface colors are set by the brand theme layer (dist/tokens.css +
+ * the client's theme CSS). Section-edge fades reference var(--page-primary)
+ * so they self-relativize with no hardcoded values here.
  *
  * Performance: aurora drift is a single animated @property gradient
  * (42s period, no transforms). Conic spotlight is one fixed element
@@ -26,22 +31,9 @@
 }
 
 :root {
-  --atmosphere-ink: #060612;
-
-  --surface-primary:        var(--atmosphere-ink);
-  --surface-secondary:      var(--atmosphere-ink);
-  --background-primary:     var(--atmosphere-ink);
-  --background-secondary:   var(--atmosphere-ink);
-  --background-tertiary:    var(--atmosphere-ink);
-  --background-input:       var(--atmosphere-ink);
-
-  --ambient-cool:           rgba(80, 110, 170, 0.10);
-  --ambient-warm:           rgba(212, 175, 110, 0.08);
-  --ambient-violet:         rgba(140, 90, 200, 0.06);
-}
-
-body {
-  background: var(--atmosphere-ink);
+  --ambient-cool:   rgba(80, 110, 170, 0.10);
+  --ambient-warm:   rgba(212, 175, 110, 0.08);
+  --ambient-violet: rgba(140, 90, 200, 0.06);
 }
 
 /* ───────────────────────────────────────────────────────────────────
@@ -121,7 +113,7 @@ section[data-ambient="center"]::before {
   background: radial-gradient(circle, var(--ambient-cool) 0%, transparent 70%);
 }
 
-/* Section-edge vignettes (same as editorial-luxury). */
+/* Section-edge vignettes — fade into the theme-resolved page color. */
 section[data-edge]::before,
 section[data-edge]::after {
   content: '';
@@ -133,11 +125,11 @@ section[data-edge]::after {
 }
 section[data-edge]::before {
   top: 0;
-  background: linear-gradient(to bottom, var(--atmosphere-ink), transparent);
+  background: linear-gradient(to bottom, var(--page-primary), transparent);
 }
 section[data-edge]::after {
   bottom: 0;
-  background: linear-gradient(to top, var(--atmosphere-ink), transparent);
+  background: linear-gradient(to top, var(--page-primary), transparent);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/content-system/atmospheres/clean-bright.css
+++ b/content-system/atmospheres/clean-bright.css
@@ -1,8 +1,8 @@
 /**
  * clean-bright atmosphere
  *
- * Pure-white, zero-atmosphere layer. Sister to minimal-clinical but
- * with an even stricter "no effects" posture — intended for SaaS/tech/
+ * Pure-white, zero-atmosphere decoration layer. Sister to minimal-clinical
+ * but with an even stricter "no effects" posture — intended for SaaS/tech/
  * startup sites where the brand lives in typography, imagery, and
  * color accents, and any atmospheric layer would compete with those
  * primary design tools.
@@ -13,22 +13,9 @@
  * semantic intent so the portal UI can offer the right one per vertical
  * without verbal overloading.
  *
- * Same observation: the body of this atmosphere is deliberately tiny
- * by design. Keep it that way.
+ * Surface colors are set by the brand theme layer (dist/tokens.css +
+ * the client's theme CSS). This atmosphere adds no color overrides.
  */
-
-:root {
-  --surface-primary:        #ffffff;
-  --surface-secondary:      #ffffff;
-  --background-primary:     #ffffff;
-  --background-secondary:   #ffffff;
-  --background-tertiary:    #ffffff;
-  --background-input:       #ffffff;
-}
-
-body {
-  background: #ffffff;
-}
 
 /* data-ambient / data-edge / data-spotlight are inert — the clean-bright
    brief is that effects belong in the component library, not the

--- a/content-system/atmospheres/editorial-luxury.css
+++ b/content-system/atmospheres/editorial-luxury.css
@@ -1,21 +1,26 @@
 /**
  * editorial-luxury atmosphere
  *
- * Dark-luxury editorial treatment. Originally developed for Birdwell &
- * Mutlak Dentistry (2026-04-21). Reference implementation lives in
- * web/birdwell-mutlak at the time of extraction (delete local
+ * Dark-luxury editorial decoration layer. Originally developed for
+ * Birdwell & Mutlak Dentistry (2026-04-21). Reference implementation
+ * lives in web/birdwell-mutlak at the time of extraction (delete local
  * brand-overrides.css once the client profile picks this atmosphere).
  *
  * Design posture:
- *   - Pure near-black (#08080a) surfaces — not #000 (avoids DPR banding)
  *   - Atmospheric gold radial orbs, blurred 120px, at 9–14% opacity
  *   - SVG Perlin film grain at 32% opacity, mix-blend overlay
  *   - Cursor-tracking spotlight on interactive cards
- *   - Section-edge vignettes for "page-turn" feel
+ *   - Section-edge vignettes for "page-turn" feel (fade into page color)
  *   - All motion gated by prefers-reduced-motion
  *
- * Cost: one fixed <body::before> GPU layer for the base vignette, one
- * fixed <body::after> for grain. Per-section orbs are lazy — only when
+ * Surface colors are set by the brand theme layer (dist/tokens.css +
+ * the client's theme CSS). The near-black page color (#08080a, not pure
+ * #000 — avoids DPR gradient banding) is emitted by the dark-dominant
+ * theme as var(--page-primary). Section-edge fades reference that token
+ * so they self-relativize with no hardcoded values here.
+ *
+ * Cost: one fixed body::before GPU layer for the base vignette, one
+ * fixed body::after for grain. Per-section orbs are lazy — only when
  * a section declares `data-ambient="..."`. Cursor spotlights only on
  * elements with `data-spotlight`.
  *
@@ -30,27 +35,12 @@
  */
 
 :root {
-  /* NEAR-black, not pure #000 — avoids DPR gradient banding. */
-  --atmosphere-ink: #08080a;
-
-  /* Collapse all surfaces onto the editorial near-black. */
-  --surface-primary:        var(--atmosphere-ink);
-  --surface-secondary:      var(--atmosphere-ink);
-  --background-primary:     var(--atmosphere-ink);
-  --background-secondary:   var(--atmosphere-ink);
-  --background-tertiary:    var(--atmosphere-ink);
-  --background-input:       var(--atmosphere-ink);
-
   /* Ambient gold values used by the atmospheric utility classes. Pulls
      from the client's --color-gold / --background-brand-primary so the
      atmosphere takes on each client's brand hue without edits here. */
-  --ambient-gold:           rgba(196, 154, 47, 0.09);
-  --ambient-gold-strong:    rgba(196, 154, 47, 0.14);
-  --ambient-cool:           rgba(60, 80, 120, 0.08);
-}
-
-body {
-  background: var(--atmosphere-ink);
+  --ambient-gold:        rgba(196, 154, 47, 0.09);
+  --ambient-gold-strong: rgba(196, 154, 47, 0.14);
+  --ambient-cool:        rgba(60, 80, 120, 0.08);
 }
 
 /* ───────────────────────────────────────────────────────────────────
@@ -176,7 +166,8 @@ section[data-ambient="depth"]::after {
 
 /* ───────────────────────────────────────────────────────────────────
  * Section-edge vignettes — "page-turn" feel between sections.
- * Applied to sections with `data-edge` attribute.
+ * Applied to sections with `data-edge` attribute. Fades into the
+ * theme-resolved page color so no hardcoded value is needed here.
  * ─────────────────────────────────────────────────────────────────── */
 section[data-edge]::before,
 section[data-edge]::after {
@@ -189,11 +180,11 @@ section[data-edge]::after {
 }
 section[data-edge]::before {
   top: 0;
-  background: linear-gradient(to bottom, var(--atmosphere-ink), transparent);
+  background: linear-gradient(to bottom, var(--page-primary), transparent);
 }
 section[data-edge]::after {
   bottom: 0;
-  background: linear-gradient(to top, var(--atmosphere-ink), transparent);
+  background: linear-gradient(to top, var(--page-primary), transparent);
 }
 
 /* ───────────────────────────────────────────────────────────────────

--- a/content-system/atmospheres/index.test.ts
+++ b/content-system/atmospheres/index.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import { describe, it, expect } from 'vitest';
 import {
   ATMOSPHERE_MANIFEST,
@@ -143,4 +144,51 @@ describe('getAtmosphereSafePairings', () => {
   it('returns an empty array for `none`', () => {
     expect(getAtmosphereSafePairings('none')).toEqual([]);
   });
+});
+
+// ── Architecture compliance gate ────────────────────────────────────
+//
+// Atmospheres must NEVER override color-foundation tokens. These tests
+// are the hard regression gate added in brik-bds#369.
+//
+// CSS files are loaded via import.meta.glob (Vite/Vitest feature) so
+// no @types/node is required.
+
+const CSS_MODULES = import.meta.glob<string>('./*.css', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+describe('Atmosphere CSS — color-foundation compliance (brik-bds#369)', () => {
+  it('finds at least 6 CSS files to validate', () => {
+    expect(Object.keys(CSS_MODULES).length).toBeGreaterThanOrEqual(6);
+  });
+
+  for (const [filePath, content] of Object.entries(CSS_MODULES)) {
+    const file = filePath.replace(/^\.\//, '');
+
+    it(`${file}: does not declare color-foundation tokens`, () => {
+      // Match property declarations of the banned semantic categories.
+      const BANNED = /--(page|surface|background|text|border)-[a-z]/;
+      const violations = content
+        .split('\n')
+        .map((line, i) => ({ line: line.trim(), num: i + 1 }))
+        .filter(({ line }) => {
+          const match = line.match(/^(--[a-z][a-zA-Z0-9-]*):/);
+          return match != null && BANNED.test(match[1]);
+        });
+      expect(violations).toEqual([]);
+    });
+
+    it(`${file}: does not set a top-level body{} rule`, () => {
+      const hasBodyBlock = /^\s*body\s*\{/m.test(content);
+      expect(hasBodyBlock).toBe(false);
+    });
+
+    it(`${file}: does not use retired --atmosphere-paper/ink local vars`, () => {
+      const hasRetiredVar = /--atmosphere-(paper|cream-paper|ink)/.test(content);
+      expect(hasRetiredVar).toBe(false);
+    });
+  }
 });

--- a/content-system/atmospheres/index.ts
+++ b/content-system/atmospheres/index.ts
@@ -10,8 +10,8 @@
  *   - Know which BDS-contract token pairings the atmosphere guarantees
  *     pass WCAG AA when the theme generator's output is layered with
  *     this atmosphere.
- *   - Decide which surface tokens (paper / accent-dark / both) the
- *     theme generator should emit alongside the atmosphere CSS.
+ *   - Understand the decoration posture the atmosphere is tuned for
+ *     (light-dominant, dark-dominant, or neutral).
  *
  * CSS files live as siblings and are exported through the package
  * exports field in package.json under `./atmospheres/*.css`.
@@ -20,9 +20,11 @@
  *   - `safePairings` — every atmosphere declares the foreground/background
  *     token pairs it expects to render. The portal preflight stops
  *     hard-coding an inline list; it reads this instead.
- *   - `surfaceProfile` — declares whether this atmosphere collapses
- *     surfaces to a single tone (`single-tone-light` / `single-tone-dark`)
- *     or supports both light + dark surface emission (`dual-mode`).
+ *   - `surfaceProfile` — declares the decoration posture the atmosphere
+ *     is tuned for (light-dominant / dark-dominant / neutral).
+ *     Atmospheres do NOT override color-foundation tokens — surface
+ *     colors come from the brand theme layer (dist/tokens.css + client
+ *     theme CSS). See brik-bds#369.
  */
 
 import type { Atmosphere } from '../vocabularies/atmosphere';
@@ -44,21 +46,24 @@ export interface SafePairing {
 }
 
 /**
- * Surface emission posture for an atmosphere. The portal theme generator
- * (W2) consumes this to decide which surface tokens to emit alongside the
- * atmosphere CSS:
+ * Decoration posture for an atmosphere — indicates what surface-tone
+ * character the atmosphere's decorative overlays are tuned for. This
+ * does NOT mean the atmosphere sets surface colors; surface colors come
+ * from the brand theme layer. The posture helps the portal and docs
+ * present the right context when pairing an atmosphere with a theme.
  *
- *   - `single-tone-light` — atmosphere collapses surfaces to a paper /
- *     ivory base (e.g. warm-soft, organic-textured). Generator emits
- *     `--surface-paper`, `--surface-paper-elevated`, `--text-on-paper`.
- *   - `single-tone-dark` — atmosphere collapses surfaces to ink / deep
- *     accent (e.g. editorial-luxury, cinematic-dramatic). Generator emits
- *     `--surface-accent-dark`, `--surface-accent-warm`, `--text-on-ink`.
- *   - `dual-mode` — atmosphere supports both light and dark surfaces
- *     within the same page (e.g. minimal-clinical's paper hero with dark
- *     CTA strip). Generator emits both sets.
- *   - `passthrough` — atmosphere is `none` or zero-effects; generator
- *     emits whatever the brand palette implies, no atmosphere overrides.
+ *   - `single-tone-light` — decoration tuned for a light-dominant page
+ *     (e.g. warm-soft, organic-textured). Grain and tints work best on
+ *     light surfaces; orbs would read as inverted on dark.
+ *   - `single-tone-dark` — decoration tuned for a dark-dominant page
+ *     (e.g. editorial-luxury, cinematic-dramatic). Gold orbs and film
+ *     grain overlay a dark page; glow reads against near-black.
+ *   - `dual-mode` — decoration is neutral enough to support both light
+ *     and dark surface zones on the same page (e.g. minimal-clinical's
+ *     plain hero with a dark CTA strip). No decoration is added; the
+ *     value exists to tell the portal both modes are valid.
+ *   - `passthrough` — atmosphere is `none` or zero-effects; no
+ *     decoration posture implied.
  */
 export type SurfaceProfile =
   | 'single-tone-light'
@@ -75,9 +80,10 @@ export interface AtmosphereManifestEntry {
   /** Short industries/verticals that naturally fit this atmosphere. */
   naturalFit: readonly string[];
   /**
-   * Surface emission posture — see SurfaceProfile docstring.
-   * The portal theme generator uses this to decide which surface tokens
-   * to emit alongside the atmosphere CSS.
+   * Decoration posture — see SurfaceProfile docstring. Indicates what
+   * surface-tone character this atmosphere's decorative overlays are
+   * tuned for. Does not drive surface token emission; surface colors
+   * come from the brand theme layer.
    */
   surfaceProfile: SurfaceProfile;
   /**
@@ -98,7 +104,7 @@ export interface AtmosphereManifestEntry {
 //
 // Centralized so multiple atmospheres can share a posture without
 // drifting (e.g. all single-tone-dark atmospheres share the same
-// inverse-text-on-ink contract). Inline-extending these in a manifest
+// dark-page contrast contract). Inline-extending these in a manifest
 // entry stays correct — the runtime sees a SafePairing[] either way.
 
 // Brand-fill button pairings split by themeMode. The brand-fill background
@@ -138,7 +144,7 @@ const BASELINE_BRAND_PAIRINGS_DARK_THEME: SafePairing[] = [
     context: 'Brand-filled buttons / pills (pressed state) on a dark page.' },
 ];
 
-/** Pairings for light-dominant atmospheres (paper-on-X, X-on-paper). */
+/** Pairings for light-dominant atmospheres. */
 const LIGHT_TONE_PAIRINGS: SafePairing[] = [
   { fg: '--text-primary', bg: '--background-primary', context: 'Body copy on the dominant light surface.' },
   { fg: '--text-primary', bg: '--background-secondary', context: 'Body copy on alternating elevated surface.' },
@@ -148,7 +154,7 @@ const LIGHT_TONE_PAIRINGS: SafePairing[] = [
   { fg: '--text-inverse', bg: '--background-inverse', context: 'Inverse block (dark CTA strip on a light page).' },
 ];
 
-/** Pairings for dark-dominant atmospheres (light text on ink). */
+/** Pairings for dark-dominant atmospheres. */
 const DARK_TONE_PAIRINGS: SafePairing[] = [
   { fg: '--text-primary', bg: '--background-primary', context: 'Body copy on the dominant dark surface.' },
   { fg: '--text-primary', bg: '--background-secondary', context: 'Body copy on the next-lightest dark surface.' },
@@ -169,7 +175,7 @@ export const ATMOSPHERE_MANIFEST: Record<Atmosphere, AtmosphereManifestEntry> = 
     slug: 'editorial-luxury',
     cssPath: '@brikdesigns/bds/atmospheres/editorial-luxury.css',
     themeMode: 'dark',
-    blurb: 'Pure near-black + gold orbs + film grain. Quiet-luxury dark treatment.',
+    blurb: 'Gold orbs + film grain overlay. Quiet-luxury dark decoration.',
     naturalFit: ['luxury dental', 'med-aesthetic', 'editorial hospitality'],
     surfaceProfile: 'single-tone-dark',
     safePairings: [...DARK_TONE_PAIRINGS, ...BASELINE_BRAND_PAIRINGS_DARK_THEME],
@@ -178,7 +184,7 @@ export const ATMOSPHERE_MANIFEST: Record<Atmosphere, AtmosphereManifestEntry> = 
     slug: 'cinematic-dramatic',
     cssPath: '@brikdesigns/bds/atmospheres/cinematic-dramatic.css',
     themeMode: 'dark',
-    blurb: 'Deep navy-black + aurora drift + conic spotlight. Theatrical dark.',
+    blurb: 'Aurora drift + conic spotlight. Theatrical dark decoration.',
     naturalFit: ['legal', 'agency', 'finance', 'dark-mode SaaS'],
     surfaceProfile: 'single-tone-dark',
     safePairings: [...DARK_TONE_PAIRINGS, ...BASELINE_BRAND_PAIRINGS_DARK_THEME],
@@ -189,9 +195,9 @@ export const ATMOSPHERE_MANIFEST: Record<Atmosphere, AtmosphereManifestEntry> = 
     themeMode: 'light',
     blurb: 'Pure white, zero atmospheric effects. Trust via precision.',
     naturalFit: ['non-luxury healthcare', 'legal (gravitas)', 'minimal SaaS'],
-    // Minimal-clinical commonly pairs a paper hero with a dark CTA
+    // Minimal-clinical commonly pairs a light hero with a dark CTA
     // strip — both surface modes need to render legibly inside the
-    // same page. The theme generator emits both surface tokens.
+    // same page. No atmosphere decoration; theme layer decides both.
     surfaceProfile: 'dual-mode',
     safePairings: [...LIGHT_TONE_PAIRINGS, ...BASELINE_BRAND_PAIRINGS_LIGHT_THEME],
   },
@@ -199,7 +205,7 @@ export const ATMOSPHERE_MANIFEST: Record<Atmosphere, AtmosphereManifestEntry> = 
     slug: 'warm-soft',
     cssPath: '@brikdesigns/bds/atmospheres/warm-soft.css',
     themeMode: 'light',
-    blurb: 'Warm ivory + quiet rose vignette + minimal grain. Anxiety-safe.',
+    blurb: 'Quiet rose vignette + minimal grain. Anxiety-safe light decoration.',
     naturalFit: ['wellness', 'therapy', 'mental health', 'recovery'],
     surfaceProfile: 'single-tone-light',
     safePairings: [...LIGHT_TONE_PAIRINGS, ...BASELINE_BRAND_PAIRINGS_LIGHT_THEME],
@@ -217,7 +223,7 @@ export const ATMOSPHERE_MANIFEST: Record<Atmosphere, AtmosphereManifestEntry> = 
     slug: 'organic-textured',
     cssPath: '@brikdesigns/bds/atmospheres/organic-textured.css',
     themeMode: 'light',
-    blurb: 'Warm cream + sepia grain + earth-tone tint. Tactile paper feel.',
+    blurb: 'Sepia grain + earth-tone radial tint. Tactile paper-texture decoration.',
     naturalFit: ['MUA', 'organic beauty', 'artisan', 'natural products'],
     surfaceProfile: 'single-tone-light',
     safePairings: [...LIGHT_TONE_PAIRINGS, ...BASELINE_BRAND_PAIRINGS_LIGHT_THEME],

--- a/content-system/atmospheres/minimal-clinical.css
+++ b/content-system/atmospheres/minimal-clinical.css
@@ -1,33 +1,19 @@
 /**
  * minimal-clinical atmosphere
  *
- * Pure-white, zero-effect layer. No vignettes, no grain, no orbs, no
- * backdrop blurs. Trust comes from type, spacing, and precision —
- * not atmosphere.
+ * Pure-white, zero-effect decoration layer. No vignettes, no grain, no
+ * orbs, no backdrop blurs. Trust comes from type, spacing, and precision
+ * — not atmosphere.
  *
  * Fit: healthcare practices not aiming luxury, legal where gravitas
  * matters more than editorial warmth, SaaS/tech with a minimal
  * aesthetic, utility-focused marketing.
  *
- * This atmosphere is deliberately tiny. The point is to establish the
- * shared attribute vocabulary (theme_mode=light + atmosphere=minimal-
- * clinical) without layering anything visually. Consumer sites pick
- * this when they want a theme with no additional decoration.
+ * Surface colors are set by the brand theme layer (dist/tokens.css +
+ * the client's theme CSS). This atmosphere adds no color overrides —
+ * it exists to establish the shared attribute vocabulary without
+ * layering anything visually.
  */
-
-:root {
-  /* Pure whites, no surface shifts. */
-  --surface-primary:        #ffffff;
-  --surface-secondary:      #ffffff;
-  --background-primary:     #ffffff;
-  --background-secondary:   #ffffff;
-  --background-tertiary:    #ffffff;
-  --background-input:       #ffffff;
-}
-
-body {
-  background: #ffffff;
-}
 
 /* No effects layer. data-ambient / data-edge / data-spotlight attributes
    on sections/cards are simply inert under this atmosphere — they don't

--- a/content-system/atmospheres/organic-textured.css
+++ b/content-system/atmospheres/organic-textured.css
@@ -1,39 +1,26 @@
 /**
  * organic-textured atmosphere
  *
- * Warm-cream textured-paper treatment. Sits between warm-soft (quieter,
+ * Textured-paper decoration layer. Sits between warm-soft (quieter,
  * wellness-coded) and editorial-luxury (dramatic, dark). Intended for
  * MUA / organic beauty / artisan / natural-products brands where the
  * brand evokes tactile materiality without going cinematic.
  *
  * Design posture:
- *   - Warm cream base (#f5efe6) — a step warmer than warm-soft
  *   - SVG grain at 40% opacity with sepia multiply (richer texture
  *     than warm-soft's 15%, but applied to light surfaces so it reads
  *     as paper rather than gritty)
  *   - Subtle earth-tone radial tint (terracotta at 4%) in bottom-right
  *   - No vignettes, no orbs, no motion
  *
- * The grain is the distinguishing move — at 40% sepia-multiply it
- * gives surfaces a tactile, recycled-paper feel that reads as
- * artisan/organic/natural rather than flat digital.
+ * Surface colors are set by the brand theme layer. The grain is the
+ * distinguishing move — at 40% sepia-multiply it gives surfaces a
+ * tactile, recycled-paper feel that reads as artisan/organic/natural
+ * rather than flat digital.
  */
 
 :root {
-  --atmosphere-cream-paper: #f5efe6;
-
-  --surface-primary:        var(--atmosphere-cream-paper);
-  --surface-secondary:      var(--atmosphere-cream-paper);
-  --background-primary:     var(--atmosphere-cream-paper);
-  --background-secondary:   var(--atmosphere-cream-paper);
-  --background-tertiary:    #ffffff;
-  --background-input:       #ffffff;
-
-  --ambient-terracotta:     rgba(180, 120, 90, 0.04);
-}
-
-body {
-  background: var(--atmosphere-cream-paper);
+  --ambient-terracotta: rgba(180, 120, 90, 0.04);
 }
 
 /* Subtle earth-tone radial in the bottom-right — warms the lower

--- a/content-system/atmospheres/warm-soft.css
+++ b/content-system/atmospheres/warm-soft.css
@@ -1,35 +1,24 @@
 /**
  * warm-soft atmosphere
  *
- * Warm-ivory light-mode treatment for wellness/therapy/recovery
- * verticals. Anxiety-sensitive audiences don't want motion or
- * cinematic flourish — this atmosphere is the opposite of
- * cinematic-dramatic: one quiet vignette, minimal grain, zero orbs
- * or spotlights.
+ * Quiet decoration layer for wellness/therapy/recovery verticals.
+ * Anxiety-sensitive audiences don't want motion or cinematic flourish —
+ * this atmosphere is the opposite of cinematic-dramatic: one quiet
+ * vignette, minimal grain, zero orbs or spotlights.
  *
  * Design posture:
- *   - Warm ivory base (#fbf7f0) — cream, not bright white
  *   - Single top-left radial vignette in rose/terracotta at 5% opacity
  *   - Subtle grain at 15% opacity (barely-there warmth, not texture)
  *   - No depth orbs, no cursor spotlights, no aurora
- *   - Section-edge vignettes optional (soft fade, not cut)
+ *   - Section-edge vignettes optional (soft fade into the page color)
+ *
+ * Surface colors are set by the brand theme layer. The section-edge
+ * fades reference var(--page-primary) so they self-relativize against
+ * whatever surface color the theme layer resolves.
  */
 
 :root {
-  --atmosphere-paper: #fbf7f0;
-
-  --surface-primary:        var(--atmosphere-paper);
-  --surface-secondary:      var(--atmosphere-paper);
-  --background-primary:     var(--atmosphere-paper);
-  --background-secondary:   var(--atmosphere-paper);
-  --background-tertiary:    #ffffff;
-  --background-input:       #ffffff;
-
-  --ambient-rose:           rgba(210, 140, 130, 0.05);
-}
-
-body {
-  background: var(--atmosphere-paper);
+  --ambient-rose: rgba(210, 140, 130, 0.05);
 }
 
 /* Single quiet top-left vignette. Warm without being cinematic. */
@@ -56,7 +45,7 @@ body::after {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.6  0 0 0 0 0.5  0 0 0 0 0.4  0 0 0 0.20 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
 }
 
-/* Section-edge soft fades — gentler than editorial-luxury's hard vignette. */
+/* Section-edge soft fades — fade into the theme's page color, not a hardcoded value. */
 section[data-edge]::before,
 section[data-edge]::after {
   content: '';
@@ -68,11 +57,11 @@ section[data-edge]::after {
 }
 section[data-edge]::before {
   top: 0;
-  background: linear-gradient(to bottom, var(--atmosphere-paper), transparent);
+  background: linear-gradient(to bottom, var(--page-primary), transparent);
 }
 section[data-edge]::after {
   bottom: 0;
-  background: linear-gradient(to top, var(--atmosphere-paper), transparent);
+  background: linear-gradient(to top, var(--page-primary), transparent);
 }
 
 /* data-ambient / data-spotlight are inert in warm-soft — anxiety-

--- a/docs-site/content/docs/theming/atmospheres.mdx
+++ b/docs-site/content/docs/theming/atmospheres.mdx
@@ -1,13 +1,17 @@
 ---
 title: Atmospheres
-description: Layer 2 of the theming cascade — CSS overlays that establish visual character (editorial-luxury, cinematic, warm-soft, and more) without duplicating CSS per client.
+description: Layer 2 of the theming cascade — CSS decoration overlays that establish visual character (editorial-luxury, cinematic, warm-soft, and more) without duplicating CSS per client.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Atmospheres are **CSS layers** that sit on top of a client's theme to establish visual character — dark-luxury-editorial, soft-wellness, clean-clinical, etc. — without duplicating CSS per client. They're orthogonal to the navigation archetype and the blueprint library: atmospheres decorate surfaces, archetypes structure the header, blueprints compose sections.
+Atmospheres are **CSS decoration layers** that sit on top of a client's theme to establish visual character — dark-luxury-editorial, soft-wellness, clean-clinical, etc. — without duplicating CSS per client. They're orthogonal to the navigation archetype and the blueprint library: atmospheres decorate surfaces, archetypes structure the header, blueprints compose sections.
 
 The portal's theme generator reads `company_profiles.atmosphere` at extraction time and emits an `@import` into the stored theme artifact pointing at `@brikdesigns/bds/atmospheres/{slug}.css`. The consumer Astro site fetches one theme artifact at build; the atmosphere cascades automatically.
+
+<Callout type="info">
+**Atmospheres are decoration only.** They add vignettes, grain, orbs, and spotlights — they do not set surface colors. Background and text colors come from the brand theme layer (`dist/tokens.css` + the client's `theme-{slug}.css`). Import `@brikdesigns/bds/page-base.css` after tokens to wire `html/body` background to `var(--page-primary)` before any atmosphere loads.
+</Callout>
 
 ## How atmospheres compose with themes
 
@@ -15,7 +19,7 @@ The portal's theme generator reads `company_profiles.atmosphere` at extraction t
 |---|---|---|
 | **Theme tokens** | `design_token_extraction` task reads `company_profiles.color_primitives` + `typography` | Brand palette, fonts, spacing, border-radius |
 | **Theme mode** | `company_profiles.theme_mode` (light / dark) | Whether text is dark-on-light or light-on-dark |
-| **Atmosphere** | `company_profiles.atmosphere` (this vocab) | Ambient layer — vignettes, grain, orbs, spotlights |
+| **Atmosphere** | `company_profiles.atmosphere` (this vocab) | Decoration layer — vignettes, grain, orbs, spotlights |
 | **Navigation IA** | `pack.navigationIA` (industry default) + portal overrides | Header archetype + scroll + mobile drawer |
 | **Blueprints** | Per-section, per-page (forthcoming) | Layout primitives |
 
@@ -41,37 +45,37 @@ Each atmosphere renders on the same compact composite (hero + services grid + CT
 
 ### editorial-luxury
 
-The quiet-luxury dark treatment developed for Birdwell & Mutlak Dentistry. Pure near-black surfaces so DPR gradient banding doesn't appear; gold radial orbs driven by `data-ambient` attributes on sections; SVG Perlin film grain at 32% opacity with `mix-blend-mode: overlay`; cursor-tracking spotlight on elements with `data-spotlight`. Honors reduced-motion.
+Gold radial orbs driven by `data-ambient` attributes on sections; SVG Perlin film grain at 32% opacity with `mix-blend-mode: overlay`; cursor-tracking spotlight on elements with `data-spotlight`. Section-edge fades reference `var(--page-primary)` from the theme layer so they blend into whatever surface color the brand sets. Honors reduced-motion.
 
 <AtmospherePreview atmosphere="editorial-luxury" />
 
 ### cinematic-dramatic
 
-Theatrical dark — deeper navy-black with an aurora-drift gradient at the top of the viewport (42s cycle, animated via `@property` interpolation) and a conic rotating spotlight on sections marked `data-ambient="spotlight"`. No grain. Heavier atmosphere is already doing the work. Fit for legal / agency / finance / dark-mode SaaS.
+Aurora-drift gradient at the top of the viewport (42s cycle, animated via `@property` interpolation) and a conic rotating spotlight on sections marked `data-ambient="spotlight"`. No grain — the aurora is already doing the atmospheric work. Section-edge fades reference `var(--page-primary)`. Fit for legal / agency / finance / dark-mode SaaS.
 
 <AtmospherePreview atmosphere="cinematic-dramatic" />
 
 ### minimal-clinical
 
-Pure white, zero atmospheric effects. Trust comes from typography and precision, not atmosphere. Intentionally small — picks the attribute vocabulary without layering anything visually. Healthcare practices that aren't aiming luxury, legal where gravitas matters more than editorial warmth, minimal SaaS.
+Zero atmospheric decoration. Trust comes from typography and precision alone. Intentionally empty — establishes the shared `data-ambient` / `data-edge` / `data-spotlight` attribute vocabulary without layering anything visually. Healthcare practices that aren't aiming luxury, legal where gravitas matters more than editorial warmth, minimal SaaS.
 
 <AtmospherePreview atmosphere="minimal-clinical" />
 
 ### warm-soft
 
-Warm ivory base with a single quiet rose vignette in the top-left corner and subtle paper-grade grain at 15% opacity. No motion, no spotlights, no depth orbs — anxiety-sensitive audiences (wellness, therapy, mental health, recovery) shouldn't see cinematic flourish.
+Single quiet rose vignette in the top-left corner and subtle grain at 15% opacity with `mix-blend-mode: multiply`. No motion, no spotlights, no depth orbs — anxiety-sensitive audiences (wellness, therapy, mental health, recovery) shouldn't see cinematic flourish. Section-edge fades reference `var(--page-primary)`.
 
 <AtmospherePreview atmosphere="warm-soft" />
 
 ### clean-bright
 
-Pure white with zero CSS effects. Brand lives entirely in typography, imagery, and color accents. Sister to `minimal-clinical` — same visual posture, different semantic intent (SaaS/tech vs healthcare/legal).
+Zero CSS decoration. Brand lives entirely in typography, imagery, and color accents. Sister to `minimal-clinical` — same visual posture, different semantic intent (SaaS/tech vs healthcare/legal).
 
 <AtmospherePreview atmosphere="clean-bright" />
 
 ### organic-textured
 
-Warm cream base with SVG Perlin grain at 40% opacity applied with `mix-blend-mode: multiply` — the sepia-texture feel of recycled paper. Subtle earth-tone radial tint in the bottom-right. Fit for MUA / organic beauty / artisan / natural-products brands.
+SVG Perlin grain at 40% opacity with `mix-blend-mode: multiply` for a tactile, recycled-paper texture. Subtle earth-tone radial tint in the bottom-right. Fit for MUA / organic beauty / artisan / natural-products brands where tactile materiality matters more than digital polish.
 
 <AtmospherePreview atmosphere="organic-textured" />
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "./styles.css": "./dist/styles.css",
     "./tokens.css": "./dist/tokens.css",
     "./bridge.css": "./dist/bridge.css",
+    "./page-base.css": "./dist/page-base.css",
     "./canonical-check": {
       "types": "./scripts/canonical-check.d.ts",
       "import": "./scripts/canonical-check.mjs",

--- a/scripts/build-dist-tokens.js
+++ b/scripts/build-dist-tokens.js
@@ -82,4 +82,19 @@ const bridge = fs.readFileSync(path.join(TOKENS_DIR, 'bridge.css'), 'utf8');
 fs.writeFileSync(path.join(DIST_DIR, 'bridge.css'), bridge);
 console.log('  ✓ dist/bridge.css');
 
+// Write page-base.css — opt-in body reset that wires html/body background
+// to var(--page-primary). Import AFTER tokens.css and BEFORE any atmosphere
+// CSS so the cascade reads: tokens → page-base → atmosphere decoration.
+const pageBase = [
+  '/* @brikdesigns/bds — Page base styles (opt-in) */',
+  '/* Import after tokens.css and before any atmosphere CSS. */',
+  'html, body {',
+  '  background: var(--page-primary);',
+  '  color: var(--text-primary);',
+  '}',
+  '',
+].join('\n');
+fs.writeFileSync(path.join(DIST_DIR, 'page-base.css'), pageBase);
+console.log('  ✓ dist/page-base.css');
+
 console.log('Token CSS build complete.');


### PR DESCRIPTION
## Summary

- Strips all `--surface-*`, `--background-*`, and `body { background: ... }` rules from all 6 atmosphere CSS files — atmospheres are now decoration-only (grain, vignettes, orbs, spotlights)
- Retires `--atmosphere-paper`, `--atmosphere-cream-paper`, `--atmosphere-ink` local vars; section-edge fades now reference `var(--page-primary)` so they self-relativize against whatever the theme layer resolves
- Adds `dist/page-base.css` opt-in reset (`html, body { background: var(--page-primary); color: var(--text-primary) }`) + build step + `@brikdesigns/bds/page-base.css` export
- Rewrites `SurfaceProfile` docstring and manifest blurbs to decoration-posture framing; removes all `paper`/`ink` vocabulary from prose
- Updates `atmospheres.mdx` with a decoration-only callout and strips surface-colour prose from per-atmosphere descriptions
- Adds CSS compliance regression tests (`import.meta.glob`) — hard gate: any atmosphere that re-introduces a color-foundation override or `body {}` block will fail CI

## Architecture

Atmospheres follow the four-layer cascade documented in `theming/index.mdx`:
1. **Tokens** — surface colors live here (theme layer)
2. **Atmosphere** — decoration only, no color decisions ← this PR enforces the boundary
3. Layout Archetypes
4. Blueprints

Unblocks Vale Partners' cream `--page-primary` (portal task): the portal theme generator already emits `--page-primary` from brand; the atmosphere layer was clobbering it with hardcoded hex.

## Test plan

- [x] All 35 tests pass (`vitest run content-system/atmospheres/index.test.ts`)
- [x] All 9 full-validation checks pass (Token Lint, JSDoc Lint, Grid Audit, Theme Compliance, Blueprint Library, Canonical Tokens, Component Axes, TypeScript, Storybook Build)
- [x] `grep -rE "---(page|surface|background|text|border)-" content-system/atmospheres/*.css` → empty
- [x] `grep -rE "atmosphere-(paper|ink|cream)" content-system/atmospheres/*.css` → empty
- [x] `grep -rE "^\s*body\s*\{" content-system/atmospheres/*.css` → empty
- [ ] Visual: confirm editorial-luxury gold orbs still read on dark theme, cinematic aurora still renders, warm-soft vignette still applies

Closes #369. Part of #532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)