### PR TITLE
feat(tokens): canonical --aspect-* token family + Frame slug API (closes #486)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -23,6 +23,7 @@ import { FeedbackWidget } from './FeedbackWidget';
 // 6. Storybook overrides (Base mode spacing, UI fixes)
 import '../tokens/figma-tokens.css';
 import '../tokens/gap-fills.css';
+import '../tokens/ratios.css';
 import '../tokens/theme-brand-brik.css';
 import '../tokens/font-audit.css';
 import '../tokens/animations.css';
@@ -314,7 +315,7 @@ const preview: Preview = {
           'Foundation',
           [
             'Design Tokens',
-            ['Overview', 'Color', 'Typography', 'Spacing', 'Border Radius', 'Border Width', 'Shadow', 'Size', 'Motion'],
+            ['Overview', 'Color', 'Typography', 'Spacing', 'Border Radius', 'Border Width', 'Shadow', 'Size', 'Motion', 'Aspect Ratios'],
             'Atmospheres',
             'Navigation Archetypes',
             'Assets',

--- a/components/ui/Frame/Frame.css
+++ b/components/ui/Frame/Frame.css
@@ -8,13 +8,33 @@
   width: 100%;
 }
 
-/* ─── Named ratio presets ────────────────────────────────────── */
+/* ─── Ratio presets ───────────────────────────────────────────
+   Token-backed via --aspect-* (BDS #486). Single source of truth lives in
+   tokens/ratios.css; this file just attaches them to Frame's BEM modifier. */
 
-.bds-frame--ratio-square    { aspect-ratio: 1 / 1; }
-.bds-frame--ratio-portrait  { aspect-ratio: 3 / 4; }
-.bds-frame--ratio-landscape { aspect-ratio: 4 / 3; }
-.bds-frame--ratio-wide      { aspect-ratio: 16 / 9; }
-.bds-frame--ratio-ultrawide { aspect-ratio: 21 / 9; }
+/* Primitives */
+.bds-frame--ratio-1-1   { aspect-ratio: var(--aspect-1-1); }
+.bds-frame--ratio-3-2   { aspect-ratio: var(--aspect-3-2); }
+.bds-frame--ratio-2-3   { aspect-ratio: var(--aspect-2-3); }
+.bds-frame--ratio-4-3   { aspect-ratio: var(--aspect-4-3); }
+.bds-frame--ratio-3-4   { aspect-ratio: var(--aspect-3-4); }
+.bds-frame--ratio-16-9  { aspect-ratio: var(--aspect-16-9); }
+.bds-frame--ratio-9-16  { aspect-ratio: var(--aspect-9-16); }
+.bds-frame--ratio-21-9  { aspect-ratio: var(--aspect-21-9); }
+
+/* Semantic aliases */
+.bds-frame--ratio-square           { aspect-ratio: var(--aspect-square); }
+.bds-frame--ratio-photo-landscape  { aspect-ratio: var(--aspect-photo-landscape); }
+.bds-frame--ratio-photo-portrait   { aspect-ratio: var(--aspect-photo-portrait); }
+.bds-frame--ratio-cinema           { aspect-ratio: var(--aspect-cinema); }
+
+/* Deprecated mode-words — kept working for one minor version.
+   Migrate: portrait → 3-4, landscape → 4-3, wide → 16-9 or cinema,
+   ultrawide → 21-9. */
+.bds-frame--ratio-portrait   { aspect-ratio: var(--aspect-3-4); }
+.bds-frame--ratio-landscape  { aspect-ratio: var(--aspect-4-3); }
+.bds-frame--ratio-wide       { aspect-ratio: var(--aspect-16-9); }
+.bds-frame--ratio-ultrawide  { aspect-ratio: var(--aspect-21-9); }
 
 /* ─── Inner content fit ──────────────────────────────────────── */
 /* Applies to the first media descendant (img / video / svg). Authors who

--- a/components/ui/Frame/Frame.tsx
+++ b/components/ui/Frame/Frame.tsx
@@ -3,22 +3,69 @@ import { bdsClass } from '../../utils';
 import './Frame.css';
 
 /**
- * Named aspect-ratio presets for the most common Brik image/illustration shapes:
- * - `square`    — 1/1
- * - `portrait`  — 3/4
- * - `landscape` — 4/3
- * - `wide`      — 16/9
- * - `ultrawide` — 21/9
+ * Aspect-ratio slug. Backed by the `--aspect-*` token family (BDS #486).
+ *
+ * **Primitives** (numerical, dimension-explicit — preferred for new code):
+ * - `1-1`  — 1/1   (square)
+ * - `3-2`  — 3/2   (DSLR landscape, service card media)
+ * - `2-3`  — 2/3   (DSLR portrait)
+ * - `4-3`  — 4/3   (legacy landscape, product shots)
+ * - `3-4`  — 3/4   (legacy portrait)
+ * - `16-9` — 16/9  (video, hero banners)
+ * - `9-16` — 9/16  (vertical video, mobile portrait)
+ * - `21-9` — 21/9  (cinematic, full-bleed)
+ *
+ * **Semantic aliases** (role-named — prefer when the role drives the choice):
+ * - `square`            — 1/1
+ * - `photo-landscape`   — 3/2
+ * - `photo-portrait`    — 2/3
+ * - `cinema`            — 16/9
+ *
+ * **Deprecated mode-words** (kept working for one minor version — migrate
+ * to primitives above):
+ * - `portrait`  → use `3-4`
+ * - `landscape` → use `4-3`
+ * - `wide`      → use `16-9` or `cinema`
+ * - `ultrawide` → use `21-9`
  */
-export type FrameRatio = 'square' | 'portrait' | 'landscape' | 'wide' | 'ultrawide';
+export type FrameRatio =
+  // Primitives
+  | '1-1'
+  | '3-2'
+  | '2-3'
+  | '4-3'
+  | '3-4'
+  | '16-9'
+  | '9-16'
+  | '21-9'
+  // Semantic aliases
+  | 'square'
+  | 'photo-landscape'
+  | 'photo-portrait'
+  | 'cinema'
+  // Deprecated mode-words
+  /** @deprecated Use `3-4` instead. */
+  | 'portrait'
+  /** @deprecated Use `4-3` instead. */
+  | 'landscape'
+  /** @deprecated Use `16-9` or `cinema` instead. */
+  | 'wide'
+  /** @deprecated Use `21-9` instead. */
+  | 'ultrawide';
+
 export type FrameFit = 'cover' | 'contain' | 'fill' | 'none';
 
 export interface FrameProps extends HTMLAttributes<HTMLElement> {
-  /** Named aspect-ratio preset. Use `customRatio` for arbitrary ratios. */
+  /**
+   * Named aspect-ratio slug. Defaults to `4-3` (legacy landscape).
+   * See `FrameRatio` for the full vocabulary. Use `customRatio` for one-offs.
+   */
   ratio?: FrameRatio;
   /**
    * Custom aspect-ratio string (CSS `aspect-ratio` syntax). Overrides `ratio`
-   * when set. Examples: `"3 / 2"`, `"5 / 4"`, `"1.618"`.
+   * when set. Prefer a `FrameRatio` slug; reserve `customRatio` for genuine
+   * one-offs that don't fit the canonical vocabulary. Examples: `"5 / 4"`,
+   * `"1.618"`.
    */
   customRatio?: string;
   /**
@@ -42,26 +89,26 @@ export interface FrameProps extends HTMLAttributes<HTMLElement> {
  *
  * @example
  * ```tsx
- * <Frame ratio="square">
+ * <Frame ratio="1-1">
  *   <img src="/icon.png" alt="" />
  * </Frame>
  *
- * <Frame ratio="wide" fit="cover">
+ * <Frame ratio="16-9" fit="cover">
  *   <Image src={hero} alt="" fill />
  * </Frame>
  *
- * <Frame customRatio="3 / 2">
- *   <video src={preview} />
+ * <Frame ratio="photo-landscape">
+ *   <img src="/product.jpg" alt="" />
  * </Frame>
  * ```
  *
  * Multi-platform note: `ratio` maps to SwiftUI `.aspectRatio(_:contentMode:)`
- * and Compose `.aspectRatio()`. The named presets are platform-portable.
+ * and Compose `.aspectRatio()`. The numerical slugs are platform-portable.
  *
  * @summary Aspect-ratio container — for images, videos, illustrations.
  */
 export function Frame({
-  ratio = 'landscape',
+  ratio = '4-3',
   customRatio,
   fit = 'cover',
   as: Element = 'div',

--- a/components/ui/MarketingIllustration/MarketingIllustration.css
+++ b/components/ui/MarketingIllustration/MarketingIllustration.css
@@ -11,11 +11,12 @@
      any container width without media queries. */
 }
 
-/* ─── Aspect ratio ────────────────────────────────────────── */
+/* ─── Aspect ratio ────────────────────────────────────────────
+   Token-backed via --aspect-* (BDS #486). */
 
-.bds-marketing-illustration--ratio-square    { aspect-ratio: 1 / 1; }
-.bds-marketing-illustration--ratio-portrait  { aspect-ratio: 3 / 4; }
-.bds-marketing-illustration--ratio-landscape { aspect-ratio: 4 / 3; }
+.bds-marketing-illustration--ratio-square    { aspect-ratio: var(--aspect-1-1); }
+.bds-marketing-illustration--ratio-portrait  { aspect-ratio: var(--aspect-3-4); }
+.bds-marketing-illustration--ratio-landscape { aspect-ratio: var(--aspect-4-3); }
 
 /* ─── Tile base ───────────────────────────────────────────── */
 

--- a/scripts/build-dist-tokens.js
+++ b/scripts/build-dist-tokens.js
@@ -4,7 +4,7 @@
  * Called by: npm run build:lib (as the final step)
  *
  * Produces:
- *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + theme-brand-brik.css + modes-*.css + gap-fills.css + animations.css concatenated
+ *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + theme-brand-brik.css + modes-*.css + gap-fills.css + ratios.css + animations.css concatenated
  *   dist/bridge.css  — clean name ↔ Webflow internal name aliases
  */
 const fs = require('fs');
@@ -68,12 +68,15 @@ for (const file of MODE_FILES) {
   }
 }
 
+// Aspect-ratio tokens — `--aspect-*` primitives + semantic aliases (BDS #486).
+const ratios = fs.readFileSync(path.join(TOKENS_DIR, 'ratios.css'), 'utf8');
+
 // Shared keyframe library — required for any component using bds-spin, bds-pulse, bds-pop, etc.
 const animations = fs.readFileSync(path.join(TOKENS_DIR, 'animations.css'), 'utf8');
 
 fs.writeFileSync(
   path.join(DIST_DIR, 'tokens.css'),
-  header + figmaTokens + darkTokens + themeBrandBrik + modeOverrides + '\n\n' + gapFills + '\n\n' + animations,
+  header + figmaTokens + darkTokens + themeBrandBrik + modeOverrides + '\n\n' + gapFills + '\n\n' + ratios + '\n\n' + animations,
 );
 console.log('  ✓ dist/tokens.css');
 

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -238,9 +238,11 @@ function parseCssTokens() {
   // Load token files
   const FIGMA_TOKENS = path.join(__dirname, '..', 'tokens', 'figma-tokens.css');
   const GAP_FILLS = path.join(__dirname, '..', 'tokens', 'gap-fills.css');
+  const RATIOS = path.join(__dirname, '..', 'tokens', 'ratios.css');
   const BRIDGE = path.join(__dirname, '..', 'tokens', 'bridge.css');
   if (fs.existsSync(FIGMA_TOKENS)) loadFromCss(FIGMA_TOKENS);
   if (fs.existsSync(GAP_FILLS)) loadFromCss(GAP_FILLS);
+  if (fs.existsSync(RATIOS)) loadFromCss(RATIOS);
   if (fs.existsSync(BRIDGE)) loadFromCss(BRIDGE);
 
   // Ensure at least one token source was loaded

--- a/stories/theming/AspectRatios.stories.tsx
+++ b/stories/theming/AspectRatios.stories.tsx
@@ -1,0 +1,255 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Frame } from '../../components/ui/Frame/Frame';
+
+/* ─── Meta ────────────────────────────────────────────────────── */
+
+const meta: Meta = {
+  title: 'Foundation/Design Tokens/Aspect Ratios',
+  tags: ['surface-shared'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Canonical aspect-ratio vocabulary backed by the `--aspect-*` token family (BDS #486). Use these tokens (or the `Frame` `ratio` slug prop) instead of hand-typed `aspect-ratio` CSS or `customRatio` strings — same drift-prevention principle as the color/spacing token families.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+/* ─── Helpers ─────────────────────────────────────────────────── */
+
+const PRIMITIVES = [
+  { slug: '1-1',  value: '1 / 1',  note: 'Square — avatars, thumbnails, service illustrations' },
+  { slug: '3-2',  value: '3 / 2',  note: 'DSLR landscape — service card media, product shots' },
+  { slug: '2-3',  value: '2 / 3',  note: 'DSLR portrait — vertical photography' },
+  { slug: '4-3',  value: '4 / 3',  note: 'Legacy landscape (Frame default)' },
+  { slug: '3-4',  value: '3 / 4',  note: 'Legacy portrait — profile cards, editorial' },
+  { slug: '16-9', value: '16 / 9', note: 'Video, hero banners, OG images' },
+  { slug: '9-16', value: '9 / 16', note: 'Vertical video, mobile portrait' },
+  { slug: '21-9', value: '21 / 9', note: 'Cinematic, full-bleed backgrounds' },
+] as const;
+
+const ALIASES = [
+  { slug: 'square',           resolves: '1-1',  note: 'Alias for `1-1`' },
+  { slug: 'photo-landscape',  resolves: '3-2',  note: 'Alias for `3-2` — role-named photo crop' },
+  { slug: 'photo-portrait',   resolves: '2-3',  note: 'Alias for `2-3` — role-named photo crop' },
+  { slug: 'cinema',           resolves: '16-9', note: 'Alias for `16-9` — role-named hero/video slot' },
+] as const;
+
+const DEPRECATED = [
+  { slug: 'portrait',  use: '3-4' },
+  { slug: 'landscape', use: '4-3' },
+  { slug: 'wide',      use: '16-9 or cinema' },
+  { slug: 'ultrawide', use: '21-9' },
+] as const;
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <section
+    style={{
+      padding: 'var(--padding-xl)',
+      borderBottom: '1px solid var(--border-secondary)',
+    }}
+  >
+    <h2
+      style={{
+        margin: 0,
+        marginBottom: 'var(--gap-lg)',
+        fontFamily: 'var(--font-family-heading)',
+        fontSize: 'var(--heading-lg)', // bds-lint-ignore
+        color: 'var(--text-primary)',
+      }}
+    >
+      {title}
+    </h2>
+    {children}
+  </section>
+);
+
+const Grid = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+      gap: 'var(--gap-lg)',
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Card = ({
+  slug,
+  token,
+  meta,
+}: {
+  slug: string;
+  token: string;
+  meta: React.ReactNode;
+}) => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 'var(--gap-sm)',
+    }}
+  >
+    <div
+      style={{
+        background: 'var(--surface-secondary)',
+        border: '1px solid var(--border-secondary)',
+        borderRadius: 'var(--border-radius-md)',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          aspectRatio: `var(${token})`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'var(--font-family-label)',
+          fontSize: 'var(--body-sm)', // bds-lint-ignore
+          color: 'var(--text-secondary)',
+          background:
+            'repeating-linear-gradient(45deg, var(--surface-primary), var(--surface-primary) 8px, var(--surface-secondary) 8px, var(--surface-secondary) 16px)',
+        }}
+      >
+        {slug}
+      </div>
+    </div>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--gap-tiny)',
+        fontFamily: 'var(--font-family-body)',
+        fontSize: 'var(--body-sm)', // bds-lint-ignore
+      }}
+    >
+      <code
+        style={{
+          fontFamily: 'var(--font-family-code, ui-monospace, monospace)',
+          fontSize: 'var(--body-xs)', // bds-lint-ignore
+          color: 'var(--text-primary)',
+        }}
+      >
+        {token}
+      </code>
+      <div style={{ color: 'var(--text-secondary)' }}>{meta}</div>
+    </div>
+  </div>
+);
+
+/* ─── Catalog ─────────────────────────────────────────────────── */
+
+/** @summary All canonical ratios, semantic aliases, and deprecated mode-words side by side. */
+export const Catalog: Story = {
+  render: () => (
+    <div style={{ fontFamily: 'var(--font-family-body)' }}>
+      <Section title="Primitives">
+        <Grid>
+          {PRIMITIVES.map(({ slug, value, note }) => (
+            <Card
+              key={slug}
+              slug={slug}
+              token={`--aspect-${slug}`}
+              meta={
+                <>
+                  {value} — {note}
+                </>
+              }
+            />
+          ))}
+        </Grid>
+      </Section>
+
+      <Section title="Semantic aliases">
+        <Grid>
+          {ALIASES.map(({ slug, resolves, note }) => (
+            <Card
+              key={slug}
+              slug={slug}
+              token={`--aspect-${slug}`}
+              meta={
+                <>
+                  Resolves to <code>--aspect-{resolves}</code> — {note}
+                </>
+              }
+            />
+          ))}
+        </Grid>
+      </Section>
+
+      <Section title="Deprecated mode-words">
+        <p
+          style={{
+            margin: 0,
+            marginBottom: 'var(--gap-md)',
+            fontSize: 'var(--body-sm)', // bds-lint-ignore
+            color: 'var(--text-secondary)',
+          }}
+        >
+          Frame’s original ratio prop accepted mode-words. These still resolve to the correct
+          ratios for one minor version — migrate to the primitive slugs above.
+        </p>
+        <ul
+          style={{
+            margin: 0,
+            padding: 0,
+            listStyle: 'none',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--gap-sm)',
+            fontFamily: 'var(--font-family-body)',
+            fontSize: 'var(--body-sm)', // bds-lint-ignore
+            color: 'var(--text-secondary)',
+          }}
+        >
+          {DEPRECATED.map(({ slug, use }) => (
+            <li key={slug}>
+              <code>{slug}</code> → use <code>{use}</code>
+            </li>
+          ))}
+        </ul>
+      </Section>
+    </div>
+  ),
+};
+
+/* ─── Frame usage ─────────────────────────────────────────────── */
+
+/** @summary `Frame` consuming the new slug vocabulary. */
+export const FrameSlugs: Story = {
+  render: () => (
+    <Section title="Frame ratio prop — slug vocabulary">
+      <Grid>
+        {(['1-1', '3-2', '2-3', '4-3', '16-9', '9-16', '21-9', 'photo-landscape', 'cinema'] as const).map((slug) => (
+          <div key={slug} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-sm)' }}>
+            <Frame
+              ratio={slug}
+              style={{
+                background:
+                  'repeating-linear-gradient(45deg, var(--surface-primary), var(--surface-primary) 8px, var(--surface-secondary) 8px, var(--surface-secondary) 16px)',
+                border: '1px solid var(--border-secondary)',
+                borderRadius: 'var(--border-radius-md)',
+              }}
+            />
+            <code
+              style={{
+                fontFamily: 'var(--font-family-code, ui-monospace, monospace)',
+                fontSize: 'var(--body-xs)', // bds-lint-ignore
+                color: 'var(--text-primary)',
+              }}
+            >
+              {`<Frame ratio="${slug}" />`}
+            </code>
+          </div>
+        ))}
+      </Grid>
+    </Section>
+  ),
+};

--- a/tokens/ratios.css
+++ b/tokens/ratios.css
@@ -1,0 +1,44 @@
+/**
+ * BDS Aspect-Ratio Tokens — Manually Maintained
+ *
+ * Loaded by: bundled into dist/tokens.css (after gap-fills, before animations).
+ * Every consumer picks these up automatically via `@import '@brikdesigns/bds/tokens.css'`.
+ * See tokens/CASCADE.md for the full load-order + decision tree.
+ *
+ * Why these are here, not in figma-tokens.css:
+ *   Aspect ratios are dimensionless `<ratio>` values, not Figma Variables.
+ *   They live alongside other manually-maintained semantic tokens until/unless
+ *   Style Dictionary gains `<ratio>` support and they migrate to Figma.
+ *
+ * Vocabulary:
+ *   Primitives use `--aspect-{w}-{h}` (numerical, dimension-explicit).
+ *   Semantic aliases use `--aspect-{role}` and resolve to a primitive.
+ *
+ * Consumed by:
+ *   - `Frame` `ratio` prop — slug suffix maps to the token name
+ *   - `MarketingIllustration` ratio classes
+ *   - Any consumer needing an `aspect-ratio: var(--aspect-*)` rule
+ *
+ * Filed: #486. Umbrella: #681 (Media category).
+ */
+
+:root {
+  /* ── Primitives ──
+     Numerical, dimension-explicit. Use these when the literal ratio matters. */
+  --aspect-1-1:  1 / 1;
+  --aspect-3-2:  3 / 2;
+  --aspect-2-3:  2 / 3;
+  --aspect-4-3:  4 / 3;
+  --aspect-3-4:  3 / 4;
+  --aspect-16-9: 16 / 9;
+  --aspect-9-16: 9 / 16;
+  --aspect-21-9: 21 / 9;
+
+  /* ── Semantic aliases ──
+     Role-named. Use these when the role drives the choice (photo crop, hero,
+     cinema slot) and the literal ratio is incidental. */
+  --aspect-square:          var(--aspect-1-1);
+  --aspect-photo-landscape: var(--aspect-3-2);
+  --aspect-photo-portrait:  var(--aspect-2-3);
+  --aspect-cinema:          var(--aspect-16-9);
+}


### PR DESCRIPTION
## Summary

Closes #486. 8 aspect-ratio primitives + 4 semantic aliases backing the `Frame` `ratio` prop slug API. Single source of truth across BDS and downstream — no more hand-typed `aspect-ratio` CSS or `customRatio` strings for the canonical set.

## What's in

### Tokens — `tokens/ratios.css`

- **Primitives** (numerical, dimension-explicit): `--aspect-{1-1, 3-2, 2-3, 4-3, 3-4, 16-9, 9-16, 21-9}`
- **Semantic aliases** (role-named): `--aspect-{square, photo-landscape, photo-portrait, cinema}`
- Registered with `scripts/lint-tokens.js` (so canonical token validation knows about them)
- Wired into `scripts/build-dist-tokens.js` cascade (concatenated into `dist/tokens.css` between gap-fills and animations)
- `tokens/ratios.css` imported into `.storybook/preview.tsx` so stories see the cascade

### Frame API

- `FrameRatio` union expanded — accepts 8 primitive slugs, 4 semantic aliases, and the original 4 mode-words marked `@deprecated` for one minor version (`portrait → 3-4`, `landscape → 4-3`, `wide → 16-9` or `cinema`, `ultrawide → 21-9`)
- Default flipped `'landscape'` → `'4-3'` — same CSS, canonical-slug default, no behavior change
- `Frame.css` ratio classes all consume `var(--aspect-*)` — token is the single source of truth, including for the deprecated mode-words

### Consumers migrated

- `MarketingIllustration.css` ratio classes now consume `var(--aspect-*)`

### Storybook

- New `Foundation/Design Tokens/Aspect Ratios` story (`stories/theming/AspectRatios.stories.tsx`) with token catalog + Frame slug usage demo
- Sort order in `.storybook/preview.tsx` updated to include Aspect Ratios under Design Tokens

## What's out (filed as follow-up scope)

- `content-system/blueprints/.../HeroSplit6040.{css,astro}` uses `aspect-ratio: 4 / 5` — not in the canonical set, intentionally left as a future decision (extend family or keep as one-off)
- `HeroSplitImageCardOverlay.astro` has a `RATIO_ASPECT` runtime lookup table — larger refactor than this PR, separate slice
- `Features3ColBrandedDark` has `aspect-ratio: 1 / 1` literals that could migrate to `var(--aspect-1-1)` — narrow follow-up

## Release implications

`dist/tokens.css` is gitignored — `--aspect-*` tokens land in consumers only after a BDS release publishes a new version. After merge, the release flow (version bump + `npm publish`) is the next step for portal#816 + brikdesigns#197 to pick this up. **Not running release in this PR — separate user-approved step.**

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint-tokens` — 0 errors (24 pre-existing warnings, all unrelated `gap-fill-drift` on icon-* aliases)
- [x] `npm run lint-jsdoc` — clean
- [x] `npm run validate` (lint-tokens + lint-jsdoc + validate:blueprints + typecheck + build-storybook) — passes end-to-end
- [x] `npm test` — 1 pre-existing failure (`Radio.stories.tsx`) on `main`, unchanged on this branch; my changes don't regress test count

## Refs

- #681 — Media category umbrella (#486 is the token slice)
- brik-client-portal#816 — first downstream consumer (CMS uploader aspect-ratio contract)
- brikdesigns#197 — first marketing-site consumer (BEM `__media` rename + Frame adoption)
- #670 / PR #708 — default flip on `HeroSplitImageCardOverlay`; long-term shape lands with this PR's slug API

🤖 Generated with [Claude Code](https://claude.com/claude-code)