### PR TITLE
search: input restore

### DIFF
--- a/components/ui/SearchInput/SearchInput.css
+++ b/components/ui/SearchInput/SearchInput.css
@@ -1,0 +1,26 @@
+@layer bds-components {
+/* SearchInput — suppress native webkit cancel button (replaced by our clear button) */
+.bds-text-input-field[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+/* SearchInput — clear button */
+
+.bds-search-input__clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--icon-sm);
+  line-height: 1;
+}
+
+.bds-search-input__clear:hover {
+  color: var(--text-primary);
+}
+}

--- a/components/ui/SearchInput/SearchInput.mdx
+++ b/components/ui/SearchInput/SearchInput.mdx
@@ -1,0 +1,39 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './SearchInput.stories';
+
+<Meta of={Stories} />
+
+# Search input
+
+<ComponentLinks slug="search-input" />
+
+Search field with a magnifying glass icon and a clear button that appears when the field has a value. Wraps [`TextInput`](/?path=/docs/components-text-input--docs) and inherits all its props except `type` (forced to `"search"`), `iconBefore` (reserved for the magnifying glass), and `iconAfter` (reserved for the clear button).
+
+## Playground
+
+<Canvas of={Stories.Default} />
+
+## Variants
+
+SearchInput has no semantic-variant axis — all variation (size, error, disabled, helper text, fullWidth) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
+
+<Canvas of={Stories.Default} />
+
+- **`sm`** — 32px height, 14px body
+- **`md`** — 40px height, 16px body (default)
+- **`lg`** — 48px height, 18px body
+
+The clear button appears automatically when the field has a value and disappears when cleared. The play function above demonstrates the full type → clear cycle.
+
+## Props
+
+<ArgTypes of={Stories} />
+
+## Notes
+
+> **Note** — SearchInput specialization is justified per [ADR-004 §Amendment 2026-05-17](../../../docs/adrs/ADR-004-component-bloat-guardrails.md): search has a distinct UX contract (search affordance, controlled clear-button interaction) that makes it a component a designer reaches for by name, not a `TextInput` usage pattern.
+
+> **Note** — For controlled usage, wire `value` + `onChange` + `onClear` together. `onClear` fires when the ✕ button is clicked; in controlled mode it is your responsibility to reset `value` to `''`.
+
+> **Note** — All `TextInput` updates (focus ring, error styling, sizing tokens) propagate here automatically. `type`, `iconBefore`, and `iconAfter` are reserved by `SearchInput`; everything else passes through.

--- a/components/ui/SearchInput/SearchInput.stories.tsx
+++ b/components/ui/SearchInput/SearchInput.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { SearchInput } from './SearchInput';
+
+/* ─── Meta ────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof SearchInput> = {
+  title: 'Components/search-input',
+  component: SearchInput,
+  tags: ['surface-shared'],
+  parameters: { layout: 'centered' },
+  decorators: [(Story) => <div style={{ width: 360 }}><Story /></div>],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size token (sm=32px, md=40px, lg=48px). Matches TextInput scale. Default `md`.',
+    },
+    label: {
+      control: 'text',
+      description: 'Optional label rendered above the field. Auto-wires `htmlFor`/`id`.',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text shown when the field is empty.',
+    },
+    helperText: {
+      control: 'text',
+      description: 'Hint text under the field. Hidden when `error` is present.',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message. Triggers `aria-invalid` and replaces `helperText`.',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretch to fill container width.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the field — non-interactive, muted appearance.',
+    },
+    onClear: {
+      action: 'cleared',
+      description:
+        'Called when the clear button is clicked. In controlled mode, use this to reset `value`.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ═══════════════════════════════════════════════════════════════
+   DEFAULT — single canonical story per ADR-010 §components without
+   a variant axis. All variation (size, error, disabled, helper) is
+   exposed via Controls. The clear button is internal to the component.
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Search field with magnifying glass icon and clear button */
+export const Default: Story = {
+  args: {
+    label: 'Search',
+    placeholder: 'Search...',
+    size: 'md',
+    fullWidth: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Search') as HTMLInputElement;
+
+    await expect(input).toBeVisible();
+    await expect(input).toHaveAttribute('type', 'search');
+
+    // Clear button is hidden when the field is empty
+    await expect(canvas.queryByRole('button', { name: 'Clear search' })).toBeNull();
+
+    // Typing reveals the clear button
+    await userEvent.type(input, 'React components');
+    await expect(canvas.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
+
+    // Clicking clear empties the field and hides the button
+    await userEvent.click(canvas.getByRole('button', { name: 'Clear search' }));
+    await expect(input).toHaveValue('');
+    await expect(canvas.queryByRole('button', { name: 'Clear search' })).toBeNull();
+
+    // Blur to avoid stale focus styling in the post-play snapshot
+    input.blur();
+  },
+};

--- a/components/ui/SearchInput/SearchInput.tsx
+++ b/components/ui/SearchInput/SearchInput.tsx
@@ -1,0 +1,120 @@
+import {
+  forwardRef,
+  useId,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from 'react';
+import { Icon } from '@iconify/react';
+import { MagnifyingGlass, X } from '../../icons';
+import { TextInput, type TextInputProps } from '../TextInput/TextInput';
+import './SearchInput.css';
+
+/**
+ * SearchInput component props.
+ *
+ * `type`, `iconBefore`, and `iconAfter` are reserved — the component
+ * sets `type="search"`, the magnifying glass icon, and the clear button
+ * internally.
+ */
+export interface SearchInputProps
+  extends Omit<TextInputProps, 'type' | 'iconBefore' | 'iconAfter'> {
+  /**
+   * Called when the clear button is clicked.
+   * In controlled mode (`value` provided) use this to reset `value`.
+   * In uncontrolled mode the field clears itself and this fires as a notification.
+   */
+  onClear?: () => void;
+}
+
+
+/**
+ * SearchInput — TextInput with a built-in magnifying glass icon and a
+ * clear button that appears when the field has a value.
+ *
+ * Composes TextInput and inherits all its props (label, size, error,
+ * helperText, fullWidth, etc.). `type`, `iconBefore`, and `iconAfter`
+ * are reserved.
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled
+ * <SearchInput label="Search" placeholder="Search products..." />
+ *
+ * // Controlled
+ * <SearchInput value={query} onChange={e => setQuery(e.target.value)} onClear={() => setQuery('')} />
+ * ```
+ *
+ * @summary Search field with magnifying glass icon and clear button
+ */
+export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ value, defaultValue, onChange, onClear, id, ...props }, ref) => {
+    const generatedId = useId();
+    const inputId = id ?? `search-input-${generatedId}`;
+    const innerRef = useRef<HTMLInputElement>(null);
+    useImperativeHandle(ref, () => innerRef.current!);
+
+    const isControlled = value !== undefined;
+
+    // Uncontrolled: track whether the field has a value to toggle the clear button.
+    const [uncontrolledHasValue, setUncontrolledHasValue] = useState(() =>
+      Boolean(defaultValue)
+    );
+
+    const hasValue = isControlled ? Boolean(value) : uncontrolledHasValue;
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      if (!isControlled) setUncontrolledHasValue(e.target.value !== '');
+      onChange?.(e);
+    };
+
+    const handleClear = () => {
+      if (!isControlled) {
+        // Clear the DOM input value and fire a synthetic input event so
+        // React's onChange fires for any uncontrolled listeners.
+        const input = innerRef.current;
+        if (input) {
+          const setter = Object.getOwnPropertyDescriptor(
+            window.HTMLInputElement.prototype,
+            'value'
+          )?.set;
+          setter?.call(input, '');
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        setUncontrolledHasValue(false);
+      }
+      onClear?.();
+    };
+
+    const clearButton = hasValue ? (
+      <button
+        type="button"
+        className="bds-search-input__clear"
+        aria-label="Clear search"
+        onClick={handleClear}
+        tabIndex={0}
+      >
+        <Icon icon={X} />
+      </button>
+    ) : null;
+
+    return (
+      <TextInput
+        ref={innerRef}
+        id={inputId}
+        type="search"
+        iconBefore={<Icon icon={MagnifyingGlass} />}
+        iconAfter={clearButton}
+        value={value}
+        defaultValue={defaultValue}
+        onChange={handleChange}
+        {...props}
+      />
+    );
+  }
+);
+
+SearchInput.displayName = 'SearchInput';
+
+export default SearchInput;

--- a/components/ui/SearchInput/index.ts
+++ b/components/ui/SearchInput/index.ts
@@ -1,0 +1,2 @@
+export { SearchInput, type SearchInputProps } from './SearchInput';
+export { default } from './SearchInput';

--- a/components/ui/TextInput/TextInput.css
+++ b/components/ui/TextInput/TextInput.css
@@ -57,18 +57,4 @@
   cursor: not-allowed;
 }
 
-/* ─── Type="search" — native clear button ─────────────────────── */
-/* Force a solid color X instead of the browser's default gradient.
- * data URI SVGs cannot reference CSS variables; #333 = text-primary default. */
-/* bds-lint-ignore — data URI SVG hardcoded color */
-.bds-text-input-field[type="search"]::-webkit-search-cancel-button {
-  -webkit-appearance: none;
-  appearance: none;
-  height: 14px;
-  width: 14px;
-  cursor: pointer;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'%3E%3Cpath fill='%23333' d='M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3l105.4 105.3c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256l105.3-105.4z'/%3E%3C/svg%3E");
-  background-size: contain;
-  background-repeat: no-repeat;
-}
 }

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -62,6 +62,7 @@ export * from './NotificationList';
 export * from './PageHeader';
 export * from './Pagination';
 export * from './PasswordInput';
+export * from './SearchInput';
 export * from './Popover';
 export * from './PricingCard';
 export * from './ProgressBar';


### PR DESCRIPTION
## Summary
- docs(adrs): add component purpose test to ADR-004 + component-build standard (#693)
- feat(inputs): restore SearchInput as first-class component

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)