### PR TITLE
password: input icon fix

### DIFF
--- a/components/ui/PasswordInput/PasswordInput.css
+++ b/components/ui/PasswordInput/PasswordInput.css
@@ -10,6 +10,11 @@
   background: none;
   cursor: pointer;
   color: var(--text-muted);
-  line-height: var(--font-line-height-tight);
+  font-size: var(--icon-sm);
+  line-height: 1;
+}
+
+.bds-password-toggle:hover {
+  color: var(--text-primary);
 }
 }

--- a/components/ui/PasswordInput/PasswordInput.tsx
+++ b/components/ui/PasswordInput/PasswordInput.tsx
@@ -1,4 +1,6 @@
 import { useState, useId } from 'react';
+import { Icon } from '@iconify/react';
+import { Eye, EyeSlash } from '../../icons';
 import { TextInput, type TextInputProps } from '../TextInput/TextInput';
 import './PasswordInput.css';
 
@@ -9,66 +11,6 @@ import './PasswordInput.css';
  * internally by the show/hide toggle.
  */
 export type PasswordInputProps = Omit<TextInputProps, 'type' | 'iconAfter'>;
-
-/**
- * Inline SVG: eye-open icon (16x16).
- * Standard eye shape — elliptical outline + filled pupil circle.
- */
-const EyeOpenIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-    focusable="false"
-  >
-    <path
-      d="M1 8C1 8 3.5 3 8 3C12.5 3 15 8 15 8C15 8 12.5 13 8 13C3.5 13 1 8 1 8Z"
-      stroke="currentColor"
-      strokeWidth="1.25"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <circle cx="8" cy="8" r="2" fill="currentColor" />
-  </svg>
-);
-
-/**
- * Inline SVG: eye-closed icon (16x16).
- * Eye shape with a diagonal slash through it.
- */
-const EyeClosedIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-    focusable="false"
-  >
-    <path
-      d="M2 2L14 14"
-      stroke="currentColor"
-      strokeWidth="1.25"
-      strokeLinecap="round"
-    />
-    <path
-      d="M6.5 5.09C7 4.71 7.48 4.5 8 4.5C10.49 4.5 12.5 7 12.5 7C12.5 7 12.14 7.52 11.5 8.13"
-      stroke="currentColor"
-      strokeWidth="1.25"
-      strokeLinecap="round"
-    />
-    <path
-      d="M4.8 5.8C3.64 6.56 2.72 7.5 2.72 7.5C2.72 7.5 4.73 10 7.22 10.44M9.5 9.5C9.07 9.82 8.56 10 8 10C6.62 10 5.5 8.88 5.5 7.5"
-      stroke="currentColor"
-      strokeWidth="1.25"
-      strokeLinecap="round"
-    />
-  </svg>
-);
 
 /**
  * PasswordInput — TextInput wrapper with show/hide password toggle.
@@ -105,7 +47,7 @@ export const PasswordInput = ({
       onClick={() => setShowPassword((prev) => !prev)}
       tabIndex={0}
     >
-      {showPassword ? <EyeClosedIcon /> : <EyeOpenIcon />}
+      <Icon icon={showPassword ? EyeSlash : Eye} />
     </button>
   );
 


### PR DESCRIPTION
## Summary
- docs(adrs): add component purpose test to ADR-004 + component-build standard (#693)
- fix(inputs): swap PasswordInput inline SVGs for Icon component

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)