### PR TITLE
cardcontrol: deprecate

### DIFF
--- a/components/ui/CardControl/CardControl.tsx
+++ b/components/ui/CardControl/CardControl.tsx
@@ -2,8 +2,10 @@ import { type HTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
 import './CardControl.css';
 
+/** @deprecated Use `Card preset="control"` instead — see #657. */
 export type CardControlActionAlign = 'center' | 'top';
 
+/** @deprecated Use `Card preset="control"` instead — see #657. */
 export interface CardControlProps extends HTMLAttributes<HTMLDivElement> {
   /** Setting / control name shown as the primary text. */
   title: string;
@@ -18,16 +20,9 @@ export interface CardControlProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * CardControl — settings control card with badge, title, description, and action.
- *
- * Equivalent to `<Card preset="control">` (added in v0.39.0). Both APIs are
- * supported and ship the same layout / visual treatment; pick whichever
- * fits the call site.
- *
- * The earlier deprecation marker (PR #244) was reversed by user decision
- * 2026-04-24 — CardControl stays as a first-class component. The
- * 2026-Q2 audit's recommendation to retire it is logged but not in
- * effect; see docs/audits/2026-Q2-component-bloat-audit.md.
+ * @deprecated Use `<Card preset="control">` instead. `CardControl` is kept
+ * during the migration window and will be removed in a future major version
+ * once the one consumer (brik-client-portal) migrates (see #657).
  *
  * @summary Settings card — title, description, badge, action
  */


### PR DESCRIPTION
## Summary
- feat(component): rename CollapsibleCard → Collapsible + Radix internals (closes #701) (#706)
- feat(card): deprecate CardControl — add @deprecated markers to type, interface, function (closes #657)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)