### PR TITLE
text: input hide border

### DIFF
--- a/components/ui/TextInput/TextInput.stories.tsx
+++ b/components/ui/TextInput/TextInput.stories.tsx
@@ -73,6 +73,10 @@ const meta: Meta<DefaultArgs> = {
       action: 'changed',
       description: 'Native change handler.',
     },
+    hideBorder: {
+      control: 'boolean',
+      description: 'Remove the field border. Use on dark/inverse surfaces where the fill provides sufficient contrast.',
+    },
     showLeadingIcon: {
       control: 'boolean',
       description: 'Story-only — toggle a sample envelope icon as `iconBefore`.',
@@ -103,6 +107,7 @@ export const Default: Story = {
     type: 'text',
     size: 'md',
     fullWidth: true,
+    hideBorder: false,
     showLeadingIcon: false,
     showTrailingIcon: false,
   },

--- a/components/ui/TextInput/TextInput.tsx
+++ b/components/ui/TextInput/TextInput.tsx
@@ -25,6 +25,8 @@ export interface TextInputProps extends Omit<InputHTMLAttributes<HTMLInputElemen
   iconBefore?: ReactNode;
   /** Optional icon after input */
   iconAfter?: ReactNode;
+  /** Hide the input border. Use on dark/inverse surfaces where the fill provides sufficient contrast. */
+  hideBorder?: boolean;
 }
 
 /**
@@ -154,6 +156,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       fullWidth = false,
       iconBefore,
       iconAfter,
+      hideBorder = false,
       className = '',
       id,
       style,
@@ -179,6 +182,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       ...sizeStyle.input,
       ...(iconBefore ? { paddingLeft: 'calc(var(--padding-xs) * 4)' } : {}),
       ...(iconAfter ? { paddingRight: 'calc(var(--padding-xs) * 4)' } : {}),
+      ...(hideBorder ? { border: 'none' } : {}),
       ...(hasError ? { borderColor: 'var(--border-negative)' } : {}),
     };
 


### PR DESCRIPTION
## Summary
- docs(text-input): narrow type control to text/email/tel/url (#699)
- feat(inputs): add NumberInput with BDS stepper buttons (#700)
- feat(text-input): add hideBorder prop for dark/inverse surface placement

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)