### PR TITLE
component: purpose framework

### DIFF
--- a/.claude/standards/component-build.md
+++ b/.claude/standards/component-build.md
@@ -35,6 +35,39 @@ Use Paper (Claude Code's HTML canvas) to iterate visually before writing `.tsx` 
 <div style="padding: 24px; color: #1a1a1a; border: 1px solid #e0e0e0;">
 ```
 
+## Component vs variant vs control — decide this first
+
+Before writing any code, place the thing you are building in one of three tiers. The tier determines where it lives, what it exports, and how it appears in Storybook.
+
+### The three tiers
+
+| Tier | Definition | Where it lives | Storybook shape |
+| --- | --- | --- | --- |
+| **Component** | Standalone purpose + recognizable identity. A designer or developer reaches for it by name because it has a distinct UX contract. | `components/ui/ComponentName/` — own directory, MDX, public export | One or more stories in its own file |
+| **Variant** | A distinct contextual expression of a component that carries its own semantic signal: own color logic, icon convention, or behavioral expectation. A designer would choose it intentionally in a wireframe. | Same directory as its component | Dedicated story (ADR-010 Q3) |
+| **Control / Prop** | Customization within a variant that does not change the component's identity or contextual meaning. | A prop or `argTypes` entry | `argTypes` only — never a story |
+
+### Decision questions
+
+1. **Would a designer or developer reach for this by name?** If yes → it is a component.
+2. **Does it carry a semantic signal a designer would choose deliberately** (own icon, own color logic, distinct behavioral expectation)? If yes → it is a variant (story). If no → it is a control.
+3. **Does it share >70% of props or CSS with an existing primitive?** If yes and the purpose test above did not already justify a component → extend the primitive with a prop instead.
+
+### Examples
+
+| Thing | Tier | Reasoning |
+| --- | --- | --- |
+| `Toast` | Component | Standalone notification surface; reached for by name |
+| `Toast` `tone="destructive"` | Variant / story | Own icon + color logic; designer picks it deliberately |
+| `Toast` `showActions={false}` | Control | Does not change Toast's identity |
+| `TextInput` | Component | Core text-entry primitive |
+| `TextInput` on-dark | Variant / story | Borderless visual contract for dark surfaces; designer chooses it intentionally |
+| `TextInput` `size="lg"` | Control | Does not change TextInput's identity |
+| `SearchInput` | Component | Distinct search affordance, clear-button interaction, `role="search"` — its own UX contract |
+| `EmailInput` | ❌ Not a component | `type="email"` is a browser hint; no UX distinction from `TextInput` |
+
+See [ADR-004 §Amendment 2026-05-17](../../docs/adrs/ADR-004-component-bloat-guardrails.md) for the full purpose-test rationale and the corrected input taxonomy.
+
 ## File structure
 
 ```
@@ -81,7 +114,7 @@ Inline `style` is acceptable only for:
 **The `__slot` suffix is not free-form.** It must come from the closed allowlist in [`docs/SLOT-ALLOWLIST.md`](../../docs/SLOT-ALLOWLIST.md). Inventing a new slot name fails the lint. See [ADR-008](../../docs/adrs/ADR-008-naming-canon-closed-allowlist.md) for the rationale.
 
 | What | Canon source |
-|---|---|
+| --- | --- |
 | BEM rules, `bds-` namespace, structural-only modifier rule, id generation | [Naming Conventions](../../docs-site/content/docs/primitives/naming-conventions.mdx) |
 | Closed allowlist of every `__slot` name | [`docs/SLOT-ALLOWLIST.md`](../../docs/SLOT-ALLOWLIST.md) |
 | Why the system runs on a closed allowlist instead of a banlist | [ADR-008](../../docs/adrs/ADR-008-naming-canon-closed-allowlist.md) |
@@ -340,7 +373,7 @@ A `@deprecated` JSDoc tag is a *promise to remove the component*, not a permanen
 Every deprecation moves through three stages:
 
 | Stage | When | What happens | What stays |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **1. Deprecation lands** | A `@deprecated` JSDoc tag is added to the exported component | Story file gets `tags: ['!manifest']`; MDX `## Notes` adds *"Deprecated — use `<X>` instead. Stories will be retired in `vN.M`."*; file a retirement-tracker issue with the target version | Component continues to ship; consumers keep working |
 | **2. Stories retired** | **Two minor releases after Stage 1** (default; override via the JSDoc sentinel below) | Delete `Component.stories.tsx` + `Component.mdx`; PR references the tracker issue | `Component.tsx` + `Component.css` + `index.ts` export remain — consumers on the old API don't break |
 | **3. Component removed** | At the next **major** release | Delete the component directory; remove `index.ts` export; confirm consumer audit (portal / renew / web/{slug}) before merge | Tracker issue closes |

--- a/docs/adrs/ADR-004-component-bloat-guardrails.md
+++ b/docs/adrs/ADR-004-component-bloat-guardrails.md
@@ -83,3 +83,44 @@ A component-bloat audit runs at least twice yearly (next: 2026-Q4) to retroactiv
 - Component-bloat audit follow-up project (tracked in memory) executes the first retroactive pass
 - PR review check (manual for now; can be partially automated via a CI step that fails when a `components/ui/*` PR description is missing the four audit-gate answers — separate task)
 - Periodic audit cadence: twice yearly minimum
+
+---
+
+## Amendment 2026-05-17 — Component purpose test
+
+**Problem:** The >70% overlap rule (§3 above) was written to prevent trivial wrappers. Applied alone it can incorrectly kill components with genuine distinct UX purpose. The 2026-04-24 consolidation of `SearchInput` into `TextInput` misapplied the rule this way: `SearchInput` shared CSS with `TextInput` but had a distinct UX contract (search affordance, clear-button interaction, `role="search"`, different semantic identity). Overlap is a necessary check, not a sufficient one.
+
+### Purpose test — precedes the overlap test
+
+Ask this question first: **would a designer or developer reach for this by name because it has a distinct UX contract?**
+
+If yes, it is a component regardless of code overlap. If no, apply the overlap rule and the three-uses test.
+
+This establishes three tiers:
+
+| Tier | Definition | Story implication |
+| --- | --- | --- |
+| **Component** | Standalone purpose + recognizable identity. Reached for by name. Has its own Storybook entry, MDX page, and public export. | One or more stories in its own directory |
+| **Variant** | A distinct contextual expression of a component that carries its own semantic signal — own color logic, icon convention, or behavioral expectation. A designer would choose it intentionally in a wireframe. | Dedicated story (ADR-010 Q3) |
+| **Control / Prop** | Customization within a variant that does not change the component's identity or contextual meaning. | `argTypes` only (ADR-010 Q2) |
+
+**Toast as the canonical example:**
+
+- `Toast` — component (standalone notification surface)
+- `Toast` with `tone="destructive"` — variant / story (own icon + color logic; a designer picks it deliberately)
+- `Toast` with `showActions={false}` — control (does not change Toast's identity)
+
+### Corrected input taxonomy
+
+The 2026-04-24 consolidation of `EmailInput` was correct (5-line wrapper, no UX distinction). The consolidation of `SearchInput` was not.
+
+| Component | Verdict | Reasoning |
+| --- | --- | --- |
+| `TextInput` | ✅ Core primitive | text, email, url — identical UX contract; `type` is a browser hint, not a UX distinction |
+| `SearchInput` | ✅ Own component | Distinct UX: search affordance, clear-button interaction, `role="search"`, different semantic identity |
+| `NumberInput` | ✅ Own component | Distinct UX: steppers, `min`/`max`/`step`, format constraint |
+| `PhoneInput` | 🟡 Future-scope | Format mask + country-code selector will justify it; do not ship a wrapper-only version |
+| `EmailInput` | ❌ Removed correctly | `type="email"` is a browser autocomplete hint; no UX distinction from `TextInput` |
+| `URLInput` | ❌ Never ship | Same reasoning as `EmailInput` |
+
+Restoration of `SearchInput` and addition of `NumberInput` as first-class components is tracked separately.


### PR DESCRIPTION
## Summary
- docs(adrs): add component purpose test to ADR-004 + component-build standard

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)