### PR TITLE
fix(tooling): bds-manifest storybook_url emits real story IDs (closes #722)

### DIFF
--- a/scripts/build-inspector-manifest.mjs
+++ b/scripts/build-inspector-manifest.mjs
@@ -48,12 +48,81 @@ function toClassPrefix(pascalName) {
 }
 
 /**
- * Storybook story-id convention: "components-{kebab}--primary" (we assume a
- * Primary story exists; if not, the URL still opens Storybook's search).
+ * Build a Storybook story ID from the component's `*.stories.tsx`:
+ *
+ *   1. Parse `meta.title` → "Containers/card" or "Components/button"
+ *   2. Slugify (lowercase, spaces → hyphens) → "containers-card"
+ *   3. Pick the story slug:
+ *      a. If a `<PascalName>.mdx` page exists → use `--overview`
+ *         (Storybook 10 autodocs slug per `.storybook/main.ts`
+ *         `docs.defaultName: 'Overview'` — opens the MDX docs view).
+ *      b. Else fall back to the first canonical story export — prefer
+ *         `Default` (ADR-010 §3 amendment), then legacy `Playground`,
+ *         then the first `export const X` declared in the file.
+ *
+ * The MDX docs view is preferred (rich landing page embedding all stories
+ * + prose docs), but components without an MDX page need a real story
+ * slug instead — `--overview` only resolves when autodocs generated it.
+ *
+ * `brik-inspect.js` validates each emitted URL against the live Storybook
+ * `/index.json` before rendering the link (see loadStorybookIndex), so a
+ * miss degrades gracefully — but the manifest should still be right.
+ *
+ * Fallback when the stories file can't be parsed: a kebab pascalName with
+ * a `components-` prefix + `--overview` slug. Surface in the build log.
  */
-function storybookStoryId(pascalName) {
-  const kebab = pascalName.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
-  return `components-${kebab}--primary`;
+function storybookStoryId(pascalName, componentDir) {
+  const fallback = (() => {
+    const kebab = pascalName.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+    return `components-${kebab}--overview`;
+  })();
+
+  const storiesPath = join(componentDir, `${pascalName}.stories.tsx`);
+  if (!existsSync(storiesPath)) return fallback;
+  const src = readFileSync(storiesPath, 'utf8');
+
+  // meta.title — match `title: '<bucket>/<slug>'` at the top of the file.
+  // Restricting to a path-shaped value (contains a `/`) avoids picking up
+  // object-literal `title:` keys inside `args` data.
+  const titleMatch = src.match(/^\s*title:\s*['"]([A-Z][^'"\n]*\/[^'"\n]+)['"]/m);
+  if (!titleMatch) return fallback;
+
+  const metaTitle = titleMatch[1];
+  const lastSlash = metaTitle.lastIndexOf('/');
+  const bucketPath = metaTitle.slice(0, lastSlash);
+  const componentSlug = metaTitle.slice(lastSlash + 1);
+
+  // Storybook slugifies: camelCase → kebab, lowercase, spaces and slashes →
+  // hyphens, drop other punctuation. The camelCase split is what turns
+  // `WithSlots` → `with-slots` (matches Storybook's story-id derivation).
+  const slugify = (s) =>
+    s
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      .toLowerCase()
+      .replace(/[\s/]+/g, '-')
+      .replace(/[^a-z0-9-]/g, '')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+
+  const idPrefix = `${slugify(bucketPath)}-${slugify(componentSlug)}`;
+
+  // Prefer the autodocs `--overview` slug when an MDX page exists. Storybook
+  // generates the autodocs entry from the MDX presence, so absent-MDX means
+  // absent-overview.
+  const mdxPath = join(componentDir, `${pascalName}.mdx`);
+  if (existsSync(mdxPath)) return `${idPrefix}--overview`;
+
+  // Else find the first canonical story export. Prefer Default (canonical
+  // per ADR-010 §3) → Playground (legacy) → first export in source order.
+  if (/^export const Default\b/m.test(src)) return `${idPrefix}--default`;
+  if (/^export const Playground\b/m.test(src)) return `${idPrefix}--playground`;
+
+  const firstExportMatch = src.match(/^export const ([A-Z][A-Za-z0-9_]*)\b/m);
+  if (firstExportMatch) {
+    return `${idPrefix}--${slugify(firstExportMatch[1])}`;
+  }
+
+  return `${idPrefix}--overview`;
 }
 
 /**
@@ -179,7 +248,7 @@ function buildComponents() {
     components[prefix] = {
       name: pascalName,
       class_prefix: prefix,
-      storybook_url: `/?path=/story/${storybookStoryId(pascalName)}`,
+      storybook_url: `/?path=/story/${storybookStoryId(pascalName, dir)}`,
       status: override.status ?? 'stable',
       introduced_in: override.introduced_in ?? null,
       deprecated_in: override.deprecated_in ?? null,


### PR DESCRIPTION
## Why

[`scripts/build-inspector-manifest.mjs`](scripts/build-inspector-manifest.mjs) was hardcoding `components-\${kebab}--primary` for every component. **None of those URLs resolved post-flatten** ([#629](https://github.com/brikdesigns/brik-bds/issues/629)) and post-rename — buckets moved to Containers/Layouts/Blocks/Sections/Tools/Deprecated, and `--primary` predates the gold-standard refactor (canonical first story is now `Default` per [ADR-010 §3 amendment](docs/adrs/ADR-010-storybook-axes-of-information.md)).

Hidden today by [`brik-inspect.js`](https://github.com/brikdesigns/brik-client-portal/blob/main/public/brik-inspect.js)'s client-side validation against `/index.json` — but the manifest was wrong, brittleness compounded with every rename, and the fix was overdue.

## Fix

`storybookStoryId(pascalName, componentDir)` now:

1. **Reads `meta.title`** from `{PascalName}.stories.tsx` → derives the real bucket slug
2. **Prefers `--overview`** (Storybook autodocs MDX page per `docs.defaultName: 'Overview'`) when a `{PascalName}.mdx` exists
3. **Falls back** to `--default` → `--playground` → first `export const X` for components without MDX
4. **Slugifies** with proper camelCase → kebab conversion (`WithSlots` → `with-slots`)

## Verification

Cross-checked every emitted URL against the live Chromatic [`/index.json`](https://main--69b8918cac3056b39424d5d3.chromatic.com/index.json) (528 stories):

| State | Result |
|---|---|
| Before | **0 / 97 resolve** |
| After | **94 / 97 resolve (97%)** |

Remaining 3 (`AlertBanner`, `AnimatedIcon`, `ServiceBadge`) are storyless dirs — graceful degradation.

## Bucket distribution after fix

51 components / 23 containers / 8 sections / 7 blocks / 5 layouts / 2 tools / 1 deprecated — matches [ADR-006 Part A](docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md).

## Consumer sync (post-merge)

After this + a new BDS release, the 3 consumer repos pull the regenerated `dist/bds-manifest.json`. Same flow as any other BDS asset bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)