### PR TITLE
bds: sheet typography foldin

### DIFF
--- a/components/ui/Field/Field.css
+++ b/components/ui/Field/Field.css
@@ -68,4 +68,28 @@
 .bds-field--inline .bds-field__empty {
   text-align: right;
 }
+
+/* ─── Compact tier ──────────────────────────────────────── */
+
+/* Compact swaps the label to --label-sm, matching SheetFieldLabel.
+   Use inside dense Sheet layouts (replaces SheetFieldLabel/SheetFieldValue). */
+.bds-field--compact .bds-field__label {
+  font-size: var(--label-sm);
+}
+
+/* ─── Helper slot ───────────────────────────────────────── */
+
+.bds-field__helper {
+  font-family: var(--font-family-label);
+  font-size: var(--label-xs);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+  margin: 0;
+  display: block;
+}
+
+.bds-field__helper--error {
+  color: var(--text-accent-red);
+}
 }

--- a/components/ui/Field/Field.stories.tsx
+++ b/components/ui/Field/Field.stories.tsx
@@ -16,7 +16,10 @@ const meta: Meta<typeof Field> = {
     label: { control: 'text' },
     children: { control: 'text' },
     layout: { control: 'select', options: ['stacked', 'inline'] },
+    tier: { control: 'select', options: ['standard', 'compact'] },
     empty: { control: 'text' },
+    helper: { control: 'text' },
+    helperTone: { control: 'select', options: ['neutral', 'error'] },
   },
 };
 
@@ -56,6 +59,24 @@ export const WithCompositeEmpty: Story = {
           />
         }
       />
+    </Frame>
+  ),
+};
+
+/** @summary `tier="compact"` replaces SheetFieldLabel + SheetFieldValue pairs */
+export const CompactTier: Story = {
+  render: () => (
+    <Frame>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
+        <Field label="Status" tier="compact">Active</Field>
+        <Field label="Notes" tier="compact" empty="—">
+          Multi-line value that wraps across lines is preserved correctly.
+        </Field>
+        <Field label="Phone" tier="compact" helper="Primary contact number">
+          (555) 867-5309
+        </Field>
+        <Field label="Insurance" tier="compact" helper="Required field" helperTone="error" />
+      </div>
     </Frame>
   ),
 };

--- a/components/ui/Field/Field.tsx
+++ b/components/ui/Field/Field.tsx
@@ -3,6 +3,8 @@ import { bdsClass } from '../../utils';
 import './Field.css';
 
 export type FieldLayout = 'stacked' | 'inline';
+export type FieldTier = 'standard' | 'compact';
+export type FieldHelperTone = 'neutral' | 'error';
 
 export interface FieldProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Field label — rendered above (stacked) or beside (inline) the value. */
@@ -12,12 +14,22 @@ export interface FieldProps extends Omit<HTMLAttributes<HTMLDivElement>, 'childr
   /** Stacked = label above value (default). Inline = label / value on one row. */
   layout?: FieldLayout;
   /**
+   * Typography tier. `standard` = `--label-md` label (default, matches edit-mode controls).
+   * `compact` = `--label-sm` label — use inside dense Sheet layouts where
+   * `SheetFieldLabel` was previously required.
+   */
+  tier?: FieldTier;
+  /**
    * Rendered when `children` is null / undefined / empty string.
    * Defaults to the inline muted string "Not set".
    * Pass `<EmptyState />` when a whole section is empty and a larger
    * treatment is warranted — prefer inline text for per-row empties.
    */
   empty?: ReactNode;
+  /** Helper or validation text rendered below the value. */
+  helper?: ReactNode;
+  /** Tone for the helper slot. `neutral` = muted gray (default). `error` = red. */
+  helperTone?: FieldHelperTone;
 }
 
 function isEmpty(value: ReactNode): boolean {
@@ -31,13 +43,20 @@ function isEmpty(value: ReactNode): boolean {
  * tags, URLs, bullet lists, and empty states. Locks label typography,
  * value spacing, and the "Not set" empty treatment.
  *
+ * Use `tier="compact"` inside dense Sheet layouts (replaces `SheetFieldLabel` /
+ * `SheetFieldValue`). Use `helper` + `helperTone` for validation or hint text
+ * (replaces `SheetHelperText`).
+ *
  * @summary Read-mode label + value pair for use inside a Sheet
  */
 export function Field({
   label,
   children,
   layout = 'stacked',
+  tier = 'standard',
   empty = 'Not set',
+  helper,
+  helperTone = 'neutral',
   className,
   style,
   ...props
@@ -46,7 +65,12 @@ export function Field({
 
   return (
     <div
-      className={bdsClass('bds-field', `bds-field--${layout}`, className)}
+      className={bdsClass(
+        'bds-field',
+        `bds-field--${layout}`,
+        tier === 'compact' && 'bds-field--compact',
+        className,
+      )}
       style={style}
       {...props}
     >
@@ -55,6 +79,16 @@ export function Field({
         <span className="bds-field__empty">{empty}</span>
       ) : (
         <div className="bds-field__value">{children}</div>
+      )}
+      {helper != null && (
+        <span
+          className={bdsClass(
+            'bds-field__helper',
+            helperTone === 'error' && 'bds-field__helper--error',
+          )}
+        >
+          {helper}
+        </span>
       )}
     </div>
   );

--- a/components/ui/Field/index.ts
+++ b/components/ui/Field/index.ts
@@ -2,5 +2,7 @@ export {
   Field,
   type FieldProps,
   type FieldLayout,
+  type FieldTier,
+  type FieldHelperTone,
 } from './Field';
 export { default } from './Field';

--- a/components/ui/SheetSection/SheetSection.css
+++ b/components/ui/SheetSection/SheetSection.css
@@ -18,13 +18,11 @@
 /* ─── Heading ───────────────────────────────────────────────── */
 
 .bds-sheet-section__heading {
-  font-family: var(--font-family-label);
-  font-size: var(--label-sm);
-  font-weight: var(--font-weight-medium);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-sm);
+  font-weight: var(--font-weight-semi-bold);
   line-height: var(--font-line-height-snug);
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: var(--text-primary);
   margin: 0;
 }
 

--- a/components/ui/SheetSection/SheetSection.tsx
+++ b/components/ui/SheetSection/SheetSection.tsx
@@ -3,10 +3,16 @@ import { bdsClass } from '../../utils';
 import './SheetSection.css';
 
 export type SheetSectionSpacing = 'md' | 'lg';
+export type SheetSectionHeadingLevel = 'h2' | 'h3' | 'h4';
 
 export interface SheetSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
-  /** Uppercase section label. Omit for intro / description-only sections. */
+  /** Section heading text. Omit for intro / description-only sections. */
   heading?: string;
+  /**
+   * Render level for the heading element. Defaults to `h3` so the Sheet's
+   * own `<h2>` title keeps outline hierarchy intact.
+   */
+  headingLevel?: SheetSectionHeadingLevel;
   /** Optional lead paragraph rendered under the heading. */
   description?: ReactNode;
   /** Section content — Field, FieldGrid, Card, CardList, Table, TagGroup, BulletList, etc. */
@@ -18,9 +24,10 @@ export interface SheetSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'ti
 /**
  * SheetSection — the named wrapper for a block inside a Sheet body.
  *
- * Pairs an uppercase section heading with its content and locks the
- * vertical rhythm between sections. Replaces ad-hoc flex-column +
- * raw `<h3>` + `detail.sectionHeading` patterns.
+ * Pairs a section heading with its content and locks the vertical rhythm
+ * between sections. The heading uses the `--heading-sm` semibold tier —
+ * always larger than Field labels so the label-above-heading inversion
+ * cannot recur (supersedes the legacy uppercase `--label-sm` treatment).
  *
  * Composes inside `<Sheet>` — one section per logical grouping of fields.
  *
@@ -28,6 +35,7 @@ export interface SheetSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'ti
  */
 export function SheetSection({
   heading,
+  headingLevel = 'h3',
   description,
   children,
   spacing = 'lg',
@@ -35,6 +43,7 @@ export function SheetSection({
   style,
   ...props
 }: SheetSectionProps) {
+  const HeadingTag = headingLevel;
   return (
     <section
       className={bdsClass(
@@ -45,7 +54,7 @@ export function SheetSection({
       style={style}
       {...props}
     >
-      {heading && <h3 className="bds-sheet-section__heading">{heading}</h3>}
+      {heading && <HeadingTag className="bds-sheet-section__heading">{heading}</HeadingTag>}
       {description && <p className="bds-sheet-section__description">{description}</p>}
       {children && <div className="bds-sheet-section__content">{children}</div>}
     </section>

--- a/components/ui/SheetSection/index.ts
+++ b/components/ui/SheetSection/index.ts
@@ -2,5 +2,6 @@ export {
   SheetSection,
   type SheetSectionProps,
   type SheetSectionSpacing,
+  type SheetSectionHeadingLevel,
 } from './SheetSection';
 export { default } from './SheetSection';

--- a/components/ui/SheetTypography/SheetFieldLabel.tsx
+++ b/components/ui/SheetTypography/SheetFieldLabel.tsx
@@ -14,18 +14,12 @@ export interface SheetFieldLabelProps
 }
 
 /**
+ * @deprecated Use `<Field tier="compact" label="..." />` for read-mode
+ * label + value pairs. For standalone labels above form controls, pass
+ * `label` directly to the control (TextInput, Select, etc.) — they
+ * render their own accessible label element.
+ *
  * @summary Field label above a Sheet value or input
- *
- * Field label inside a Sheet body. Sits one tier below `<SheetSectionTitle>`
- * — label family, `--label-sm`, semibold, muted text, Title Case transform.
- * Use above `<SheetFieldValue>` in read mode, or above a `<TextInput>` /
- * `<CatalogPicker>` / other editor in edit mode.
- *
- * Renders as `<label>` when `htmlFor` is provided so screen readers can
- * associate it with the input; falls back to `<span>` for read-only
- * displays where no input exists.
- *
- * @see docs/LAYOUT-CONTEXTS.md for the typography-tier rules.
  */
 export function SheetFieldLabel({
   htmlFor,

--- a/components/ui/SheetTypography/SheetFieldValue.tsx
+++ b/components/ui/SheetTypography/SheetFieldValue.tsx
@@ -12,17 +12,10 @@ export interface SheetFieldValueProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
+ * @deprecated Use `<Field tier="compact" label="..." />` instead — pass
+ * the value as children. The `empty` prop maps to `Field.empty`.
+ *
  * @summary Read-mode display of a field value in a Sheet
- *
- * Read-mode display of a field value inside a Sheet body. Body family,
- * `--body-md`, regular weight, primary text, preserves whitespace so
- * multi-line values render correctly. Pair with `<SheetFieldLabel>` above.
- *
- * When the value is empty (null, undefined, or an empty string), renders
- * the `empty` prop instead — muted, italic — so missing fields read
- * consistently across every sheet without per-consumer placeholder logic.
- *
- * @see docs/LAYOUT-CONTEXTS.md for the typography-tier rules.
  */
 export function SheetFieldValue({
   empty = 'Not set',

--- a/components/ui/SheetTypography/SheetHelperText.tsx
+++ b/components/ui/SheetTypography/SheetHelperText.tsx
@@ -13,19 +13,10 @@ export interface SheetHelperTextProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 /**
+ * @deprecated Use `<Field helper="..." helperTone="error" />` instead.
+ * The `tone` prop maps to `Field.helperTone`.
+ *
  * @summary Helper or error text below a Sheet field
- *
- * Small hint or error text in a Sheet body. Label family, `--label-xs`,
- * regular weight, muted text. Always smaller than `<SheetFieldLabel>`, so
- * the reading order is preserved: section title → field label → value →
- * helper.
- *
- * Use for:
- *   - Helper captions ("Comma-separated list")
- *   - Validation errors (`tone="error"`)
- *   - Per-field provenance chips ("Seeded from industry pack")
- *
- * @see docs/LAYOUT-CONTEXTS.md for the typography-tier rules.
  */
 export function SheetHelperText({
   tone = 'neutral',

--- a/components/ui/SheetTypography/SheetSectionTitle.tsx
+++ b/components/ui/SheetTypography/SheetSectionTitle.tsx
@@ -12,19 +12,12 @@ export interface SheetSectionTitleProps extends HTMLAttributes<HTMLHeadingElemen
 }
 
 /**
+ * @deprecated Use `<SheetSection heading="..." />` instead.
+ * `SheetSection.heading` now uses the same `--heading-sm` semibold tier;
+ * the legacy uppercase `--label-sm` treatment has been retired. Pass
+ * `headingLevel` to `SheetSection` when you need an element other than `h3`.
+ *
  * @summary Section heading inside a Sheet body
- *
- * Top-of-section heading inside a Sheet body. Locks to the Sheet-context
- * section-heading tier — heading family, `--heading-sm`, semibold, primary
- * text, no uppercase transform. Always renders larger than `<SheetFieldLabel>`
- * so the label-larger-than-heading inversion flagged in the 2026-04-22
- * portal audit can't recur.
- *
- * Distinct from `<SheetSection heading="...">` — which uses the legacy
- * `--label-sm` uppercase treatment — and from `<Sheet title="...">`, which
- * owns the top-level sheet title at `--heading-md`.
- *
- * @see docs/LAYOUT-CONTEXTS.md for the typography-tier rules.
  */
 export function SheetSectionTitle({
   level = 'h3',


### PR DESCRIPTION
## Summary
- chore(release): bump to 0.68.2 (#678)
- fix(button): use --text-inverse for button-inverse variant text (#679)
- fix(card): prevent direct Badge child from stretching to full card width (#680)
- fix(atmospheres): strip color-foundation overrides, retire paper/ink vars (#369) (#682)
- feat(field): add tier/helper props; upgrade SheetSection heading; deprecate SheetTypography (ADR-004)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)