### PR TITLE
refactor(tokens): poppy hex → primitive refs in theme-brand-brik

### DIFF
--- a/tokens/theme-brand-brik.css
+++ b/tokens/theme-brand-brik.css
@@ -22,13 +22,13 @@
   /* Page */
   --page-primary: var(--color-grayscale-white);
   --page-secondary: var(--color-grayscale-lightest);
-  --page-brand-primary: #e35335;
+  --page-brand-primary: var(--color-poppy-light);
   /* Text */
   --text-primary: var(--color-grayscale-darkest);
   --text-secondary: var(--color-grayscale-dark);
   --text-muted: var(--color-grayscale-light);
   --text-inverse: var(--color-grayscale-white);
-  --text-brand-primary: #e35335;
+  --text-brand-primary: var(--color-poppy-light);
   /* Surface */
   --surface-primary: var(--color-grayscale-white);
   --surface-secondary: var(--color-grayscale-lightest);
@@ -46,17 +46,17 @@
   --background-inverse: var(--color-grayscale-darkest);
   --background-input: var(--color-grayscale-white);
   --background-image: #17171799;
-  --background-image-brand: #e35335;
+  --background-image-brand: var(--color-poppy-light);
   /* Border */
   --border-primary: var(--color-grayscale-darkest);
   --border-secondary: var(--color-grayscale-lighter);
   --border-muted: var(--color-grayscale-lighter);
-  --border-brand-primary: #e35335;
+  --border-brand-primary: var(--color-poppy-light);
   --border-input: var(--color-grayscale-light);
   --border-inverse: var(--color-grayscale-white);
   --border-on-color-dark: white;
   /* Brand palette overrides (neutral intermediate layer) */
-  --brand-primary: #e35335;
+  --brand-primary: var(--color-poppy-light);
   --brand-secondary: #f1f0ec;
   --brand-accent: #f4d364;
   --brand-tertiary: #9ada6c;
@@ -77,13 +77,13 @@
   /* Page */
   --page-primary: var(--color-grayscale-black);
   --page-secondary: var(--color-grayscale-darker);
-  --page-brand-primary: #e35335;
+  --page-brand-primary: var(--color-poppy-light);
   /* Text */
   --text-primary: var(--color-grayscale-lightest);
   --text-secondary: var(--color-grayscale-light);
   --text-muted: var(--color-grayscale-dark);
   --text-inverse: var(--color-grayscale-black);
-  --text-brand-primary: #e35335;
+  --text-brand-primary: var(--color-poppy-light);
   --text-on-color-dark: var(--color-grayscale-white);
   --text-on-color-light: var(--color-grayscale-black);
   --text-disabled: var(--color-grayscale-dark);
@@ -104,7 +104,7 @@
   --background-input: var(--color-grayscale-black);
   --background-muted: var(--color-grayscale-darker);
   --background-image: #000000cc;
-  --background-image-brand: #e35335;
+  --background-image-brand: var(--color-poppy-light);
   --background-brand-primary-hover: var(--color-poppy-lighter);
   --background-brand-primary-pressed: var(--color-poppy-lightest);
   --background-disabled: var(--color-grayscale-darker);
@@ -116,7 +116,7 @@
   --border-primary: var(--color-grayscale-darker);
   --border-secondary: var(--color-grayscale-light);
   --border-muted: var(--color-grayscale-dark);
-  --border-brand-primary: #e35335;
+  --border-brand-primary: var(--color-poppy-light);
   --border-input: var(--color-grayscale-dark);
   --border-inverse: var(--color-grayscale-black);
   --border-on-color-dark: var(--color-grayscale-black);


### PR DESCRIPTION
## Summary

Pure form-only refactor in `theme-brand-brik`. Brings the file in line with the Tier 2 rule `pr-checklist.sh` enforces: "Every semantic token references a primitive via var() — no raw hex in Tier 2".

**No value changes.** The underlying color stays `#e35335` (poppy-light) in both light and dark modes for every changed token. `dist/tokens.css` rebuilt and confirmed identical resolved values.

## Scope (9 tokens, poppy family only)

Light mode (5):
- `--page-brand-primary`
- `--text-brand-primary`
- `--background-image-brand`
- `--border-brand-primary`
- `--brand-primary`

Dark mode (4):
- `--page-brand-primary`
- `--text-brand-primary`
- `--background-image-brand`
- `--border-brand-primary`

All `#e35335` → `var(--color-poppy-light)`.

## Excluded — already covered by #710

- `--surface-brand-primary` (light + dark)
- `--background-brand-primary` (light + dark)
- Their state-pair siblings

PR #710 changes both form AND value (poppy-light → poppy-dark for AA). This PR explicitly skips those four tokens to avoid merge conflicts.

## Excluded — separate concern, tracked in follow-up issue

Tan / canary / sage / blue-mute family raw-hex aliases. **Correction from earlier draft of this PR body:** the primitives DO exist in BDS canonical:
- `--color-tan-lightest` (#f1f0ec)
- `--color-yellow-light` (#f4d364)
- `--color-green-dark` (#9ada6c)
- `--color-blue-light` (#8ebbcc)

These could all be converted to `var()` refs in a follow-up PR. Held back from this one because:
1. Two of the tokens (`--brand-tertiary`, `--brand-dark`) raise design questions worth resolving first — `--brand-tertiary`'s value mismatches the Brik green primitive (`--theme-brik-green: #bcff8c`), and `--brand-dark` semantically names a light blue.
2. The whole `--brand-{accent,tertiary,dark}` block in `theme-brand-brik` re-declares the canonical defaults from `figma-tokens.css:299-302`. Cleaning these up may overlap with deciding whether the theme should override them at all.

Out of scope — no primitive exists:
- `--brand-accent` (`#f4d364`), `--brand-tertiary` (`#9ada6c`), `--brand-dark` (`#8ebbcc`) — primitives EXIST per above; held for design decisions, not blocked on primitives.
- `--background-image` (alpha-mixed darks), `--border-on-color-dark: white` (literal CSS color, not a brand value).

## What this does NOT fix

The AA gaps on `--text-brand-primary` (3.78:1 poppy text on white) and `--page-brand-primary` are NOT addressed here. Switching from raw hex to a `var()` ref to the same primitive doesn't change the resolved color. The AA fix for those tokens is tracked as step 3 of the revised brikdesigns#227 PR sequence — separate concern.

## Verification

- ✅ `validate:full` — all 10 checks PASS (Token Lint, JSDoc, Grid, Theme Compliance, Blueprint, BCS Vocab, Canonical Tokens, Component Axes, TypeScript, Storybook Build)
- ✅ `dist/tokens.css` rebuilt — net +10 `var(--color-poppy-light)` references in built output, all consuming the existing canonical primitive
- ✅ No `dist/` changes that aren't traceable to source

## Manual checks needed

- [ ] Visual diff sanity (none expected — values identical) on portal + renew-pms Storybook surfaces consuming `.theme-brand-brik`
- [ ] Chromatic regression review (if wired) — expected: no pixels change

## Refs

- brikdesigns#227 — token migration umbrella (this PR satisfies the principle of consistent primitive refs in theme-brand-brik for the poppy family)
- brik-bds#710 — sibling PR shipping the AA fix on `--surface-brand-primary` / `--background-brand-primary`. This PR does the same form-cleanup on the rest of the poppy palette. Order-independent — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)