### PR TITLE
docs(stories): migrate Card family to ADR-010 gold-standard shape

### DIFF
--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -14,7 +14,7 @@ Flexible content container. A single primitive serves four shapes via the `prese
 
 ## Playground
 
-<Canvas of={Stories.Default} />
+<Canvas of={Stories.Playground} />
 
 ## Variants
 

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -44,7 +44,7 @@ type Story = StoryObj<typeof Card>;
  *
  * @summary Flexible content slot — composable subcomponents
  */
-export const Default: Story = {
+export const Playground: Story = {
   args: {
     variant: 'outlined',
     padding: 'md',

--- a/components/ui/Card/CardSummary.mdx
+++ b/components/ui/Card/CardSummary.mdx
@@ -3,46 +3,14 @@ import * as Stories from './CardSummary.stories';
 
 <Meta of={Stories} />
 
-# Card summary
+# Card summary *(deprecated)*
 
-Compact metric card for displaying a labeled value with an optional text link. Designed for dashboards, summaries, and stat displays.
-
----
+> **Deprecated.** Use `<Card preset="summary">` instead — same props (`label`, `value`, `type`, `textLink`), same layout, same number formatting. See the [Card](?path=/docs/containers-card--docs) page for the canonical implementation.
 
 ## Playground
 
-Use the Controls panel to explore all props interactively.
-
 <Canvas of={Stories.Playground} />
-
-## Variants
-
-Numeric and price types, with and without text links, plus stacked layout.
-
-<Canvas of={Stories.Variants} />
-
-- **`numeric`** — Plain formatted number (default)
-- **`price`** — USD currency with dollar sign and decimals
-
-## Patterns
-
-Dashboard metrics grid with mixed types.
-
-<Canvas of={Stories.Patterns} />
-
----
 
 ## Props
 
 <ArgTypes of={Stories} />
-
----
-
-## Usage
-
-```tsx
-import { CardSummary } from '@brik/bds';
-
-<CardSummary label="Total" value={42} />
-<CardSummary label="Revenue" value={48250.75} type="price" textLink={{ label: "Details", href: "/revenue" }} />
-```

--- a/components/ui/Card/CardSummary.stories.tsx
+++ b/components/ui/Card/CardSummary.stories.tsx
@@ -2,14 +2,28 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CardSummary } from './CardSummary';
 
 const meta: Meta<typeof CardSummary> = {
-  title: 'Containers/card-summary',
+  title: 'Deprecated/card-summary',
   component: CardSummary,
-  tags: ['surface-shared'],
+  tags: ['surface-shared', '!manifest'],
   parameters: { layout: 'centered' },
   argTypes: {
-    type: { control: 'select', options: ['numeric', 'price'] },
-    label: { control: 'text' },
-    value: { control: 'text' },
+    label: {
+      control: 'text',
+      description: 'Stat label rendered above the value.',
+    },
+    value: {
+      control: 'text',
+      description: 'Stat value. Numbers format via `Intl.NumberFormat` based on `type`; strings render verbatim.',
+    },
+    type: {
+      control: 'select',
+      options: ['numeric', 'price'],
+      description: '`numeric` (default) = locale integer; `price` = USD currency. Ignored when `value` is a string.',
+    },
+    textLink: {
+      control: false,
+      description: 'Optional secondary action — `{ label, href?, onClick? }`.',
+    },
   },
   decorators: [(Story) => <div style={{ width: 322 }}><Story /></div>],
 };
@@ -17,23 +31,10 @@ const meta: Meta<typeof CardSummary> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/* ─── Layout helpers ─────────────────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-    {children}
-  </span>
-);
-
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%' }}>
-    {children}
-  </div>
-);
-
-/* ─── Playground ─────────────────────────────────────────────── */
-
-/** @summary Interactive playground for prop tweaking */
+/**
+ * @deprecated Use `<Card preset="summary">` instead — same props, same layout.
+ * @summary Deprecated — use Card preset="summary"
+ */
 export const Playground: Story = {
   args: {
     label: 'Total',
@@ -41,51 +42,4 @@ export const Playground: Story = {
     type: 'numeric',
     textLink: { label: 'Text Link', href: '#' },
   },
-};
-
-/* ─── Variants ───────────────────────────────────────────────── */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Numeric with link</SectionLabel>
-      <CardSummary label="Total" value={0} type="numeric" textLink={{ label: 'Text Link', href: '#' }} />
-
-      <SectionLabel>Price with link</SectionLabel>
-      <CardSummary label="Amount Due" value={0} type="price" textLink={{ label: 'Text Link', href: '#' }} />
-
-      <SectionLabel>Numeric without link</SectionLabel>
-      <CardSummary label="Total" value={0} type="numeric" />
-
-      <SectionLabel>Price without link</SectionLabel>
-      <CardSummary label="Amount Due" value={0} type="price" />
-
-      <SectionLabel>Stacked (border removed between)</SectionLabel>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
-        <CardSummary label="Total" value={0} type="numeric" textLink={{ label: 'Text Link', href: '#' }} style={{ borderBottom: 'none' }} />
-        <CardSummary label="Amount Due" value={0} type="price" textLink={{ label: 'Text Link', href: '#' }} />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ─── Patterns ───────────────────────────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  decorators: [(Story) => <div style={{ width: 1000 }}><Story /></div>],
-  render: () => (
-    <Stack>
-      <SectionLabel>Dashboard metrics grid</SectionLabel>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--gap-md)', width: '100%' }}>
-        <CardSummary label="Orders" value={156} textLink={{ label: 'View', href: '#' }} />
-        <CardSummary label="Revenue" value={24830} type="price" textLink={{ label: 'View', href: '#' }} />
-        <CardSummary label="Customers" value={892} />
-        <CardSummary label="Avg. Order" value={159.17} type="price" />
-        <CardSummary label="Returns" value={3} textLink={{ label: 'Review', href: '#' }} />
-        <CardSummary label="Refunds" value={478.5} type="price" textLink={{ label: 'Review', href: '#' }} />
-      </div>
-    </Stack>
-  ),
 };

--- a/components/ui/CardControl/CardControl.mdx
+++ b/components/ui/CardControl/CardControl.mdx
@@ -8,7 +8,7 @@ import * as Stories from './CardControl.stories';
 
 <ComponentLinks slug="card-control" />
 
-Settings control card with badge, title, description, and an action slot. Used for toggles, configuration options, and status displays.
+Settings control card with badge, title, description, and an action slot. Used for toggles, configuration options, and status displays. Also available as `<Card preset="control">` — same layout, different API entry point.
 
 ## Playground
 
@@ -16,25 +16,23 @@ Settings control card with badge, title, description, and an action slot. Used f
 
 ## Variants
 
-Switch actions, button actions, status badges, and minimal layout.
-
-<Canvas of={Stories.Variants} />
-
 ### Action alignment
 
-Use `actionAlign="top"` when the description wraps to multiple lines — the CTA anchors to the upper-right corner instead of drifting to the vertical center.
+`actionAlign="center"` (default) aligns the action to the vertical midline. Use `actionAlign="top"` when the description wraps to multiple lines so the CTA anchors to the upper-right corner.
 
 <Canvas of={Stories.ActionAlignment} />
 
 ## Patterns
 
-Settings panel with mixed action types.
+### Settings panel
 
-<Canvas of={Stories.Patterns} />
+Mixed action types (Switch + Button) wired with live state — the typical settings section with independently toggleable rows.
+
+<Canvas of={Stories.SettingsPanel} />
 
 ### Toggle switch panel
 
-Multi-row notification panel using switches with top-aligned actions — a common settings-page layout.
+Multi-row notification panel with `actionAlign="top"` — each row is independently toggled via a Switch.
 
 <Canvas of={Stories.ToggleSwitchPanel} />
 

--- a/components/ui/CardControl/CardControl.stories.tsx
+++ b/components/ui/CardControl/CardControl.stories.tsx
@@ -12,9 +12,27 @@ const meta: Meta<typeof CardControl> = {
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
-    title: { control: 'text' },
-    description: { control: 'text' },
-    actionAlign: { control: 'inline-radio', options: ['center', 'top'] },
+    title: {
+      control: 'text',
+      description: 'Control label shown as the primary text.',
+    },
+    description: {
+      control: 'text',
+      description: 'Optional supporting copy displayed below the title.',
+    },
+    actionAlign: {
+      control: 'inline-radio',
+      options: ['center', 'top'],
+      description: '`center` (default) aligns the action to the vertical midline; `top` anchors it to the upper-right corner — use for long descriptions.',
+    },
+    badge: {
+      control: false,
+      description: 'Optional leading element (typically a `<Badge>` with a status icon) rendered before the text block.',
+    },
+    action: {
+      control: false,
+      description: 'Trailing action element — typically a `<Switch>`, `<Button>`, or link.',
+    },
   },
 };
 
@@ -37,7 +55,7 @@ const Stack = ({ children }: { children: React.ReactNode }) => (
 
 /* ─── Playground ─────────────────────────────────────────────── */
 
-/** @summary Interactive playground for prop tweaking */
+/** @summary Interactive sandbox — Switch action wired via local state (Q4) */
 export const Playground: Story = {
   render: (args) => {
     const [checked, setChecked] = useState(true);
@@ -58,7 +76,13 @@ export const Playground: Story = {
 
 /* ─── Action alignment ───────────────────────────────────────── */
 
-/** @summary Action alignment */
+/**
+ * `actionAlign="center"` vs `actionAlign="top"` — use `top` when the
+ * description wraps to multiple lines so the CTA anchors to the upper-right
+ * corner rather than drifting to the vertical center.
+ *
+ * @summary actionAlign — center vs top alignment
+ */
 export const ActionAlignment: Story = {
   render: () => (
     <Stack>
@@ -91,64 +115,22 @@ export const ActionAlignment: Story = {
   ),
 };
 
-/* ─── Variants ───────────────────────────────────────────────── */
+/* ─── Patterns (Q4 — stateful compositions) ─────────────────── */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>With switch action</SectionLabel>
-      <CardControl
-        title="Notifications"
-        description="Receive email notifications for updates"
-        badge={<Badge size="xs" status="positive" icon={<Icon icon="ph:check" />} />}
-        action={<Switch checked onChange={() => {}} />}
-      />
-
-      <SectionLabel>With button action</SectionLabel>
-      <CardControl
-        title="Security Settings"
-        description="Configure two-factor authentication"
-        badge={<Badge size="xs" status="info" icon={<Icon icon="ph:shield-check" />} />}
-        action={<Button variant="outline" size="sm">Configure</Button>}
-      />
-
-      <SectionLabel>Error status</SectionLabel>
-      <CardControl
-        title="Connection Failed"
-        description="Unable to reach the API server"
-        badge={<Badge size="xs" status="error" icon={<Icon icon="ph:x-circle" />} />}
-        action={<Button variant="primary" size="sm">Retry</Button>}
-      />
-
-      <SectionLabel>Warning status</SectionLabel>
-      <CardControl
-        title="Storage Almost Full"
-        description="You have used 90% of your available storage"
-        badge={<Badge size="xs" status="warning" icon={<Icon icon="ph:warning" />} />}
-        action={<Button variant="outline" size="sm">Upgrade</Button>}
-      />
-
-      <SectionLabel>Minimal (no badge or description)</SectionLabel>
-      <CardControl
-        title="Auto-save"
-        action={<Switch checked={false} onChange={() => {}} />}
-      />
-    </Stack>
-  ),
-};
-
-/* ─── Patterns ───────────────────────────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
+/**
+ * Three settings rows with mixed action types (Switch + Button) wired
+ * via local state. The stateful Switch action requires hook-driven state
+ * that args can't express.
+ *
+ * @summary Settings panel — mixed actions, live state
+ */
+export const SettingsPanel: Story = {
   render: () => {
     const [notifications, setNotifications] = useState(true);
     const [darkMode, setDarkMode] = useState(false);
 
     return (
       <Stack>
-        <SectionLabel>Settings panel</SectionLabel>
         <CardControl
           title="Notifications"
           description="Receive email notifications for updates"
@@ -174,7 +156,12 @@ export const Patterns: Story = {
 
 /* ─── Toggle switch panel ────────────────────────────────────── */
 
-/** @summary Toggle switch panel */
+/**
+ * Multi-row notification panel using `actionAlign="top"` switches — a common
+ * settings-page layout where each row is independently toggled.
+ *
+ * @summary Notification preferences — multi-row toggle panel
+ */
 export const ToggleSwitchPanel: Story = {
   render: () => {
     const [email, setEmail] = useState(true);
@@ -184,7 +171,6 @@ export const ToggleSwitchPanel: Story = {
 
     return (
       <Stack>
-        <SectionLabel>Notification preferences — multi-row toggle panel</SectionLabel>
         <CardControl
           actionAlign="top"
           title="Email updates"

--- a/components/ui/CardList/CardList.mdx
+++ b/components/ui/CardList/CardList.mdx
@@ -30,21 +30,15 @@ Equal-column layout — each card stretches to fill its share of the row. Use fo
 
 ### Horizontal — fit content
 
-`fitContent` lets cards size to their own intrinsic width instead of stretching equally.
+`fitContent` lets cards size to their own intrinsic width instead of stretching equally. Use when card widths are explicitly set and equal columns would distort them.
 
 <Canvas of={Stories.HorizontalFitContent} />
 
 ### Gap scale
 
-Four locked gap sizes — `sm`, `md`, `lg`, `xl`.
+Four locked gap sizes — `sm`, `md`, `lg`, `xl`. Side-by-side comparison.
 
 <Canvas of={Stories.GapScale} />
-
-## Patterns
-
-Service grid and vertical news stack — recurring CardList compositions.
-
-<Canvas of={Stories.Patterns} />
 
 ## Props
 

--- a/components/ui/CardList/CardList.stories.tsx
+++ b/components/ui/CardList/CardList.stories.tsx
@@ -11,9 +11,20 @@ const meta: Meta<typeof CardList> = {
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
-    orientation: { control: 'inline-radio', options: ['vertical', 'horizontal'] },
-    gap: { control: 'select', options: ['sm', 'md', 'lg', 'xl'] },
-    fitContent: { control: 'boolean' },
+    orientation: {
+      control: 'inline-radio',
+      options: ['vertical', 'horizontal'],
+      description: '`vertical` stacks cards in a column; `horizontal` places them in equal-width columns side by side.',
+    },
+    gap: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'xl'],
+      description: 'Spacing between cards. Locked to the 4-step gap scale.',
+    },
+    fitContent: {
+      control: 'boolean',
+      description: 'When `true`, horizontal cards size to their own intrinsic width instead of stretching equally.',
+    },
   },
 };
 
@@ -183,61 +194,6 @@ export const HorizontalFitContent: Story = {
           <CardDescription>Narrowest card.</CardDescription>
         </Card>
       </CardList>
-    </Stack>
-  ),
-};
-
-/* ─── Patterns ───────────────────────────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Service grid (3-column horizontal)</SectionLabel>
-      <CardList orientation="horizontal" gap="lg">
-        <Card variant="outlined" padding="lg">
-          <Badge>Design</Badge>
-          <CardTitle>Brand identity</CardTitle>
-          <CardDescription>Logo, type, and tone — the foundation every campaign builds on.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-        <Card variant="outlined" padding="lg">
-          <Badge>Build</Badge>
-          <CardTitle>Web development</CardTitle>
-          <CardDescription>Production sites built on the components your designers already know.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-        <Card variant="outlined" padding="lg">
-          <Badge>Run</Badge>
-          <CardTitle>Ongoing partnership</CardTitle>
-          <CardDescription>Iterate after launch with a team that already knows your stack.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-      </CardList>
-
-      <SectionLabel>Vertical news stack (in a sidebar)</SectionLabel>
-      <div style={{ width: 360 }}>
-        <CardList orientation="vertical" gap="md">
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">Q1 review</CardTitle>
-            <CardDescription>What shipped, what slipped, and what's queued for Q2.</CardDescription>
-          </Card>
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">New hires</CardTitle>
-            <CardDescription>Three engineers and a designer joined this month.</CardDescription>
-          </Card>
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">Roadmap update</CardTitle>
-            <CardDescription>Two features promoted from Next to Now after customer feedback.</CardDescription>
-          </Card>
-        </CardList>
-      </div>
     </Stack>
   ),
 };

--- a/components/ui/CardTestimonial/CardTestimonial.mdx
+++ b/components/ui/CardTestimonial/CardTestimonial.mdx
@@ -8,7 +8,7 @@ import * as Stories from './CardTestimonial.stories';
 
 <ComponentLinks slug="card-testimonial" />
 
-Customer testimonial card with quote, attribution, and optional star rating. Supports brand (colored background) and outlined variants.
+Customer testimonial card with quote, attribution, and optional star rating. Supports brand (colored background) and outlined variants. Toggle `rating` to 0 via Controls to hide the star row.
 
 ## Playground
 
@@ -16,20 +16,26 @@ Customer testimonial card with quote, attribution, and optional star rating. Sup
 
 ## Variants
 
-Brand, outlined, without rating, and minimal attribution.
+### Brand
 
-<Canvas of={Stories.Variants} />
+`variant="brand"` — colored background with inverse text. Default. Use on marketing pages against a white or light-gray section background.
 
-- **`brand`** — Colored background with inverse text (default)
-- **`outlined`** — Light background with border
+<Canvas of={Stories.Brand} />
+
+### Outlined
+
+`variant="outlined"` — light background with border. Use when the section background conflicts with the brand-colored card.
+
+<Canvas of={Stories.Outlined} />
 
 ## Patterns
 
-Mixed variant testimonials in a grid layout.
+### Testimonials grid
 
-<Canvas of={Stories.Patterns} />
+Three testimonials in a responsive grid — the canonical social-proof section layout mixing brand and outlined variants.
+
+<Canvas of={Stories.TestimonialsGrid} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/CardTestimonial/CardTestimonial.stories.tsx
+++ b/components/ui/CardTestimonial/CardTestimonial.stories.tsx
@@ -7,40 +7,36 @@ const meta: Meta<typeof CardTestimonial> = {
   tags: ['surface-web'],
   parameters: { layout: 'centered' },
   argTypes: {
-    variant: { control: 'select', options: ['brand', 'outlined'] },
-    rating: { control: { type: 'range', min: 0, max: 5, step: 1 } },
-    quote: { control: 'text' },
-    authorName: { control: 'text' },
-    authorRole: { control: 'text' },
+    variant: {
+      control: 'select',
+      options: ['brand', 'outlined'],
+      description: '`brand` (default) = colored background with inverse text; `outlined` = light background with border.',
+    },
+    quote: {
+      control: 'text',
+      description: 'Testimonial quote text.',
+    },
+    authorName: {
+      control: 'text',
+      description: 'Customer name rendered below the quote.',
+    },
+    authorRole: {
+      control: 'text',
+      description: 'Optional role or company rendered below the author name.',
+    },
+    rating: {
+      control: { type: 'range', min: 0, max: 5, step: 1 },
+      description: 'Star rating 0–5. Omit to hide the rating row entirely.',
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof CardTestimonial>;
 
-/* ─── Layout helpers ─────────────────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-    {children}
-  </span>
-);
-
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%' }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-lg)', flexWrap: 'wrap' }}>
-    {children}
-  </div>
-);
-
 /* ─── Playground ─────────────────────────────────────────────── */
 
-/** @summary Interactive playground for prop tweaking */
+/** @summary Interactive sandbox — toggle variant and rating via Controls */
 export const Playground: Story = {
   args: {
     quote: 'Square has completely transformed how we handle payments. The analytics alone have helped us grow 40% this year.',
@@ -52,95 +48,75 @@ export const Playground: Story = {
   decorators: [(Story) => <div style={{ width: 380 }}><Story /></div>],
 };
 
-/* ─── Variants ───────────────────────────────────────────────── */
+/* ─── Variants (Q3 — one per semantic starting point) ────────── */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Brand variant</SectionLabel>
-      <Row>
-        <div style={{ width: 380 }}>
-          <CardTestimonial
-            variant="brand"
-            quote="Incredible results from day one. Highly recommend."
-            authorName="Sarah Chen"
-            authorRole="Owner, Bloom Cafe"
-            rating={5}
-          />
-        </div>
-      </Row>
-
-      <SectionLabel>Outlined variant</SectionLabel>
-      <Row>
-        <div style={{ width: 380 }}>
-          <CardTestimonial
-            variant="outlined"
-            quote="Professional, responsive, and creative. Our new site has driven 3x more leads."
-            authorName="Marcus Johnson"
-            authorRole="Marketing Director, Apex Corp"
-            rating={5}
-          />
-        </div>
-      </Row>
-
-      <SectionLabel>Without rating</SectionLabel>
-      <Row>
-        <div style={{ width: 380 }}>
-          <CardTestimonial
-            variant="brand"
-            quote="Working with this team felt like an extension of our own company."
-            authorName="Emily Rodriguez"
-            authorRole="CEO, Greenfield Digital"
-          />
-        </div>
-      </Row>
-
-      <SectionLabel>Minimal attribution (no role)</SectionLabel>
-      <Row>
-        <div style={{ width: 380 }}>
-          <CardTestimonial
-            variant="brand"
-            quote="Best investment we made this year. Period."
-            authorName="Alex Turner"
-            rating={5}
-          />
-        </div>
-      </Row>
-    </Stack>
-  ),
+/**
+ * `variant="brand"` — colored background with inverse text. Default variant.
+ * Use on marketing pages with a brand-primary color field.
+ *
+ * @summary variant="brand" — colored background
+ */
+export const Brand: Story = {
+  args: {
+    variant: 'brand',
+    quote: 'Incredible results from day one. Highly recommend.',
+    authorName: 'Sarah Chen',
+    authorRole: 'Owner, Bloom Cafe',
+    rating: 5,
+  },
+  decorators: [(Story) => <div style={{ width: 380 }}><Story /></div>],
 };
 
-/* ─── Patterns ───────────────────────────────────────────────── */
+/**
+ * `variant="outlined"` — light background with border. Use when the
+ * section background conflicts with the brand-colored card.
+ *
+ * @summary variant="outlined" — light background with border
+ */
+export const Outlined: Story = {
+  args: {
+    variant: 'outlined',
+    quote: 'Professional, responsive, and creative. Our new site has driven 3x more leads.',
+    authorName: 'Marcus Johnson',
+    authorRole: 'Marketing Director, Apex Corp',
+    rating: 5,
+  },
+  decorators: [(Story) => <div style={{ width: 380 }}><Story /></div>],
+};
 
-/** @summary Common usage patterns */
-export const Patterns: Story = {
+/* ─── Patterns (Q4 — irreducible compositions) ───────────────── */
+
+/**
+ * Three testimonials in a responsive grid — the canonical social-proof
+ * section layout mixing brand and outlined variants.
+ *
+ * @summary Mixed-variant testimonials grid
+ */
+export const TestimonialsGrid: Story = {
+  decorators: [(Story) => <div style={{ maxWidth: 1200 }}><Story /></div>],
   render: () => (
-    <Stack>
-      <SectionLabel>Mixed variant testimonials grid</SectionLabel>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--gap-lg)', maxWidth: 1200 }}>
-        <CardTestimonial
-          variant="brand"
-          quote="Square has completely transformed how we handle payments. The analytics alone have helped us grow 40% this year."
-          authorName="Sarah Chen"
-          authorRole="Owner, Bloom Cafe"
-          rating={5}
-        />
-        <CardTestimonial
-          variant="outlined"
-          quote="The team was incredibly responsive and delivered beyond our expectations."
-          authorName="Marcus Johnson"
-          authorRole="Marketing Director, Apex Corp"
-          rating={5}
-        />
-        <CardTestimonial
-          variant="brand"
-          quote="Best investment we made this year. Communication was seamless."
-          authorName="Emily Rodriguez"
-          authorRole="CEO, Greenfield Digital"
-          rating={4}
-        />
-      </div>
-    </Stack>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--gap-lg)' }}>
+      <CardTestimonial
+        variant="brand"
+        quote="Square has completely transformed how we handle payments. The analytics alone have helped us grow 40% this year."
+        authorName="Sarah Chen"
+        authorRole="Owner, Bloom Cafe"
+        rating={5}
+      />
+      <CardTestimonial
+        variant="outlined"
+        quote="The team was incredibly responsive and delivered beyond our expectations."
+        authorName="Marcus Johnson"
+        authorRole="Marketing Director, Apex Corp"
+        rating={5}
+      />
+      <CardTestimonial
+        variant="brand"
+        quote="Best investment we made this year. Communication was seamless."
+        authorName="Emily Rodriguez"
+        authorRole="CEO, Greenfield Digital"
+        rating={4}
+      />
+    </div>
   ),
 };

--- a/components/ui/CollapsibleCard/CollapsibleCard.mdx
+++ b/components/ui/CollapsibleCard/CollapsibleCard.mdx
@@ -8,7 +8,7 @@ import * as Stories from './CollapsibleCard.stories';
 
 <ComponentLinks slug="collapsible-card" />
 
-Expandable content section with a clickable header. Use for FAQs, settings panels, and long-form content that benefits from progressive disclosure.
+Expandable content section with a clickable header. Use for FAQs, settings panels, and long-form content that benefits from progressive disclosure. `defaultOpen` controls the initial state; pass `open` + `onOpenChange` for fully controlled usage.
 
 ## Playground
 
@@ -16,17 +16,26 @@ Expandable content section with a clickable header. Use for FAQs, settings panel
 
 ## Variants
 
-Collapsed, expanded, without section label, and with rich content.
+### Default open
 
-<Canvas of={Stories.Variants} />
+`defaultOpen={true}` — starts expanded. Use when the section content is immediately relevant and collapsing is secondary.
+
+<Canvas of={Stories.DefaultOpen} />
 
 ## Patterns
 
-Stacked proposal sections in an accordion-style layout.
+### Rich content
 
-<Canvas of={Stories.Patterns} />
+Demonstrates the `children` slot with nested headings and lists — content too structured to express as a plain string.
+
+<Canvas of={Stories.WithRichContent} />
+
+### Proposal sections
+
+Four numbered sections stacked as an accordion. The primary production use case — each section collapses independently.
+
+<Canvas of={Stories.ProposalSections} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/CollapsibleCard/CollapsibleCard.stories.tsx
+++ b/components/ui/CollapsibleCard/CollapsibleCard.stories.tsx
@@ -2,26 +2,9 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CollapsibleCard } from './CollapsibleCard';
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
 const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
   <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
 );
-
-/* ─── Meta ────────────────────────────────────────────── */
 
 const meta: Meta<typeof CollapsibleCard> = {
   title: 'Containers/collapsible-card',
@@ -30,20 +13,27 @@ const meta: Meta<typeof CollapsibleCard> = {
   parameters: { layout: 'padded' },
   decorators: [(Story) => <div style={{ maxWidth: 640 }}><Story /></div>],
   argTypes: {
-    sectionLabel: { control: 'text' },
-    title: { control: 'text' },
-    defaultOpen: { control: 'boolean' },
+    sectionLabel: {
+      control: 'text',
+      description: 'Optional section number or label rendered above the title in a muted style.',
+    },
+    title: {
+      control: 'text',
+      description: 'Clickable header text that toggles the panel.',
+    },
+    defaultOpen: {
+      control: 'boolean',
+      description: 'Initial open state (uncontrolled). Use `open` + `onOpenChange` for controlled mode.',
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof CollapsibleCard>;
 
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Playground ─────────────────────────────────────────────── */
 
-/** @summary Interactive playground for prop tweaking */
+/** @summary Interactive sandbox — toggle defaultOpen, sectionLabel via Controls */
 export const Playground: Story = {
   args: {
     sectionLabel: 'Section 01',
@@ -53,113 +43,81 @@ export const Playground: Story = {
   },
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — States, with/without section label, rich content
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Variants (Q3 — semantic starting points) ──────────────── */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
+/**
+ * `defaultOpen={true}` — card starts expanded. Use when the section
+ * content is immediately relevant and collapsing is secondary.
+ *
+ * @summary defaultOpen=true — starts expanded
+ */
+export const DefaultOpen: Story = {
   args: {
-    title: 'Overview',
-    children: 'Content',
+    sectionLabel: 'Section 01',
+    title: 'Overview and Goals',
+    defaultOpen: true,
+    children: 'This section starts expanded. Users can collapse it once they have read the content.',
   },
+};
+
+/* ─── Patterns (Q4 — irreducible compositions) ───────────────── */
+
+/**
+ * Rich HTML content in the children slot — headings, lists, and
+ * multiple content blocks that args can't express as a plain string.
+ *
+ * @summary Rich content slot — nested headings and lists
+ */
+export const WithRichContent: Story = {
   render: () => (
-    <Stack>
+    <CollapsibleCard sectionLabel="Section 03" title="Project Timeline" defaultOpen>
       <div>
-        <SectionLabel>Collapsed (default)</SectionLabel>
-        <CollapsibleCard
-          sectionLabel="Section 01"
-          title="Overview and Goals"
-        >
-          Strategic overview of the project objectives and expected outcomes.
-        </CollapsibleCard>
+        <h4 style={{ margin: '0 0 var(--gap-md)', color: 'var(--text-primary)' }}>Phase 1: Discovery</h4>
+        <ul style={{ margin: '0 0 var(--gap-lg)', paddingLeft: 'var(--padding-lg)', color: 'var(--text-secondary)' }}>
+          <li>Stakeholder interviews</li>
+          <li>Competitive analysis</li>
+          <li>Requirements gathering</li>
+        </ul>
+        <h4 style={{ margin: '0 0 var(--gap-md)', color: 'var(--text-primary)' }}>Phase 2: Design</h4>
+        <ul style={{ margin: 0, paddingLeft: 'var(--padding-lg)', color: 'var(--text-secondary)' }}>
+          <li>Wireframes and prototypes</li>
+          <li>Visual design</li>
+          <li>Design review</li>
+        </ul>
       </div>
-
-      <div>
-        <SectionLabel>Expanded</SectionLabel>
-        <CollapsibleCard
-          sectionLabel="Section 02"
-          title="Scope of Project"
-          defaultOpen
-        >
-          Detailed breakdown of deliverables and service offerings.
-        </CollapsibleCard>
-      </div>
-
-      <div>
-        <SectionLabel>Without section label</SectionLabel>
-        <CollapsibleCard
-          title="Settings"
-          defaultOpen
-        >
-          A collapsible card without a section label — useful for settings panels or standalone collapsible areas.
-        </CollapsibleCard>
-      </div>
-
-      <div>
-        <SectionLabel>With rich content</SectionLabel>
-        <CollapsibleCard
-          sectionLabel="Section 03"
-          title="Project Timeline"
-          defaultOpen
-        >
-          <div>
-            <h4 style={{ margin: '0 0 var(--gap-md)', color: 'var(--text-primary)' }}>Phase 1: Discovery</h4>
-            <ul style={{ margin: '0 0 var(--gap-lg)', paddingLeft: 'var(--padding-lg)', color: 'var(--text-secondary)' }}>
-              <li>Stakeholder interviews</li>
-              <li>Competitive analysis</li>
-              <li>Requirements gathering</li>
-            </ul>
-            <h4 style={{ margin: '0 0 var(--gap-md)', color: 'var(--text-primary)' }}>Phase 2: Design</h4>
-            <ul style={{ margin: 0, paddingLeft: 'var(--padding-lg)', color: 'var(--text-secondary)' }}>
-              <li>Wireframes and prototypes</li>
-              <li>Visual design</li>
-              <li>Design review</li>
-            </ul>
-          </div>
-        </CollapsibleCard>
-      </div>
-    </Stack>
+    </CollapsibleCard>
   ),
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Proposal sections (accordion layout)
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  args: {
-    title: 'Overview',
-    children: 'Content',
-  },
+/**
+ * Four stacked CollapsibleCards forming a numbered proposal — the primary
+ * real-world use case. Sections are independently collapsible.
+ *
+ * @summary Stacked proposal sections — accordion layout
+ */
+export const ProposalSections: Story = {
   render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Proposal sections</SectionLabel>
-        <Stack gap="var(--gap-lg)">
-          <CollapsibleCard sectionLabel="Section 01" title="Overview and Goals">
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
-              Strategic overview of the project objectives and expected outcomes.
-            </p>
-          </CollapsibleCard>
-          <CollapsibleCard sectionLabel="Section 02" title="Scope of Project">
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
-              Detailed breakdown of deliverables and service offerings.
-            </p>
-          </CollapsibleCard>
-          <CollapsibleCard sectionLabel="Section 03" title="Project Timeline">
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
-              Phased timeline with milestones and deliverable dates.
-            </p>
-          </CollapsibleCard>
-          <CollapsibleCard sectionLabel="Section 04" title="Fee Summary">
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
-              Pricing breakdown with service-level detail.
-            </p>
-          </CollapsibleCard>
-        </Stack>
-      </div>
+    <Stack gap="var(--gap-lg)">
+      <CollapsibleCard sectionLabel="Section 01" title="Overview and Goals">
+        <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+          Strategic overview of the project objectives and expected outcomes.
+        </p>
+      </CollapsibleCard>
+      <CollapsibleCard sectionLabel="Section 02" title="Scope of Project">
+        <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+          Detailed breakdown of deliverables and service offerings.
+        </p>
+      </CollapsibleCard>
+      <CollapsibleCard sectionLabel="Section 03" title="Project Timeline">
+        <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+          Phased timeline with milestones and deliverable dates.
+        </p>
+      </CollapsibleCard>
+      <CollapsibleCard sectionLabel="Section 04" title="Fee Summary">
+        <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
+          Pricing breakdown with service-level detail.
+        </p>
+      </CollapsibleCard>
     </Stack>
   ),
 };

--- a/components/ui/PricingCard/PricingCard.mdx
+++ b/components/ui/PricingCard/PricingCard.mdx
@@ -16,17 +16,20 @@ A pricing tier display card with title, price, features list, and call-to-action
 
 ## Variants
 
-Standard, highlighted with badge, and free tier configurations.
+### Highlighted
 
-<Canvas of={Stories.Variants} />
+`highlighted` applies accent treatment — use for the recommended or most popular tier. Pair with a `<Badge>` for the "Most popular" label.
+
+<Canvas of={Stories.Highlighted} />
 
 ## Patterns
 
-Three-tier pricing grid — the typical side-by-side layout with the middle plan highlighted.
+### Pricing grid
 
-<Canvas of={Stories.Patterns} />
+Three-tier side-by-side layout — the canonical pricing section with the middle plan highlighted.
+
+<Canvas of={Stories.PricingGrid} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/PricingCard/PricingCard.stories.tsx
+++ b/components/ui/PricingCard/PricingCard.stories.tsx
@@ -1,29 +1,7 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PricingCard } from './PricingCard';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Meta ────────────────────────────────────────────── */
 
 const meta: Meta<typeof PricingCard> = {
   title: 'Containers/pricing-card',
@@ -32,18 +10,43 @@ const meta: Meta<typeof PricingCard> = {
   parameters: { layout: 'centered' },
   decorators: [(Story) => <div style={{ width: 320 }}><Story /></div>],
   argTypes: {
-    title: { control: 'text' },
-    price: { control: 'text' },
-    period: { control: 'text' },
-    description: { control: 'text' },
-    highlighted: { control: 'boolean' },
+    title: {
+      control: 'text',
+      description: 'Plan name rendered as the card heading.',
+    },
+    price: {
+      control: 'text',
+      description: 'Price string (e.g. `"$49"`, `"Free"`). Rendered verbatim — format before passing.',
+    },
+    period: {
+      control: 'text',
+      description: 'Billing cadence suffix rendered after the price (e.g. `"/month"`). Omit for free tiers.',
+    },
+    description: {
+      control: 'text',
+      description: 'One-line plan summary rendered below the price.',
+    },
+    highlighted: {
+      control: 'boolean',
+      description: 'Applies accent treatment — use for the recommended or most popular tier.',
+    },
+    badge: {
+      control: false,
+      description: 'Optional badge rendered above the title (e.g. "Most popular"). Pass a `<Badge>` element.',
+    },
+    features: {
+      control: false,
+      description: 'Array of feature strings rendered as a checklist.',
+    },
+    action: {
+      control: false,
+      description: 'CTA element (typically `<Button fullWidth>`). Anchored to the card bottom.',
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof PricingCard>;
-
-/* ─── Shared data ─────────────────────────────────────── */
 
 const commonFeatures = [
   'Unlimited projects',
@@ -52,11 +55,9 @@ const commonFeatures = [
   'Analytics dashboard',
 ];
 
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Playground ─────────────────────────────────────────────── */
 
-/** @summary Interactive playground for prop tweaking */
+/** @summary Interactive sandbox — toggle highlighted, period via Controls */
 export const Playground: Story = {
   args: {
     title: 'Professional',
@@ -68,105 +69,70 @@ export const Playground: Story = {
   },
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Highlighted, free tier, no features
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Variants (Q3 — semantic starting points) ───────────────── */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  decorators: [(Story) => <div style={{ width: 900 }}><Story /></div>],
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Standard</SectionLabel>
-        <div style={{ width: 320 }}>
-          <PricingCard
-            title="Professional"
-            price="$49"
-            period="/month"
-            description="For growing businesses that need more power."
-            features={commonFeatures}
-            action={<Button variant="primary" fullWidth>Get started</Button>}
-          />
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel>Highlighted with badge</SectionLabel>
-        <div style={{ width: 320 }}>
-          <PricingCard
-            title="Professional"
-            price="$49"
-            period="/month"
-            description="Most popular choice for growing businesses."
-            features={commonFeatures}
-            badge={<Badge status="positive" size="sm">Most popular</Badge>}
-            action={<Button variant="primary" fullWidth>Get started</Button>}
-            highlighted
-          />
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel>Free tier (no period)</SectionLabel>
-        <div style={{ width: 320 }}>
-          <PricingCard
-            title="Starter"
-            price="Free"
-            description="Get started with the basics."
-            features={['1 project', 'Community support', 'Basic analytics']}
-            action={<Button variant="outline" fullWidth>Sign up free</Button>}
-          />
-        </div>
-      </div>
-    </Stack>
-  ),
+/**
+ * `highlighted` plan — the recommended or most popular tier. Rendered with
+ * accent treatment and typically accompanied by a "Most popular" badge.
+ *
+ * @summary highlighted=true — recommended/most popular tier
+ */
+export const Highlighted: Story = {
+  args: {
+    title: 'Professional',
+    price: '$49',
+    period: '/month',
+    description: 'Most popular choice for growing businesses.',
+    features: commonFeatures,
+    badge: <Badge status="positive" size="sm">Most popular</Badge>,
+    action: <Button variant="primary" fullWidth>Get started</Button>,
+    highlighted: true,
+  },
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Pricing grid (3-tier layout)
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Patterns (Q4 — irreducible compositions) ───────────────── */
 
-/** @summary Common usage patterns */
-export const Patterns: Story = {
+/**
+ * Three-tier pricing grid — the canonical side-by-side layout with the
+ * middle plan highlighted. The grid layout requires multiple PricingCards
+ * with coordinated props that can't be expressed via a single component's args.
+ *
+ * @summary Three-tier pricing grid — starter / pro / enterprise
+ */
+export const PricingGrid: Story = {
   decorators: [(Story) => <div style={{ maxWidth: 1000 }}><Story /></div>],
   render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Three-tier pricing grid</SectionLabel>
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(3, 1fr)',
-          gap: 'var(--padding-lg)',
-          alignItems: 'start',
-        }}>
-          <PricingCard
-            title="Starter"
-            price="Free"
-            description="Get started with the basics."
-            features={['1 project', 'Community support', 'Basic analytics']}
-            action={<Button variant="outline" fullWidth>Sign up free</Button>}
-          />
-          <PricingCard
-            title="Professional"
-            price="$49"
-            period="/month"
-            description="Most popular choice for growing businesses."
-            features={['Unlimited projects', 'Priority support', 'Custom domain', 'Analytics dashboard', 'API access']}
-            badge={<Badge status="positive" size="sm">Most popular</Badge>}
-            action={<Button variant="primary" fullWidth>Get started</Button>}
-            highlighted
-          />
-          <PricingCard
-            title="Enterprise"
-            price="$199"
-            period="/month"
-            description="For large teams with advanced needs."
-            features={['Everything in Professional', 'Dedicated account manager', 'SLA guarantee', 'Custom integrations']}
-            action={<Button variant="outline" fullWidth>Contact sales</Button>}
-          />
-        </div>
-      </div>
-    </Stack>
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, 1fr)',
+      gap: 'var(--padding-lg)',
+      alignItems: 'start',
+    }}>
+      <PricingCard
+        title="Starter"
+        price="Free"
+        description="Get started with the basics."
+        features={['1 project', 'Community support', 'Basic analytics']}
+        action={<Button variant="outline" fullWidth>Sign up free</Button>}
+      />
+      <PricingCard
+        title="Professional"
+        price="$49"
+        period="/month"
+        description="Most popular choice for growing businesses."
+        features={['Unlimited projects', 'Priority support', 'Custom domain', 'Analytics dashboard', 'API access']}
+        badge={<Badge status="positive" size="sm">Most popular</Badge>}
+        action={<Button variant="primary" fullWidth>Get started</Button>}
+        highlighted
+      />
+      <PricingCard
+        title="Enterprise"
+        price="$199"
+        period="/month"
+        description="For large teams with advanced needs."
+        features={['Everything in Professional', 'Dedicated account manager', 'SLA guarantee', 'Custom integrations']}
+        action={<Button variant="outline" fullWidth>Contact sales</Button>}
+      />
+    </div>
   ),
 };


### PR DESCRIPTION
## Summary

- Applies ADR-010 story-vs-control matrix (Q2/Q3/Q4) to all 7 Card family components: Card, CardSummary, CardControl, CardList, CardTestimonial, CollapsibleCard, PricingCard
- Removes banned named exports (`Variants`, `Patterns`, `Tones`, `Examples`) — replaces with descriptive export names
- Adds `@summary` JSDoc on every export and `argType` descriptions (with `control: false` for slot props)
- Moves CardSummary to `Deprecated/` sidebar bucket with `!manifest` tag (component has `@deprecated` JSDoc pointing to `<Card preset="summary">`)
- Promotes Q3 args stories: `Highlighted`, `DefaultOpen`, `Brand`, `Outlined`, `ActionAlignment`
- Promotes Q4 render stories: `PricingGrid`, `ProposalSections`, `TestimonialsGrid`, `SettingsPanel`, `ToggleSwitchPanel`, `WithRichContent`
- MDX pages updated throughout: Variants + Patterns sections with correct Canvas refs, all 77 pages pass ADR-007 recipe lint

## Test plan

- [x] TypeScript clean (`tsc --noEmit`)
- [x] Token lint: 0 violations
- [x] JSDoc lint: all exports have `@summary`, all props have descriptions, all meta has `surface-*` tag
- [x] ADR-007 MDX recipe lint: 77/77 conforming
- [x] Full validation suite: 10/10 checks pass
- [x] Storybook build succeeds

Closes part of #656 (Card family batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)