### PR TITLE
bds: release 0.70.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.68.2",
+  "version": "0.70.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.68.2",
+      "version": "0.70.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

- Minor bump — ships [#688](https://github.com/brikdesigns/brik-bds/pull/688) (NavItem + SubNavigation + collapsed SidebarNavigation + `position` prop + `profile` slot).

## Consumer sync plan

- [ ] **Portal** — `npm update @brikdesigns/bds` after merge + version publish. [Portal PR-2](https://github.com/brikdesigns/brik-client-portal/issues/767) (queued) will simultaneously: opt into `position=\"sticky\"` + `profile` slot, drop `marginLeft: 260px` workaround in settings layout, wire the new `SubNavigation` for `/settings/*`, and add stub routes for the gated surfaces.
- [ ] **renew-pms** — no sync needed; does not consume `SidebarNavigation` (bespoke `AppSidebar`). Future migration to the BDS canonical primitives is a separate effort.
- [ ] **brikdesigns** — no sync needed; no consumer.

## Backward compat (no breakage on bump)

- `userSection` retained as deprecated alias of `profile`.
- `position` defaults to `'fixed'` (preserves existing layout behavior).
- New active-item color (brand-primary) is a deliberate canonical alignment with the renew-pms reference; no opt-out.

## Release steps after merge

1. \`git tag v0.70.0 && git push origin v0.70.0\`
2. \`.github/workflows/release.yml\` validates + publishes to GitHub Packages.

## Test plan

- [x] All 10 BDS validation gates pass (token, jsdoc, grid, theme, blueprints, BCS, canonical, axes, typescript, Storybook build)
- [ ] After publish: verify the package is at 0.70.0 on GitHub Packages registry
- [ ] After publish: portal PR-2 bumps + consumes; preview deploy renders the two-column shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)