### PR TITLE
fix(blueprint): HeroSplitImageCardOverlay default to square (#670)

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -66,7 +66,7 @@ interface Props extends BlueprintProps {
   imageRatio?: FrameRatio;
 }
 
-const { section, imageRatio = 'landscape' } = Astro.props;
+const { section, imageRatio = 'square' } = Astro.props;
 
 const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
 const titleId = `${section.sectionKey}-title`;
@@ -149,7 +149,7 @@ const cta = section.cta;
       <aside class="bp-hero-img-card__media-card">
         <div
           class="bp-hero-img-card__image-frame"
-          style={imageRatio !== 'landscape' ? `--_bp-image-ratio: ${RATIO_ASPECT[imageRatio]}` : undefined}
+          style={imageRatio !== 'square' ? `--_bp-image-ratio: ${RATIO_ASPECT[imageRatio]}` : undefined}
         >
           <img
             src={priceCard.imageUrl}
@@ -180,7 +180,7 @@ const cta = section.cta;
         class="bp-hero-img-card__missing"
         data-content-needed="hero_image_url"
         role="presentation"
-        style={imageRatio !== 'landscape' ? `--_bp-image-ratio: ${RATIO_ASPECT[imageRatio]}` : undefined}
+        style={imageRatio !== 'square' ? `--_bp-image-ratio: ${RATIO_ASPECT[imageRatio]}` : undefined}
       >
         <p class="bp-hero-img-card__missing-label">
           Hero image card missing for this page.
@@ -315,7 +315,7 @@ const cta = section.cta;
   }
 
   .bp-hero-img-card__image-frame {
-    aspect-ratio: var(--_bp-image-ratio, 4 / 3);
+    aspect-ratio: var(--_bp-image-ratio, 1 / 1);
     overflow: hidden;
     border-radius: var(--border-radius-md);
     background: var(--surface-secondary);
@@ -354,7 +354,7 @@ const cta = section.cta;
   }
 
   .bp-hero-img-card__missing {
-    aspect-ratio: var(--_bp-image-ratio, 4 / 3);
+    aspect-ratio: var(--_bp-image-ratio, 1 / 1);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -77,7 +77,7 @@ const interiorHeroSection: BlueprintProps['section'] = {
   ],
   audience: 'information',
   priceCard: {
-    imageUrl: 'https://placehold.co/640x480/eaf1fb/1f3d70?text=Deliverable',
+    imageUrl: 'https://placehold.co/600x600/eaf1fb/1f3d70?text=Deliverable',
     imageAlt: '',
     priceLabel: 'Starting at',
     price: '$249',
@@ -137,4 +137,26 @@ type Story = StoryObj<typeof HeroSplitImageCardOverlay>;
  */
 export const Playground: Story = {
   args: baseProps,
+};
+
+/**
+ * @summary Landscape photography variant — opt in via `imageRatio="landscape"`
+ * when the priceCard image is a 4:3 photo rather than a 1:1 illustration.
+ * The default is `square` because Brik's CMS service/plan illustrations are
+ * uploaded at 1:1; this variant documents how callers with landscape source
+ * assets opt out.
+ */
+export const LandscapePhotography: Story = {
+  args: {
+    ...baseProps,
+    imageRatio: 'landscape',
+    section: {
+      ...interiorHeroSection,
+      sectionKey: 'hero-img-card-landscape',
+      priceCard: {
+        ...interiorHeroSection.priceCard!,
+        imageUrl: 'https://placehold.co/640x480/eaf1fb/1f3d70?text=Landscape+Photo',
+      },
+    },
+  },
 };

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -27,7 +27,7 @@ interface Props extends BlueprintProps {
   imageRatio?: FrameRatio;
 }
 
-export function HeroSplitImageCardOverlay({ section, imageRatio = 'landscape' }: Props) {
+export function HeroSplitImageCardOverlay({ section, imageRatio = 'square' }: Props) {
   const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
   const titleId = `${section.sectionKey}-title`;
   const eyebrow = section.subheading;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

- Flip `HeroSplitImageCardOverlay` `imageRatio` default from `'landscape'` → `'square'`
- Closes brik-bds#670 — 1:1 service/plan illustrations no longer clip in the 4:3 default frame

## Context

The blueprint defaulted to `landscape` (4:3), but Brik's CMS service/plan illustrations are 1:1. `object-fit: cover` (Frame primitive default) clipped ~12.5% off the top and bottom of every default-rendered priceCard image. Observable on brikdesigns staging:

- `/plans/[slug]` heroes — never opted into `imageRatio`, so they currently clip
- `/services/{cat}/{slug}` heroes — were patched with explicit `imageRatio=\"square\"` in brikdesigns commit 4754caf as a per-call workaround

Cross-repo `gh search code HeroSplitImageCardOverlay --owner brikdesigns` confirms brikdesigns is the **only consumer** of this blueprint outside BDS itself (portal + renew-pms don't use it). The default flip is safe.

## Changes

- `content-system/blueprints/react/HeroSplitImageCardOverlay.tsx` — default arg `'landscape'` → `'square'`
- `content-system/blueprints/astro/HeroSplitImageCardOverlay.astro` — same default flip; flip the two `!== 'landscape'` style-emit guards to `!== 'square'`; flip the two CSS \`aspect-ratio\` fallbacks from \`4 / 3\` → \`1 / 1\`
- `HeroSplitImageCardOverlay.stories.tsx` — Playground placeholder 640×480 → 600×600 (1:1 matches new default); new \`LandscapePhotography\` variant story documents how photography callers opt back into \`landscape\`
- `package.json` — 0.71.0 → 0.71.1 (patch: bug fix, no prop API change)

## Consumer sync plan

- [ ] brikdesigns: \`npm install @brikdesigns/bds@0.71.1\` after release; drop redundant \`imageRatio=\"square\"\` from \`services/[categorySlug]/[serviceSlug]/page.tsx\`; \`/plans/[slug]\` auto-fixed (follow-on PR)
- [ ] portal: not a consumer — no action
- [ ] renew-pms: not a consumer — no action

## Test plan

- [x] \`npm run validate:full\` passes locally (10/10 checks incl. Storybook build)
- [ ] Chromatic visual diff approved (Playground now 1:1, new LandscapePhotography story)

## Knowledge capture

- [ ] Non-obvious decisions / learnings captured: \`brik-rag remember \"<key insight>\"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)