### PR TITLE
feat(component): rename CollapsibleCard → Collapsible + Radix internals (closes #701)

### DIFF
--- a/components/ui/Collapsible/Collapsible.css
+++ b/components/ui/Collapsible/Collapsible.css
@@ -1,0 +1,102 @@
+@layer bds-components {
+/* Collapsible — expandable content section (progressive disclosure primitive) */
+
+/* ─── Root container ──────────────────────────────────── */
+
+.bds-collapsible {
+  background-color: var(--surface-primary);
+  padding: var(--padding-lg);
+  border-radius: var(--border-radius-md);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ─── Trigger (header) ────────────────────────────────── */
+
+.bds-collapsible__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  cursor: pointer;
+  gap: var(--gap-lg);
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+}
+
+.bds-collapsible__header:focus-visible {
+  outline: 2px solid var(--border-brand-primary);
+  outline-offset: 2px;
+  border-radius: var(--border-radius-sm);
+}
+
+.bds-collapsible__header-left {
+  display: flex;
+  flex-direction: column;
+  gap: var(--padding-lg);
+  flex: 1;
+  min-width: 0;
+}
+
+.bds-collapsible__header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-md);
+}
+
+/* ─── Section label ───────────────────────────────────── */
+
+.bds-collapsible__section-label {
+  font-family: var(--font-family-heading);
+  font-weight: var(--font-weight--semi-bold);
+  font-size: var(--heading-tiny);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: var(--font-line-height-tight);
+  margin: 0;
+}
+
+/* ─── Title ───────────────────────────────────────────── */
+
+.bds-collapsible__title {
+  font-family: var(--font-family-heading);
+  font-weight: var(--font-weight--bold);
+  font-size: var(--heading-sm);
+  color: var(--text-primary);
+  line-height: var(--font-line-height-tight);
+  margin: 0;
+}
+
+/* ─── Toggle icon ─────────────────────────────────────── */
+
+.bds-collapsible__toggle {
+  width: 40px; /* bds-lint-ignore — icon button touch target */
+  height: 40px; /* bds-lint-ignore */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--background-secondary);
+  border-radius: var(--border-radius-md);
+  flex-shrink: 0;
+  color: var(--text-primary);
+  font-size: var(--body-lg); /* bds-lint-ignore — icon sizing */
+}
+
+.bds-collapsible__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bds-collapsible[data-state="open"] .bds-collapsible__icon--plus { display: none; }
+.bds-collapsible[data-state="closed"] .bds-collapsible__icon--minus { display: none; }
+
+/* ─── Content area ────────────────────────────────────── */
+
+.bds-collapsible__content {
+  margin-top: var(--padding-lg);
+}
+}

--- a/components/ui/Collapsible/Collapsible.mdx
+++ b/components/ui/Collapsible/Collapsible.mdx
@@ -1,0 +1,31 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './Collapsible.stories';
+
+<Meta of={Stories} />
+
+# Collapsible
+
+<ComponentLinks slug="collapsible" />
+
+Progressive disclosure primitive — expandable content section with a clickable header (section label, title, and +/− toggle). Use for proposal sections, settings panels, FAQs, or any content that benefits from reveal-on-demand.
+
+Wraps `@radix-ui/react-collapsible` for correct `aria-expanded`, keyboard handling (Enter / Space), and focus management. BDS owns the visual surface and slot layout.
+
+## Playground
+
+Toggle `defaultOpen` and `sectionLabel` via Controls to explore the args-driven surface.
+
+<Canvas of={Stories.Default} />
+
+## Variants
+
+### Controlled mode
+
+Use `isOpen` + `onOpenChange` when parent state must drive the transition — for example, "expand all" / "collapse all" controls, wizard steps, or accordion groups. Uncontrolled (`defaultOpen`) is the default and covers most use cases.
+
+<Canvas of={Stories.Controlled} />
+
+## Props
+
+<ArgTypes of={Stories} />

--- a/components/ui/Collapsible/Collapsible.stories.tsx
+++ b/components/ui/Collapsible/Collapsible.stories.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Collapsible } from './Collapsible';
+
+const meta: Meta<typeof Collapsible> = {
+  title: 'Components/collapsible',
+  component: Collapsible,
+  tags: ['surface-shared'],
+  parameters: { layout: 'padded' },
+  decorators: [(Story) => <div style={{ maxWidth: 640 }}><Story /></div>],
+  argTypes: {
+    sectionLabel: { control: 'text' },
+    title: { control: 'text' },
+    defaultOpen: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Collapsible>;
+
+/**
+ * Args-driven sandbox. Toggle `defaultOpen` and `sectionLabel` via Controls.
+ *
+ * @summary Expandable content section with header toggle
+ */
+export const Default: Story = {
+  args: {
+    sectionLabel: 'Section 01',
+    title: 'Overview and Goals',
+    defaultOpen: false,
+    children: 'This is the collapsible content area. It can contain any content including text, lists, tables, or nested components.',
+  },
+};
+
+/**
+ * Controlled mode — `isOpen` + `onOpenChange` wired via `useState`. Use when
+ * parent state must drive the open/closed transition (e.g. "expand all" /
+ * "collapse all" buttons, wizard steps, or accordion groups).
+ *
+ * @summary Controlled open state via isOpen + onOpenChange
+ */
+export const Controlled: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
+        <div style={{ display: 'flex', gap: 'var(--gap-sm)' }}>
+          <button type="button" onClick={() => setOpen(true)} style={{ cursor: 'pointer' }}>Expand</button>
+          <button type="button" onClick={() => setOpen(false)} style={{ cursor: 'pointer' }}>Collapse</button>
+        </div>
+        <Collapsible
+          sectionLabel="Section 01"
+          title="Controlled by parent state"
+          isOpen={open}
+          onOpenChange={setOpen}
+        >
+          This section's open state is controlled externally. The parent's Expand / Collapse
+          buttons drive the transition — the trigger fires onOpenChange but does
+          not manage state internally.
+        </Collapsible>
+      </div>
+    );
+  },
+};

--- a/components/ui/Collapsible/Collapsible.tsx
+++ b/components/ui/Collapsible/Collapsible.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { type ReactNode, type HTMLAttributes } from 'react';
+import * as RadixCollapsible from '@radix-ui/react-collapsible';
+import { Icon } from '@iconify/react';
+import { Plus, Minus } from '../../icons';
+import { bdsClass } from '../../utils';
+import './Collapsible.css';
+
+export interface CollapsibleProps extends HTMLAttributes<HTMLDivElement> {
+  /** Section label displayed above the title (e.g. "Section 01") */
+  sectionLabel?: string;
+  /** Title shown in the trigger header */
+  title: string;
+  /** Content revealed when expanded */
+  children: ReactNode;
+  /** Controlled: whether the section is expanded */
+  isOpen?: boolean;
+  /** Callback fired when open state changes */
+  onOpenChange?: (isOpen: boolean) => void;
+  /** Initial open state (uncontrolled) */
+  defaultOpen?: boolean;
+  /** Additional actions rendered in the header alongside the toggle */
+  headerActions?: ReactNode;
+}
+
+/**
+ * Progressive disclosure primitive — expandable content section with a
+ * clickable header (section label + title + +/− toggle). Wraps
+ * `@radix-ui/react-collapsible` for correct `aria-expanded`, keyboard
+ * handling, and focus management.
+ *
+ * Supports both uncontrolled (`defaultOpen`) and controlled
+ * (`isOpen` + `onOpenChange`) modes.
+ *
+ * @summary Expandable content section with header toggle
+ */
+export function Collapsible({
+  sectionLabel,
+  title,
+  children,
+  isOpen,
+  onOpenChange,
+  defaultOpen = false,
+  headerActions,
+  className,
+  style,
+  ...props
+}: CollapsibleProps) {
+  return (
+    <RadixCollapsible.Root
+      open={isOpen}
+      onOpenChange={onOpenChange}
+      defaultOpen={defaultOpen}
+      className={bdsClass('bds-collapsible', className)}
+      style={style}
+      {...props}
+    >
+      <RadixCollapsible.Trigger className="bds-collapsible__header">
+        <div className="bds-collapsible__header-left">
+          {sectionLabel && (
+            <span className="bds-collapsible__section-label">{sectionLabel}</span>
+          )}
+          <h3 className="bds-collapsible__title">{title}</h3>
+        </div>
+        <div className="bds-collapsible__header-right">
+          {headerActions}
+          <span className="bds-collapsible__toggle" aria-hidden="true">
+            <span className="bds-collapsible__icon bds-collapsible__icon--plus">
+              <Icon icon={Plus} />
+            </span>
+            <span className="bds-collapsible__icon bds-collapsible__icon--minus">
+              <Icon icon={Minus} />
+            </span>
+          </span>
+        </div>
+      </RadixCollapsible.Trigger>
+      <RadixCollapsible.Content className="bds-collapsible__content">
+        {children}
+      </RadixCollapsible.Content>
+    </RadixCollapsible.Root>
+  );
+}
+
+export default Collapsible;

--- a/components/ui/Collapsible/index.ts
+++ b/components/ui/Collapsible/index.ts
@@ -1,0 +1,2 @@
+export { Collapsible, type CollapsibleProps } from './Collapsible';
+export { default } from './Collapsible';

--- a/components/ui/CollapsibleCard/index.ts
+++ b/components/ui/CollapsibleCard/index.ts
@@ -1,2 +1,4 @@
-export { CollapsibleCard, type CollapsibleCardProps } from './CollapsibleCard';
-export { default } from './CollapsibleCard';
+// @deprecated — CollapsibleCard has been renamed to Collapsible.
+// Import from '@brikdesigns/bds' as before; this bridge re-export will be
+// removed in a future major version after consumers migrate to Collapsible.
+export { Collapsible as CollapsibleCard, type CollapsibleProps as CollapsibleCardProps } from '../Collapsible';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -29,6 +29,7 @@ export * from './Checkbox';
 export * from './Checklist';
 export * from './Chip';
 export * from './Cluster';
+export * from './Collapsible';
 export * from './CollapsibleCard';
 export * from './CompletionToggle';
 export * from './Counter';

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",
         "@iconify/react": ">=5.0.0",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-popover": "^1.1.15"
       },
       "bin": {
@@ -1496,6 +1497,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.0",
     "@notionhq/client": "^3.1.3",
     "@storybook/addon-a11y": "10.3.6",
     "@storybook/addon-docs": "10.3.6",
@@ -85,6 +86,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/browser": "^4.1.2",
     "@vitest/browser-playwright": "^4.1.4",
+    "axe-core": "^4.10.0",
     "chromatic": "^15.3.0",
     "dotenv": "^16.6.1",
     "husky": "^9.1.7",
@@ -96,9 +98,7 @@
     "style-dictionary": "^5.3.1",
     "typescript": "^5.5.0",
     "vite": "^6.4.2",
-    "vitest": "^4.1.2",
-    "@axe-core/playwright": "^4.10.0",
-    "axe-core": "^4.10.0"
+    "vitest": "^4.1.2"
   },
   "peerDependencies": {
     "@iconify/react": ">=5.0.0",
@@ -184,6 +184,7 @@
   "dependencies": {
     "@iconify-json/ph": "^1.2.2",
     "@iconify/react": ">=5.0.0",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-popover": "^1.1.15"
   }
 }


### PR DESCRIPTION
## Summary

- **New `components/ui/Collapsible/`** — canonical home for the component going forward (`Collapsible`, `CollapsibleProps`, stories, MDX, CSS)
- **Radix internals** — replaces bespoke `useState` / `onKeyDown` / `role="button"` / manual `aria-expanded` with `@radix-ui/react-collapsible` (`Root`, `Trigger`, `Content`) for correct semantics and WAI-ARIA keyboard handling
- **CSS class rename** — `bds-collapsible-card__*` → `bds-collapsible__*`; icon toggle driven by `data-state="open|closed"` from Radix instead of conditional render
- **Sidebar taxonomy** — `Containers/collapsible-card` → `Components/collapsible` (interaction primitive, not a Container)
- **Re-export bridge** — `CollapsibleCard/index.ts` re-exports `Collapsible as CollapsibleCard` and `CollapsibleProps as CollapsibleCardProps`; one consumer (brik-client-portal `agreement-content.tsx`) is unaffected

## Consumer impact

| Repo | File | Action required |
|---|---|---|
| brik-client-portal | `src/components/agreement-content.tsx` | None — bridge active until consumer migrates |

## Test plan

- [ ] `Components/collapsible` appears in Storybook sidebar under Components
- [ ] Default story: `defaultOpen` toggle works; section label renders; content reveals/hides
- [ ] Controlled story: Expand/Collapse buttons drive open state
- [ ] Keyboard: focus trigger, press Enter → opens; press Space → closes
- [ ] `aria-expanded` attribute flips correctly in DevTools
- [ ] `import { CollapsibleCard } from '@brikdesigns/bds'` still resolves (bridge)
- [ ] Old `Containers/collapsible-card` sidebar entry is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)