### PR TITLE
docs(adrs): unify canonical first-story name to `Default` (supersedes legacy `Playground`)

### DIFF
--- a/.claude/standards/storybook-mdx-recipe.md
+++ b/.claude/standards/storybook-mdx-recipe.md
@@ -5,7 +5,7 @@ type: reference
 scope: brik-bds
 applies-to: "**/components/ui/**/*.mdx, **/stories/**/*.mdx, **/content-system/**/*.mdx"
 retrieved-via: brik-rag query "storybook mdx recipe standard"
-last-verified: 2026-05-13
+last-verified: 2026-05-18
 ---
 
 # Storybook MDX recipe (BDS)
@@ -31,9 +31,9 @@ import * as Stories from './{Component}.stories';
 
 One- or two-sentence description. What it does, not when to use it.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
@@ -48,7 +48,9 @@ One- or two-sentence description. What it does, not when to use it.
 <ArgTypes of={Stories} />
 ```
 
-That's the **canonical shape**: Title → Links → Description → Playground → Variants → (Patterns) → Props. Three sections can sit between Props and end-of-file, each fixed in position when present:
+That's the **canonical shape**: Title → Links → Description → Default → Variants → (Patterns) → Props. Three sections can sit between Props and end-of-file, each fixed in position when present:
+
+> **Legacy `## Playground` accepted.** Files migrated before the 2026-05-18 amendment ship `## Playground` + `export const Playground` instead of `## Default` + `export const Default`. The lint accepts either as the first required section. New components MUST use `## Default`. See [ADR-010 §3 amendment](../../docs/adrs/ADR-010-storybook-axes-of-information.md).
 
 - `## Patterns` — **conditionally required**. Include IFF the matching `*.stories.tsx` ships any Q4 (irreducible composition) or Q5 (`play`-only interaction) story per ADR-010. If the component has only Q3 semantic-variant stories, omit the section entirely. When present, it sits between `## Variants` and `## Props` and must contain at least one `<Canvas>`. **Never invent a Q4 story to make this section non-empty** — see [story-shape standard §Don't contrive Q4 stories to satisfy lint](./storybook-story-shape.md).
 - `## CSS Override API` — table of component-scoped CSS variables, with one example. Required if the component exposes any.
@@ -123,14 +125,14 @@ This is the highest-friction collision in the system. ADR-006 bans `Variants` / 
 | `export const Variants` | n/a | **Banned** |
 | `export const Tones` | n/a | **Banned** |
 | `export const Patterns` | n/a | **Banned** |
-| `export const Playground` | Referenced via `<Canvas of={Stories.Playground} />` | **Required** |
+| `export const Default` | Referenced via `<Canvas of={Stories.Default} />` | **Required** (`Playground` accepted as legacy on grandfathered files) |
 | `export const Warning`, `Error`, etc. | Referenced via `<Canvas of={Stories.Warning} />` under `## Variants` | **Required** (one per meaningful state) |
 
 A new component written under both standards looks like this:
 
 ```tsx
 // {Component}.stories.tsx
-export const Playground = ...      // sandbox
+export const Default = ...         // canonical sandbox
 export const Warning = ...         // per-state, named after the state
 export const Error = ...
 export const OnboardingChecklist = ...   // irreducible composition
@@ -138,6 +140,9 @@ export const OnboardingChecklist = ...   // irreducible composition
 
 ```mdx
 {/* {Component}.mdx */}
+## Default
+<Canvas of={Stories.Default} />
+
 ## Variants
 ### Warning
 <Canvas of={Stories.Warning} />
@@ -226,7 +231,7 @@ A page conforms when:
 1. Imports `Meta`, `Canvas`, `ArgTypes` from `@storybook/addon-docs/blocks`, imports `* as Stories`, imports `ComponentLinks`, contains `<Meta of={Stories} />`.
 2. The first heading is one `# {Component name}`. Nothing above it except the imports and `<Meta>`.
 3. Immediately after H1: `<ComponentLinks slug="..." />` then a 1–2 sentence description paragraph.
-4. Required sections appear in this order, no omissions, no deviations from spelling: `## Playground` → `## Variants` → `## Props`. `## Patterns` is conditional — when present it sits between `## Variants` and `## Props` and must contain a `<Canvas>`. `## CSS Override API` and `## Notes` are optional and follow `## Props` in that order.
+4. Required sections appear in this order, no omissions, no deviations from spelling: `## Default` → `## Variants` → `## Props`. The first section may alternatively be `## Playground` on files grandfathered by the [2026-05-18 amendment](../../docs/adrs/ADR-007-storybook-page-recipe.md#amendments) — lint accepts either. `## Patterns` is conditional — when present it sits between `## Variants` and `## Props` and must contain a `<Canvas>`. `## CSS Override API` and `## Notes` are optional and follow `## Props` in that order.
 5. No `---` dividers anywhere in the file.
 6. No `## Usage`, `## When to use`, `## When NOT to use`, `## Source attribution`, `## Tokens`, or other narrative-bearing section.
 7. Every `<Canvas>` references a story exported from the matching `*.stories.tsx`.

--- a/docs/adrs/ADR-001-bds-find.md
+++ b/docs/adrs/ADR-001-bds-find.md
@@ -61,7 +61,7 @@ Single `dist/bds-manifest.json` file, extending the existing artifact `scripts/b
   "composition": ["TextInput", "TextArea", "Select", "Button", "Field"],
   "status": "stable",
   "introducedIn": "0.18.0",
-  "storybookUrl": "https://bds.brikdesigns.com/?path=/story/displays-form-form--playground",
+  "storybookUrl": "https://bds.brikdesigns.com/?path=/story/displays-form-form--default",
   "reuse": { "portal": true, "renew-pms": false, "brikdesigns": true }
 }
 ```
@@ -134,7 +134,7 @@ MATCH (0.92) — Form
   class: bds-form                 status: stable
   use-cases: contact form, feedback form
   composes: TextInput, TextArea, Select, Button
-  storybook: https://bds.brikdesigns.com/?path=/story/displays-form-form--playground
+  storybook: https://bds.brikdesigns.com/?path=/story/displays-form-form--default
   theme-via: colors, spacing, typography
   fixed:     validation-behavior, keyboard-nav
 

--- a/docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md
+++ b/docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md
@@ -1,6 +1,6 @@
 # ADR-006 — Storybook Taxonomy + Story Shape
 
-**Status:** Accepted (2026-04-26); Part A amended 2026-05-16 (6-bucket flat taxonomy — see Amendments)
+**Status:** Accepted (2026-04-26); Part A amended 2026-05-16 (6-bucket flat taxonomy — see Amendments); Part B amended 2026-05-18 (canonical first-story name → `Default`; see Amendments)
 **Date:** 2026-04-26
 **Supersedes:** —
 **Superseded by:** —
@@ -60,9 +60,11 @@ The Storybook sidebar uses **six flat component top-levels** plus the unchanged 
 
 ### Part B — Story shape: what's inside the file
 
+> **Amended 2026-05-18** — canonical first-story name renamed from `Playground` to `Default`. See the 2026-05-18 amendment entry and [ADR-010 §3 amendment](./ADR-010-storybook-axes-of-information.md). Legacy `Playground` exports are grandfathered; migration is forward-only.
+
 The story-shape decision lives here at the high level; the operational rules + the story-vs-control matrix are codified separately:
 
-- **Two story shapes per file** — `Playground` (args-driven sandbox) + one story per meaningful state, named directly (`Warning`, not `Variants > Warning`).
+- **Two story shapes per file** — `Default` (args-driven sandbox; canonical first story) + one story per meaningful state, named directly (`Warning`, not `Variants > Warning`).
 - **No `Variants` / `Tones` / `Patterns` gallery buckets** inside a component file. They duplicate the sidebar, break Controls, and merge axes that should split.
 - **Narrow exception:** single-axis comparison galleries (`Sizes`, `Densities`, `Placements`) earn one dedicated story when side-by-side comparison is the entire point AND the autodocs page can't make the same comparison clear AND it's one axis, not a mix.
 - **`render` is for irreducible cases only** — multi-component composition or hook-driven state machines args can't express. Not for documentation galleries.
@@ -92,7 +94,7 @@ Decision: ADR-007 wins on file content because it's already merged and lint-enfo
 
 - Title goes under `<Bucket>/<component>` using the flat bucket table in Part A (e.g. `Components/button`, `Containers/card`, `Blocks/field`).
 - No subcategory layer (`Components/Action/button` is the old style — superseded).
-- File contains `Playground` (args + controls) plus one args-driven story per meaningful state.
+- File contains `Default` (args + controls; canonical first story) plus one args-driven story per meaningful state.
 - No `Variants` / `Tones` / `Patterns` gallery buckets.
 - Deprecated components move to `Deprecated/<component>` with `tags: ['!manifest']`.
 - Axis-only galleries (`Sizes`, `Placements`) only when the narrow exception applies.
@@ -130,7 +132,7 @@ Pre-existing `*.stories.tsx` files keep whatever shape ADR-007's page-recipe pas
 
 - Chromatic catches per-state regressions instead of masking them in stacks
 - MCP discovery returns the actual states agents need to recommend in portal/renew-pms
-- Controls work on every story, not just `Playground`
+- Controls work on every story, not just the canonical `Default`
 - Each state has a permalink and an a11y check
 - Sidebar collapses from 3-5 inconsistent top-levels to 4 disciplined ones
 - Story files get shorter (`<Stack>` / `<SectionLabel>` helpers and `render` blocks drop out)
@@ -167,6 +169,14 @@ The Components table in Part A is amended:
 - **`completion-toggle`** added to `Form` (was missing from the original table). Stays in `Form` as the atomic primitive paired with `checklist` as the labeled-row composition, mirroring the `Checkbox` / `Radio` pattern of atomic primitives staying in `Form`.
 
 These are table top-ups, not structural changes — no new subcategories, just member reassignment. Lands alongside the Storybook title moves in a follow-on PR.
+
+### 2026-05-18 — Part B: canonical first-story name → `Default`
+
+The canonical first story per file is renamed from `Playground` to `Default`. Operational rule and migration posture live in [ADR-010 §3 amendment](./ADR-010-storybook-axes-of-information.md). Part B's prose now reads `Default (args-driven sandbox)`; legacy `Playground` exports are grandfathered until each file is touched anyway.
+
+**Decision driver:** The Button + TextInput gold-standard refactors ([PR #614](https://github.com/brikdesigns/brik-bds/pull/614), [PR #620](https://github.com/brikdesigns/brik-bds/pull/620), and the rest of the [#618](https://github.com/brikdesigns/brik-bds/issues/618) Batch A series) all landed `export const Default` while the ADRs and the recipe lint still named `Playground` as canonical. The name `Default` matches Carbon's named-reference shape and removes the friction between section heading (`## Playground`) and the actual story it embedded (`Stories.Default`) observed on the first 31 refactored files.
+
+The recipe lint accepts either name as the first required section during the transition. PR review enforces `Default` for net-new components.
 
 ### 2026-05-16 — Part A: 6-bucket flat taxonomy (#629)
 

--- a/docs/adrs/ADR-007-storybook-page-recipe.md
+++ b/docs/adrs/ADR-007-storybook-page-recipe.md
@@ -1,6 +1,6 @@
 # ADR-007 — Storybook component page recipe
 
-**Status:** Accepted (2026-05-04)
+**Status:** Accepted (2026-05-04); Amended 2026-05-18 (canonical first section renamed `## Playground` → `## Default`; see Amendments)
 **Date:** 2026-05-04
 **Supersedes:** —
 **Superseded by:** —
@@ -68,7 +68,9 @@ Carbon explicitly does **not** duplicate usage-guideline or accessibility conten
 
 Define a normative **component page recipe** and codify it as ADR-007. New component pages MUST conform; existing pages migrated in batches per the Implementation Plan below.
 
-The **operational recipe** — required imports, the canonical shape (`Title → ComponentLinks → Description → Playground → Variants → (Patterns) → Props`, with `## Patterns` conditionally required only when the component has Q4/Q5 stories per ADR-010), optional sections (`## CSS Override API`, `## Notes`), banned section list, callout vocabulary, foundation/dashboard page templates, stub pattern — lives in [`.claude/standards/storybook-mdx-recipe.md`](../../.claude/standards/storybook-mdx-recipe.md) and is auto-retrieved by the [`storybook-mdx-recipe`](../../.claude/skills/storybook-mdx-recipe/SKILL.md) skill at `*.mdx` edit time. The lint script [`scripts/lint-storybook-recipe.js`](../../scripts/lint-storybook-recipe.js) is the enforcement layer.
+The **operational recipe** — required imports, the canonical shape (`Title → ComponentLinks → Description → Default → Variants → (Patterns) → Props`, with `## Patterns` conditionally required only when the component has Q4/Q5 stories per ADR-010), optional sections (`## CSS Override API`, `## Notes`), banned section list, callout vocabulary, foundation/dashboard page templates, stub pattern — lives in [`.claude/standards/storybook-mdx-recipe.md`](../../.claude/standards/storybook-mdx-recipe.md) and is auto-retrieved by the [`storybook-mdx-recipe`](../../.claude/skills/storybook-mdx-recipe/SKILL.md) skill at `*.mdx` edit time. The lint script [`scripts/lint-storybook-recipe.js`](../../scripts/lint-storybook-recipe.js) is the enforcement layer.
+
+> **2026-05-18 amendment** — the canonical first section is now `## Default` (story export: `Default`). `## Playground` is grandfathered on existing files; the lint accepts either. See the Amendments section below and [ADR-010 §3 amendment](./ADR-010-storybook-axes-of-information.md).
 
 This ADR governs the **decisions** that produced the recipe; the standard governs the operational details.
 
@@ -80,7 +82,7 @@ The recipe is not Carbon's verbatim — it adopts the load-bearing parts (triple
 |---|---|---|
 | Triple-link header (`Source \| Usage \| Accessibility`) | `<ComponentLinks slug="..." />` block rendering the same three links, generated from one prop | One-line authoring; one place to change the URL pattern when docs-site routing changes |
 | `## Table of Contents` (doctoc-managed) | Storybook 10's auto-TOC (already enabled in `.storybook/preview.tsx`) | TOC is page chrome, not content. doctoc adds a commit-time dependency we don't need |
-| `## Overview` (prose + first Canvas) | Description (free text after `<ComponentLinks>`) → `## Playground` | "Playground" is the term Brik already uses; "Overview" duplicates the page title |
+| `## Overview` (prose + first Canvas) | Description (free text after `<ComponentLinks>`) → `## Default` | Matches Carbon's `--default` story slug and the canonical first-story name unified in [ADR-010 §3 amendment](./ADR-010-storybook-axes-of-information.md). Initially named `## Playground` (2026-05-04 acceptance); renamed in the 2026-05-18 amendment after the gold-standard refactors shipped `export const Default`. |
 | Variant H3s with optional prose, no second-level grouping | Two H2s — `## Variants` (visual/state variants) + `## Patterns` (real-world compositions) | Brik's existing implicit shape, kept. Carbon flattens to one tier; Brik's two-tier helps a reader skim "show me all states" vs "show me how this is actually used" |
 | `## Component API` | `## Props` | Shorter, matches what authors already write |
 | Per-prop H3 expansion under Component API (inconsistent in Carbon) | Not in the recipe. If specific props need narrative, write the narrative on docs-site, link from `## Notes` | Avoids the prop-page becoming a second usage doc |
@@ -203,14 +205,14 @@ The collision risk reads from the section names. ADR-006 explicitly bans these a
 | `export const Variants` | n/a | **Banned** |
 | `export const Tones` | n/a | **Banned** |
 | `export const Patterns` | n/a | **Banned** |
-| `export const Playground` | Referenced via `<Canvas of={Stories.Playground} />` | **Required** |
+| `export const Default` | Referenced via `<Canvas of={Stories.Default} />` | **Required** (`Playground` accepted as legacy on grandfathered files) |
 | `export const Warning`, `Error`, etc. | Referenced via `<Canvas of={Stories.Warning} />` under `## Variants` H3 sub-section | **Required** (one per meaningful state) |
 
 A new component written under both ADRs looks like this:
 
 ```tsx
 // {Component}.stories.tsx — ADR-006-conformant
-export const Playground = ...        // args-driven sandbox
+export const Default = ...           // canonical args-driven sandbox
 export const Warning = ...           // per-state, named after the state
 export const Error = ...
 export const Success = ...
@@ -219,6 +221,9 @@ export const OnboardingChecklist = ...   // composition (irreducible — args ca
 
 ```mdx
 {/* {Component}.mdx — ADR-007-conformant */}
+## Default
+<Canvas of={Stories.Default} />
+
 ## Variants
 ### Warning
 <Canvas of={Stories.Warning} />
@@ -254,7 +259,7 @@ A page **conforms to ADR-007** when:
 1. Top of file imports `Meta`, `Canvas`, `ArgTypes` from `@storybook/addon-docs/blocks`, imports `* as Stories`, imports `ComponentLinks`, contains `<Meta of={Stories} />`.
 2. The first heading is one `# {Component name}`. Nothing above it except the imports and `<Meta>`.
 3. Immediately after H1: `<ComponentLinks slug="..." />` then a 1–2 sentence description paragraph.
-4. Required sections appear in this order, no omissions, no deviations from spelling: `## Playground`, `## Variants`, `## Props`. `## Patterns` is conditionally required — present only when the component has Q4/Q5 stories per ADR-010; when present it sits between `## Variants` and `## Props` and must contain a `<Canvas>`. `## CSS Override API` and `## Notes` are optional and follow `## Props` in that order.
+4. Required sections appear in this order, no omissions, no deviations from spelling: `## Default`, `## Variants`, `## Props`. The first section may alternatively be `## Playground` on files that have not yet migrated per the [2026-05-18 amendment](#amendments) — lint accepts either; PR review enforces `## Default` for net-new components. `## Patterns` is conditionally required — present only when the component has Q4/Q5 stories per ADR-010; when present it sits between `## Variants` and `## Props` and must contain a `<Canvas>`. `## CSS Override API` and `## Notes` are optional and follow `## Props` in that order.
 5. No `---` dividers anywhere in the file.
 6. No `## Usage`, `## When to use`, `## When NOT to use`, `## Source attribution`, `## Tokens`, or other narrative-bearing section. (Stubs MAY appear in the description: "See usage at [design.brikdesigns.com/docs/components/{slug}](...).")
 7. Every `<Canvas>` references a story exported from the file's matching `*.stories.tsx`.
@@ -262,6 +267,23 @@ A page **conforms to ADR-007** when:
 9. The page passes a static lint check: `scripts/lint-storybook-recipe.js` (added in Phase 1) reports zero violations.
 
 A page violates ADR-007 if any of the above fails. Phase 3 closes when 100% of `components/ui/*/*.mdx` files conform.
+
+## Amendments
+
+### 2026-05-18 — Canonical first section renamed `## Playground` → `## Default`
+
+The first required H2 section is renamed from `## Playground` to `## Default`. The matching story export and Canvas reference rename in lockstep (`export const Default`, `<Canvas of={Stories.Default} />`).
+
+**Operational rule and migration posture** live in [ADR-010 §3 amendment](./ADR-010-storybook-axes-of-information.md). Summary:
+
+- **New canon:** `## Default` heading, `export const Default`, `<Canvas of={Stories.Default} />`
+- **Legacy accepted:** `## Playground` + `export const Playground` on files that have not yet been touched
+- **Migration:** forward-only — rename when a file is touched anyway; no retroactive sweep
+- **Lint:** [`scripts/lint-storybook-recipe.js`](../../scripts/lint-storybook-recipe.js) accepts either as the first required section during the transition
+
+**Decision driver:** The Button + TextInput + 29 other gold-standard refactors landed `export const Default` while the recipe still required `## Playground` as the heading. The two stayed compatible (the heading and the canvas-of reference don't have to share a name), but it produced exactly the cross-referencing friction this recipe was meant to remove — a reader sees `## Playground` over a Canvas that links to `Stories.Default` and has to reconcile. Renaming closes that gap.
+
+**Audit table above is not updated.** The "current state" table in [§Audit](#audit--current-state-of-six-representative-brik-component-pages) captures sections as named when the migration began. Those files still ship `## Playground`; the lint accepts them; they migrate to `## Default` opportunistically. Updating the table retroactively would erase the historical record this ADR is meant to preserve.
 
 ---
 

--- a/docs/adrs/ADR-010-storybook-axes-of-information.md
+++ b/docs/adrs/ADR-010-storybook-axes-of-information.md
@@ -1,6 +1,6 @@
 # ADR-010 — Storybook axes of information: story vs. control vs. toolbar
 
-**Status:** Accepted (2026-05-13); Amended (2026-05-14 — Q3 axis clarification + Patterns/Forms relocation; 2026-05-14 §2 — input-component specialization rule, all driven by [#618](https://github.com/brikdesigns/brik-bds/issues/618))
+**Status:** Accepted (2026-05-13); Amended (2026-05-14 — Q3 axis clarification + Patterns/Forms relocation; 2026-05-14 §2 — input-component specialization rule; 2026-05-18 §3 — canonical first-story name unified to `Default`, all driven by [#618](https://github.com/brikdesigns/brik-bds/issues/618))
 **Date:** 2026-05-13
 **Supersedes:** Part of [ADR-006 §Part B](./ADR-006-storybook-taxonomy-and-story-shape.md) — operational decision about *which axis becomes a story* now lives here. ADR-006 retains the two-shape model.
 **Superseded by:** —
@@ -67,7 +67,7 @@ type PricingCardArgs = {
   cta: Args<typeof Button>;
 };
 
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     header: { plan: 'Pro', price: '$49' },
     features: { items: ['Unlimited', 'Priority support'] },
@@ -84,15 +84,15 @@ The Button story file is the named test case. **Before the audit: 22 exports.**
 
 | Today | ADR-010 disposition | Why |
 |---|---|---|
-| `Playground` | Keep | Canonical sandbox |
-| `Primary` `Secondary` `Outline` `Ghost` `Inverse` `OnColor` `Danger` `DangerOutline` `DangerGhost` `Destructive` `Positive` `Selected` | Keep (12) | Q3 — each is a semantic starting point an agent reaches for |
-| `Disabled` `Loading` | Collapse | Q2 — boolean state, becomes Control on every variant |
+| `Playground` | Rename → `Default` | Canonical sandbox; name unified to `Default` per §3 amendment below |
+| `Primary` `Secondary` `Outline` `Ghost` `Inverse` `OnColor` `Danger` `DangerOutline` `DangerGhost` `Destructive` `Positive` `Selected` | Collapse to `variant` Control | Per [PR #614](https://github.com/brikdesigns/brik-bds/pull/614) Button refactor — variants are pure hierarchy/color (no semantic role / icon / context differences), so the Q-tree collapses to Q2 Controls on `Default`. The disposition row above is what ADR-010 originally proposed before the Button refactor narrowed it further. |
+| `Disabled` `Loading` | Collapse | Q2 — boolean state, becomes Control |
 | `WithIconBefore` `WithIconAfter` | Collapse | Q2 — icon-slot prop, becomes Control |
 | `FullWidth` | Collapse | Q2 — boolean, becomes Control |
 | `Sizes` | Keep | ADR-006 axis-only-gallery exception (one axis, side-by-side comparison) |
 | `Tiny` `Small` `Medium` `Large` `ExtraLarge` | Collapse into `Sizes` | Q2 — covered by the axis gallery |
 
-**After: ~13 exports** (Playground + 12 semantic variants + 1 `Sizes` axis gallery). Same coverage, ~40% fewer exports, every state navigable via Controls on every story.
+**After: ~3 exports** (`Default` + `IconOnly` discriminated-union showcase + `Sizes` axis gallery). The 12 per-variant rows above were the initial proposal; the realized refactor collapsed further once it became clear Button variants don't carry semantic-role differences. Same coverage, ~85% fewer exports, every state navigable via Controls on `Default`.
 
 ### Applied — components without a variant axis
 
@@ -156,6 +156,39 @@ If the only differences from `TextInput` are **defaults** (icon convention, `typ
 Rationale: 5 specialized inputs that all wrap TextInput introduce drift risk (focus ring, error styling, sizing tokens diverging across siblings), maintenance overhead (every TextInput improvement propagated to N wrappers), and MCP discovery noise (agents disambiguating between TextInput and EmailInput when the only difference is a default). The bar for promotion has to be real behavior, not naming.
 
 The decision rule applies symmetrically to other primitive families — `Button` doesn't get `SaveButton` / `DeleteButton` wrappers because those are usage patterns of `variant` + `children`. The same logic applies here.
+
+### Canonical first-story name — `Default`
+
+> **Amendment 2026-05-18 §3** — unifies the canonical first-story name across
+> all components, regardless of whether a variant axis applies. Supersedes
+> earlier language in this ADR (and in ADR-006 §Part B / ADR-007's recipe)
+> that named `Playground` as the canonical sandbox.
+
+Every component story file exports exactly one canonical sandbox story named **`Default`**. Carbon's [Checkbox page](https://react.carbondesignsystem.com/?path=/story/components-checkbox--default) and [Button page](https://react.carbondesignsystem.com/?path=/story/components-button--default) both use this name; matching the named reference removes the "is this Carbon-aligned?" friction.
+
+```tsx
+/** @summary Interactive Button — text, icon, or link via Controls */
+export const Default: Story = {
+  args: { variant: 'primary', size: 'md', children: 'Button' },
+};
+```
+
+The story serves both roles the legacy `Playground` name implied:
+
+1. **Default render** — what the component looks like with sensible defaults, the artifact agents return from `get-documentation`.
+2. **Sandbox** — every prop is a Control, so a viewer exercises the component without leaving the story.
+
+The two roles always collapsed into the same story. Naming it `Default` makes that the obvious thing; `Playground` framed it as a side-feature and produced authoring drift (per-state stories added to compensate for the perceived sandbox-only purpose of `Playground`).
+
+| Surface | New canonical | Legacy (grandfathered) |
+|---|---|---|
+| Story export | `export const Default` | `export const Playground` accepted on untouched files |
+| MDX heading | `## Default` | `## Playground` accepted on untouched files |
+| Canvas reference | `<Canvas of={Stories.Default} />` | `<Canvas of={Stories.Playground} />` accepted |
+
+**Migration is forward-only**, matching ADR-006 §Migration. When any reason brings you into a file, rename the canonical story to `Default` and update the matching MDX section + Canvas reference in the same PR. Don't open retroactive sweep PRs whose only diff is the rename — they add review surface without changing behavior.
+
+[`scripts/lint-storybook-recipe.js`](../../scripts/lint-storybook-recipe.js) accepts either `## Default` or `## Playground` as the first required section during the transition. PR review enforces `Default` for net-new components.
 
 ### The five toolbar globals
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -28,8 +28,9 @@ The "how do component pages look and behave" cluster.
 
 | ADR | Status | Decision |
 |---|---|---|
-| [ADR-006](./ADR-006-storybook-taxonomy-and-story-shape.md) | **Accepted** (2026-04-26, amended 2026-05-05) | Four content top-levels (Foundations / Components / Patterns / Theming), one alphabetical subcategory layer under Components, two-shape story files (Playground + one-story-per-state) |
-| [ADR-007](./ADR-007-storybook-page-recipe.md) | **Accepted** (2026-05-04) | Normative MDX page recipe — Carbon-style triple-link header (ComponentLinks), six required sections in a fixed order, lint-enforced via `scripts/lint-storybook-recipe.js` |
+| [ADR-006](./ADR-006-storybook-taxonomy-and-story-shape.md) | **Accepted** (2026-04-26; Part A amended 2026-05-16 → 6-bucket flat taxonomy; Part B amended 2026-05-18 → canonical first story renamed `Default`) | Six flat component top-levels (Components / Containers / Blocks / Layouts / Sections / Tools), no subcategory layer, two-shape story files (`Default` + one-story-per-state) |
+| [ADR-007](./ADR-007-storybook-page-recipe.md) | **Accepted** (2026-05-04, amended 2026-05-18 → first section renamed `## Default`) | Normative MDX page recipe — Carbon-style triple-link header (ComponentLinks), required sections in fixed order (`## Default` → `## Variants` → `## Props`), lint-enforced via `scripts/lint-storybook-recipe.js` |
+| [ADR-010](./ADR-010-storybook-axes-of-information.md) | **Accepted** (2026-05-13, amended 2026-05-14 + 2026-05-18) | Story-vs-control matrix — Q1 toolbar global / Q2 argTypes-only / Q3 dedicated story (Orientation \| Layout \| Semantic-variant) / Q4 irreducible render / Q5 play-only. Canonical first story is `Default` regardless of variant axis. |
 
 These compose: ADR-006 governs *story files* (where stories live, what shape); ADR-007 governs *MDX pages* (how the page is structured around those stories). When they conflicted (ADR-006 forbids `Variants` story exports, ADR-007's original recipe required them), ADR-007's amendment landed first to reconcile.
 

--- a/scripts/lint-storybook-recipe.js
+++ b/scripts/lint-storybook-recipe.js
@@ -31,12 +31,19 @@ const path = require('path');
 // Recipe (mirror of ADR-007, Acceptance Criteria 1-9)
 // ---------------------------------------------------------------------------
 
-const REQUIRED_SECTIONS = ['## Playground', '## Variants', '## Props'];
-
-// H2 sections that MUST contain at least one `<Canvas of=...>` somewhere in
-// their body (including H3 sub-sections). Props uses `<ArgTypes>` not
-// `<Canvas>` and is excluded.
-const SECTIONS_REQUIRING_CANVAS = ['## Playground', '## Variants'];
+// Required H2 sections in order. The first slot accepts either `## Default`
+// (canonical, 2026-05-18 amendment to ADR-007) OR `## Playground` (legacy,
+// grandfathered on files predating the amendment). See:
+//   - docs/adrs/ADR-007-storybook-page-recipe.md#amendments
+//   - docs/adrs/ADR-010-storybook-axes-of-information.md (§3 amendment)
+// All sections marked requiresCanvas:true must contain at least one `<Canvas>`
+// in their body (including H3 sub-sections). `## Props` uses `<ArgTypes>` not
+// `<Canvas>`; excluded from the canvas check.
+const REQUIRED_SECTION_SPECS = [
+  { names: ['## Default', '## Playground'], canonical: '## Default', requiresCanvas: true },
+  { names: ['## Variants'], canonical: '## Variants', requiresCanvas: true },
+  { names: ['## Props'], canonical: '## Props', requiresCanvas: false },
+];
 
 // `## Patterns` is conditionally required — present only when the component
 // has Q4 (irreducible composition) or Q5 (play-only) stories per ADR-010.
@@ -151,23 +158,37 @@ function lintFile(filePath) {
   const h2s = headings.filter((h) => h.level === 2);
   const h2Texts = h2s.map((h) => h.text);
 
-  for (const required of REQUIRED_SECTIONS) {
-    if (!h2Texts.includes(required)) {
+  // For each required spec, find which (if any) of its accepted names is present.
+  // matchedSections is parallel to REQUIRED_SECTION_SPECS — entries are either
+  // {spec, h2Index, h2Text} or null when no accepted name is present.
+  const matchedSections = REQUIRED_SECTION_SPECS.map((spec) => {
+    for (const name of spec.names) {
+      const idx = h2Texts.indexOf(name);
+      if (idx !== -1) return { spec, h2Index: idx, h2Text: name };
+    }
+    return null;
+  });
+
+  REQUIRED_SECTION_SPECS.forEach((spec, i) => {
+    if (matchedSections[i] === null) {
+      const label = spec.names.length === 1
+        ? `\`${spec.canonical}\``
+        : `\`${spec.canonical}\` (or legacy \`${spec.names.filter((n) => n !== spec.canonical).join('`, `')}\`)`;
       violations.push({
         rule: 'missing-required-section',
-        message: `Missing required section: \`${required}\``,
+        message: `Missing required section: ${label}`,
       });
     }
-  }
+  });
 
   // Required sections are in order (when all present)
-  const requiredPresent = REQUIRED_SECTIONS.filter((s) => h2Texts.includes(s));
-  const requiredIndices = requiredPresent.map((s) => h2Texts.indexOf(s));
-  const isOrdered = requiredIndices.every((idx, i) => i === 0 || idx > requiredIndices[i - 1]);
+  const presentIndices = matchedSections.filter((m) => m !== null).map((m) => m.h2Index);
+  const isOrdered = presentIndices.every((idx, i) => i === 0 || idx > presentIndices[i - 1]);
   if (!isOrdered) {
+    const expected = REQUIRED_SECTION_SPECS.map((s) => s.canonical).join(' → ');
     violations.push({
       rule: 'required-section-order',
-      message: `Required sections are out of order. Expected: ${REQUIRED_SECTIONS.join(' → ')}`,
+      message: `Required sections are out of order. Expected: ${expected}`,
     });
   }
 
@@ -246,14 +267,23 @@ function lintFile(filePath) {
     return lines.slice(startIdx, endIdxExclusive).join('\n');
   }
 
-  for (const required of [...SECTIONS_REQUIRING_CANVAS, ...CONDITIONAL_SECTIONS_WITH_CANVAS]) {
-    const h2 = h2s.find((h) => h.text === required);
+  // Canvas requirement: walk required specs (using whichever alias matched)
+  // plus the conditional Patterns section.
+  const canvasTargets = [
+    ...matchedSections
+      .filter((m) => m !== null && m.spec.requiresCanvas)
+      .map((m) => ({ text: m.h2Text, isRequired: true })),
+    ...CONDITIONAL_SECTIONS_WITH_CANVAS.map((name) => ({ text: name, isRequired: false })),
+  ];
+
+  for (const target of canvasTargets) {
+    const h2 = h2s.find((h) => h.text === target.text);
     if (!h2) continue; // required: already flagged by missing-required-section; conditional: absent is OK
     const body = bodyOfH2(h2.line);
     if (!/<Canvas\b/.test(body)) {
       violations.push({
         rule: 'missing-canvas',
-        message: `\`${required}\` has no \`<Canvas>\` block. ${SECTIONS_REQUIRING_CANVAS.includes(required) ? 'Required sections' : 'Sections present in the file'} must demo at least one story.`,
+        message: `\`${target.text}\` has no \`<Canvas>\` block. ${target.isRequired ? 'Required sections' : 'Sections present in the file'} must demo at least one story.`,
         line: h2.line,
       });
     }


### PR DESCRIPTION
## Why

Four-way drift between ADRs/standards/lint and the gold-standard refactors that landed under #618 Batch A. 31 of 88 story files already ship `export const Default`, but the ADRs, recipe lint, and operational standard still named `Playground` as the canonical sandbox — producing the friction where `Button.mdx`'s `## Playground` heading framed a `<Canvas of={Stories.Default}>`.

This PR is **documentation + lint only**. No `*.stories.tsx` / `*.mdx` files in `components/ui/` are touched — those migrate forward-only when the file is opened anyway.

## What changes

| Surface | Before | After |
|---|---|---|
| Canonical story export | `export const Playground` | `export const Default` (`Playground` accepted as legacy) |
| Canonical MDX heading | `## Playground` | `## Default` (`## Playground` accepted as legacy) |
| Canvas reference | `<Canvas of={Stories.Playground} />` | `<Canvas of={Stories.Default} />` (either accepted) |
| Lint enforcement | `scripts/lint-storybook-recipe.js` required literal `## Playground` | `REQUIRED_SECTION_SPECS` first slot accepts either name |

### Files

- **ADR-010 §3 amendment** — generalizes the `Default` rule to all components regardless of variant axis; updates the Button before/after disposition table to reflect [PR #614](https://github.com/brikdesigns/brik-bds/pull/614)'s realized shape (3 exports, not 13); composite-components code example renamed.
- **ADR-006 Part B amendment** — prose updated, legacy preserved.
- **ADR-007 amendment** — required first section renamed, recipe + reconciliation table + acceptance criteria updated. Audit/migration tables kept intact as historical record.
- **`.claude/standards/storybook-mdx-recipe.md`** — recipe template, code example, acceptance criteria, `last-verified` bump. Re-ingested to brik-rag via `scripts/ingest-storybook-mdx-recipe-standard.sh`.
- **`scripts/lint-storybook-recipe.js`** — `REQUIRED_SECTION_SPECS` with one-of name lists; canvas-requirement loop walks matched alias.
- **ADR-001** — two example storybook URL slugs updated (`--playground` → `--default`).
- **`docs/adrs/README.md`** — status rows refreshed for ADR-006/007/010.

## Verification

- `node scripts/lint-storybook-recipe.js --enforce` → 81/81 component MDX pages conform (no false fails)
- Positive test (temp fixture with `## Default` heading + `export const Default` story) → conforms
- `npm run typecheck` → passes (no TS touched)
- `pr-task.sh` validation suite — all 10 checks pass (token lint, theme compliance, storybook build, etc.)

## Out of scope (forward-only migration)

The 81 legacy MDX files keep `## Playground` until they're touched anyway. The 57 stories files keep `export const Playground` until touched. PR review enforces `Default` for net-new components.

## Test plan
- [x] `npm run lint-storybook-recipe` clean against current corpus
- [x] Lint accepts a hypothetical new file with `## Default` heading
- [x] Lint still rejects banned sections (`## Usage`, `## When to use`, etc.) — no logic change to those rules
- [x] Storybook build passes
- [ ] Reviewer spot-check: a future component PR with `## Default` heading + `Stories.Default` Canvas passes lint without code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)