### PR TITLE
chore(tokens): retire references to orphan --brand-{tier} tokens (#712 phase 1-3)

### DIFF
--- a/tokens/bridge.css
+++ b/tokens/bridge.css
@@ -65,15 +65,6 @@
   --color-page-brand: var(--page-brand-primary);
 
   /* ═══════════════════════════════════════════════
-     Color: Theme
-     ═══════════════════════════════════════════════ */
-  --color-theme-primary: var(--brand-primary);
-  --color-theme-secondary: var(--brand-secondary);
-  --color-theme-tertiary: var(--brand-tertiary);
-  --color-theme-accent: var(--brand-accent);
-  --color-theme-fourth: var(--brand-dark);
-
-  /* ═══════════════════════════════════════════════
      Typography: Font Family
      ═══════════════════════════════════════════════ */
   --typography-font-family-body: var(--font-family-body);

--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -90,10 +90,10 @@
   /* ── Semantic Tokens Not Yet in Figma/SD ── */
   --surface-nav: var(--color-grayscale-white);
   --surface-navigation: var(--color-grayscale-white); /* canonical; --surface-nav kept for backward compat */
-  --surface-brand-secondary: var(--brand-accent);
+  --surface-brand-secondary: var(--color-yellow-light);
   --background-brand-secondary: var(--color-grayscale-white);
   --background-image: #17171799; /* bds-lint-ignore — semi-transparent dark overlay; no primitive equivalent exists yet. Promote to Figma once an opacity token primitive is available. */
-  --background-image-brand: var(--brand-primary);
+  --background-image-brand: var(--color-poppy-light);
   --box-shadow-none: 0px;
 
   /* ── Status Semantic Tokens ── (now in figma-tokens.css via Style Dictionary) */

--- a/tokens/theme-brand-brik.css
+++ b/tokens/theme-brand-brik.css
@@ -65,12 +65,6 @@
   --border-input: var(--color-grayscale-light);
   --border-inverse: var(--color-grayscale-white);
   --border-on-color-dark: white;
-  /* Brand palette overrides (neutral intermediate layer) */
-  --brand-primary: var(--color-poppy-light);
-  --brand-secondary: #f1f0ec;
-  --brand-accent: #f4d364;
-  --brand-tertiary: #9ada6c;
-  --brand-dark: #8ebbcc;
   /* Typography */
   --font-family-body: Poppins, sans-serif;
   --font-family-label: Poppins, sans-serif;


### PR DESCRIPTION
## Summary

Phase 1–3 of brik-bds#712 — retire all internal BDS references to the non-conformant `--brand-{primary,secondary,tertiary,accent,dark}` tokens. After this PR lands, **zero references to `var(--brand-{tier})` remain in BDS**, unblocking the upstream Figma source retirement (Phase 4).

This is a behavior-equivalent refactor. Resolved CSS values are unchanged; the change is purely how tokens reference each other in the cascade.

## Why these are drift

Per [`feedback_bds_token_anatomy.md`](https://github.com/anthropics/claude-code/issues) (agent memory) + `docs-site/content/docs/getting-started/cascade.mdx`, the BDS token tiers are:

| Tier | Form | Example |
|---|---|---|
| Raw | Literal hex | `#e35335` |
| Primitive | `--color-{family}-{step}` | `--color-poppy-light` |
| Semantic | `--{purpose}-{role}` | `--background-brand-primary` |

The bare `--brand-{tier}` form lacks the `{purpose}` prefix the anatomy requires. The legitimate composed forms `--{purpose}-brand-{tier}` (`--background-brand-primary`, `--text-brand-primary`, `--surface-brand-primary`, `--border-brand-primary`) exist canonically and are actively used. The bare `--brand-{tier}` tokens are orphans.

## Ecosystem audit (verified before edit)

Audited 14 active Brik repos: 7 web (`_newclient`, `birdwell-mutlak`, `brikdesigns`, `memphis-dental`, `nickstanerson.com`, `tncld`, `vale-partners`), 3 product (`brik-client-portal`, `freedom-client-portal`, `renew-pms`), 4 brik core (`brik-events`, `brik-llm`, `brik-templates`, `brik-website-themes`).

| Check | Result |
|---|---|
| Explicit `@brikdesigns/bds/bridge.css` imports | **0** across all 14 repos |
| `--color-theme-{primary,secondary,tertiary,accent,fourth}` (the 5 bridge.css aliases sourced from orphans) | **0** consumers across all 14 repos |
| `var(--brand-{tier})` direct refs in components/stories | **0** |
| BDS namespace consumption in live `www.brikdesigns.com` CSS (477 KB Webflow bundle) | **0** — Webflow uses its own `--_color---*` + `--brand--*` double-dash namespaces |

The Astro client sites (birdwell-mutlak, memphis-dental) and `brik-client-portal/src/lib/theming/generate-theme-css.ts` DO consume other bridge.css aliases (`--color-text-*`, `--color-background-*`, `--color-border-*` — all sourced from legitimate canonical tokens). Those bridge entries are untouched.

## Edits

### 1. `tokens/theme-brand-brik.css` — delete redundant re-declaration

```diff
   --border-on-color-dark: white;
-  /* Brand palette overrides (neutral intermediate layer) */
-  --brand-primary: var(--color-poppy-light);
-  --brand-secondary: #f1f0ec;
-  --brand-accent: #f4d364;
-  --brand-tertiary: #9ada6c;
-  --brand-dark: #8ebbcc;
   /* Typography */
```

These were re-declaring the canonical defaults from `figma-tokens.css:299-302` with identical values — pure duplication. Zero behavioral change.

### 2. `tokens/bridge.css` — delete entire Color:Theme block

```diff
-  /* ═══════════════════════════════════════════════
-     Color: Theme
-     ═══════════════════════════════════════════════ */
-  --color-theme-primary: var(--brand-primary);
-  --color-theme-secondary: var(--brand-secondary);
-  --color-theme-tertiary: var(--brand-tertiary);
-  --color-theme-accent: var(--brand-accent);
-  --color-theme-fourth: var(--brand-dark);
-
```

All 5 aliases sourced from orphan `--brand-{tier}` tokens. All 5 have zero consumers per the audit above.

### 3. `tokens/gap-fills.css` — re-source two internal lookups

```diff
-  --surface-brand-secondary: var(--brand-accent);
+  --surface-brand-secondary: var(--color-yellow-light);
-  --background-image-brand: var(--brand-primary);
+  --background-image-brand: var(--color-poppy-light);
```

Same resolved values (`#f4d364` and `#e35335` respectively); just routes through the canonical primitive directly instead of through the orphan alias.

## Verification

- ✅ `npm run validate:full` — all 10 checks PASS (Token Lint, JSDoc, Grid, Theme Compliance, Blueprint, BCS Vocab, Canonical Tokens, Component Axes, TypeScript, Storybook Build)
- ✅ `dist/tokens.css` rebuilt; `rg 'var\(--brand-(primary|secondary|tertiary|accent|dark)\)' tokens/ components/ stories/` returns **0 matches**
- ✅ Net diff: 3 files, 2 insertions, 17 deletions

## Manual check before merge

- [ ] Storybook visual sanity check — no story consumes the deleted bridge aliases; expected zero visual change. If anything changes, that's an unaudited consumer worth surfacing.

## Out of scope (separate follow-up)

`tokens/bridge.css` is `@deprecated` per its own header. After this PR, only the `--color-{text,background,border,page}-*` legacy aliases remain — these are actively consumed by Astro client sites + portal theme generator. Full bridge.css retirement would require migrating those consumers to canonical `--{purpose}-*` names directly. Will file as a separate backlog item; rough timing aligned with the year-long Webflow sunset since the same teams will touch those client sites anyway.

## Release plan

Recommend bundling this with the upcoming Figma-source retirement (Phase 4) into a single **v0.73.0** release:

1. **Now** — merge this PR. Internal cleanup; orphans still exist in `figma-tokens.css` but BDS no longer references them.
2. **Next** — designer retires `primitives/value.{brand, theme.brik, theme.blue}` groups from Tokens Studio in BDS Foundations Figma file.
3. **Then** — `./scripts/figma-pull-tokens.sh` → `npm run build:sd-figma` → `validate:full`. Open release PR for v0.73.0.

Both phases together are behavior-equivalent (orphans had zero consumers). The split into two PRs gives a clean rollback point if any unaudited consumer surfaces.

## Refs

- brik-bds#712 — umbrella (phased plan + audit findings)
- brikdesigns#227 step 4 — depends on #712 resolutions (unblocks after Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)