### PR TITLE
docs(stories): Card family Phase A — story consolidation + shape cleanup

### DIFF
--- a/.claude/standards/storybook-story-shape.md
+++ b/.claude/standards/storybook-story-shape.md
@@ -6,6 +6,7 @@ scope: brik-bds
 applies-to: "**/components/ui/**/*.stories.tsx, **/content-system/blueprints/**/*.stories.tsx, **/stories/**/*.stories.tsx"
 retrieved-via: brik-rag query "storybook story shape standard"
 last-verified: 2026-05-17
+last-updated: 2026-05-17
 ---
 
 # Storybook story-shape standard (BDS)
@@ -103,6 +104,37 @@ A comparison gallery earns **one** dedicated story when **and only when** all th
 3. It's one axis, not a mix — `Sizes` is fine; `Sizes-and-tones` is not.
 
 Story is named after the axis (`Sizes`, `Densities`, `Placements`) — **never** `Variants` / `Patterns` / `Examples`.
+
+## Multi-preset Container pattern
+
+A Container built with a `preset` discriminator (a string union that selects between locked-down layouts) gets **one story per preset value** in the **base component's stories file**. Each preset is a Q3 story — a semantic starting template agents and developers reach for directly.
+
+**Where stories live:** all preset stories live in `ComponentA.stories.tsx`. If a preset was originally shipped as a standalone component (e.g. `CardControl` → `Card preset="control"`), its story consolidates into the base component's file when the standalone is deprecated.
+
+**Diagnostic:** if a standalone component is fully expressible as `<ComponentA preset="b" ... />` with no behavioral difference, its story belongs in `ComponentA.stories.tsx`. A separate `ComponentB.stories.tsx` for a preset is legacy — consolidate when touching that file.
+
+**Surface-tag conflict:** if a preset component has a narrower surface tag than the base (e.g. a `surface-web`-only component inside a `surface-shared` base), use story-level `tags` to scope that story:
+
+```tsx
+export const Pricing: Story = {
+  tags: ['surface-web'],  // narrower than meta.tags — web-only
+  ...
+};
+```
+
+**Card as the canonical reference** (all stories in `Card.stories.tsx`):
+
+| Story | What it shows | Source |
+| --- | --- | --- |
+| `Default` | Flexible `children` slot, variant + padding Controls | `Card` (no preset) |
+| `Control` | Settings row: badge + title + description + action | `Card preset="control"` |
+| `Summary` | Compact metric/stat card | `Card preset="summary"` |
+| `Display` | Content card for `bds-card-grid` | `Card preset="display"` |
+| `Pricing` | Web-only pricing tier with feature list | `PricingCard` (story consolidated; component file stays for `surface-web` CSS isolation) |
+
+**Wrong-layer check:** before classifying a component as `Containers/`, ask: does it carry its own visual surface (`border` / `background` / `padding` / `elevation`)? If not, it is a **`Layouts/`** component (pure arrangement, no surface). `CardList` (a `<ul>` spacing wrapper) is `Layouts/`, not `Containers/`.
+
+**Name-layer check:** "Card" in a component name implies Container-layer ancestry. If the component is actually an interaction primitive (`CollapsibleCard` — no `bds-card` class) or a semantic quotation block (`CardTestimonial` — `<figure>/<blockquote>`), the "Card" prefix is wrong. File a rename issue (#701, #702); do not propagate the misnomer in new story files.
 
 ## `render` is for irreducible cases only
 
@@ -359,6 +391,7 @@ If you find yourself wanting to "clean up" an existing file's `export const Vari
 
 ## Pre-commit agent checklist
 
+0. **Check for preset consolidation.** If the component being storied is marked `@deprecated` and superseded by a `preset` on another component, its story belongs in the parent component's stories file — not a new `Component.stories.tsx`. See `## Multi-preset Container pattern`.
 1. **Read three sibling story files** in the same `components/ui/<Subcategory>/` folder. Match their `title:` prefix, surface tag, and overall shape.
 2. **Verify the two-shape model** — file exports `Default` plus one story per meaningful state. No `Variants` / `Tones` / `Patterns` story exports (in new files).
 3. **Apply the matrix** — boolean / icon-slot states are Controls, not stories. Toolbar-global axes (theme/density/viewport/locale/motion) are never stories.

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -8,7 +8,7 @@ import * as Stories from './Card.stories';
 
 <ComponentLinks slug="card" />
 
-Flexible content container. A single primitive serves four shapes via the `preset` discriminator: a default flexible content slot (no `preset`), and three locked-down layouts — `control`, `summary`, and `display` — that subsume the legacy `CardControl` and `CardSummary` components (per ADR-004).
+Flexible content container. A single primitive serves four shapes via the `preset` discriminator: a default flexible content slot (no `preset`), and three locked-down layouts — `control`, `summary`, and `display` — that subsume the legacy `CardControl` and `CardSummary` components (per ADR-004). The web-only `PricingCard` component is documented alongside these presets as part of the Card family.
 
 > **Note** — Multi-card compositions (service grids, feature grids, blog rolls) live in the [`Card Grid`](?path=/docs/theming-blueprints-card-grid--docs) blueprint, not on this page. This page documents the Card primitive itself.
 
@@ -37,6 +37,14 @@ The `preset` prop selects the shape. Default (no `preset`) gives a flexible `chi
 `preset="display"` — generic content-grid card for `bds-card-grid`. All affordances (`image`, `tag`, `badge`, `action`, `href`) are optional slots so one primitive serves any content type — service, blog post, customer story, property listing, team bio.
 
 <Canvas of={Stories.Display} />
+
+### Pricing (web)
+
+`PricingCard` — pricing tier with title, price block, feature checklist, and call-to-action. The `highlighted` prop marks the recommended tier with brand surface treatment. Web surface only (`surface-web`).
+
+> **Note** — `PricingCard` is a standalone component (`import { PricingCard } from '@brikdesigns/bds'`), not a `preset` on `Card`. It is documented here because it is part of the Card family. Its CSS is isolated to `surface-web` pages.
+
+<Canvas of={Stories.Pricing} />
 
 ## Props
 

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Card, CardTitle, CardDescription, CardFooter } from './Card';
 import { Button } from '../Button';
 import { Badge } from '../Badge';
+import { PricingCard } from '../PricingCard';
 
 const meta: Meta<typeof Card> = {
   title: 'Containers/card',
@@ -201,5 +202,40 @@ export const Display: Story = {
       </div>
     ),
   ],
+};
+
+/**
+ * `PricingCard` — web-only pricing tier with price block, feature checklist,
+ * and optional highlighted (recommended) state. Component lives in
+ * `components/ui/PricingCard/`; story lives here because PricingCard is part
+ * of the Card family and its `highlighted` prop is a Q3 semantic variant.
+ *
+ * @summary PricingCard — web-only pricing tier with feature list
+ */
+export const Pricing: Story = {
+  tags: ['surface-web'],
+  render: () => (
+    <div style={{ width: 320 }}>
+      <PricingCard
+        title="Professional"
+        price="$49"
+        period="/month"
+        description="Most popular choice for growing businesses."
+        features={[
+          'Unlimited projects',
+          'Priority support',
+          'Custom domain',
+          'Analytics dashboard',
+        ]}
+        badge={<Badge status="positive" size="sm">Most popular</Badge>}
+        action={
+          <Button variant="primary" style={{ width: '100%' }}>
+            Get started
+          </Button>
+        }
+        highlighted
+      />
+    </div>
+  ),
 };
 

--- a/components/ui/CardControl/CardControl.mdx
+++ b/components/ui/CardControl/CardControl.mdx
@@ -8,35 +8,19 @@ import * as Stories from './CardControl.stories';
 
 <ComponentLinks slug="card-control" />
 
-Settings control card with badge, title, description, and an action slot. Used for toggles, configuration options, and status displays.
+> **Deprecated** — Use [`Card preset="control"`](?path=/docs/containers-card--docs) instead. `CardControl` is kept for the migration window and will be removed in a future release. See [#657](https://github.com/brikdesigns/brik-bds/issues/657).
+
+Settings control card with badge, title, description, and an action slot. Superseded by `Card preset="control"` (per ADR-004).
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Switch actions, button actions, status badges, and minimal layout.
+See [`Card preset="control"`](?path=/docs/containers-card--docs) for the full variant set — control alignment, badge status, and action types are all documented there.
 
-<Canvas of={Stories.Variants} />
-
-### Action alignment
-
-Use `actionAlign="top"` when the description wraps to multiple lines — the CTA anchors to the upper-right corner instead of drifting to the vertical center.
-
-<Canvas of={Stories.ActionAlignment} />
-
-## Patterns
-
-Settings panel with mixed action types.
-
-<Canvas of={Stories.Patterns} />
-
-### Toggle switch panel
-
-Multi-row notification panel using switches with top-aligned actions — a common settings-page layout.
-
-<Canvas of={Stories.ToggleSwitchPanel} />
+<Canvas of={Stories.Default} />
 
 ## Props
 

--- a/components/ui/CardControl/CardControl.stories.tsx
+++ b/components/ui/CardControl/CardControl.stories.tsx
@@ -4,12 +4,16 @@ import { Icon } from '@iconify/react';
 import { CardControl } from './CardControl';
 import { Badge } from '../Badge';
 import { Switch } from '../Switch';
-import { Button } from '../Button';
 
+/**
+ * @deprecated Use `Card preset="control"` instead. See the
+ * [Card](?path=/docs/containers-card--docs) page for the canonical reference.
+ * CardControl is kept during the migration window (see #657).
+ */
 const meta: Meta<typeof CardControl> = {
   title: 'Containers/card-control',
   component: CardControl,
-  tags: ['surface-shared'],
+  tags: ['surface-shared', '!manifest'],
   parameters: { layout: 'padded' },
   argTypes: {
     title: { control: 'text' },
@@ -21,24 +25,11 @@ const meta: Meta<typeof CardControl> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/* ─── Layout helpers ─────────────────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-    {children}
-  </span>
-);
-
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%', maxWidth: 600 }}>
-    {children}
-  </div>
-);
-
-/* ─── Playground ─────────────────────────────────────────────── */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * @deprecated Use `Card preset="control"` — see Card stories for the canonical reference.
+ * @summary Deprecated: use Card preset="control"
+ */
+export const Default: Story = {
   render: (args) => {
     const [checked, setChecked] = useState(true);
     return (
@@ -54,166 +45,5 @@ export const Playground: Story = {
     description: 'Receive email notifications for updates',
     actionAlign: 'center',
   },
-};
-
-/* ─── Action alignment ───────────────────────────────────────── */
-
-/** @summary Action alignment */
-export const ActionAlignment: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>actionAlign = "center" (default)</SectionLabel>
-      <CardControl
-        title="Push notifications"
-        description="Get alerts for replies, mentions, and direct messages across all of your connected devices."
-        badge={<Badge size="xs" status="info" icon={<Icon icon="ph:bell" />} />}
-        action={<Button variant="outline" size="sm">Configure</Button>}
-      />
-
-      <SectionLabel>actionAlign = "top" — CTA anchored to upper-right</SectionLabel>
-      <CardControl
-        actionAlign="top"
-        title="Push notifications"
-        description="Get alerts for replies, mentions, and direct messages across all of your connected devices."
-        badge={<Badge size="xs" status="info" icon={<Icon icon="ph:bell" />} />}
-        action={<Button variant="outline" size="sm">Configure</Button>}
-      />
-
-      <SectionLabel>actionAlign = "top" — with switch toggle</SectionLabel>
-      <CardControl
-        actionAlign="top"
-        title="Two-factor authentication"
-        description="Require a verification code from your authenticator app in addition to your password on every sign-in."
-        badge={<Badge size="xs" status="positive" icon={<Icon icon="ph:shield-check" />} />}
-        action={<Switch checked onChange={() => {}} />}
-      />
-    </Stack>
-  ),
-};
-
-/* ─── Variants ───────────────────────────────────────────────── */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>With switch action</SectionLabel>
-      <CardControl
-        title="Notifications"
-        description="Receive email notifications for updates"
-        badge={<Badge size="xs" status="positive" icon={<Icon icon="ph:check" />} />}
-        action={<Switch checked onChange={() => {}} />}
-      />
-
-      <SectionLabel>With button action</SectionLabel>
-      <CardControl
-        title="Security Settings"
-        description="Configure two-factor authentication"
-        badge={<Badge size="xs" status="info" icon={<Icon icon="ph:shield-check" />} />}
-        action={<Button variant="outline" size="sm">Configure</Button>}
-      />
-
-      <SectionLabel>Error status</SectionLabel>
-      <CardControl
-        title="Connection Failed"
-        description="Unable to reach the API server"
-        badge={<Badge size="xs" status="error" icon={<Icon icon="ph:x-circle" />} />}
-        action={<Button variant="primary" size="sm">Retry</Button>}
-      />
-
-      <SectionLabel>Warning status</SectionLabel>
-      <CardControl
-        title="Storage Almost Full"
-        description="You have used 90% of your available storage"
-        badge={<Badge size="xs" status="warning" icon={<Icon icon="ph:warning" />} />}
-        action={<Button variant="outline" size="sm">Upgrade</Button>}
-      />
-
-      <SectionLabel>Minimal (no badge or description)</SectionLabel>
-      <CardControl
-        title="Auto-save"
-        action={<Switch checked={false} onChange={() => {}} />}
-      />
-    </Stack>
-  ),
-};
-
-/* ─── Patterns ───────────────────────────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => {
-    const [notifications, setNotifications] = useState(true);
-    const [darkMode, setDarkMode] = useState(false);
-
-    return (
-      <Stack>
-        <SectionLabel>Settings panel</SectionLabel>
-        <CardControl
-          title="Notifications"
-          description="Receive email notifications for updates"
-          badge={<Badge size="xs" status="positive" icon={<Icon icon="ph:bell" />} />}
-          action={<Switch checked={notifications} onChange={(e) => setNotifications(e.target.checked)} />}
-        />
-        <CardControl
-          title="Dark Mode"
-          description="Switch to a darker color theme"
-          badge={<Badge size="xs" status="info" icon={<Icon icon="ph:gear" />} />}
-          action={<Switch checked={darkMode} onChange={(e) => setDarkMode(e.target.checked)} />}
-        />
-        <CardControl
-          title="Security"
-          description="Configure two-factor authentication"
-          badge={<Badge size="xs" status="info" icon={<Icon icon="ph:shield-check" />} />}
-          action={<Button variant="outline" size="sm">Configure</Button>}
-        />
-      </Stack>
-    );
-  },
-};
-
-/* ─── Toggle switch panel ────────────────────────────────────── */
-
-/** @summary Toggle switch panel */
-export const ToggleSwitchPanel: Story = {
-  render: () => {
-    const [email, setEmail] = useState(true);
-    const [sms, setSms] = useState(false);
-    const [product, setProduct] = useState(true);
-    const [marketing, setMarketing] = useState(false);
-
-    return (
-      <Stack>
-        <SectionLabel>Notification preferences — multi-row toggle panel</SectionLabel>
-        <CardControl
-          actionAlign="top"
-          title="Email updates"
-          description="Product announcements, billing receipts, and security alerts delivered to your inbox."
-          badge={<Badge size="xs" status="positive" icon={<Icon icon="ph:envelope" />} />}
-          action={<Switch checked={email} onChange={(e) => setEmail(e.target.checked)} />}
-        />
-        <CardControl
-          actionAlign="top"
-          title="SMS alerts"
-          description="Critical security alerts sent to your verified phone number. Carrier rates may apply."
-          badge={<Badge size="xs" status="info" icon={<Icon icon="ph:device-mobile" />} />}
-          action={<Switch checked={sms} onChange={(e) => setSms(e.target.checked)} />}
-        />
-        <CardControl
-          actionAlign="top"
-          title="Product updates"
-          description="New features, product news, and the occasional deep-dive on what the team is shipping."
-          badge={<Badge size="xs" status="info" icon={<Icon icon="ph:sparkle" />} />}
-          action={<Switch checked={product} onChange={(e) => setProduct(e.target.checked)} />}
-        />
-        <CardControl
-          actionAlign="top"
-          title="Marketing emails"
-          description="Seasonal promotions and partner offers. You can unsubscribe at any time from the footer of any email."
-          badge={<Badge size="xs" status="warning" icon={<Icon icon="ph:megaphone" />} />}
-          action={<Switch checked={marketing} onChange={(e) => setMarketing(e.target.checked)} />}
-        />
-      </Stack>
-    );
-  },
+  decorators: [(Story) => <div style={{ maxWidth: 560 }}><Story /></div>],
 };

--- a/components/ui/CardList/CardList.mdx
+++ b/components/ui/CardList/CardList.mdx
@@ -8,43 +8,19 @@ import * as Stories from './CardList.stories';
 
 <ComponentLinks slug="card-list" />
 
-Layout primitive for arrays of `Card`. Locks orientation, gap, and width-distribution rules so consumers don't reach for raw `display: grid`.
+Layout wrapper for arrays of `Card`. Locks orientation, gap, and width-distribution rules so consumers don't reach for raw `display: flex`. A `Layouts/` primitive — no visual surface of its own.
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-### Vertical
-
-Stacked layout — full-width cards in a column. Use for sidebars, news lists, and compact card stacks.
-
-<Canvas of={Stories.Vertical} />
-
-### Horizontal
-
-Equal-column layout — each card stretches to fill its share of the row. Use for service grids, feature lists, and testimonial rows.
-
-<Canvas of={Stories.Horizontal} />
-
-### Horizontal — fit content
-
-`fitContent` lets cards size to their own intrinsic width instead of stretching equally.
-
-<Canvas of={Stories.HorizontalFitContent} />
-
 ### Gap scale
 
-Four locked gap sizes — `sm`, `md`, `lg`, `xl`.
+Four spacing steps between cards — `sm`, `md`, `lg`, `xl`. Use `md` (default) for standard card stacks; `lg` or `xl` for marketing grids with more visual breathing room.
 
 <Canvas of={Stories.GapScale} />
-
-## Patterns
-
-Service grid and vertical news stack — recurring CardList compositions.
-
-<Canvas of={Stories.Patterns} />
 
 ## Props
 

--- a/components/ui/CardList/CardList.stories.tsx
+++ b/components/ui/CardList/CardList.stories.tsx
@@ -1,12 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CardList } from './CardList';
 import { Card, CardTitle, CardDescription, CardFooter } from '../Card/Card';
-import { CardTestimonial } from '../CardTestimonial';
 import { Button } from '../Button';
-import { Badge } from '../Badge';
 
 const meta: Meta<typeof CardList> = {
-  title: 'Containers/card-list',
+  title: 'Layouts/card-list',
   component: CardList,
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
@@ -20,24 +18,13 @@ const meta: Meta<typeof CardList> = {
 export default meta;
 type Story = StoryObj<typeof CardList>;
 
-/* ─── Layout helpers ─────────────────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-    {children}
-  </span>
-);
-
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%', maxWidth: 1100 }}>
-    {children}
-  </div>
-);
-
-/* ─── Playground ─────────────────────────────────────────────── */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Layout wrapper for arrays of cards. Toggle `orientation`, `gap`, and
+ * `fitContent` via Controls to exercise the full layout surface.
+ *
+ * @summary Stack of cards — orientation, gap, and fitContent via Controls
+ */
+export const Default: Story = {
   args: {
     orientation: 'vertical',
     gap: 'md',
@@ -49,210 +36,36 @@ export const Playground: Story = {
         <Card variant="outlined" padding="md">
           <CardTitle as="h4">Card one</CardTitle>
           <CardDescription>Short description for the first card in the list.</CardDescription>
+          <CardFooter><Button variant="outline" size="sm">View</Button></CardFooter>
         </Card>
         <Card variant="outlined" padding="md">
           <CardTitle as="h4">Card two</CardTitle>
           <CardDescription>Short description for the second card in the list.</CardDescription>
+          <CardFooter><Button variant="outline" size="sm">View</Button></CardFooter>
         </Card>
         <Card variant="outlined" padding="md">
           <CardTitle as="h4">Card three</CardTitle>
           <CardDescription>Short description for the third card in the list.</CardDescription>
+          <CardFooter><Button variant="outline" size="sm">View</Button></CardFooter>
         </Card>
       </CardList>
     </div>
   ),
 };
 
-/* ─── Vertical layout ────────────────────────────────────────── */
-
-/** @summary Vertical */
-export const Vertical: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Vertical — generic Card</SectionLabel>
-      <div style={{ width: 480 }}>
-        <CardList orientation="vertical" gap="md">
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">Quarterly report</CardTitle>
-            <CardDescription>Summary of Q1 performance across all channels.</CardDescription>
-            <CardFooter>
-              <Button variant="outline" size="sm">View</Button>
-            </CardFooter>
-          </Card>
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">Team update</CardTitle>
-            <CardDescription>New hires, role changes, and milestones this month.</CardDescription>
-            <CardFooter>
-              <Button variant="outline" size="sm">View</Button>
-            </CardFooter>
-          </Card>
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">Product roadmap</CardTitle>
-            <CardDescription>Upcoming features planned for the next two quarters.</CardDescription>
-            <CardFooter>
-              <Button variant="outline" size="sm">View</Button>
-            </CardFooter>
-          </Card>
-        </CardList>
-      </div>
-
-    </Stack>
-  ),
-};
-
-/* ─── Horizontal layout ──────────────────────────────────────── */
-
-/** @summary Horizontal */
-export const Horizontal: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Horizontal — equal columns (default)</SectionLabel>
-      <CardList orientation="horizontal" gap="lg">
-        <Card variant="outlined" padding="lg">
-          <Badge>Design</Badge>
-          <CardTitle>Design</CardTitle>
-          <CardDescription>Brand, identity, and design systems.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-        <Card variant="outlined" padding="lg">
-          <Badge>Development</Badge>
-          <CardTitle>Development</CardTitle>
-          <CardDescription>Full-stack product engineering.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-        <Card variant="outlined" padding="lg">
-          <Badge>Strategy</Badge>
-          <CardTitle>Strategy</CardTitle>
-          <CardDescription>Roadmapping and growth operations.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-      </CardList>
-
-      <SectionLabel>Horizontal — CardTestimonial (brand + outlined)</SectionLabel>
-      <CardList orientation="horizontal" gap="lg">
-        <CardTestimonial
-          variant="brand"
-          quote="Square has completely transformed how we handle payments. The analytics alone have helped us grow 40% this year."
-          authorName="Sarah Chen"
-          authorRole="Owner, Bloom Cafe"
-          rating={5}
-        />
-        <CardTestimonial
-          variant="outlined"
-          quote="Professional, responsive, and creative. Our new site has driven 3x more leads."
-          authorName="Marcus Johnson"
-          authorRole="Marketing Director, Apex Corp"
-          rating={5}
-        />
-        <CardTestimonial
-          variant="brand"
-          quote="Working with this team felt like an extension of our own company."
-          authorName="Emily Rodriguez"
-          authorRole="CEO, Greenfield Digital"
-          rating={4}
-        />
-      </CardList>
-    </Stack>
-  ),
-};
-
-/* ─── Fit content ────────────────────────────────────────────── */
-
-/** @summary Horizontal fit content */
-export const HorizontalFitContent: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Horizontal — fitContent (items size to own width)</SectionLabel>
-      <CardList orientation="horizontal" gap="md" fitContent>
-        <Card variant="outlined" padding="md" style={{ width: 200 }}>
-          <CardTitle as="h4">200px</CardTitle>
-          <CardDescription>Fixed width card.</CardDescription>
-        </Card>
-        <Card variant="outlined" padding="md" style={{ width: 280 }}>
-          <CardTitle as="h4">280px</CardTitle>
-          <CardDescription>Different fixed width.</CardDescription>
-        </Card>
-        <Card variant="outlined" padding="md" style={{ width: 160 }}>
-          <CardTitle as="h4">160px</CardTitle>
-          <CardDescription>Narrowest card.</CardDescription>
-        </Card>
-      </CardList>
-    </Stack>
-  ),
-};
-
-/* ─── Patterns ───────────────────────────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Service grid (3-column horizontal)</SectionLabel>
-      <CardList orientation="horizontal" gap="lg">
-        <Card variant="outlined" padding="lg">
-          <Badge>Design</Badge>
-          <CardTitle>Brand identity</CardTitle>
-          <CardDescription>Logo, type, and tone — the foundation every campaign builds on.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-        <Card variant="outlined" padding="lg">
-          <Badge>Build</Badge>
-          <CardTitle>Web development</CardTitle>
-          <CardDescription>Production sites built on the components your designers already know.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-        <Card variant="outlined" padding="lg">
-          <Badge>Run</Badge>
-          <CardTitle>Ongoing partnership</CardTitle>
-          <CardDescription>Iterate after launch with a team that already knows your stack.</CardDescription>
-          <CardFooter>
-            <Button variant="outline" size="sm">Learn more</Button>
-          </CardFooter>
-        </Card>
-      </CardList>
-
-      <SectionLabel>Vertical news stack (in a sidebar)</SectionLabel>
-      <div style={{ width: 360 }}>
-        <CardList orientation="vertical" gap="md">
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">Q1 review</CardTitle>
-            <CardDescription>What shipped, what slipped, and what's queued for Q2.</CardDescription>
-          </Card>
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">New hires</CardTitle>
-            <CardDescription>Three engineers and a designer joined this month.</CardDescription>
-          </Card>
-          <Card variant="outlined" padding="md">
-            <CardTitle as="h4">Roadmap update</CardTitle>
-            <CardDescription>Two features promoted from Next to Now after customer feedback.</CardDescription>
-          </Card>
-        </CardList>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ─── Gap scale ──────────────────────────────────────────────── */
-
-/** @summary Gap scale */
+/**
+ * All four gap values side by side — `sm`, `md`, `lg`, `xl`.
+ *
+ * @summary Gap scale — sm / md / lg / xl
+ */
 export const GapScale: Story = {
   render: () => (
-    <Stack>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', maxWidth: 720 }}>
       {(['sm', 'md', 'lg', 'xl'] as const).map((g) => (
         <div key={g}>
-          <SectionLabel>{`gap = ${g}`}</SectionLabel>
+          <p style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 'var(--gap-sm)' }}>{`gap = ${g}`}</p>
           <CardList orientation="horizontal" gap={g}>
-            {[1, 2, 3, 4].map((n) => (
+            {[1, 2, 3].map((n) => (
               <Card key={n} variant="outlined" padding="md">
                 <CardTitle as="h4">{`Card ${n}`}</CardTitle>
               </Card>
@@ -260,6 +73,6 @@ export const GapScale: Story = {
           </CardList>
         </div>
       ))}
-    </Stack>
+    </div>
   ),
 };

--- a/components/ui/CardTestimonial/CardTestimonial.mdx
+++ b/components/ui/CardTestimonial/CardTestimonial.mdx
@@ -8,28 +8,22 @@ import * as Stories from './CardTestimonial.stories';
 
 <ComponentLinks slug="card-testimonial" />
 
-Customer testimonial card with quote, attribution, and optional star rating. Supports brand (colored background) and outlined variants.
+Customer testimonial card with quote, attribution, and optional star rating.
+
+> **Rename in progress** — This component will be renamed `Testimonial` in a future release (see [#702](https://github.com/brikdesigns/brik-bds/issues/702)). The export name and import path are unchanged until then.
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Brand, outlined, without rating, and minimal attribution.
+### Outlined
 
-<Canvas of={Stories.Variants} />
+`variant="outlined"` swaps the brand-tinted surface for a neutral background with border. Use on light-background sections where the brand fill would compete with surrounding content.
 
-- **`brand`** — Colored background with inverse text (default)
-- **`outlined`** — Light background with border
-
-## Patterns
-
-Mixed variant testimonials in a grid layout.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.Outlined} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/CardTestimonial/CardTestimonial.stories.tsx
+++ b/components/ui/CardTestimonial/CardTestimonial.stories.tsx
@@ -18,30 +18,13 @@ const meta: Meta<typeof CardTestimonial> = {
 export default meta;
 type Story = StoryObj<typeof CardTestimonial>;
 
-/* ─── Layout helpers ─────────────────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-    {children}
-  </span>
-);
-
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%' }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-lg)', flexWrap: 'wrap' }}>
-    {children}
-  </div>
-);
-
-/* ─── Playground ─────────────────────────────────────────────── */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Brand variant (default) — brand-tinted card surface for marketing sections.
+ * Toggle `rating` and omit `authorRole` via Controls for other configurations.
+ *
+ * @summary Customer testimonial — brand surface, quote + attribution + stars
+ */
+export const Default: Story = {
   args: {
     quote: 'Square has completely transformed how we handle payments. The analytics alone have helped us grow 40% this year.',
     authorName: 'Sarah Chen',
@@ -52,95 +35,19 @@ export const Playground: Story = {
   decorators: [(Story) => <div style={{ width: 380 }}><Story /></div>],
 };
 
-/* ─── Variants ───────────────────────────────────────────────── */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Brand variant</SectionLabel>
-      <Row>
-        <div style={{ width: 380 }}>
-          <CardTestimonial
-            variant="brand"
-            quote="Incredible results from day one. Highly recommend."
-            authorName="Sarah Chen"
-            authorRole="Owner, Bloom Cafe"
-            rating={5}
-          />
-        </div>
-      </Row>
-
-      <SectionLabel>Outlined variant</SectionLabel>
-      <Row>
-        <div style={{ width: 380 }}>
-          <CardTestimonial
-            variant="outlined"
-            quote="Professional, responsive, and creative. Our new site has driven 3x more leads."
-            authorName="Marcus Johnson"
-            authorRole="Marketing Director, Apex Corp"
-            rating={5}
-          />
-        </div>
-      </Row>
-
-      <SectionLabel>Without rating</SectionLabel>
-      <Row>
-        <div style={{ width: 380 }}>
-          <CardTestimonial
-            variant="brand"
-            quote="Working with this team felt like an extension of our own company."
-            authorName="Emily Rodriguez"
-            authorRole="CEO, Greenfield Digital"
-          />
-        </div>
-      </Row>
-
-      <SectionLabel>Minimal attribution (no role)</SectionLabel>
-      <Row>
-        <div style={{ width: 380 }}>
-          <CardTestimonial
-            variant="brand"
-            quote="Best investment we made this year. Period."
-            authorName="Alex Turner"
-            rating={5}
-          />
-        </div>
-      </Row>
-    </Stack>
-  ),
-};
-
-/* ─── Patterns ───────────────────────────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Mixed variant testimonials grid</SectionLabel>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--gap-lg)', maxWidth: 1200 }}>
-        <CardTestimonial
-          variant="brand"
-          quote="Square has completely transformed how we handle payments. The analytics alone have helped us grow 40% this year."
-          authorName="Sarah Chen"
-          authorRole="Owner, Bloom Cafe"
-          rating={5}
-        />
-        <CardTestimonial
-          variant="outlined"
-          quote="The team was incredibly responsive and delivered beyond our expectations."
-          authorName="Marcus Johnson"
-          authorRole="Marketing Director, Apex Corp"
-          rating={5}
-        />
-        <CardTestimonial
-          variant="brand"
-          quote="Best investment we made this year. Communication was seamless."
-          authorName="Emily Rodriguez"
-          authorRole="CEO, Greenfield Digital"
-          rating={4}
-        />
-      </div>
-    </Stack>
-  ),
+/**
+ * `variant="outlined"` — neutral surface with border for light backgrounds
+ * where the brand fill would compete with surrounding content.
+ *
+ * @summary variant="outlined" — neutral surface with border
+ */
+export const Outlined: Story = {
+  args: {
+    quote: 'Professional, responsive, and creative. Our new site has driven 3x more leads in six months.',
+    authorName: 'Marcus Johnson',
+    authorRole: 'Marketing Director, Apex Corp',
+    rating: 5,
+    variant: 'outlined',
+  },
+  decorators: [(Story) => <div style={{ width: 380 }}><Story /></div>],
 };

--- a/components/ui/CollapsibleCard/CollapsibleCard.mdx
+++ b/components/ui/CollapsibleCard/CollapsibleCard.mdx
@@ -10,23 +10,20 @@ import * as Stories from './CollapsibleCard.stories';
 
 Expandable content section with a clickable header. Use for FAQs, settings panels, and long-form content that benefits from progressive disclosure.
 
+> **Rename in progress** — This component will be renamed `Collapsible` in a future release (see [#701](https://github.com/brikdesigns/brik-bds/issues/701)). The export name and import path are unchanged until then.
+
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Collapsed, expanded, without section label, and with rich content.
+### Controlled mode
 
-<Canvas of={Stories.Variants} />
+Use `isOpen` + `onOpenChange` when parent state must drive the transition — for example, "expand all" / "collapse all" controls, wizard steps, or accordion groups. Uncontrolled (`defaultOpen`) is the default and covers most use cases.
 
-## Patterns
-
-Stacked proposal sections in an accordion-style layout.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.Controlled} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/CollapsibleCard/CollapsibleCard.stories.tsx
+++ b/components/ui/CollapsibleCard/CollapsibleCard.stories.tsx
@@ -1,27 +1,6 @@
-import React from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CollapsibleCard } from './CollapsibleCard';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Meta ────────────────────────────────────────────── */
 
 const meta: Meta<typeof CollapsibleCard> = {
   title: 'Containers/collapsible-card',
@@ -39,12 +18,12 @@ const meta: Meta<typeof CollapsibleCard> = {
 export default meta;
 type Story = StoryObj<typeof CollapsibleCard>;
 
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Args-driven sandbox. Toggle `defaultOpen` and `sectionLabel` via Controls.
+ *
+ * @summary Expandable content section with header toggle
+ */
+export const Default: Story = {
   args: {
     sectionLabel: 'Section 01',
     title: 'Overview and Goals',
@@ -53,113 +32,33 @@ export const Playground: Story = {
   },
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — States, with/without section label, rich content
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  args: {
-    title: 'Overview',
-    children: 'Content',
-  },
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Collapsed (default)</SectionLabel>
+/**
+ * Controlled mode — `isOpen` + `onOpenChange` wired via `useState`. Use when
+ * parent state must drive the open/closed transition (e.g. "expand all" /
+ * "collapse all" buttons, wizard steps, or accordion groups).
+ *
+ * @summary Controlled open state via isOpen + onOpenChange
+ */
+export const Controlled: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
+        <div style={{ display: 'flex', gap: 'var(--gap-sm)' }}>
+          <button type="button" onClick={() => setOpen(true)} style={{ cursor: 'pointer' }}>Expand</button>
+          <button type="button" onClick={() => setOpen(false)} style={{ cursor: 'pointer' }}>Collapse</button>
+        </div>
         <CollapsibleCard
           sectionLabel="Section 01"
-          title="Overview and Goals"
+          title="Controlled by parent state"
+          isOpen={open}
+          onOpenChange={setOpen}
         >
-          Strategic overview of the project objectives and expected outcomes.
+          This card's open state is controlled externally. The parent's Expand / Collapse
+          buttons drive the transition — the card's own toggle fires onOpenChange but does
+          not manage state internally.
         </CollapsibleCard>
       </div>
-
-      <div>
-        <SectionLabel>Expanded</SectionLabel>
-        <CollapsibleCard
-          sectionLabel="Section 02"
-          title="Scope of Project"
-          defaultOpen
-        >
-          Detailed breakdown of deliverables and service offerings.
-        </CollapsibleCard>
-      </div>
-
-      <div>
-        <SectionLabel>Without section label</SectionLabel>
-        <CollapsibleCard
-          title="Settings"
-          defaultOpen
-        >
-          A collapsible card without a section label — useful for settings panels or standalone collapsible areas.
-        </CollapsibleCard>
-      </div>
-
-      <div>
-        <SectionLabel>With rich content</SectionLabel>
-        <CollapsibleCard
-          sectionLabel="Section 03"
-          title="Project Timeline"
-          defaultOpen
-        >
-          <div>
-            <h4 style={{ margin: '0 0 var(--gap-md)', color: 'var(--text-primary)' }}>Phase 1: Discovery</h4>
-            <ul style={{ margin: '0 0 var(--gap-lg)', paddingLeft: 'var(--padding-lg)', color: 'var(--text-secondary)' }}>
-              <li>Stakeholder interviews</li>
-              <li>Competitive analysis</li>
-              <li>Requirements gathering</li>
-            </ul>
-            <h4 style={{ margin: '0 0 var(--gap-md)', color: 'var(--text-primary)' }}>Phase 2: Design</h4>
-            <ul style={{ margin: 0, paddingLeft: 'var(--padding-lg)', color: 'var(--text-secondary)' }}>
-              <li>Wireframes and prototypes</li>
-              <li>Visual design</li>
-              <li>Design review</li>
-            </ul>
-          </div>
-        </CollapsibleCard>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Proposal sections (accordion layout)
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  args: {
-    title: 'Overview',
-    children: 'Content',
+    );
   },
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Proposal sections</SectionLabel>
-        <Stack gap="var(--gap-lg)">
-          <CollapsibleCard sectionLabel="Section 01" title="Overview and Goals">
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
-              Strategic overview of the project objectives and expected outcomes.
-            </p>
-          </CollapsibleCard>
-          <CollapsibleCard sectionLabel="Section 02" title="Scope of Project">
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
-              Detailed breakdown of deliverables and service offerings.
-            </p>
-          </CollapsibleCard>
-          <CollapsibleCard sectionLabel="Section 03" title="Project Timeline">
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
-              Phased timeline with milestones and deliverable dates.
-            </p>
-          </CollapsibleCard>
-          <CollapsibleCard sectionLabel="Section 04" title="Fee Summary">
-            <p style={{ margin: 0, color: 'var(--text-secondary)' }}>
-              Pricing breakdown with service-level detail.
-            </p>
-          </CollapsibleCard>
-        </Stack>
-      </div>
-    </Stack>
-  ),
 };

--- a/components/ui/PricingCard/PricingCard.mdx
+++ b/components/ui/PricingCard/PricingCard.mdx
@@ -8,25 +8,22 @@ import * as Stories from './PricingCard.stories';
 
 <ComponentLinks slug="pricing-card" />
 
+> **Stories moved** — The canonical PricingCard stories now live on the [Card](?path=/docs/containers-card--docs) page under `## Variants > Pricing`. This page remains during the migration window.
+
 A pricing tier display card with title, price, features list, and call-to-action. Supports a highlighted state for the recommended plan.
 
 ## Playground
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Standard, highlighted with badge, and free tier configurations.
+### Highlighted
 
-<Canvas of={Stories.Variants} />
+`highlighted=true` marks this tier as the recommended plan with brand surface treatment.
 
-## Patterns
-
-Three-tier pricing grid — the typical side-by-side layout with the middle plan highlighted.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.Highlighted} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/PricingCard/PricingCard.stories.tsx
+++ b/components/ui/PricingCard/PricingCard.stories.tsx
@@ -1,36 +1,18 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PricingCard } from './PricingCard';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Meta ────────────────────────────────────────────── */
-
+/**
+ * @deprecated Stories for PricingCard now live in Card.stories.tsx
+ * (`Containers/card` sidebar entry). This file is kept during the migration
+ * window and will be removed in a future release.
+ */
 const meta: Meta<typeof PricingCard> = {
   title: 'Containers/pricing-card',
   component: PricingCard,
-  tags: ['surface-web'],
+  tags: ['surface-web', '!manifest'],
   parameters: { layout: 'centered' },
-  decorators: [(Story) => <div style={{ width: 320 }}><Story /></div>],
   argTypes: {
     title: { control: 'text' },
     price: { control: 'text' },
@@ -43,8 +25,6 @@ const meta: Meta<typeof PricingCard> = {
 export default meta;
 type Story = StoryObj<typeof PricingCard>;
 
-/* ─── Shared data ─────────────────────────────────────── */
-
 const commonFeatures = [
   'Unlimited projects',
   'Priority support',
@@ -52,121 +32,33 @@ const commonFeatures = [
   'Analytics dashboard',
 ];
 
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Pricing tier card — see Card stories for the canonical reference */
+export const Default: Story = {
   args: {
     title: 'Professional',
     price: '$49',
     period: '/month',
     description: 'For growing businesses that need more power.',
     features: commonFeatures,
-    action: <Button variant="primary" fullWidth>Get started</Button>,
+    action: <Button variant="primary" style={{ width: '100%' }}>Get started</Button>,
   },
+  decorators: [(Story) => <div style={{ width: 320 }}><Story /></div>],
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Highlighted, free tier, no features
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  decorators: [(Story) => <div style={{ width: 900 }}><Story /></div>],
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Standard</SectionLabel>
-        <div style={{ width: 320 }}>
-          <PricingCard
-            title="Professional"
-            price="$49"
-            period="/month"
-            description="For growing businesses that need more power."
-            features={commonFeatures}
-            action={<Button variant="primary" fullWidth>Get started</Button>}
-          />
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel>Highlighted with badge</SectionLabel>
-        <div style={{ width: 320 }}>
-          <PricingCard
-            title="Professional"
-            price="$49"
-            period="/month"
-            description="Most popular choice for growing businesses."
-            features={commonFeatures}
-            badge={<Badge status="positive" size="sm">Most popular</Badge>}
-            action={<Button variant="primary" fullWidth>Get started</Button>}
-            highlighted
-          />
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel>Free tier (no period)</SectionLabel>
-        <div style={{ width: 320 }}>
-          <PricingCard
-            title="Starter"
-            price="Free"
-            description="Get started with the basics."
-            features={['1 project', 'Community support', 'Basic analytics']}
-            action={<Button variant="outline" fullWidth>Sign up free</Button>}
-          />
-        </div>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Pricing grid (3-tier layout)
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  decorators: [(Story) => <div style={{ maxWidth: 1000 }}><Story /></div>],
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Three-tier pricing grid</SectionLabel>
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(3, 1fr)',
-          gap: 'var(--padding-lg)',
-          alignItems: 'start',
-        }}>
-          <PricingCard
-            title="Starter"
-            price="Free"
-            description="Get started with the basics."
-            features={['1 project', 'Community support', 'Basic analytics']}
-            action={<Button variant="outline" fullWidth>Sign up free</Button>}
-          />
-          <PricingCard
-            title="Professional"
-            price="$49"
-            period="/month"
-            description="Most popular choice for growing businesses."
-            features={['Unlimited projects', 'Priority support', 'Custom domain', 'Analytics dashboard', 'API access']}
-            badge={<Badge status="positive" size="sm">Most popular</Badge>}
-            action={<Button variant="primary" fullWidth>Get started</Button>}
-            highlighted
-          />
-          <PricingCard
-            title="Enterprise"
-            price="$199"
-            period="/month"
-            description="For large teams with advanced needs."
-            features={['Everything in Professional', 'Dedicated account manager', 'SLA guarantee', 'Custom integrations']}
-            action={<Button variant="outline" fullWidth>Contact sales</Button>}
-          />
-        </div>
-      </div>
-    </Stack>
-  ),
+/**
+ * `highlighted=true` — recommended tier treatment with brand surface.
+ * @summary highlighted=true — recommended tier
+ */
+export const Highlighted: Story = {
+  args: {
+    title: 'Professional',
+    price: '$49',
+    period: '/month',
+    description: 'Most popular choice for growing businesses.',
+    features: commonFeatures,
+    badge: <Badge status="positive" size="sm">Most popular</Badge>,
+    action: <Button variant="primary" style={{ width: '100%' }}>Get started</Button>,
+    highlighted: true,
+  },
+  decorators: [(Story) => <div style={{ width: 320 }}><Story /></div>],
 };


### PR DESCRIPTION
## Summary

Phase A of the 2026-05-17 card-family architecture review. **Stories and MDX only** — zero component API, export name, or CSS changes. Zero consumer-breaking changes.

- Updates the storybook-story-shape standard with the multi-preset Container pattern (brik-rag re-ingested)
- Consolidates PricingCard story under Card; marks CardControl stories deprecated
- Reclassifies CardList from `Containers/` → `Layouts/` (no visual surface)
- Cleans remaining Card family stories to ADR-010 gold standard (Default + one Q3)
- Adds rename-in-progress banners on CollapsibleCard (#701) and CardTestimonial (#702)

## Changes per component

| Component | Before | After | Notes |
|---|---|---|---|
| Card | Default + Control + Summary + Display | + **Pricing** story | PricingCard story consolidated here |
| PricingCard | Playground + Variants + Patterns | Default + Highlighted; `!manifest` | Canonical story now under Card |
| CardControl | Playground + ActionAlignment + Variants + Patterns + ToggleSwitchPanel | Default; `!manifest` | Deprecation per #657 |
| CardList | Playground + Vertical + Horizontal + HorizontalFitContent + Patterns + GapScale | **Default + GapScale**; title `Layouts/` | Reclassified as layout primitive |
| CollapsibleCard | Playground + Variants + Patterns | **Default + Controlled** | Rename to Collapsible tracked in #701 |
| CardTestimonial | Playground + Variants + Patterns | **Default + Outlined** | Rename to Testimonial tracked in #702 |

**Net: 850 lines deleted, 216 added. MDX lint 78/78 clean. TypeCheck clean.**

## Standard update

`.claude/standards/storybook-story-shape.md` gains a `## Multi-preset Container pattern` section encoding:
- Where preset stories live (base component's file)
- Surface-tag conflict resolution (story-level `tags`)
- Wrong-layer diagnostic (Layout vs Container)
- Name-layer check (Card prefix implies Container ancestry)

Re-ingested into brik-rag at session end.

## Pre-existing test failure

`Radio/Radio.stories.tsx > Single` fails on `main` before this branch — confirmed pre-existing, unrelated to this PR.

## Related issues

- Closes partial scope of: [#656](https://github.com/brikdesigns/brik-bds/issues/656) Phase 3b (Card family story shape)
- Advances: [#587](https://github.com/brikdesigns/brik-bds/issues/587) Storybook standards rearchitect
- Informs: [#657](https://github.com/brikdesigns/brik-bds/issues/657) CardControl deprecation
- Files rename work: [#701](https://github.com/brikdesigns/brik-bds/issues/701) CollapsibleCard → Collapsible, [#702](https://github.com/brikdesigns/brik-bds/issues/702) CardTestimonial → Testimonial

## Test plan

- [ ] MDX lint passes (78/78 — confirmed in commit hook)
- [ ] TypeCheck passes (confirmed in commit hook)
- [ ] Storybook: `Card` sidebar entry shows Default, Control, Summary, Display, Pricing
- [ ] Storybook: `Layouts/card-list` appears in Layouts bucket
- [ ] Storybook: PricingCard and CardControl sidebar entries are hidden (`!manifest`) but still accessible by direct URL
- [ ] CollapsibleCard shows Default + Controlled stories; Controlled demo works interactively
- [ ] CardTestimonial shows Default (brand) + Outlined stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)