### PR TITLE
feat(inputs): add NumberInput with BDS stepper buttons

### DIFF
--- a/components/ui/NumberInput/NumberInput.css
+++ b/components/ui/NumberInput/NumberInput.css
@@ -1,0 +1,45 @@
+@layer bds-components {
+/* NumberInput — hide native browser spinners */
+.bds-text-input-field[type="number"]::-webkit-outer-spin-button,
+.bds-text-input-field[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  appearance: none;
+  margin: 0;
+}
+
+.bds-text-input-field[type="number"] {
+  -moz-appearance: textfield;
+}
+
+/* NumberInput — stepper column */
+.bds-number-input__steppers {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+}
+
+.bds-number-input__step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1;
+  height: 50%;
+}
+
+.bds-number-input__step:hover {
+  color: var(--text-primary);
+}
+
+.bds-number-input__step:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+}

--- a/components/ui/NumberInput/NumberInput.mdx
+++ b/components/ui/NumberInput/NumberInput.mdx
@@ -1,0 +1,37 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './NumberInput.stories';
+
+<Meta of={Stories} />
+
+# Number input
+
+<ComponentLinks slug="number-input" />
+
+Numeric input with BDS-styled increment / decrement steppers. Hides the native browser spinners and replaces them with caret buttons that respect `min`, `max`, and `step`. Wraps [`TextInput`](/?path=/docs/components-text-input--docs) and inherits all its props except `type` (forced to `"number"`) and `iconAfter` (reserved for the steppers).
+
+## Playground
+
+<Canvas of={Stories.Default} />
+
+## Variants
+
+NumberInput has no semantic-variant axis — all variation (size, min/max/step, error, disabled, helper text, fullWidth) is exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
+
+<Canvas of={Stories.Default} />
+
+- **`sm`** — 32px height, 14px body
+- **`md`** — 40px height, 16px body (default)
+- **`lg`** — 48px height, 18px body
+
+The stepper buttons are always present. Clicking increment / decrement fires `onChange` with the new value, so controlled and uncontrolled modes both work identically.
+
+## Props
+
+<ArgTypes of={Stories} />
+
+## Notes
+
+> **Note** — NumberInput specialization is justified per [ADR-004 §Amendment 2026-05-17](../../../docs/adrs/ADR-004-component-bloat-guardrails.md): steppers are distinct interactive behavior beyond `type="number"`. For plain text, email, tel, or url inputs use [`TextInput`](/?path=/docs/components-text-input--docs) directly.
+
+> **Note** — All `TextInput` updates (focus ring, error styling, sizing tokens) propagate here automatically. `type` and `iconAfter` are reserved by `NumberInput`; everything else passes through.

--- a/components/ui/NumberInput/NumberInput.stories.tsx
+++ b/components/ui/NumberInput/NumberInput.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { NumberInput } from './NumberInput';
+
+/* ─── Meta ────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof NumberInput> = {
+  title: 'Components/number-input',
+  component: NumberInput,
+  tags: ['surface-shared'],
+  parameters: { layout: 'centered' },
+  decorators: [(Story) => <div style={{ width: 240 }}><Story /></div>],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size token (sm=32px, md=40px, lg=48px). Default `md`.',
+    },
+    label: {
+      control: 'text',
+      description: 'Optional label rendered above the field.',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text shown when the field is empty.',
+    },
+    helperText: {
+      control: 'text',
+      description: 'Hint text under the field. Hidden when `error` is present.',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message. Triggers `aria-invalid` and replaces `helperText`.',
+    },
+    min: {
+      control: 'number',
+      description: 'Minimum allowed value.',
+    },
+    max: {
+      control: 'number',
+      description: 'Maximum allowed value.',
+    },
+    step: {
+      control: 'number',
+      description: 'Increment / decrement amount. Default `1`.',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Stretch to fill container width.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the field and steppers — non-interactive, muted appearance.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ═══════════════════════════════════════════════════════════════
+   DEFAULT — single canonical story per ADR-010 §components without
+   a variant axis. All variation (size, min/max/step, error, disabled)
+   is exposed via Controls. The stepper buttons are internal.
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Numeric input with increment / decrement stepper buttons */
+export const Default: Story = {
+  args: {
+    label: 'Quantity',
+    defaultValue: 1,
+    min: 0,
+    max: 99,
+    step: 1,
+    size: 'md',
+    fullWidth: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Quantity') as HTMLInputElement;
+
+    await expect(input).toBeVisible();
+    await expect(input).toHaveAttribute('type', 'number');
+
+    // Increment via stepper
+    await userEvent.click(canvas.getByRole('button', { name: 'Increment' }));
+    await expect(input).toHaveValue(2);
+
+    // Decrement via stepper
+    await userEvent.click(canvas.getByRole('button', { name: 'Decrement' }));
+    await expect(input).toHaveValue(1);
+
+    // Blur to avoid stale focus styling in post-play snapshot
+    input.blur();
+  },
+};

--- a/components/ui/NumberInput/NumberInput.tsx
+++ b/components/ui/NumberInput/NumberInput.tsx
@@ -1,0 +1,121 @@
+import {
+  forwardRef,
+  useId,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import { Icon } from '@iconify/react';
+import { CaretUp, CaretDown } from '../../icons';
+import { TextInput, type TextInputProps } from '../TextInput/TextInput';
+import './NumberInput.css';
+
+/**
+ * NumberInput component props.
+ *
+ * `type` and `iconAfter` are reserved — the component sets `type="number"`
+ * and manages the stepper buttons internally.
+ */
+export interface NumberInputProps
+  extends Omit<TextInputProps, 'type' | 'iconAfter'> {
+  /** Minimum allowed value. Forwarded to the native input. */
+  min?: number;
+  /** Maximum allowed value. Forwarded to the native input. */
+  max?: number;
+  /** Step increment / decrement amount. Defaults to 1. */
+  step?: number;
+}
+
+/**
+ * Dispatch a synthetic input event so React's onChange fires when
+ * the stepper buttons mutate the DOM value directly.
+ */
+function fireInputEvent(input: HTMLInputElement, newValue: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(input, newValue);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/**
+ * NumberInput — TextInput with BDS-styled increment / decrement steppers.
+ *
+ * Hides the native browser spinners and replaces them with BDS caret
+ * buttons. Respects `min`, `max`, and `step`. Works in both controlled
+ * (`value` + `onChange`) and uncontrolled (`defaultValue`) modes.
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled
+ * <NumberInput label="Quantity" defaultValue={1} min={1} max={99} />
+ *
+ * // Controlled
+ * <NumberInput label="Quantity" value={qty} onChange={e => setQty(Number(e.target.value))} min={1} max={99} />
+ * ```
+ *
+ * @summary Numeric input with increment / decrement stepper buttons
+ */
+export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
+  ({ min, max, step = 1, id, ...props }, ref) => {
+    const generatedId = useId();
+    const inputId = id ?? `number-input-${generatedId}`;
+    const innerRef = useRef<HTMLInputElement>(null);
+    useImperativeHandle(ref, () => innerRef.current!);
+
+    const clamp = (value: number) => {
+      let v = value;
+      if (min !== undefined) v = Math.max(min, v);
+      if (max !== undefined) v = Math.min(max, v);
+      return v;
+    };
+
+    const handleStep = (direction: 1 | -1) => {
+      const input = innerRef.current;
+      if (!input) return;
+      const current = parseFloat(input.value) || 0;
+      const next = clamp(current + direction * step);
+      fireInputEvent(input, String(next));
+    };
+
+    const steppers = (
+      <div className="bds-number-input__steppers">
+        <button
+          type="button"
+          className="bds-number-input__step"
+          aria-label="Increment"
+          tabIndex={-1}
+          onClick={() => handleStep(1)}
+        >
+          <Icon icon={CaretUp} />
+        </button>
+        <button
+          type="button"
+          className="bds-number-input__step"
+          aria-label="Decrement"
+          tabIndex={-1}
+          onClick={() => handleStep(-1)}
+        >
+          <Icon icon={CaretDown} />
+        </button>
+      </div>
+    );
+
+    return (
+      <TextInput
+        ref={innerRef}
+        id={inputId}
+        type="number"
+        iconAfter={steppers}
+        min={min}
+        max={max}
+        step={step}
+        {...props}
+      />
+    );
+  }
+);
+
+NumberInput.displayName = 'NumberInput';
+
+export default NumberInput;

--- a/components/ui/NumberInput/index.ts
+++ b/components/ui/NumberInput/index.ts
@@ -1,0 +1,2 @@
+export { NumberInput, type NumberInputProps } from './NumberInput';
+export { default } from './NumberInput';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -61,6 +61,7 @@ export * from './NavItem';
 export * from './NotificationList';
 export * from './PageHeader';
 export * from './Pagination';
+export * from './NumberInput';
 export * from './PasswordInput';
 export * from './SearchInput';
 export * from './Popover';


### PR DESCRIPTION
## Summary

- Adds `NumberInput` — a first-class component wrapping `TextInput` with BDS-styled increment / decrement stepper buttons
- Hides native browser spinners; replaces with `CaretUp` / `CaretDown` caret buttons from `icons.ts`
- Respects `min`, `max`, and `step`; works in both controlled (`value` + `onChange`) and uncontrolled (`defaultValue`) modes
- Justified per ADR-004 §Amendment 2026-05-17: steppers are distinct interactive behavior beyond `type="number"`

## Files

- `components/ui/NumberInput/NumberInput.tsx` — component
- `components/ui/NumberInput/NumberInput.css` — hides webkit/moz spinners; stepper layout
- `components/ui/NumberInput/NumberInput.stories.tsx` — Storybook stories
- `components/ui/NumberInput/NumberInput.mdx` — Storybook docs page
- `components/ui/NumberInput/index.ts` — barrel export
- `components/ui/index.ts` — added `export * from './NumberInput'`

## Test plan

- [ ] Steppers render inside the input (no native browser spinners visible)
- [ ] Increment / decrement fires `onChange` in controlled mode
- [ ] `min` / `max` clamp prevents stepping out of bounds
- [ ] `step` prop respected (default 1)
- [ ] Uncontrolled (`defaultValue`) mode works identically
- [ ] All 10 validation checks pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)