### PR TITLE
bds: addable consolidation

### DIFF
--- a/components/ui/AddableComboList/AddableComboList.tsx
+++ b/components/ui/AddableComboList/AddableComboList.tsx
@@ -49,27 +49,12 @@ const BUTTON_SIZE: Record<AddableComboListSize, ButtonSize> = { sm: 'sm', md: 'm
 const INPUT_SIZE: Record<AddableComboListSize, TextInputSize> = { sm: 'sm', md: 'md', lg: 'lg' };
 
 /**
- * AddableComboList — suggestion-driven combobox for tag-style multi-select
- * with free-form fallback.
- *
- * Typing filters the suggestion list (case-insensitive contains match). Users
- * can pick from suggestions via keyboard or click, or type a free-form value
- * and press Enter (unless `strict` is true). Already-selected suggestions are
- * hidden from the dropdown. Duplicates are rejected with a brief visual flash.
- *
- * Vocabulary-agnostic — the portal wires in BCS getters via the `suggestions`
- * prop; the component does not import from content-system.
- *
- * @example
- * ```tsx
- * <AddableComboList
- *   label="Services Offered"
- *   values={services}
- *   onChange={setServices}
- *   suggestions={getIndustryServices(industrySlug)}
- *   placeholder="Search or add a service…"
- * />
- * ```
+ * @deprecated Use `<AddableTagList suggestions={...} />` instead (ADR-003).
+ * `AddableTagList` covers both plain text lists and suggestion-backed
+ * combobox lists with a single API. Direct replacement:
+ * `<AddableComboList values={v} onChange={o} suggestions={s} />` →
+ * `<AddableTagList values={v} onChange={o} suggestions={s} />`
+ * Note: `maxEntries` was renamed to `maxItems`.
  *
  * @summary Suggestion-driven combobox tag input (multi-select)
  */

--- a/components/ui/AddableTagList/AddableTagList.css
+++ b/components/ui/AddableTagList/AddableTagList.css
@@ -1,0 +1,147 @@
+@layer bds-components {
+/**
+ * BDS AddableTagList — reveal-on-click tag list with optional suggestion combobox.
+ *
+ * Consolidates AddableTextList (plain) and AddableComboList (suggestion-backed)
+ * into a single component. See ADR-003.
+ *
+ * Naming: .bds-addable-tag-list, .bds-addable-tag-list__{element}
+ */
+
+/* ─── Root ────────────────────────────────────────────────── */
+
+.bds-addable-tag-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  width: 100%;
+}
+
+/* ─── Label ───────────────────────────────────────────────── */
+
+.bds-addable-tag-list__label {
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+/* ─── Tag row ─────────────────────────────────────────────── */
+
+.bds-addable-tag-list__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  align-items: center;
+}
+
+@keyframes bds-tag-list-flash {
+  0%   { outline: 2px solid transparent; }
+  25%  { outline: 2px solid var(--border-brand-primary); }
+  75%  { outline: 2px solid var(--border-brand-primary); }
+  100% { outline: 2px solid transparent; }
+}
+
+.bds-addable-tag-list__tags--flash {
+  border-radius: var(--border-radius-sm);
+  animation: bds-tag-list-flash 0.6s var(--ease-out);
+}
+
+/* ─── Empty state ─────────────────────────────────────────── */
+
+.bds-addable-tag-list__empty {
+  font-family: var(--font-family-body);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ─── Input area ──────────────────────────────────────────── */
+
+.bds-addable-tag-list__combobox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+}
+
+.bds-addable-tag-list__input-row {
+  display: flex;
+  gap: var(--gap-sm);
+  align-items: flex-start;
+  width: 100%;
+}
+
+.bds-addable-tag-list__input-wrap {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* ─── Suggestion dropdown ─────────────────────────────────── */
+
+@keyframes bds-tag-list-dropdown-enter {
+  from { opacity: 0; transform: translateY(-4px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.bds-addable-tag-list__dropdown {
+  position: absolute;
+  top: calc(100% + var(--gap-xs));
+  left: 0;
+  right: 0;
+  z-index: 200;
+  list-style: none;
+  margin: 0;
+  padding: var(--padding-sm);
+  background-color: var(--background-primary);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-lg);
+  max-height: 240px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  animation: bds-tag-list-dropdown-enter var(--duration-fast) var(--ease-out);
+  transform-origin: top center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bds-addable-tag-list__dropdown {
+    animation: none;
+  }
+}
+
+/* ─── Option ─────────────────────────────────────────────── */
+
+.bds-addable-tag-list__option {
+  padding: var(--padding-tiny) var(--padding-sm);
+  border-radius: var(--border-radius-sm);
+  font-family: var(--font-family-body);
+  font-size: var(--body-md);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-out);
+}
+
+.bds-addable-tag-list__option:hover,
+.bds-addable-tag-list__option--active {
+  background-color: var(--surface-secondary);
+}
+
+/* ─── Strict hint ────────────────────────────────────────── */
+
+.bds-addable-tag-list__strict-hint {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  color: var(--text-muted);
+}
+
+/* ─── Helper text ────────────────────────────────────────── */
+
+.bds-addable-tag-list__helper {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+}
+}

--- a/components/ui/AddableTagList/AddableTagList.stories.tsx
+++ b/components/ui/AddableTagList/AddableTagList.stories.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { AddableTagList } from './AddableTagList';
+
+// ── Suggestion seeds ──────────────────────────────────────────────────────────
+
+const DENTAL_SERVICES = [
+  'Preventive Care / Cleaning',
+  'Deep Cleaning (Scaling & Root Planing)',
+  'Fillings (Composite)',
+  'Crowns',
+  'Bridges',
+  'Root Canal Therapy',
+  'Teeth Whitening',
+  'Porcelain Veneers',
+  'Dental Bonding',
+  'Invisalign / Clear Aligners',
+  'Dental Implants',
+  'Tooth Extractions',
+  'Wisdom Tooth Removal',
+  'Pediatric Dentistry',
+  'Sedation Dentistry',
+  'Emergency Dental Care',
+];
+
+const DENTAL_INSURANCE = [
+  'Delta Dental',
+  'Blue Cross Blue Shield',
+  'Cigna Dental',
+  'Aetna Dental',
+  'MetLife Dental',
+  'Guardian Dental',
+  'Humana Dental',
+  'United Concordia',
+];
+
+// ── Meta ──────────────────────────────────────────────────────────────────────
+
+/**
+ * AddableTagList — reveal-on-click tag list with optional suggestion combobox.
+ *
+ * Without `suggestions`: plain text input, Enter commits.
+ * With `suggestions`: combobox with filtered dropdown.
+ * Replaces `AddableTextList` and `AddableComboList`. See ADR-003.
+ *
+ * @summary Reveal-on-click tag list with optional suggestion combobox
+ */
+const meta: Meta<typeof AddableTagList> = {
+  title: 'Containers/addable-tag-list',
+  component: AddableTagList,
+  tags: ['surface-product'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    label: { control: 'text' },
+    addLabel: { control: 'text' },
+    placeholder: { control: 'text' },
+    helperText: { control: 'text' },
+    emptyLabel: { control: 'text' },
+    disabled: { control: 'boolean' },
+    strict: { control: 'boolean' },
+    allowDuplicates: { control: 'boolean' },
+    maxItems: { control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AddableTagList>;
+
+// ── Controlled wrapper ────────────────────────────────────────────────────────
+
+const Controlled = (args: React.ComponentProps<typeof AddableTagList>) => {
+  const [values, setValues] = useState<string[]>(args.values ?? []);
+  return (
+    <div style={{ width: 420 }}>
+      <AddableTagList
+        {...args}
+        values={values}
+        onChange={(next) => {
+          setValues(next);
+          args.onChange?.(next);
+        }}
+      />
+    </div>
+  );
+};
+
+// ── Stories ───────────────────────────────────────────────────────────────────
+
+/** @summary Plain mode — no suggestions, free-form text entry */
+export const Plain: Story = {
+  name: 'Default (plain)',
+  args: {
+    label: 'Anti-messages',
+    values: [],
+    placeholder: 'e.g. No price-first positioning',
+    addLabel: 'Add',
+    emptyLabel: 'No messages added yet.',
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+/** @summary Combobox mode — suggestion-backed, free-form fallback */
+export const WithSuggestions: Story = {
+  name: 'With Suggestions',
+  args: {
+    label: 'Services Offered',
+    suggestions: DENTAL_SERVICES,
+    values: [],
+    placeholder: 'Search or add a service…',
+    addLabel: 'Add Service',
+    emptyLabel: 'No services added yet.',
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+/** @summary Strict mode — only listed suggestions accepted */
+export const StrictMode: Story = {
+  name: 'Strict Mode',
+  args: {
+    label: 'Insurance Providers',
+    suggestions: DENTAL_INSURANCE,
+    values: ['Delta Dental'],
+    placeholder: 'Search providers…',
+    addLabel: 'Add Provider',
+    strict: true,
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+/** @summary Disabled — read-only chip display */
+export const Disabled: Story = {
+  args: {
+    label: 'Services Offered',
+    suggestions: DENTAL_SERVICES,
+    values: ['Dental Implants', 'Invisalign / Clear Aligners', 'Preventive Care / Cleaning'],
+    disabled: true,
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+/**
+ * Patterns — plain mode alongside suggestion-backed mode.
+ * @summary Common usage patterns
+ */
+export const Patterns: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: 480 }}>
+      <Controlled
+        label="Anti-messages"
+        values={['No price-first positioning']}
+        placeholder="e.g. No price-first positioning"
+        addLabel="Add"
+        helperText="Things the brand should never say."
+        onChange={() => {}}
+      />
+      <Controlled
+        label="Services Offered"
+        suggestions={DENTAL_SERVICES}
+        values={['Preventive Care / Cleaning', 'Crowns']}
+        placeholder="Search or add a service…"
+        addLabel="Add Service"
+        helperText="Pick from the catalog or add a custom service."
+        onChange={() => {}}
+      />
+      <Controlled
+        label="Insurance Networks"
+        suggestions={DENTAL_INSURANCE}
+        values={['Delta Dental', 'Blue Cross Blue Shield']}
+        strict
+        placeholder="Pick from the network list…"
+        addLabel="Add Network"
+        helperText="Strict — only accepted carriers from the catalog."
+        onChange={() => {}}
+      />
+    </div>
+  ),
+};
+
+// ── Interaction stories ───────────────────────────────────────────────────────
+
+/** @summary Plain mode — Enter commits */
+export const PlainEnterCommits: Story = {
+  name: 'Interaction — plain Enter commits',
+  args: { label: 'Tags', values: [], addLabel: 'Add', onChange: fn() },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /add/i }));
+    const input = canvas.getByRole('textbox');
+    await userEvent.type(input, 'My tag{Enter}');
+    await waitFor(() => expect(args.onChange).toHaveBeenCalledWith(['My tag']));
+  },
+};
+
+/** @summary Combobox — select from dropdown */
+export const SelectFromDropdown: Story = {
+  name: 'Interaction — select from dropdown',
+  args: {
+    label: 'Services', suggestions: DENTAL_SERVICES, values: [],
+    placeholder: 'Search…', addLabel: 'Add Service', onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /add service/i }));
+    const input = canvas.getByRole('combobox');
+    await userEvent.type(input, 'Crown');
+    const option = await canvas.findByRole('option', { name: 'Crowns' }, { timeout: 3000 });
+    await userEvent.click(option);
+    await waitFor(() => expect(args.onChange).toHaveBeenCalledWith(['Crowns']));
+  },
+};
+
+/** @summary Strict rejects free form */
+export const StrictRejectsFreeForm: Story = {
+  name: 'Interaction — strict rejects free-form',
+  args: {
+    label: 'Insurance', suggestions: DENTAL_INSURANCE, values: [],
+    strict: true, placeholder: 'Search…', addLabel: 'Add', onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /add/i }));
+    const input = canvas.getByRole('combobox');
+    await userEvent.type(input, 'Random Insurer{Enter}');
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    await expect(args.onChange).not.toHaveBeenCalled();
+  },
+};

--- a/components/ui/AddableTagList/AddableTagList.tsx
+++ b/components/ui/AddableTagList/AddableTagList.tsx
@@ -1,0 +1,327 @@
+import { useRef, useState, useCallback, type KeyboardEvent } from 'react';
+import { Icon } from '@iconify/react';
+import { bdsClass } from '../../utils';
+import { Button, type ButtonSize } from '../Button';
+import { Tag, type TagSize } from '../Tag';
+import { TextInput, type TextInputSize } from '../TextInput';
+import { useSuggestionFilter } from '../shared/useSuggestionFilter';
+import './AddableTagList.css';
+
+export type AddableTagListSize = 'sm' | 'md' | 'lg';
+
+export interface AddableTagListProps {
+  /** Current list of tag values. */
+  values: string[];
+  /** Called with the updated values when user adds or removes a tag. */
+  onChange: (next: string[]) => void;
+  /**
+   * Optional suggestion set. When provided the component renders a combobox —
+   * typing filters the list, Enter commits the highlighted suggestion or a
+   * free-form value. When omitted the component is a plain text input.
+   */
+  suggestions?: string[];
+  /**
+   * When true, only values present in `suggestions` can be added (free-form
+   * entries are rejected). Only meaningful when `suggestions` is provided.
+   * Default false.
+   */
+  strict?: boolean;
+  /** Optional field label. */
+  label?: string;
+  /** Helper text below the list. */
+  helperText?: string;
+  /** Placeholder shown in the reveal input. */
+  placeholder?: string;
+  /** Text on the reveal button and accessible add label. Default "Add". */
+  addLabel?: string;
+  /** Accessible label for the remove button on each tag. Default "Remove". */
+  removeLabel?: string;
+  /** Text shown when `values` is empty and input is not revealed. */
+  emptyLabel?: string;
+  /** Size for input, button, and tags. Default "md". */
+  size?: AddableTagListSize;
+  /** Renders tags as read-only chips with no input controls. */
+  disabled?: boolean;
+  /** Maximum number of entries. Input is hidden when reached. */
+  maxItems?: number;
+  /** Allow duplicate values (case-insensitive). Default false. */
+  allowDuplicates?: boolean;
+  /** Additional className applied to root. */
+  className?: string;
+}
+
+const TAG_SIZE: Record<AddableTagListSize, TagSize> = { sm: 'sm', md: 'md', lg: 'md' };
+const BUTTON_SIZE: Record<AddableTagListSize, ButtonSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+const INPUT_SIZE: Record<AddableTagListSize, TextInputSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+
+/**
+ * AddableTagList — reveal-on-click list of removable text tags.
+ *
+ * Without `suggestions`: plain text input, Enter commits.
+ * With `suggestions`: combobox — typing filters the list, arbitrary free-form
+ * entries are also accepted unless `strict` is true.
+ *
+ * Replaces `AddableTextList` (plain) and `AddableComboList` (suggestion-backed)
+ * with a single API. See ADR-003.
+ *
+ * @example
+ * ```tsx
+ * // Plain
+ * <AddableTagList label="Anti-messages" values={msgs} onChange={setMsgs} />
+ *
+ * // Suggestion-backed
+ * <AddableTagList
+ *   label="Services Offered"
+ *   values={services}
+ *   onChange={setServices}
+ *   suggestions={getIndustryServices(industrySlug)}
+ *   placeholder="Search or add a service…"
+ * />
+ * ```
+ *
+ * @summary Reveal-on-click list of text tags with optional suggestion combobox
+ */
+export function AddableTagList({
+  values,
+  onChange,
+  suggestions,
+  strict = false,
+  label,
+  helperText,
+  placeholder,
+  addLabel = 'Add',
+  removeLabel = 'Remove',
+  emptyLabel,
+  size = 'md',
+  disabled = false,
+  maxItems,
+  allowDuplicates = false,
+  className,
+}: AddableTagListProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [flashDupe, setFlashDupe] = useState(false);
+  const isComboMode = suggestions !== undefined;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const atLimit = typeof maxItems === 'number' && values.length >= maxItems;
+
+  const triggerDupeFlash = useCallback(() => {
+    setFlashDupe(true);
+    setTimeout(() => setFlashDupe(false), 600);
+  }, []);
+
+  const remove = (index: number) => {
+    onChange(values.filter((_, i) => i !== index));
+  };
+
+  // Always call the hook — plain mode gets suggestions=[] so filtered is always
+  // empty and the dropdown never renders, giving plain Enter-to-commit UX.
+  const combo = useSuggestionFilter({
+    suggestions: suggestions ?? [],
+    // Bypass duplicate check inside the hook when allowDuplicates=true
+    selectedValues: allowDuplicates ? [] : values,
+    strict: isComboMode ? strict : false,
+    onCommit: (value) => {
+      onChange([...values, value]);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    },
+    onCancel: () => {
+      setIsEditing(false);
+    },
+    onDuplicate: isComboMode ? triggerDupeFlash : undefined,
+    onBackspaceEmpty: () => {
+      if (values.length > 0) onChange(values.slice(0, -1));
+    },
+  });
+
+  const reveal = () => {
+    combo.reset();
+    setIsEditing(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    if (!containerRef.current?.contains(e.relatedTarget as Node)) {
+      combo.closeList();
+      if (!combo.query.trim()) {
+        setIsEditing(false);
+        combo.reset();
+      }
+    }
+  };
+
+  const handlePlainKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      combo.commitValue(combo.query);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setIsEditing(false);
+      combo.reset();
+    } else if (e.key === 'Backspace' && combo.query.length === 0) {
+      if (values.length > 0) onChange(values.slice(0, -1));
+    }
+  };
+
+  const showEmpty = values.length === 0 && !isEditing && emptyLabel;
+
+  return (
+    <div className={bdsClass('bds-addable-tag-list', className)}>
+      {label && <span className="bds-addable-tag-list__label">{label}</span>}
+
+      {values.length > 0 && (
+        <div
+          className={bdsClass(
+            'bds-addable-tag-list__tags',
+            isComboMode && flashDupe && 'bds-addable-tag-list__tags--flash',
+          )}
+          role="list"
+          aria-label={label ? `${label} values` : 'Selected values'}
+        >
+          {values.map((value, index) => (
+            <Tag
+              key={`${index}-${value}`}
+              size={TAG_SIZE[size]}
+              onRemove={disabled ? undefined : () => remove(index)}
+              role="listitem"
+              aria-label={`${value}${!disabled ? `, ${removeLabel}` : ''}`}
+            >
+              {value}
+            </Tag>
+          ))}
+        </div>
+      )}
+
+      {showEmpty && (
+        <span className="bds-addable-tag-list__empty">{emptyLabel}</span>
+      )}
+
+      {!disabled && isEditing && !atLimit && (
+        <div
+          ref={isComboMode ? containerRef : undefined}
+          className="bds-addable-tag-list__combobox"
+          onBlur={isComboMode ? handleBlur : undefined}
+        >
+          <div className="bds-addable-tag-list__input-row">
+            <div className="bds-addable-tag-list__input-wrap" style={{ position: 'relative' }}>
+              <TextInput
+                ref={inputRef}
+                {...(isComboMode ? {
+                  id: combo.comboId,
+                  role: 'combobox' as const,
+                  'aria-expanded': combo.isOpen,
+                  'aria-haspopup': 'listbox' as const,
+                  'aria-controls': combo.listboxId,
+                  'aria-activedescendant': combo.activeDescendant,
+                  'aria-autocomplete': 'list' as const,
+                  autoComplete: 'off',
+                  onFocus: () => {
+                    if (combo.query.trim() && combo.filtered.length > 0) combo.openList();
+                  },
+                } : {})}
+                size={INPUT_SIZE[size]}
+                value={combo.query}
+                onChange={combo.handleInputChange}
+                onKeyDown={isComboMode ? combo.handleKeyDown : handlePlainKeyDown}
+                onBlur={!isComboMode ? () => {
+                  if (!combo.query.trim()) {
+                    setIsEditing(false);
+                    combo.reset();
+                  }
+                } : undefined}
+                placeholder={placeholder}
+                aria-label={label ? `Add ${label}` : 'Add item'}
+                fullWidth
+              />
+
+              {isComboMode && combo.isOpen && combo.filtered.length > 0 && (
+                <ul
+                  ref={listboxRef}
+                  id={combo.listboxId}
+                  role="listbox"
+                  aria-label={label ? `${label} suggestions` : 'Suggestions'}
+                  className="bds-addable-tag-list__dropdown"
+                >
+                  {combo.filtered.map((suggestion, idx) => (
+                    <li
+                      key={suggestion}
+                      id={`${combo.comboId}-option-${idx}`}
+                      role="option"
+                      aria-selected={idx === combo.activeIndex}
+                      className={bdsClass(
+                        'bds-addable-tag-list__option',
+                        idx === combo.activeIndex && 'bds-addable-tag-list__option--active',
+                      )}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        combo.commitValue(suggestion);
+                      }}
+                    >
+                      {suggestion}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <Button
+              size={BUTTON_SIZE[size]}
+              variant="primary"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                if (isComboMode && combo.activeIndex >= 0 && combo.filtered[combo.activeIndex]) {
+                  combo.commitValue(combo.filtered[combo.activeIndex]);
+                } else {
+                  combo.commitValue(combo.query);
+                }
+              }}
+              aria-label={addLabel}
+            >
+              {addLabel}
+            </Button>
+            <Button
+              size={BUTTON_SIZE[size]}
+              variant="ghost"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                setIsEditing(false);
+                combo.reset();
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+
+          {isComboMode && strict && combo.query.trim() &&
+            !suggestions.some((s) => s.toLowerCase() === combo.query.trim().toLowerCase()) && (
+            <span className="bds-addable-tag-list__strict-hint" aria-live="polite">
+              Only suggestions can be added in strict mode.
+            </span>
+          )}
+        </div>
+      )}
+
+      {!disabled && !isEditing && !atLimit && (
+        <div>
+          <Button
+            size={BUTTON_SIZE[size]}
+            variant="outline"
+            onClick={reveal}
+          >
+            <Icon icon="ph:plus" />
+            {addLabel}
+          </Button>
+        </div>
+      )}
+
+      {helperText && (
+        <span className="bds-addable-tag-list__helper">{helperText}</span>
+      )}
+    </div>
+  );
+}
+
+export default AddableTagList;

--- a/components/ui/AddableTagList/index.ts
+++ b/components/ui/AddableTagList/index.ts
@@ -1,0 +1,6 @@
+export {
+  AddableTagList,
+  type AddableTagListProps,
+  type AddableTagListSize,
+} from './AddableTagList';
+export { default } from './AddableTagList';

--- a/components/ui/AddableTextList/AddableTextList.tsx
+++ b/components/ui/AddableTextList/AddableTextList.tsx
@@ -57,21 +57,11 @@ function warnStructuredContent(value: string, label?: string) {
 }
 
 /**
- * AddableTextList — list of text values with a reveal-on-click add pattern.
- *
- * The input is hidden until the user clicks the "Add new" button. Pressing
- * Enter commits the value, Escape cancels. Existing values render as
- * removable Tags.
- *
- * @example
- * ```tsx
- * <AddableTextList
- *   label="Services Offered"
- *   values={services}
- *   onChange={setServices}
- *   placeholder="e.g. Dental cleaning"
- * />
- * ```
+ * @deprecated Use `<AddableTagList />` instead (ADR-003).
+ * `AddableTagList` covers both plain text lists and suggestion-backed
+ * combobox lists with a single API. Direct replacement:
+ * `<AddableTextList values={v} onChange={o} />` →
+ * `<AddableTagList values={v} onChange={o} />`
  *
  * @summary Reveal-on-click list of single-line text entries
  */

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -4,6 +4,7 @@ export * from './ActivityTimeline';
 export * from './AddableComboList';
 export * from './AddableEntryList';
 export * from './AddableFieldRowList';
+export * from './AddableTagList';
 export * from './AddableTextList';
 export * from './AddressInput';
 export * from './AnimatedIcon';

--- a/manifest/component-axes.json
+++ b/manifest/component-axes.json
@@ -20,6 +20,13 @@
       "lg"
     ]
   },
+  "AddableTagList": {
+    "size": [
+      "sm",
+      "md",
+      "lg"
+    ]
+  },
   "AddableTextList": {
     "size": [
       "sm",


### PR DESCRIPTION
## Summary
- chore(release): bump to 0.68.2 (#678)
- fix(button): use --text-inverse for button-inverse variant text (#679)
- fix(card): prevent direct Badge child from stretching to full card width (#680)
- fix(atmospheres): strip color-foundation overrides, retire paper/ink vars (#369) (#682)
- feat(addable-tag-list): add AddableTagList, deprecate TextList + ComboList (ADR-003)
- chore(manifest): update component-axes for AddableTagList

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)