### PR TITLE
docs(bds): refresh stale code comments for post-#629 / post-#724 state (closes #723)

### DIFF
--- a/.storybook/public/brik-inspect.js
+++ b/.storybook/public/brik-inspect.js
@@ -188,11 +188,14 @@
   }
 
   // Live Storybook story index. Used to verify manifest-emitted story IDs
-  // actually resolve before we render an "Open in Storybook" link — the
-  // BDS manifest currently hardcodes `components-${slug}--primary`, which
-  // does not match the real story tree (stories live under deeper paths
-  // like `components-indicator-badge--overview`). Until the brik-bds
-  // manifest builder reads the live index, we validate client-side.
+  // actually resolve before we render an "Open in Storybook" link. The
+  // BDS manifest builder now derives bucket-aware slugs from each
+  // component's meta.title (e.g. `containers-card--overview`,
+  // `components-badge--overview`) per brik-bds#724. A consumer running
+  // against a stale `bds-manifest.json` (BDS bump pending) may still
+  // emit URLs that don't match the live story tree, so we keep the
+  // client-side validation as a safety net — broken URLs hide the
+  // "Open in Storybook" link instead of producing a 404 click.
   //   storybookIndex === null  → not yet loaded (or CORS/404 failure)
   //   storybookIndex instanceof Set → known-valid story IDs
   let storybookIndex = null;

--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -188,11 +188,14 @@
   }
 
   // Live Storybook story index. Used to verify manifest-emitted story IDs
-  // actually resolve before we render an "Open in Storybook" link — the
-  // BDS manifest currently hardcodes `components-${slug}--primary`, which
-  // does not match the real story tree (stories live under deeper paths
-  // like `components-indicator-badge--overview`). Until the brik-bds
-  // manifest builder reads the live index, we validate client-side.
+  // actually resolve before we render an "Open in Storybook" link. The
+  // BDS manifest builder now derives bucket-aware slugs from each
+  // component's meta.title (e.g. `containers-card--overview`,
+  // `components-badge--overview`) per brik-bds#724. A consumer running
+  // against a stale `bds-manifest.json` (BDS bump pending) may still
+  // emit URLs that don't match the live story tree, so we keep the
+  // client-side validation as a safety net — broken URLs hide the
+  // "Open in Storybook" link instead of producing a 404 click.
   //   storybookIndex === null  → not yet loaded (or CORS/404 failure)
   //   storybookIndex instanceof Set → known-valid story IDs
   let storybookIndex = null;

--- a/scripts/extract-component-inventory.mjs
+++ b/scripts/extract-component-inventory.mjs
@@ -12,7 +12,7 @@
  * v1 fields (minimal-core per #603 scoping):
  *   - Name              — component dir name (e.g. Button)
  *   - Component path    — components/ui/Button/Button.tsx
- *   - Story title       — meta.title literal (e.g. Components/Action/button)
+ *   - Story title       — meta.title literal (e.g. Components/button, Containers/card; post-#629 flat taxonomy)
  *   - Surface           — derived from meta.tags surface-* (shared/web/product/unknown)
  *   - Story exports     — raw count of `export const X (: Story)?` (excludes default meta)
  *   - Deprecated        — meta.tags includes `!manifest`


### PR DESCRIPTION
## Why

Two cosmetic comment refreshes — no behavior change. Brings code-level documentation in line with the realized state after the [#629 sidebar flatten](https://github.com/brikdesigns/brik-bds/issues/629) and the [PR #724 manifest-builder fix](https://github.com/brikdesigns/brik-bds/pull/724). Closes [#723](https://github.com/brikdesigns/brik-bds/issues/723).

## What changed

### 1. `brik-inspect.js` comment block (lines 190-198)

The old comment described a state that no longer exists:

```diff
  // Live Storybook story index. Used to verify manifest-emitted story IDs
- // actually resolve before we render an "Open in Storybook" link — the
- // BDS manifest currently hardcodes `components-${slug}--primary`, which
- // does not match the real story tree (stories live under deeper paths
- // like `components-indicator-badge--overview`). Until the brik-bds
- // manifest builder reads the live index, we validate client-side.
+ // actually resolve before we render an "Open in Storybook" link. The
+ // BDS manifest builder now derives bucket-aware slugs from each
+ // component's meta.title (e.g. `containers-card--overview`,
+ // `components-badge--overview`) per brik-bds#724. A consumer running
+ // against a stale `bds-manifest.json` (BDS bump pending) may still
+ // emit URLs that don't match the live story tree, so we keep the
+ // client-side validation as a safety net — broken URLs hide the
+ // "Open in Storybook" link instead of producing a 404 click.
```

**Both halves of the original were stale:**
- The manifest builder no longer hardcodes `--primary` slugs (PR #724 fixed it)
- The example `components-indicator-badge--overview` uses the abolished pre-flatten subcategory pattern; post-#629 Badge sits at `components-badge--overview`

The new comment correctly explains why client-side validation still matters (consumers running against stale manifests).

### 2. `extract-component-inventory.mjs` docstring (line 15)

```diff
- *   - Story title       — meta.title literal (e.g. Components/Action/button)
+ *   - Story title       — meta.title literal (e.g. Components/button, Containers/card; post-#629 flat taxonomy)
```

The `Components/Action/*` subcategory pattern was abolished by [PR #674](https://github.com/brikdesigns/brik-bds/pull/674).

## Files

- `components/ui/BrikDevBar/widgets/inspect-widget.js` (canonical source)
- `.storybook/public/brik-inspect.js` (synced via `./scripts/sync-devbar-widgets.sh`)
- `scripts/extract-component-inventory.mjs`

## Consumer-side sync — deferred

`brik-client-portal/public/brik-inspect.js`, `renew-pms/public/brik-inspect.js`, `web/brikdesigns/public/brik-inspect.js`, and `brik-client-portal/scripts/mockup-shared/inspect-widget.js` will pick up the refreshed comment on their next sync cycle (typically the next BDS bump that touches widgets). Not blocking — comment-only update, zero behavior change.

## Verification
- [x] `npm run typecheck` clean
- [x] Anti-slop CRITICAL scan passes
- [x] All 10 pre-push validation checks pass
- [x] Sync ran successfully — canonical and `.storybook/public` copy identical (`diff` confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)