### PR TITLE
fix(tokens): AA-clear --text-brand-primary in theme-brand-brik light

### DIFF
--- a/tokens/theme-brand-brik.css
+++ b/tokens/theme-brand-brik.css
@@ -28,7 +28,10 @@
   --text-secondary: var(--color-grayscale-dark);
   --text-muted: var(--color-grayscale-light);
   --text-inverse: var(--color-grayscale-white);
-  --text-brand-primary: var(--color-poppy-light);
+  /* AA fix: poppy-light text on white page = 3.80:1, fails AA Normal.
+     Shift to poppy-dark (8.5:1 on white). Dark-mode value stays poppy-light
+     below (5.52:1 on black) — poppy-dark on black = 3.48:1 would regress. */
+  --text-brand-primary: var(--color-poppy-dark);
   /* Surface */
   --surface-primary: var(--color-grayscale-white);
   --surface-secondary: var(--color-grayscale-lightest);


### PR DESCRIPTION
## Summary

Light-mode `--text-brand-primary` in `theme-brand-brik` was `var(--color-poppy-light)` (`#e35335`): poppy-text on white page bg = **3.80:1**, fails WCAG 2.1 AA Normal at body sizes. Shifted to `var(--color-poppy-dark)` (`#b0351b`): **8.5:1** on white — passes AA cleanly.

Dark-mode value unchanged. Math: poppy-light on near-black = 5.52:1 (passes AA Normal); poppy-dark on black would drop to ~3.48:1 (regression). Documented in inline comment.

Closes brikdesigns#227 step 3 — the final remaining Category A AA-fix item.

## Diff (theme-brand-brik.css, +4 / -1)

```diff
   --text-inverse: var(--color-grayscale-white);
-  --text-brand-primary: var(--color-poppy-light);
+  /* AA fix: poppy-light text on white page = 3.80:1, fails AA Normal.
+     Shift to poppy-dark (8.5:1 on white). Dark-mode value stays poppy-light
+     below (5.52:1 on black) — poppy-dark on black = 3.48:1 would regress. */
+  --text-brand-primary: var(--color-poppy-dark);
```

## Immediate user-visible impact: zero

No current consumer applies `.theme-brand-brik` to body in production:
- **brikdesigns** — `applyToBody={false}`, re-declares brand block locally in `globals.css` (already poppy-dark light + poppy-light dark per b88855c)
- **portal** — `applyToBody={false}`, has its own `theme-brik.css` / `theme-brik-portal.css`
- **renew-pms** — uses `.theme-renew` (different theme entirely)

This is a **correctness fix for future adopters** — specifically when brikdesigns migrates to consume `theme-brand-brik` directly (brikdesigns#227 step 5). It also keeps `theme-brand-brik` internally consistent with brik-bds#710's `--surface-brand-primary` AA fix.

## Out of scope

- `--page-brand-primary` — zero references across BDS components/stories + brikdesigns / portal / renew-pms. The earlier #227 inventory speculated about body-text contrast on this full-bleed surface, but with no actual consumers the AA risk is theoretical. Hold for if/when it gets adopted.
- `--brand-primary` (intermediate) — left at `var(--color-poppy-light)` per #711's form refactor. Re-evaluate as part of brik-bds#712 (brand-* token audit umbrella).

## Verification

- ✅ `validate:full` — all 10 checks PASS (Token Lint, JSDoc, Grid, Theme Compliance, Blueprint, BCS Vocab, Canonical Tokens, Component Axes, TypeScript, Storybook Build)
- ✅ `dist/tokens.css` rebuilt — confirmed `--text-brand-primary` resolves to `var(--color-poppy-dark)` in `theme-brand-brik` light block only
- ✅ `pr-checklist.sh` automated checks pass

## Manual checks needed before merge

- [ ] Storybook spot-check: any story referencing `--text-brand-primary` under `theme-brand-brik` light (e.g., `ContrastCompliance.stories.tsx`, `ThemeSwitcher.stories.tsx`, `CardSummary.css`) — confirm color shifted from bright orange to deeper burgundy-red
- [ ] No regression on dark-mode storybook surfaces (dark value unchanged, but worth a visual confirmation)

## Release plan

This change does NOT need an immediate release. Recommend batching with the next BDS PR or two (e.g., when #712 lands a `--brand-tertiary` fix, when a new component lands) and releasing as v0.73.0. The current consumer overrides mean no urgency.

## Refs

- brikdesigns#227 step 3 — closes the AA-fix sequence for `theme-brand-brik`
- brik-bds#710 — sibling surface-token AA fix (the pattern this mirrors)
- brikdesigns#219 / commit b88855c — brikdesigns-local mirror of this exact change
- brik-bds#712 — brand-* token audit (separate concern: redundant overrides, `--brand-tertiary` value mismatch, `--brand-dark` naming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)