### PR TITLE
bds: release 0.72.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.70.0",
+  "version": "0.72.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.70.0",
+      "version": "0.72.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.71.1",
+  "version": "0.72.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Minor bump — ships the three commits ahead of `v0.71.1`:

- [#709](https://github.com/brikdesigns/brik-bds/pull/709) testimonial: rename
- [#710](https://github.com/brikdesigns/brik-bds/pull/710) `fix(tokens):` AA-clear primary button surface + pair state siblings — fixes WCAG 2.1 AA failure on `theme-brand-brik` primary buttons (white-on-poppy-light, 3.78:1 → 6.23:1) and pairs the previously-missing `--surface-brand-primary-hover/-pressed` + `--background-brand-primary-hover/-pressed` state siblings (parallel bug to #226's secondary-button gap)
- [#711](https://github.com/brikdesigns/brik-bds/pull/711) `refactor(tokens):` form-only — replaces raw `#e35335` with `var(--color-poppy-light)` across the rest of the poppy family (`--page-brand-primary`, `--text-brand-primary`, `--background-image-brand`, `--border-brand-primary`, `--brand-primary`). No value changes.

## Consumer sync plan

- [ ] **brikdesigns** — `npm update @brikdesigns/bds` after publish. Expected outcome: the ~120 baselined white-on-poppy entries in [`tests/a11y/baseline.json`](https://github.com/brikdesigns/brikdesigns/blob/main/tests/a11y/baseline.json) stop firing on the next CI run. Follow-up burn-down PR removes them (issue [brikdesigns#40](https://github.com/brikdesigns/brikdesigns/issues/40)).
- [ ] **portal (brik-client-portal)** — `npm update @brikdesigns/bds`. Visual check: any surface applying `.theme-brand-brik` to a `.bds-button--primary` will go from bright orange (poppy-light) to deeper burgundy-red (poppy-dark). Hover/pressed previously fell back to canonical blue — now correctly poppy.
- [ ] **renew-pms** — same as portal. Visual review on `.bds-button--primary` under `.theme-brand-brik`.

## Backward compat

- No API/prop breakage. All changes are in CSS tokens.
- `--surface-brand-primary` and `--background-brand-primary` change value (poppy-light → poppy-dark in `theme-brand-brik`). This is a **visible** brand change for consumers applying the theme. Documented in #710's PR body. Consumers that previously relied on the broken white-on-poppy-light contrast (none, by design) would be affected, but the change is the AA fix the system was missing.
- `theme-brand-brik` light + dark now declare `--surface-brand-primary-hover/-pressed` + `--background-brand-primary-hover/-pressed`. Previously these fell through to canonical `--theme-blue-blue-*` (blue) when `.theme-brand-brik` was applied — anyone who saw poppy-rest + blue-hover was hitting a bug.
- `--color-poppy-light` primitive ref now used everywhere in `theme-brand-brik` for the poppy family; resolved value unchanged.

## Release steps after merge

1. `git tag -a -s v0.72.0 -m "bds: release 0.72.0"` (annotated, signed)
2. `git push origin v0.72.0`
3. `.github/workflows/release.yml` validates `package.json` version matches the tag, then publishes to GitHub Packages.

## Test plan

- [x] All 10 BDS validation gates pass locally (Token Lint, JSDoc, Grid, Theme Compliance, Blueprint Library, BCS Vocab, Canonical Tokens, Component Axes, TypeScript, Storybook Build)
- [ ] After publish: verify the package is at 0.72.0 on GitHub Packages registry
- [ ] After publish in each consumer: visual check on `.bds-button--primary` under `.theme-brand-brik`
- [ ] After brikdesigns sync: re-run `npm run test:a11y` against staging deploy-preview, confirm baselined white-on-poppy entries no longer fire, ship burn-down PR

## Notes

`package-lock.json` self-reference was drifted at `0.70.0` (the v0.71.0 / v0.71.1 bumps didn't catch the lockfile); aligned to `0.72.0` in the same commit per the prior release-bump pattern ([7ad7be8](https://github.com/brikdesigns/brik-bds/commit/7ad7be8)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)