### PR TITLE
docs(architecture): lock six-concept token vocabulary + Library architecture + Theming Dimensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ This CLAUDE.md is `@import`-ed by every consumer of `@brikdesigns/bds` — the B
 ## Where deeper context lives
 
 - **Documentation system** (tier table, mental model, lifecycle, decision tree) → [`docs-site/content/docs/getting-started/documentation-system.mdx`](docs-site/content/docs/getting-started/documentation-system.mdx) — published at design.brikdesigns.com/docs/getting-started/documentation-system
-- **Token discipline** (3-layer architecture, semantic categories, service-token isolation) → `brik-rag query "token discipline"`
+- **Token system vocabulary** (the six locked concepts: Anatomy / Tier / Library / Layer / Mode / Tenet) → [Token Anatomy](docs-site/content/docs/primitives/token-anatomy.mdx) → published at design.brikdesigns.com/docs/primitives/token-anatomy. Read first before referencing any token.
+- **Library Architecture** (Foundations Library vs Brand Kit Library + multi-Library Style Dictionary pull) → [Figma Library Architecture](docs-site/content/docs/getting-started/figma-library-architecture.mdx)
+- **Token discipline** (semantic categories, service-token isolation, drift patterns) → `brik-rag query "token discipline"`
 - **Token PR checklist** → [`docs/TOKEN-PR-CHECKLIST.md`](docs/TOKEN-PR-CHECKLIST.md)
 - **Release procedure** → [`docs/RELEASE.md`](docs/RELEASE.md)
 - **Component build rules** → [`.claude/standards/component-build.md`](.claude/standards/component-build.md) — auto-retrieved by the [`component-build`](.claude/skills/component-build/SKILL.md) skill on `components/ui/**/*.{tsx,css}` edits

--- a/docs-site/content/docs/getting-started/cascade.mdx
+++ b/docs-site/content/docs/getting-started/cascade.mdx
@@ -1,105 +1,129 @@
 ---
 title: The Cascade
-description: How BDS layers theming — two-tier token cascade, four theming layers, and the modes axis.
+description: How BDS tokens flow from Library → CSS Layer → consumer. Six disambiguated concepts (Anatomy, Tier, Library, Layer, Mode, Tenet) keep the system from drifting.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-BDS theming layers across **two token tiers**, **four theming layers**, and **modes** as a separate axis. Components stay untouched as each layer composes a different decision.
+BDS resolves tokens through a strict cascade: **Libraries** define values, **Tiers** stack abstractions, **Layers** order the CSS @layer at runtime, and **Modes** vary values on orthogonal axes. Every consumer (portal, renew-pms, brikdesigns, every client site) follows the same path. Six words for six independent concepts — see [Token Anatomy](/docs/primitives/token-anatomy) for the full disambiguation map.
 
-## Two-tier token cascade
-
-Every consumer — portal, renew-pms, brikdesigns, each client site — loads tokens in the same order:
+## The 30-second overview
 
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│  TIER 1 — BDS Foundations  (never edited by consumers)                  │
-│                                                                         │
-│  Bundled into dist/tokens.css in this order:                            │
-│    figma-tokens.css       — auto-generated semantic + primitive (light) │
-│    figma-tokens-dark.css  — dark-mode overrides via [data-theme="dark"] │
-│    theme-brand-brik.css   — Brik's own brand defaults (.theme-brand-brik) │
-│    modes-borderwidth.css  — borderwidth mode picks ([data-mode-borderwidth]) │
-│    gap-fills.css          — tokens not yet in Figma                     │
-│    animations.css         — keyframe library                            │
-└──────────────────────────────┬──────────────────────────────────────────┘
-                               │  CSS cascade (consumer's globals.css)
-┌──────────────────────────────▼──────────────────────────────────────────┐
-│  TIER 2 — Client Theme  (theme-{client}.css in the consuming project)   │
-│                                                                         │
-│  Same semantic token names as Tier 1, different values for this brand.  │
-│  One file per client. Cascade wins. Components are untouched.           │
-└─────────────────────────────────────────────────────────────────────────┘
+LIBRARY                       TIER             LAYER                    MODE
+─────────────────────────────────────────────────────────────────────────────────
+Foundations Library      →    Raw → Primitive  →  @layer bds-tokens    × color
+[Client] Brand Kit       →    Primitive →      →  @layer client-theme  × borderwidth
+                              Semantic            @layer client-overrides  × spacing, etc.
+                              ↑
+                              Components consume Semantic only.
 ```
 
-Token names are fixed in Tier 1. Only values change in Tier 2. Full bundle order in [`tokens/CASCADE.md`](https://github.com/brikdesigns/brik-bds/blob/main/tokens/CASCADE.md).
+Different concepts, different words. Mixing them produces parallel-taxonomy drift (the failure mode that retired `--theme-brik-*` and `--brand-{tier}` in brik-bds#712).
+
+## CSS Layers — the runtime cascade
+
+Every consumer's `globals.css` declares this `@layer` order **before any imports**:
+
+```css
+@layer bds-tokens, bds-components, client-theme, client-overrides;
+```
+
+The four Layers, in cascade order (last wins):
+
+| Layer | What lives here | Editable by consumers? |
+|---|---|---|
+| `bds-tokens` | Foundations Library output (`figma-tokens.css` + `figma-tokens-dark.css`) — primitives + base semantics | **No** — comes from BDS |
+| `bds-components` | BDS component CSS (`@brikdesigns/bds/styles.css` and per-component CSS files) | **No** — comes from BDS |
+| `client-theme` | The client's Brand Kit output (`theme-{client}.css`) — same semantic names, brand values | **Yes** — one per client |
+| `client-overrides` | Per-consumer surgical tweaks that don't belong in the Brand Kit (rare; should be temporary) | Yes — keep small |
 
 <Callout type="warn">
-  **Do not import these CSS files** — deprecated or scoped to other surfaces:
-  - `overrides.css` — deprecated shim. Use `gap-fills.css` directly.
-  - `react-tokens.css` — deprecated, manually maintained, prone to drift.
-  - `webflow-tokens.css` — Webflow-only (circular refs, 8 theme blocks).
-  - `website-themes.css` — website template themes, not for app projects.
+  **Layer order is the contract.** `bds-tokens` must declare before `client-theme`, and `client-theme` before `client-overrides`. Out-of-order `@layer` declarations break the Brand Kit's ability to override.
 </Callout>
 
-### What's inside Tier 1
+### What's in the BDS bundle (`bds-tokens` + `bds-components`)
 
-| File | Purpose | Editable? |
+`dist/tokens.css` (shipped via `@brikdesigns/bds/tokens.css`) concatenates, in order:
+
+| File | Lands in | Purpose |
 |---|---|---|
-| `figma-tokens.css` | Auto-generated primitives + semantic tokens (light) | **No** — regenerated from Figma |
-| `figma-tokens-dark.css` | Dark-mode semantic overrides scoped to `[data-theme="dark"]` | **No** — regenerated from Figma |
-| `theme-brand-brik.css` | Brik's own brand colors / fonts (scoped to `.theme-brand-brik`) | Yes |
-| `modes-borderwidth.css` | Borderwidth mode picks via `[data-mode-borderwidth="thin\|bold"]` | Yes |
-| `gap-fills.css` | Any token not yet in Figma — extended status, presence, interaction states, etc. | Yes (with `TODO: promote to Figma` comment) |
-| `animations.css` | Shared keyframe library (`bds-spin`, `bds-pulse`, etc.) | Yes |
+| `figma-tokens.css` | `bds-tokens` | Foundations Library output — primitives + universal semantic defaults (light mode) |
+| `figma-tokens-dark.css` | `bds-tokens` | Foundations Library — dark mode (scoped to `:root[data-theme="dark"]`) |
+| `theme-brand-brik.css` | `bds-tokens` | Brik's own Brand Kit baked into BDS (scoped to `.theme-brand-brik`) — present because Brik is BDS's first-party brand |
+| `modes-borderwidth.css`, `modes-spacing.css` | `bds-tokens` | Mode mode overrides (see [Modes](#modes--orthogonal-axes) below) |
+| `gap-fills.css` | `bds-tokens` | Hand-authored bridge for tokens not yet in Figma — destined to migrate into Foundations Library |
+| `animations.css` | `bds-tokens` | Shared keyframes (`bds-spin`, `bds-pulse`, etc.) |
 
-### Tier 2 — what a client theme overrides
+<Callout type="warn">
+  **Do not import these files directly** — they're internal to the bundle. Consumers import `@brikdesigns/bds/tokens.css` only. Deprecated or out-of-scope CSS:
+  - `bridge.css` — `@deprecated`; opt-in legacy aliases for projects not yet on canonical names
+  - `react-tokens.css`, `webflow-tokens.css`, `website-themes.css` — superseded / surface-specific
+</Callout>
 
-The full overridability matrix lives in [Client Themes](/docs/theming/client-themes#overridability-matrix). Short version:
+### What lives in the `client-theme` Layer
+
+A consumer's `theme-{client}.css` overrides Brand Kit-controlled semantic tokens. Full matrix in [Client Themes](/docs/theming/client-themes). Short version:
 
 | Token group | Per-client override? |
 |---|---|
 | Brand colors (`--background-brand-primary`, `--text-brand-primary`, `--surface-brand-primary`, `--border-brand-primary`) | **Required** |
-| Brand interaction states (`--background-brand-primary-hover/-pressed`) | **Required if brand colors change** |
-| Page + surfaces (`--page-primary`, `--surface-primary`, `--surface-secondary`) | **Recommended** |
-| Fonts (`--font-family-heading/body/label`) | **Optional** |
-| Status (`--background/surface/text/border-positive/negative/warning`) | **Yes** if brand red/green/yellow clashes |
-| Extended status / presence / shadows | **No** |
+| Brand interaction states (`--background-brand-primary-hover` / `-pressed`) | **Required if brand colors change** |
+| Page + surface neutrals (`--page-primary`, `--surface-primary`, `--surface-secondary`) | **Recommended** |
+| Fonts (`--font-family-heading` / `-body` / `-label`) | **Optional** |
+| Status (`--background-positive` / `-negative` / `-warning`, etc.) | **Yes** if brand red/green/yellow clashes |
+| Extended status / presence / shadows | **No** — system invariants |
 
-## Theming is bigger than tokens
+## Theming Dimensions — composable per client
 
-The cascade above is **Layer 1** of the theming model. There are four layers total:
+CSS Layers handle the **values** cascade. But Theming as a whole composes across four independent **Theming Dimensions** (each a separate decision a client makes):
 
-| Layer | Decides | Lives in |
+| Theming Dimension | Decides | Where it lives |
 |---|---|---|
-| **1. Tokens** | Color / type / spacing values | `theme-{client}.css` (Tier 2) |
-| **2. Atmosphere** | Ambient decoration — vignettes, grain, orbs, spotlights | `@brikdesigns/bds/atmospheres/{slug}.css` |
-| **3. Layout Archetypes** | Site-header + site-footer shape, scroll + drawer behavior | `<SiteHeader>` / `<SiteFooter>` from `@brikdesigns/bds/blueprints-astro` |
-| **4. Blueprints** | Section composition — hero / services / testimonials shapes | Authored in BDS, tagged by mood + industry |
+| **Tokens** | Color / type / spacing values | Brand Kit Library → `theme-{client}.css` in `client-theme` Layer |
+| **Atmospheres** | Ambient decoration — grain, vignettes, orbs, spotlights | `@brikdesigns/bds/atmospheres/{slug}.css` |
+| **Layout Archetypes** | Site-header + footer shape, scroll + drawer behavior | `<SiteHeader>` / `<SiteFooter>` from blueprints |
+| **Blueprints** | Section composition — hero / services / testimonials shapes | Authored in BDS, tagged by mood + industry |
 
-Layers are independent. A client redefines tokens, keeps the industry's default atmosphere, swaps to a non-default nav archetype, uses the same blueprints another client uses — nothing cross-couples.
+A client picks values for each Dimension independently. Three different Dimensions == three different decisions — composing nothing cross-couples. Full Theming Tenet overview at [Theming](/docs/theming).
 
 <Callout type="warn">
-  **Atmospheres decorate; tokens decide values.** Atmosphere CSS files MUST NOT override `--page-*`, `--surface-*`, `--background-*`, `--text-*`, or `--border-*` — those are theme-layer concerns. See [Theming Overview → Layer 2](/docs/theming#layer-2--atmosphere).
+  **Atmospheres decorate; tokens decide values.** Atmosphere CSS files MUST NOT override `--page-*`, `--surface-*`, `--background-*`, `--text-*`, or `--border-*` — those are Tokens-Dimension concerns. Atmosphere is for decorative-only properties (filters, masks, pseudo-element graphics, etc.).
 </Callout>
 
-Full deep-dive: [Theming Overview](/docs/theming).
+## Sibling Tenets — Motion and Content
 
-## Modes — orthogonal axis
+The Theming Tenet handles per-client visual variation. Two peer Tenets handle the rest of what makes a client experience:
 
-Style Dictionary collections each have multiple modes (color: light/dark; borderwidth: thin/standard/bold; spacing: compact/default/comfortable/spacious; etc.). When a mode is **wired**, consumers can pick it via an attribute on `<html>`:
+- **Motion Tenet** — animation tokens (timing, easing, choreography) and motion behaviors. Canonical home: [Motion](/docs/motion).
+- **Content Tenet** — voice, tone, copy patterns, vocabularies (industries, brand voices, compliance). Canonical home: [Content System](/docs/content-system).
+
+Foundation, Theming, Motion, Content are the four **Tenets** of BDS. Tokens span Foundation (universal canon) and Theming (brand variation), but they're values inside the larger system, not the system itself.
+
+## Modes — orthogonal axes
+
+A Mode varies a token's *value* on a system-wide axis any consumer can toggle. Modes are **orthogonal** to Library, Layer, and Tier — every semantic token can have per-mode values without changing its name.
 
 ```html
-<html data-theme="dark" data-mode-borderwidth="bold">
+<html data-theme="dark" data-mode-borderwidth="bold" data-mode-spacing="comfortable">
 ```
 
-Each wired mode emits a `tokens/modes-{collection}.css` file scoped via `[data-mode-{collection}="value"]`. Today only `color` (via legacy `[data-theme]`) and `borderwidth` are wired. The other seven collections are dormant — see [#340](https://github.com/brikdesigns/brik-bds/issues/340) for the wiring plan.
+| Mode collection | Attribute | Default | Other values | Wired? |
+|---|---|---|---|---|
+| `color` | `data-theme` (legacy attribute) | `light` | `dark` | ✅ |
+| `borderwidth` | `data-mode-borderwidth` | `default` | `thin`, `bold` | ✅ |
+| `spacing` | `data-mode-spacing` | `default` | `compact`, `comfortable`, `spacious` | ✅ |
+| `border-radius` | `data-mode-radius` | `soft` | `sharp`, `round`, `pill` | ⏳ [#340](https://github.com/brikdesigns/brik-bds/issues/340) |
+| `typography` | `data-mode-typography` | `default` | `compact`, `comfortable`, `spacious` | ⏳ #340 |
+| `elevation` | `data-mode-elevation` | `subtle` | `flat`, `lifted`, `dramatic` | ⏳ #340 |
+| `breakpoint` | `data-mode-breakpoint` | `default` | `compact`, `comfortable` | ⏳ #340 |
+| `icon` | `data-mode-icon` | `solid` | `outline` | ⏳ #340 |
 
-Modes vary token *values* on a system-wide axis any consumer can toggle. They are **not** a substitute for atmospheres (decoration) or for client themes (per-brand values).
+Each wired mode emits a `tokens/modes-{collection}.css` file scoped via `[data-mode-{collection}="value"]`. Modes are **not** a substitute for Theming Dimensions (which compose subsystems per brand) or for Brand Kit overrides (which change *values*, not modes).
 
 ## Color foundations vocabulary
 
-The semantic color token families components reference, and the *only* names a Tier 2 client theme should override:
+Semantic color tokens — the names components reference, and the only names a Brand Kit's `theme-{client}.css` should override:
 
 | Family | Concept | Examples |
 |---|---|---|
@@ -109,36 +133,39 @@ The semantic color token families components reference, and the *only* names a T
 | `--text-*` | Type colors | `--text-primary`, `--text-brand-primary`, `--text-on-color-dark` |
 | `--border-*` | Edge colors | `--border-primary`, `--border-brand-primary`, `--border-input` |
 
-Full vocabulary at [Primitives → Color](/docs/primitives/color). The canonical registry is the live `dist/tokens.css` bundle.
+Full registry at [Color](/docs/primitives/color). Canonical bundle: `dist/tokens.css`.
 
 <Callout type="warn">
-  **Names not in the registry are not real.** Inventing a `--surface-paper`, `--text-on-ink`, or `-soft` / `-warm` modifier creates parallel taxonomy drift. If you need a new token, add it to BDS first via Figma → Tokens Studio → Style Dictionary. See [Primitives → Color](/docs/primitives/color).
+  **Names not in the registry are not real.** Inventing a `--surface-paper`, `--text-on-ink`, `-soft` / `-warm` modifier, or a `--theme-brik-*` / `--brand-{tier}` namespace creates parallel taxonomy drift. If you need a new token, add it to a Library first via Figma → Tokens Studio → Style Dictionary. See [Token Anatomy](/docs/primitives/token-anatomy) for the closed forms.
 </Callout>
 
-## Switches — `<html>` attributes
+## `<html>` attribute switchboard
 
 | Attribute | Values | Effect |
 |---|---|---|
-| `data-theme` | `light` (default) / `dark` | Switches color collection mode (legacy selector for the color mode) |
-| `data-mode-borderwidth` | `thin` / `bold` (omit for Standard) | Picks borderwidth mode |
-| `data-audience` / `data-service` / `data-department` | Per-site convention | Re-binds canonical brand tokens within the subtree (multi-brand client pattern — see [Client Themes → scope binding](/docs/theming/client-themes#per-audience-or-service-line-scope-binding)) |
+| `data-theme` | `light` (default) / `dark` | Color mode |
+| `data-mode-borderwidth` | `default` (omit) / `thin` / `bold` | Borderwidth mode |
+| `data-mode-spacing` | `default` (omit) / `compact` / `comfortable` / `spacious` | Spacing density mode |
+| `data-audience` / `data-service` / `data-department` | Per-site convention | Re-binds canonical brand tokens within a subtree (multi-brand pattern — see [Client Themes → scope binding](/docs/theming/client-themes#per-audience-or-service-line-scope-binding)) |
 
-Storybook's paintbrush toolbar sets `data-theme` automatically. Product apps use `<ThemeProvider>`. Astro / Webflow / static consumers set the attribute manually on `<html>`.
+Storybook's paintbrush toolbar sets `data-theme` automatically. React apps use `<ThemeProvider>`. Astro / Webflow / static consumers set attributes manually on `<html>`.
 
-## Where this is enforced
+## Where the cascade is enforced
 
-| Gate | What it checks | Where |
+| Gate | What it checks | Where it runs |
 |---|---|---|
-| `scripts/lint-tokens.js` | Hex values in component CSS, nonexistent `var()` references, primitives used outside their semantic category | BDS pre-commit + CI (`npm run validate`) |
-| `scripts/canonical-check.mjs` | `--text-*` / `--surface-*` / `--background-*` / `--border-*` / `--color-*` token names exist in `dist/tokens.css` | BDS pre-commit + CI |
-| `@brikdesigns/bds/canonical-check` (consumer dep) | Same canonical-check engine published for consumer repos | Consumer pre-commit + CI via `token-audit.sh --canonical-only` |
+| `scripts/lint-tokens.js` | Hex values in component CSS, nonexistent `var()` references, Primitives used outside their Semantic category | BDS pre-commit + CI (`npm run validate`) |
+| `scripts/canonical-check.mjs` | `--text-*` / `--surface-*` / `--background-*` / `--border-*` / `--color-*` names exist in `dist/tokens.css` | BDS pre-commit + CI |
+| `@brikdesigns/bds/canonical-check` (consumer dep) | Same engine published for consumer repos | Consumer pre-commit + CI via `token-audit.sh --canonical-only` |
 
 Run BDS gates locally: `npm run validate`. Consumer gates: `./scripts/token-audit.sh --canonical-only`.
 
 ## Related
 
-- [Theming Overview](/docs/theming) — the four-layer cascade in depth
-- [Client Themes](/docs/theming/client-themes) — Tier 2 override matrix + minimal template
-- [Atmospheres](/docs/theming/atmospheres) — Layer 2 decoration overlays
-- [Primitives → Color](/docs/primitives/color) — semantic color vocabulary
-- [`tokens/CASCADE.md`](https://github.com/brikdesigns/brik-bds/blob/main/tokens/CASCADE.md) — file-level decision tree
+- [Token Anatomy](/docs/primitives/token-anatomy) — the six-concept disambiguation map + Tier abstraction stack
+- [Library Architecture](/docs/getting-started/figma-library-architecture) — Foundations vs Brand Kit Libraries + the Style Dictionary pipeline
+- [Theming](/docs/theming) — full Theming Tenet (Tokens / Atmospheres / Layout / Blueprints Dimensions)
+- [Client Themes](/docs/theming/client-themes) — per-client override matrix + minimal `theme-{client}.css` template
+- [Atmospheres](/docs/theming/atmospheres) — the Atmospheres Dimension
+- [Color](/docs/primitives/color) — full canonical color registry
+- [`tokens/CASCADE.md`](https://github.com/brikdesigns/brik-bds/blob/main/tokens/CASCADE.md) — file-level decision tree (cross-repo)

--- a/docs-site/content/docs/getting-started/figma-library-architecture.mdx
+++ b/docs-site/content/docs/getting-started/figma-library-architecture.mdx
@@ -1,0 +1,100 @@
+---
+title: Library Architecture
+description: BDS sources tokens from two logical libraries — the Foundations Library (universal, agnostic) and per-client Brand Kit Libraries — composed by Style Dictionary into the shipped CSS bundle.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A **Library** is the authoritative source of token definitions for a scope. BDS uses two:
+
+- **Foundations Library** — universal, brand-agnostic. Owns math scales (typography / spacing / elevation / motion), grayscale primitives, system messaging primitives, and base semantic tokens that have a sensible default before any brand applies.
+- **[Client] Brand Kit Library** — one per client. Owns brand color primitives (poppy / tan / etc. for Brik; whatever palette the client has), brand semantic overrides (light + dark), and any client-specific mode picks.
+
+<Callout type="info">
+  "Library" is a logical concept, implementation-agnostic. Today both libraries are Figma files managed via the Tokens Studio plugin. If the storage layer changes (raw DTCG JSON, Penpot, etc.), the Library distinction still holds — it's a *role*, not a tool.
+</Callout>
+
+## What each Library owns
+
+| Library | Primitives | Semantic tokens | Modes |
+|---|---|---|---|
+| **Foundations** | `--color-grayscale-*`, `--color-system-*`, `--font-size-*`, `--space-*`, `--border-radius-*`, `--shadow-*`, motion primitives, annotation | Universal defaults (`--text-primary`, `--surface-primary`, `--background-positive`, etc.) | borderwidth, spacing, typography, elevation, breakpoint, radius, icon |
+| **Brand Kit** (per client) | Brand color family ramps (`--color-poppy-*`, `--color-tan-*`, etc.) | Brand overrides on the same canonical names (`--background-brand-primary`, `--text-brand-primary`, plus service-line semantics where applicable) | `color` (light / dark) per brand |
+
+<Callout type="warn">
+  **Foundations Library MUST NOT carry brand-specific values.** That's the failure pattern brik-bds#712 retired — the deleted `primitives/value.{brand, theme.brik, theme.blue}` groups were brand-specific tokens sitting in Foundations. If a token would change per client, it belongs in a Brand Kit, not in Foundations.
+</Callout>
+
+## How the libraries compose
+
+Both libraries flow through the same Style Dictionary pipeline, into the same `dist/tokens.css` bundle, scoped to different CSS [Layers](/docs/getting-started/cascade#css-layers):
+
+```
+┌──────────────────────────┐         ┌────────────────────────────┐
+│  Foundations Library     │         │  [Client] Brand Kit Library│
+│  (Figma — Tokens Studio) │         │  (Figma — Tokens Studio)   │
+└────────────┬─────────────┘         └────────────────┬───────────┘
+             │ pull-variables.js                      │ pull-variables.js
+             │ (channel id)                           │ (channel id)
+             ▼                                        ▼
+   design-tokens/foundations.json        design-tokens/brand-kits/{slug}.json
+             │                                        │
+             └────────────────┬───────────────────────┘
+                              │ Style Dictionary
+                              ▼
+              tokens/figma-tokens.css            (Foundations → @layer bds-tokens)
+              tokens/figma-tokens-dark.css       (Foundations dark mode)
+              tokens/theme-{client}.css          (Brand Kit → @layer client-theme)
+
+                              │ build-dist-tokens.js
+                              ▼
+                       dist/tokens.css           (shipped to consumers)
+```
+
+<Callout type="warn">
+  **Current state vs target state.** Today, `design-tokens/tokens-studio.json` is a pre-separation merged snapshot that combines Foundations + Brik Brand Kit content. The multi-library pull procedure (separate JSON per library, merged at build time) is the target architecture — not yet fully wired. Tracked under brik-bds#712. Until the pull is multi-library, manual care is required when refreshing the snapshot.
+</Callout>
+
+## Pull procedure
+
+Each library has its own channel ID in the WebSocket relay. The `start-figma-relay.sh` script runs the relay on port `3055`; the user / designer opens each Figma file with the Tokens Studio plugin and runs `pull-variables.js` per library.
+
+```bash
+# 1. Start the relay (idempotent — no-op if already running)
+./scripts/start-figma-relay.sh
+
+# 2. Pull each library separately (read-only)
+bun scripts/pull-variables.js <foundations-channel-id> > design-tokens/foundations.json
+bun scripts/pull-variables.js <brand-kit-channel-id>   > design-tokens/brand-kits/brik.json
+
+# 3. (Future: merge step lands here, replacing today's monolithic tokens-studio.json)
+
+# 4. Build CSS
+npm run build:all-tokens
+```
+
+<Callout type="info">
+  Channel IDs are short, single-use tokens emitted by the Tokens Studio plugin when a Figma file is opened. They expire when the Figma session closes. **Never commit a channel ID** — it's session-scoped, not configuration.
+</Callout>
+
+## When to add a Brand Kit
+
+| Scenario | Library decision |
+|---|---|
+| New client onboarding (Vale / Renew / Memphis / etc.) | Create a new Brand Kit Library in Figma. Set up brand color primitives + brand semantic overrides + dark mode. Emit `theme-{client}.css`. |
+| Brand refresh on an existing client | Update the client's Brand Kit Library only. Foundations doesn't change. Pull → rebuild → ship the regenerated `theme-{client}.css`. |
+| New universal token (math scale, system color, base semantic) | Add to **Foundations Library**. Affects every brand. Coordinate via PR + Chromatic. |
+| New brand-specific concept (service-line, audience-scoped color, custom dimension) | Add to the relevant **Brand Kit Library** as a brand-specific semantic token (e.g., `--background-service-marketing`). Foundations stays untouched. |
+
+## Drift signals — when a Library boundary is being violated
+
+- A new token name shaped `--brand-{tier}` or `--theme-{name}-*` shows up in `dist/tokens.css` → Library boundary violation. Move it to Brand Kit (or retire if redundant).
+- A consumer hand-overrides a primitive in their local `globals.css` instead of updating their Brand Kit Library → drift. The override belongs in the Brand Kit so it propagates to anyone consuming the same brand.
+- A "demo" or "structural" color sits in Foundations → boundary violation. Demo content belongs in a Brand Kit (or stories), never in canonical Foundations.
+
+## Related
+
+- [Token Anatomy](/docs/primitives/token-anatomy) — the four-tier abstraction stack the libraries feed into
+- [The Cascade](/docs/getting-started/cascade) — how Library output maps to CSS Layers at consumer runtime
+- [Style Dictionary build pipeline](/docs/react-reference/utilities#style-dictionary-build-pipeline) — commands + outputs per library
+- [Client Themes](/docs/theming/client-themes) — the consumer-side `theme-{client}.css` override matrix (the runtime shape Brand Kits emit into)

--- a/docs-site/content/docs/getting-started/index.mdx
+++ b/docs-site/content/docs/getting-started/index.mdx
@@ -9,13 +9,17 @@ Consumers import from `@brikdesigns/bds`. There is no submodule, no copy-paste �
 
 ## How this site is organized
 
-- **Primitives** — the design tokens everything inherits from. Color foundations (`--page-*`, `--surface-*`, `--background-*`, `--text-*`, `--border-*`), typography, spacing, radius, shadow, sizing.
-- **Theming** — the four layers that turn primitives into per-client visual identity. Tokens (Tier 2 client overrides), atmospheres (decoration overlays), layout archetypes (nav + footer), blueprints (section composition).
-- **Components** — React building blocks every product surface composes from.
+BDS has four **Tenets**: Foundation, Theming, Motion, Content. Each gets its own section here:
+
+- **Primitives (Foundation)** — universal token canon: color foundations (`--page-*`, `--surface-*`, `--background-*`, `--text-*`, `--border-*`), typography, spacing, radius, shadow, sizing. Start with [Token Anatomy](/docs/primitives/token-anatomy) for the six-concept vocabulary every other page builds on.
+- **Theming** — composing per-client brand identity across four [Theming Dimensions](/docs/theming): Tokens (brand overrides via `theme-{client}.css` in `@layer client-theme`), Atmospheres (decoration overlays), Layout Archetypes (nav + footer), Blueprints (section composition).
+- **Motion** — animation tokens + behaviors (CSS reveals, GSAP, premium effects).
 - **Content System** — industry packs, voice definitions, the BCS vocabulary that selects theming defaults.
-- **Motion** — the orthogonal motion tenet (CSS reveals, GSAP, premium effects).
-- **Documentation system** — the tier model and lifecycle behind how BDS is documented (read before contributing docs changes).
+- **Components** — React building blocks every product surface composes from.
+- **Documentation system** — how BDS is documented (read before contributing docs changes).
 - **Page templates** — the standard shape every docs page follows.
+
+New to the token system? Read [Token Anatomy](/docs/primitives/token-anatomy) and [Library Architecture](/docs/getting-started/figma-library-architecture) first — they lock the vocabulary every other section uses.
 
 ## How this site relates to Storybook
 

--- a/docs-site/content/docs/getting-started/meta.json
+++ b/docs-site/content/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Getting Started",
-  "pages": ["index", "installation", "cascade", "framework-guides", "react-composition", "documentation-system", "page-templates"]
+  "pages": ["index", "installation", "cascade", "figma-library-architecture", "framework-guides", "react-composition", "documentation-system", "page-templates"]
 }

--- a/docs-site/content/docs/getting-started/react-composition.mdx
+++ b/docs-site/content/docs/getting-started/react-composition.mdx
@@ -23,7 +23,7 @@ Reference implementation: [`brik-client-portal`](https://github.com/brikdesigns/
 
 ## 1. `src/lib/tokens.ts` — typed primitives
 
-Maps Figma style names to CSS-custom-property references. **One leaf = one `var()`.** These reference the property (not the resolved value), so they work correctly with theme + mode switches and Tier 2 brand overrides.
+Maps Figma style names to CSS-custom-property references. **One leaf = one `var()`.** These reference the property (not the resolved value), so they work correctly with [Mode](/docs/getting-started/cascade#modes--orthogonal-axes) switches and per-client Brand Kit overrides emitted into `@layer client-theme`.
 
 ```ts title="src/lib/tokens.ts"
 export const font = {

--- a/docs-site/content/docs/primitives/interaction-states.mdx
+++ b/docs-site/content/docs/primitives/interaction-states.mdx
@@ -1,0 +1,95 @@
+---
+title: Interaction States
+description: Tokens for hover, press, focus, and disabled states. Composable across surfaces via overlay primitives + per-brand state-pair semantics.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Every interactive component (button, card, tag, chip, link) uses the same interaction-state vocabulary. Two layers compose:
+
+1. **Composable overlay primitives** — transparent overlays that work on *any* surface (brand, neutral, status, service-line) without needing a unique hover token per color.
+2. **Brand state pairs** — solid `-hover` / `-pressed` Semantic tokens on brand-colored surfaces (filled brand buttons) where an overlay would be visually weak.
+
+## Overlay primitives — composable hover/press
+
+| Token | Light mode | Dark mode | Purpose |
+|---|---|---|---|
+| `--state-hover-overlay` | `rgba(0, 0, 0, 0.04)` | `rgba(255, 255, 255, 0.06)` | Subtle hover overlay on any surface |
+| `--state-pressed-overlay` | `rgba(0, 0, 0, 0.08)` | `rgba(255, 255, 255, 0.10)` | Stronger overlay for `:active` / press |
+| `--state-focus` | aliases `--border-brand-primary` | aliases `--border-brand-primary` | Keyboard focus ring color |
+| `--state-disabled-opacity` | `0.4` | `0.4` | Opacity for disabled elements |
+
+<Callout type="info">
+  **Why overlays?** A transparent overlay works on ANY background — brand, surface-secondary, status-positive, service-line — without needing a unique hover token per color. One token handles every context. Solid `-hover` tokens only exist where the brand-fill cases need them.
+</Callout>
+
+### Component usage pattern
+
+```css
+/* Hover — composable overlay on any background */
+.bds-component:hover {
+  box-shadow: inset 0 0 0 999px var(--state-hover-overlay);
+}
+
+/* Press — stronger overlay */
+.bds-component:active {
+  box-shadow: inset 0 0 0 999px var(--state-pressed-overlay);
+}
+
+/* Focus — reuses existing border-width token; offset is fixed at 2px for a11y */
+.bds-component:focus-visible {
+  outline: var(--border-width-lg) solid var(--state-focus);
+  outline-offset: 2px;
+}
+
+/* Brand button hover — solid primitive (not overlay) since fill needs a real shift */
+.bds-button--primary:hover {
+  background-color: var(--background-brand-primary-hover);
+}
+
+/* Disabled */
+.bds-component--disabled {
+  opacity: var(--state-disabled-opacity);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+```
+
+## Brand state pairs — solid `-hover` / `-pressed`
+
+For brand-colored surfaces (filled primary buttons, brand backgrounds), the overlay approach gets visually weak — the inset overlay against a vibrant brand color doesn't read as a strong-enough interaction signal. These surfaces use **solid state-pair Semantic tokens** that map to deeper / lighter primitives in the brand color ramp:
+
+| Token | Light mode source | Dark mode source |
+|---|---|---|
+| `--background-brand-primary-hover` | One step deeper in the brand ramp (e.g., `--color-poppy-darker`) | One step lighter (e.g., `--color-poppy-lighter`) |
+| `--background-brand-primary-pressed` | Two steps deeper (e.g., `--color-poppy-darkest`) | Two steps lighter (e.g., `--color-poppy-lightest`) |
+| `--surface-brand-primary-hover` | Same ramp pattern as background-hover | Same |
+| `--surface-brand-primary-pressed` | Same ramp pattern as background-pressed | Same |
+
+<Callout type="warn">
+  **State-pair siblings are required when a Brand Kit overrides `--background-brand-primary` or `--surface-brand-primary`.** Override the base color without pairing the `-hover` / `-pressed` siblings, and the canonical default leaks through on interaction. The cleanup in brik-bds#710 retired exactly this pattern of bug.
+</Callout>
+
+## Focus ring rules
+
+- **Width** uses `--border-width-lg` — no new dimension token. Mode picks (`data-mode-borderwidth`) propagate automatically.
+- **Offset** is hardcoded `2px` in CSS — accessibility fixed value, not themeable.
+- **Color** aliases `--border-brand-primary` so the focus ring picks up brand identity automatically when a Brand Kit applies.
+
+## Decision tree — overlay vs solid
+
+Walk this top-down when implementing a component's hover/press:
+
+1. **Is the resting background a brand color or status color** (filled buttons, brand badges)?
+   - Yes → use solid `-hover` / `-pressed` Semantic tokens (`--background-brand-primary-hover`, etc.).
+2. **Is the resting background a neutral surface** (cards, list items, ghost buttons, links on `--surface-primary`)?
+   - Yes → use overlay primitives (`--state-hover-overlay`, `--state-pressed-overlay`).
+3. **Is the component a link or text-button** (no fill, color shift only)?
+   - Use the overlay primitive OR shift the text color one tier deeper (e.g., `--text-brand-primary` → `--color-poppy-darker` on hover). Don't compose both.
+
+## Related
+
+- [Token Anatomy](/docs/primitives/token-anatomy) — the four-tier abstraction these state tokens sit at (Semantic Tier)
+- [The Cascade](/docs/getting-started/cascade) — how state tokens compose with [Modes](/docs/getting-started/cascade#modes--orthogonal-axes) and brand overrides
+- [Color](/docs/primitives/color) — the Primitive ramps the brand state pairs draw from
+- [Client Themes](/docs/theming/client-themes) — Brand Kit override matrix (state pairs are required when brand colors change)

--- a/docs-site/content/docs/primitives/meta.json
+++ b/docs-site/content/docs/primitives/meta.json
@@ -2,7 +2,9 @@
   "title": "Foundation",
   "pages": [
     "index",
+    "token-anatomy",
     "color",
+    "interaction-states",
     "typography",
     "spacing",
     "size",

--- a/docs-site/content/docs/primitives/naming-conventions.mdx
+++ b/docs-site/content/docs/primitives/naming-conventions.mdx
@@ -468,6 +468,21 @@ The element / BEM table above lists which HTML elements each role maps to. The i
   This is a discipline rule, not a build-time lint (yet). If a wrapper is ambiguous about its role, add a BEM class with the role name before you add any CSS.
 </Callout>
 
+## Tag vs Badge — nouns vs verbs
+
+A common confusion: when to use a `Tag` component vs a `Badge`. The distinction is **what the element labels**, not how it looks.
+
+| Element | Shape | Token source | Purpose | Examples |
+|---|---|---|---|---|
+| **Tag** | Soft rounded (`--border-radius-sm`) | Service-line / domain tokens (`--background-service-marketing`, etc.) | **Nouns** — categories, labels, classifications | "Clinical", "Front Desk", "OSHA", "Marketing" |
+| **Badge** | Pill (`--border-radius-pill`) | Status tokens (`--background-positive`, `--background-warning`, etc.) | **Verbs / states** — statuses, outcomes, transient states | "Active", "New", "Completed", "Pending" |
+
+The grammatical test resolves edge cases: if the label answers *what kind is this thing?* → Tag. If it answers *what state is this thing in?* → Badge.
+
+<Callout type="warn">
+  **Don't mix the token sources.** A Tag that uses status tokens (`--background-positive`) reads as a state when it should read as a category. A Badge that uses service-line tokens (`--background-service-marketing`) reads as a category when it should read as a state. The wrong combination obscures meaning even if the colors "look fine."
+</Callout>
+
 ## Related
 
 - [Design Tokens overview](/docs/primitives) — the architecture these names sit inside

--- a/docs-site/content/docs/primitives/token-anatomy.mdx
+++ b/docs-site/content/docs/primitives/token-anatomy.mdx
@@ -1,0 +1,142 @@
+---
+title: Token Anatomy
+description: The six disambiguated concepts that describe every BDS token — Anatomy, Tier, Library, Layer, Mode, Tenet — and the four-tier abstraction stack every token belongs to.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Every BDS token answers six independent questions. Without distinct vocabulary for each, agents and humans invent parallel taxonomies and the system drifts (portal #512 / #553, retired `--theme-brik-*`, retired `--brand-{tier}`). This page locks the vocabulary so the discipline lives in the words themselves.
+
+## Six concepts, six words
+
+| Concept | Term | Question it answers | Values |
+|---|---|---|---|
+| Naming structure | **Anatomy** | How is it *named*? | `--{purpose}-{role}[-{state}]` |
+| Abstraction level | **Tier** | What *kind* of token is it? | Raw · Primitive · Semantic · Component |
+| Source of truth | **Library** | Where is it *defined*? | Foundations Library · [Client] Brand Kit Library |
+| CSS cascade origin | **Layer** | Which `@layer` *carries its value*? | `bds-tokens` · `bds-components` · `client-theme` · `client-overrides` |
+| Value axis | **Mode** | Which axis *varies its value*? | color light/dark · borderwidth thin/bold · spacing compact/spacious / etc. |
+| System pillar | **Tenet** | Which *system pillar* governs it? | Foundation · Theming · Motion · Content |
+
+**These are orthogonal.** A token has one answer for each. Mixing them — calling `--brand-tertiary` a "tier" because it sits at the top level — is the failure mode the cleanup retired.
+
+<Callout type="warn">
+  **Before referencing a token name, you should be able to answer all six.** If you can't, you're guessing — verify against the canonical registry (`dist/tokens.css`) first.
+</Callout>
+
+## Anatomy — the naming formula
+
+Every token name follows `--{purpose}-{role}[-{state}]`. Each segment is fixed vocabulary:
+
+| Segment | Allowed values | Example |
+|---|---|---|
+| `purpose` | `page`, `surface`, `background`, `text`, `border`, `color` (primitives only) | `--background-…` |
+| `role` | Closed list — see [Color foundations vocabulary](/docs/getting-started/cascade#color-foundations-vocabulary) | `--background-brand-primary` |
+| `state` (optional) | `hover`, `pressed`, `disabled` | `--background-brand-primary-hover` |
+
+Status, service-line, and presence semantic tokens follow the same anatomy with their own role vocabularies (`--background-positive`, `--background-service-marketing`, `--background-presence-online`).
+
+<Callout type="error">
+  **Token names without a `purpose` prefix are drift.** Examples retired by brik-bds#712: `--brand-primary` (missing purpose; legitimate form is `--{purpose}-brand-primary`), `--theme-brik-*` (entire namespace violates the anatomy). If you see something shaped `--brand-X` or `--theme-X-Y` in old code, it's drift and should not be referenced.
+</Callout>
+
+## Tier — the four-tier abstraction stack
+
+Every token sits at exactly one Tier. Higher tiers reference lower tiers via `var()`. Components only consume the upper tiers.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Tier 4 — Component    (TBD — placeholder)              │
+│  Component-scoped tokens, bound to a specific component │
+│  Example: --bds-button-primary-padding-x (not yet       │
+│  emitted as a tier; deliberately unspecified)           │
+└─────────────────────────────────────────────────────────┘
+                          ▲
+                          │ var()
+┌─────────────────────────────────────────────────────────┐
+│  Tier 3 — Semantic     (what components consume)        │
+│  --{purpose}-{role}: var(--color-{family}-{step})       │
+│  Example: --background-brand-primary:                   │
+│             var(--color-poppy-dark)                     │
+└─────────────────────────────────────────────────────────┘
+                          ▲
+                          │ var()
+┌─────────────────────────────────────────────────────────┐
+│  Tier 2 — Primitive    (named raw values)               │
+│  --color-{family}-{step}: #hex                          │
+│  Example: --color-poppy-dark: #b0351b                   │
+└─────────────────────────────────────────────────────────┘
+                          ▲
+                          │
+┌─────────────────────────────────────────────────────────┐
+│  Tier 1 — Raw          (literal hex / numeric value)    │
+│  Not a CSS variable — the literal value before naming.  │
+│  Example: #b0351b                                       │
+└─────────────────────────────────────────────────────────┘
+```
+
+### What lives at each Tier
+
+| Tier | Naming | Source | Components reference it? |
+|---|---|---|---|
+| **Raw** | Literal `#b0351b` | Figma swatch / hex chosen by design | **No** — never in component CSS |
+| **Primitive** | `--color-{family}-{step}` (color), `--font-size-{step}` (type), `--space-{step}` (spacing), etc. | Auto-generated from Figma Variables → Style Dictionary | **No** — never in component CSS (use Semantic) |
+| **Semantic** | `--{purpose}-{role}` — Color foundations vocabulary | Auto-generated; client themes override **values** with same **names** | **Yes** — this is the contract |
+| **Component** | TBD — deliberately unspecified | TBD | TBD |
+
+<Callout type="warn">
+  **Components consume Semantic tokens, never Primitives directly.** A button's CSS references `--background-brand-primary`, not `--color-poppy-dark`. Why: Semantic is the layer that varies per brand. Bypassing it locks the component to one brand.
+</Callout>
+
+### About Tier 4 (Component)
+
+The system has not yet specified a Component tier. The pattern would be `--bds-{component}-{property}` — component-scoped tokens that bind a specific component to specific values. Today most components consume Semantic tokens directly, which is sufficient for current scale. **Do not invent Component-tier tokens** until the canonical pattern lands.
+
+## How the six concepts map to a real token
+
+Take `--background-brand-primary` (the hot path):
+
+| Concept | Answer |
+|---|---|
+| Anatomy | `--{purpose: background}-{role: brand-primary}` |
+| Tier | Semantic |
+| Library | Defined in **Foundations Library** as the canonical name; the *value* is overridden by each **Brand Kit Library** |
+| Layer | `bds-tokens` for the canonical default; `client-theme` for the per-client override |
+| Mode | Varies by `color` mode (light / dark) |
+| Tenet | Foundation (token canon) + Theming (brand override) |
+
+Every legitimate token answers all six. If a token doesn't fit any one of them, it's drift.
+
+## Drift patterns to recognize (and not extend)
+
+| Drift pattern | Why it's wrong | Retired in |
+|---|---|---|
+| `--theme-{name}-*` (`--theme-brik-green`, `--theme-blue-blue-light`) | Doesn't match Anatomy — no `purpose` prefix. Duplicate alias of a `--color-{family}-{step}` primitive. | brik-bds#712 / [#727](https://github.com/brikdesigns/brik-bds/pull/727) |
+| `--brand-{tier}` (`--brand-primary`, `--brand-tertiary`) | Brand-tier names without `purpose` prefix. Legitimate composed form is `--{purpose}-brand-{tier}`. | brik-bds#712 / [#727](https://github.com/brikdesigns/brik-bds/pull/727) |
+| `--surface-paper`, `--text-on-ink`, `--surface-soft`, `--surface-warm` | Invented modifiers or invented `role` values that aren't in the closed Color foundations vocabulary. Always parallel taxonomy. | portal [#512 / #553](https://github.com/brikdesigns/brik-client-portal/pull/553) (rolled back) |
+| Component CSS reading `--color-{family}-{step}` directly | Bypasses the Semantic tier. Locks the component to one brand. | Caught by `scripts/lint-tokens.js` |
+
+<Callout type="error">
+  **Inventing parallel taxonomy is the failure mode this vocabulary exists to prevent.** Three rollbacks (portal #512, portal #553, brik-bds#712 cleanup) trace to agents inventing names that *almost* fit. When in doubt, verify in `dist/tokens.css` — if the name isn't there, it isn't real.
+</Callout>
+
+## Verifying a token before referencing it
+
+```bash
+# Is this name in the canonical registry?
+rg '\-\-{token-name}' node_modules/@brikdesigns/bds/dist/tokens.css
+
+# Or run the consumer-side gate
+./scripts/token-audit.sh --canonical-only
+```
+
+If the gate is missing or the name isn't found, **stop**. Don't ship a `var()` call against a name that doesn't exist.
+
+## Related
+
+- [The Cascade](/docs/getting-started/cascade) — Layer ordering, modes, color foundations vocabulary
+- [Figma Library architecture](/docs/getting-started/figma-library-architecture) — Foundations Library vs Brand Kit Library
+- [Color](/docs/primitives/color) — full canonical color registry
+- [Color primitive tiers](/docs/content-system/vocabularies/color-primitive-tier) — the closed `tier` vocabulary used by the portal theme generator
+- [Naming Conventions](/docs/primitives/naming-conventions) — BEM slot vocabulary (different domain — component class names, not token names)
+- [Style Dictionary build pipeline](/docs/react-reference/utilities#style-dictionary-build-pipeline) — how Figma → Library → Layer → CSS happens

--- a/docs-site/content/docs/react-reference/utilities.mdx
+++ b/docs-site/content/docs/react-reference/utilities.mdx
@@ -13,33 +13,61 @@ This page covers tooling that sits **inside BDS** — what BDS builds, ships, an
 
 ## Style Dictionary build pipeline
 
-BDS owns the source-of-truth pipeline. Consumers never run these — they consume the compiled outputs via `@brikdesigns/bds`. Knowing the pipeline matters when a token is missing or a rename is in flight.
+BDS owns the source-of-truth pipeline. Consumers never run these — they consume the compiled outputs via `@brikdesigns/bds`. Knowing the pipeline matters when a token is missing, a rename is in flight, or a Library is being refreshed.
+
+### Two-Library composition
+
+BDS sources tokens from two logical [Libraries](/docs/getting-started/figma-library-architecture) — the **Foundations Library** (universal, agnostic) and the **Brik Brand Kit Library** (brand-specific values). Both are Figma files managed via Tokens Studio. The pipeline pulls each via the WebSocket relay (port `3055`), then Style Dictionary composes them into the shipped bundle:
 
 ```
-Figma Variables
-   │ (export via dev plugin + WebSocket relay :3055)
-   ▼
-design-tokens/tokens-studio.json
-   │ (Style Dictionary)
-   ▼
-tokens/figma-tokens.css        ← light mode CSS (consumed everywhere)
-tokens/figma-tokens-dark.css   ← dark mode CSS (scoped to [data-theme="dark"])
-build/figma/js/tokens.mjs      ← JS object form
-build/figma/swift/*.swift      ← iOS sync
+┌──────────────────────────┐         ┌────────────────────────────┐
+│  Foundations Library     │         │  Brik Brand Kit Library    │
+│  (Figma — Tokens Studio) │         │  (Figma — Tokens Studio)   │
+└────────────┬─────────────┘         └────────────────┬───────────┘
+             │ bun pull-variables.js <channel>        │ bun pull-variables.js <channel>
+             ▼                                        ▼
+   design-tokens/foundations.json       design-tokens/brand-kits/brik.json
+             │                                        │
+             └────────────────┬───────────────────────┘
+                              │ Style Dictionary
+                              ▼
+        tokens/figma-tokens.css         (Foundations primitives + base semantics — @layer bds-tokens)
+        tokens/figma-tokens-dark.css    (Foundations dark — scoped to [data-theme="dark"])
+        tokens/theme-brand-brik.css     (Brik Brand Kit — scoped to .theme-brand-brik)
+        build/figma/js/tokens.mjs       (JS object form)
+        build/figma/swift/*.swift       (iOS sync)
+                              │ scripts/build-dist-tokens.js
+                              ▼
+                       dist/tokens.css  (shipped to consumers via @brikdesigns/bds/tokens.css)
 ```
+
+<Callout type="warn">
+  **Current state vs target.** Today `design-tokens/tokens-studio.json` is a single pre-separation merged snapshot containing both Foundations and Brand Kit content. The per-Library JSON split (`foundations.json` + `brand-kits/{slug}.json`) is the target architecture. Until the multi-Library pull lands, manual care is required when refreshing the snapshot. Tracked in brik-bds#712.
+</Callout>
+
+### Commands
 
 | Command | Input | Output |
 | --- | --- | --- |
+| `./scripts/start-figma-relay.sh` | (none) | Starts the WebSocket relay on port 3055 (idempotent — no-op if running) |
+| `bun scripts/pull-variables.js <channel-id>` | Live Figma file via relay | JSON dump of all variables (stdout — pipe to a file under `design-tokens/`) |
+| `./scripts/figma-pull-tokens.sh [channel-id]` | (relay channel) | One-shot wrapper: pull + sync + build |
 | `npm run build:sd-figma` | `design-tokens/tokens-studio.json` | `tokens/figma-tokens.css`, JS, Swift |
 | `npm run build:sd-dark` | same JSON, `color=dark` mode | `tokens/figma-tokens-dark.css` |
-| `npm run build:all-tokens` | both | full rebuild (light + dark) |
-| `npm run build:lib` | full repo | publishable `dist/` |
+| `npm run build:modes` | same JSON | `tokens/modes-{collection}.css` per wired mode |
+| `npm run build:all-tokens` | all the above SD steps | Full rebuild (light + dark + modes) |
+| `npm run build:dist-tokens` | all `tokens/*.css` | `dist/tokens.css` (concatenation + bundle) |
+| `npm run build:lib` | full repo | Publishable `dist/` |
 
 <Callout type="warn">
-  **Never hand-edit `tokens/figma-tokens.css`.** It's regenerated on every build and your edit will silently disappear. Add the token in Figma → re-export tokens-studio.json → rerun `build:sd-figma`. The only manual token file is `tokens/gap-fills.css`, for tokens that are not yet in Figma.
+  **Never hand-edit `tokens/figma-tokens.css` or `tokens/figma-tokens-dark.css`.** They're regenerated on every build and your edit will silently disappear. Add the token to the appropriate **Library** in Figma → re-pull → rerun `build:sd-figma`. The only manual token files are `tokens/gap-fills.css` (tokens not yet in Figma — destined to migrate) and `tokens/theme-brand-brik.css` (Brik's own Brand Kit — pending automated emission from a Brand Kit pull).
 </Callout>
 
-See [Primitives → Color](/docs/primitives/color) for the canonical token registry, and [Theming → Atmospheres](/docs/theming/atmospheres) for the dark / atmosphere overlay contract.
+<Callout type="error">
+  **Never call the Figma Variables REST API.** It's Enterprise-tier and not on Brik's plan. The relay + Tokens Studio dev plugin is the only sanctioned path from Figma → JSON.
+</Callout>
+
+See [Token Anatomy](/docs/primitives/token-anatomy) for the four-tier abstraction this pipeline emits, [Library Architecture](/docs/getting-started/figma-library-architecture) for the per-Library detail, and [The Cascade](/docs/getting-started/cascade) for how the CSS output composes at runtime.
 
 ## `bds-find` — component discoverability CLI
 

--- a/docs-site/content/docs/theming/atmospheres.mdx
+++ b/docs-site/content/docs/theming/atmospheres.mdx
@@ -1,16 +1,16 @@
 ---
 title: Atmospheres
-description: Layer 2 of the theming cascade — CSS decoration overlays that establish visual character (editorial-luxury, cinematic, warm-soft, and more) without duplicating CSS per client.
+description: The Atmospheres Theming Dimension — CSS decoration overlays that establish visual character (editorial-luxury, cinematic, warm-soft, and more) without duplicating CSS per client.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Atmospheres are **CSS decoration layers** that sit on top of a client's theme to establish visual character — dark-luxury-editorial, soft-wellness, clean-clinical, etc. — without duplicating CSS per client. They're orthogonal to the navigation archetype and the blueprint library: atmospheres decorate surfaces, archetypes structure the header, blueprints compose sections.
+Atmospheres are **CSS decoration overlays** that sit on top of a client's Tokens Dimension to establish visual character — dark-luxury-editorial, soft-wellness, clean-clinical, etc. — without duplicating CSS per client. One of the four [Theming Dimensions](/docs/theming), orthogonal to Tokens, Layout Archetypes, and Blueprints.
 
 The portal's theme generator reads `company_profiles.atmosphere` at extraction time and emits an `@import` into the stored theme artifact pointing at `@brikdesigns/bds/atmospheres/{slug}.css`. The consumer Astro site fetches one theme artifact at build; the atmosphere cascades automatically.
 
 <Callout type="info">
-**Atmospheres are decoration only.** They add vignettes, grain, orbs, and spotlights — they do not set surface colors. Background and text colors come from the brand theme layer (`dist/tokens.css` + the client's `theme-{slug}.css`). Import `@brikdesigns/bds/page-base.css` after tokens to wire `html/body` background to `var(--page-primary)` before any atmosphere loads.
+**Atmospheres are decoration only.** They add vignettes, grain, orbs, and spotlights — they do not set surface colors. Background and text colors come from the Tokens Dimension (`dist/tokens.css` + the client's `theme-{slug}.css` in `@layer client-theme`). Import `@brikdesigns/bds/page-base.css` after tokens to wire `html/body` background to `var(--page-primary)` before any atmosphere loads.
 </Callout>
 
 ## How atmospheres compose with themes
@@ -103,7 +103,7 @@ When building a new client site:
 ## Related
 
 - [Theming Overview](/docs/theming) — the four-layer cascade in context
-- [Client Themes](/docs/theming/client-themes) — Layer 1, the brand-token override layer below the atmosphere
+- [Client Themes](/docs/theming/client-themes) — the Tokens Dimension below the atmosphere
 - [Layout Archetypes](/docs/theming/layout-archetypes) — site-header and site-footer pattern vocabularies
 - [Blueprints](/docs/theming/blueprints) — page-layout vocabulary (separate axis from atmosphere)
 - [Content System / Industries](/docs/content-system/industries) — industry packs declare default atmospheres

--- a/docs-site/content/docs/theming/blueprints.mdx
+++ b/docs-site/content/docs/theming/blueprints.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blueprints
-description: Layer 4 of the theming cascade — named layout + interaction patterns that ground AI mockup generation with concrete structural constraints.
+description: The Blueprints Theming Dimension — named layout + interaction patterns that ground AI mockup generation with concrete structural constraints.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/docs-site/content/docs/theming/client-themes.mdx
+++ b/docs-site/content/docs/theming/client-themes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Client Themes
-description: Layer 1 of the theming cascade — per-client semantic token overrides. Override matrix, minimal theme-{client}.css template, and interaction-state rules.
+description: The Tokens Theming Dimension — per-client semantic token overrides. Override matrix, minimal theme-{client}.css template, and interaction-state rules.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
@@ -269,5 +269,5 @@ This is exactly what `.body.theme-client-sim` demonstrates in the toolbar.
 ## Related
 
 - [Theming Overview](/docs/theming) — the four-layer cascade in context
-- [Atmospheres](/docs/theming/atmospheres) — Layer 2 CSS overlays
+- [Atmospheres](/docs/theming/atmospheres) — the Atmospheres Dimension (CSS decoration overlays)
 - [Primitives → Color](/docs/primitives/color) — the semantic tokens this layer overrides

--- a/docs-site/content/docs/theming/index.mdx
+++ b/docs-site/content/docs/theming/index.mdx
@@ -1,33 +1,37 @@
 ---
 title: Theming
-description: Compose per-client brand identity across four orthogonal layers.
+description: Compose per-client brand identity across four orthogonal Theming Dimensions — Tokens, Atmospheres, Layout, Blueprints.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Cards, Card } from 'fumadocs-ui/components/card';
 
-Theming is how a single component library renders as a different brand for every client. BDS answers *"what is this thing and how does it behave?"* in components; the Theming tenet answers *"what does it look like for this brand?"* Clients never change components — they change theming decisions, composed across four orthogonal layers.
+Theming is how a single component library renders as a different brand for every client. BDS answers *"what is this thing and how does it behave?"* in components; the Theming **Tenet** answers *"what does it look like for this brand?"* Clients never change components — they change theming decisions, composed across four orthogonal **Theming Dimensions**.
 
-Theming is a **tenet of the system alongside Foundation, Motion, and Content.** If design tokens are the atoms, theming is the instrument that plays them in a different key.
+Theming is one of four **Tenets** of the system: Foundation, Theming, Motion, Content. If design tokens are the atoms, theming is the instrument that plays them in a different key.
 
 <Callout type="info">
   **Audience:** primarily websites (Astro, Webflow) and any product surface that needs per-client branding. Foundation tokens are shared across product and websites; theming is where the per-client divergence happens.
 </Callout>
 
-## The four theming layers
+## The four Theming Dimensions
 
-| Layer | Decides | Lives in | Override per client? |
+| Dimension | Decides | Lives in | Override per client? |
 |---|---|---|---|
-| **1. Tokens** | Color, type, spacing values | `theme-{client}.css` | Required |
-| **2. Atmosphere** | Ambient mood — grain, glow, vignettes, surface treatments | `@brikdesigns/bds/atmospheres/{slug}.css` | Optional — industry default can win |
-| **3. Layout Archetypes** | Site-header *and* site-footer shape, plus scroll + drawer behavior | `<SiteHeader>` and `<SiteFooter>` from `@brikdesigns/bds/blueprints-astro` | Optional — industry default can win |
-| **4. Blueprint** | Section composition — how a hero / services / testimonials slot is built | Authored in BDS, tagged by mood + industry | Authored centrally; clients pick |
+| **Tokens** | Color, type, spacing values | `theme-{client}.css` (`@layer client-theme`) | Required |
+| **Atmospheres** | Ambient mood — grain, glow, vignettes, surface treatments | `@brikdesigns/bds/atmospheres/{slug}.css` | Optional — industry default can win |
+| **Layout Archetypes** | Site-header *and* site-footer shape, plus scroll + drawer behavior | `<SiteHeader>` and `<SiteFooter>` from `@brikdesigns/bds/blueprints-astro` | Optional — industry default can win |
+| **Blueprints** | Section composition — how a hero / services / testimonials slot is built | Authored in BDS, tagged by mood + industry | Authored centrally; clients pick |
 
-Layers are independent. A client can redefine tokens, keep the industry's default atmosphere, swap to a non-default navigation archetype, and use the same blueprints another client uses — nothing cross-couples. Each layer has its own deep-dive page; the sections below summarize each and link out.
+Dimensions are independent. A client can redefine tokens, keep the industry's default atmosphere, swap to a non-default navigation archetype, and use the same blueprints another client uses — nothing cross-couples. Each Dimension has its own deep-dive page; the sections below summarize each and link out.
 
-## Layer 1 — Tokens
+<Callout type="warn">
+  **"Dimension" not "Layer".** Older docs called these four "Layers" — confusing because CSS `@layer` is also called Layer (the `bds-tokens` / `client-theme` cascade). They're distinct concepts: a Theming Dimension is a *what to decide*; a CSS Layer is a *where the decision's CSS lands*. See [Token Anatomy](/docs/primitives/token-anatomy) for the full six-concept disambiguation.
+</Callout>
 
-Layer 1 is the token override. Every consuming project loads BDS canon first (`@brikdesigns/bds/tokens.css`), then the per-client theme override (`theme-{client}.css`) which redefines the same semantic token names with brand values. Components never change.
+## Tokens Dimension
+
+The Tokens Dimension is the brand-value override. Every consuming project loads BDS canon first (`@brikdesigns/bds/tokens.css` — Foundations Library + Brik Brand Kit), then the per-client theme override (`theme-{client}.css`) in `@layer client-theme` which redefines the same semantic token names with brand values. Components never change.
 
 Full architecture, import order, and the `<html>` switch table: [The Cascade](/docs/getting-started/cascade).
 
@@ -52,15 +56,15 @@ Full override matrix and the minimal `theme-{client}.css` template: [Client Them
 
 Some clients carry multiple brand colors at once — Vale Partners has three audience verticals, brikdesigns.com has service lines. Instead of inventing role-specific canonical tokens (`--background-land-primary`, etc.), the system re-binds the same canonical tokens inside `[data-audience=X]` / `[data-service=X]` scopes. Components stay scope-blind — they keep referencing `--background-brand-primary` — while the page expresses N brand colors simultaneously. Adding an audience is one CSS block; canonical never grows. Full pattern: [Client Themes → Per-audience scope binding](/docs/theming/client-themes#per-audience-or-service-line-scope-binding).
 
-## Layer 2 — Atmosphere
+## Atmospheres Dimension
 
-An atmosphere is a **CSS overlay** that sits on top of the token layer to establish visual character — dark-luxury-editorial, soft-wellness, clean-clinical, etc. — without duplicating CSS per client. Atmospheres decorate surfaces (grain, glow, vignettes, spotlights); tokens decide the underlying values.
+An atmosphere is a **CSS overlay** that sits on top of the Tokens Dimension to establish visual character — dark-luxury-editorial, soft-wellness, clean-clinical, etc. — without duplicating CSS per client. Atmospheres decorate surfaces (grain, glow, vignettes, spotlights); tokens decide the underlying values.
 
 Industry packs declare a default atmosphere. A client site fetches a single theme artifact at build; the atmosphere cascades automatically. Clients can override the pack default by setting `company_profiles.atmosphere` in the portal.
 
 Full vocabulary, previews per atmosphere, and composition rules: [Atmospheres](/docs/theming/atmospheres).
 
-## Layer 3 — Layout Archetypes (Navigation + Footer)
+## Layout Archetypes Dimension
 
 The locked sets of site-header and site-footer patterns Brik builds from — e.g. nav: `editorial-transparent`, `sidebar-rail`, `glass-floating`; footer: `directory`, `cta-anchored`, `compliance-heavy`. Each industry pack declares a default archetype for both; consumer sites render the shapes via the BDS `<SiteHeader>` and `<SiteFooter>` components at build time.
 
@@ -68,11 +72,11 @@ Nav and footer are sibling vocabularies — paired but independent. They are ort
 
 Full vocabularies, scroll + drawer behavior options, and per-industry defaults: [Layout Archetypes](/docs/theming/layout-archetypes). *(Footer is v0.1 — `<SiteFooter>` render lands in blueprints-astro v0.2.)*
 
-## Layer 4 — Blueprint
+## Blueprints Dimension
 
 Tokens answer *how does it look.* Blueprints answer *how is it composed.* A blueprint is a named layout + interaction pattern (e.g. `hero_editorial`, `services_clinical_grid`) that constrains how a section is built — structural slots, mood tags, industry tags, CSS hints. Blueprints are the layer AI mockup generators use to ground their output: they pick blueprints by mood and industry, then apply the active theme's tokens to render.
 
-Blueprints live alongside theming because they make the same kind of decision — a structural one that varies per brand and content direction. Authoring rules, mood → personality and mood → visual style bridges, and the full coverage matrix: [Blueprints](/docs/theming/blueprints).
+Blueprints sit inside the Theming Tenet because they make the same kind of decision as the other three Dimensions — a structural one that varies per brand and content direction. Authoring rules, mood → personality and mood → visual style bridges, and the full coverage matrix: [Blueprints](/docs/theming/blueprints).
 
 ## Brik's built-in themes
 
@@ -106,13 +110,13 @@ Before a client brand goes live, test it in Storybook. Three checks:
 2. **Font-family correctness.** Switch to **Client Sim** in the toolbar. Any component using the wrong `--font-family-*` token (e.g. a heading using `--font-family-body`) becomes immediately visible because the three families are assigned distinct typefaces.
 3. **Interaction states.** Hover every primary button. If the hover state stays Poppy red after a brand change, the client theme is missing `--background-brand-primary-hover`.
 
-## Explore the layers
+## Explore the Theming Dimensions
 
 <Cards>
-  <Card title="Client Themes" href="/docs/theming/client-themes" description="Layer 1 — override matrix and minimal theme-{client}.css template." />
-  <Card title="Atmospheres" href="/docs/theming/atmospheres" description="Layer 2 — CSS overlays for editorial-luxury, cinematic, warm-soft, and more." />
-  <Card title="Layout Archetypes" href="/docs/theming/layout-archetypes" description="Layer 3 — site-header and site-footer patterns, scroll + drawer behavior." />
-  <Card title="Blueprints" href="/docs/theming/blueprints" description="Layer 4 — section composition tagged by mood + industry." />
+  <Card title="Client Themes" href="/docs/theming/client-themes" description="Tokens Dimension — override matrix and minimal theme-{client}.css template." />
+  <Card title="Atmospheres" href="/docs/theming/atmospheres" description="Atmospheres Dimension — CSS overlays for editorial-luxury, cinematic, warm-soft, and more." />
+  <Card title="Layout Archetypes" href="/docs/theming/layout-archetypes" description="Layout Archetypes Dimension — site-header and site-footer patterns, scroll + drawer behavior." />
+  <Card title="Blueprints" href="/docs/theming/blueprints" description="Blueprints Dimension — section composition tagged by mood + industry." />
 </Cards>
 
 ## Related

--- a/docs-site/content/docs/theming/layout-archetypes.mdx
+++ b/docs-site/content/docs/theming/layout-archetypes.mdx
@@ -1,11 +1,11 @@
 ---
 title: Layout Archetypes
-description: Layer 3 — locked vocabularies for site-header and site-footer patterns. Paired but independent.
+description: The Layout Archetypes Theming Dimension — locked vocabularies for site-header and site-footer patterns. Paired but independent.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Layer 3 of the theming cascade covers **site chrome shape** — the header at the top of every page and the footer at the bottom. Two sibling vocabularies, paired but orthogonal: a client can pick `editorial-transparent` nav with `legal_heavy` footer, or `utility-first` nav with `cta_focused` footer, or any other combination.
+The Layout Archetypes Dimension covers **site chrome shape** — the header at the top of every page and the footer at the bottom. Two sibling vocabularies, paired but orthogonal: a client can pick `editorial-transparent` nav with `legal_heavy` footer, or `utility-first` nav with `cta_focused` footer, or any other combination. One of the four [Theming Dimensions](/docs/theming).
 
 Each industry pack declares a default for both in its `navigationIA` and `footerArchetype` fields. Consumer sites render the shapes at build time via the BDS `<SiteHeader>` and `<SiteFooter>` components from `@brikdesigns/bds/blueprints-astro`.
 

--- a/tokens/CASCADE.md
+++ b/tokens/CASCADE.md
@@ -3,6 +3,19 @@
 Canonical reference for what each file in `tokens/` does, where it loads,
 and how to decide where a change belongs.
 
+## Vocabulary
+
+This doc uses the locked BDS token vocabulary (see [Token Anatomy](../docs-site/content/docs/primitives/token-anatomy.mdx) for the full disambiguation map):
+
+- **Library** — the logical source of token definitions (Foundations Library / [Client] Brand Kit Library). Today: Figma files managed via Tokens Studio.
+- **Layer** — a CSS `@layer` in the cascade (`bds-tokens` / `bds-components` / `client-theme` / `client-overrides`). Where a token's *value* lands at runtime.
+- **Tier** — a token's abstraction level (Raw / Primitive / Semantic / Component). Independent from Layer.
+- **Mode** — an orthogonal axis varying token values (color light/dark, borderwidth thin/standard/bold, etc.).
+- **Theming Dimension** — composable subsystem of the Theming Tenet (Tokens / Atmospheres / Layout / Blueprints).
+- **Tenet** — system pillar (Foundation / Theming / Motion / Content).
+
+**Older docs called the BDS-bundle vs client-theme split "Tier 1 / Tier 2".** That nomenclature is retired — "Tier" now refers exclusively to token abstraction (Raw/Primitive/Semantic/Component). The runtime cascade is described as CSS Layers.
+
 ## What ships to consumers
 
 `dist/tokens.css` is the bundle shipped to downstream consumers (portal,


### PR DESCRIPTION
## Summary

Foundational documentation overhaul. Locks the BDS token-system vocabulary to **six disambiguated concepts**, each with a distinct word, so future agents (and humans) can navigate the system without inventing parallel taxonomies. This is the meta-fix behind brik-bds#712 — the drift retirement (PR #727) addresses tokens that violate the anatomy; this PR codifies the anatomy.

## The locked vocabulary

| Concept | Term | Question it answers | Values |
|---|---|---|---|
| Naming structure | **Anatomy** | How is it *named*? | `--{purpose}-{role}[-{state}]` |
| Abstraction level | **Tier** | What *kind* of token is it? | Raw · Primitive · Semantic · Component (TBD) |
| Source of truth | **Library** | Where is it *defined*? | Foundations Library · [Client] Brand Kit Library |
| CSS cascade origin | **Layer** | Which `@layer` *carries its value*? | `bds-tokens` · `bds-components` · `client-theme` · `client-overrides` |
| Value axis | **Mode** | Which axis *varies its value*? | color light/dark · borderwidth · spacing / etc. |
| System pillar | **Tenet** | Which *system pillar* governs it? | Foundation · Theming · Motion · Content |

Inside the Theming Tenet: four orthogonal **Theming Dimensions** — Tokens, Atmospheres, Layout Archetypes, Blueprints (older docs called these "Layers"; retired because "Layer" now means CSS `@layer` exclusively).

## What changed

### New pages
- **[`primitives/token-anatomy.mdx`](docs-site/content/docs/primitives/token-anatomy.mdx)** — the canonical six-concept disambiguation map + four-tier abstraction stack + drift patterns. The first page agents should read.
- **[`getting-started/figma-library-architecture.mdx`](docs-site/content/docs/getting-started/figma-library-architecture.mdx)** — Foundations Library vs Brand Kit Library + multi-Library Style Dictionary pull procedure + when-to-add a Brand Kit.
- **[`primitives/interaction-states.mdx`](docs-site/content/docs/primitives/interaction-states.mdx)** — overlay primitives + brand state pairs (lifted from Notion, refreshed to current poppy brand).

### Rewritten
- **`getting-started/cascade.mdx`** — full rewrite using locked vocabulary. CSS Layers replace "Tier 1/Tier 2" CSS-cascade terminology. Theming Dimensions replace "four layers". Adds Library→Layer flow diagram.
- **`react-reference/utilities.mdx` § Style Dictionary build pipeline** — multi-Library pull diagram (Foundations channel + Brand Kit channel → composed bundle). Documents `pull-variables.js` + the relay.
- **`theming/index.mdx`** — four "Layers" renamed to four Theming Dimensions. Tenet framing surfaced explicitly.

### Aligned (vocabulary-only edits)
- `theming/atmospheres.mdx`, `layout-archetypes.mdx`, `client-themes.mdx`, `blueprints.mdx` — descriptions + cross-refs use new vocabulary
- `getting-started/index.mdx` — section overview restructured around the four Tenets
- `getting-started/react-composition.mdx` — "Tier 2 brand overrides" → "`@layer client-theme` overrides"
- `primitives/naming-conventions.mdx` — adds Tag-vs-Badge section (nouns vs verbs; service-line vs status tokens)
- `tokens/CASCADE.md` — adds vocabulary header pointing to canonical docs

### Navigation
- `primitives/meta.json` — adds `token-anatomy` (after index) + `interaction-states`
- `getting-started/meta.json` — adds `figma-library-architecture` (after `cascade`)

### Memory + CLAUDE.md
- `feedback_bds_token_anatomy.md` memory rewritten to capture the locked six-concept vocabulary, Theming Dimensions, Library architecture, and verification procedure
- `brik-bds/CLAUDE.md` updated to point at Token Anatomy + Figma Library Architecture as canonical entry points

## Verification

- ✅ `npm run validate:full` — all 10 checks PASS (Token Lint, JSDoc, Grid, Theme Compliance, Blueprint Library, BCS Vocab, Canonical Tokens, Component Axes, TypeScript, Storybook Build)
- ✅ Zero remaining "Tier 1 / Tier 2 / Layer 1-4 / four layers" stale references in token-cascade context (the documentation-system.mdx CLAUDE.md-tier table is a different domain and intentionally untouched)

## Net diff

`17 files changed, 563 insertions(+), 131 deletions(-)`

## Why this matters for scale

Every client onboarding == one new Brand Kit Library + selections across Theming Dimensions. Agents can answer "is this token canon or drift?" by checking the six-question test. Motion + Content Tenets sit alongside Theming as peer pillars, with their own canonical docs sections — extensible to new Tenets as they emerge. The vocabulary is the architecture; ambiguity in the words produces ambiguity in the implementation (portal #512/#553, brik-bds#712 cleanup).

## Follow-ups (separate work)

- **Notion archival** — three stale pages get tombstoned in a separate operation immediately after this PR lands (Relationship Map, Design Token Structure, Design Token Packing Readme). All have wrong tier framing or stale BDS version.
- **Brand Kit semantic-layer drift** — audit surfaced 31 non-conformant top-level tokens in the Brik Brand Kit's color collection (e.g., `primary`, `success`, `service-marketing-light` as standalone). Worth filing as a separate Brand Kit audit issue.
- **Multi-Library pull pipeline wiring** — the target architecture is documented; the actual pipeline split (separate `foundations.json` + `brand-kits/{slug}.json` JSON inputs) lands as a follow-up.
- **RAG ingest** — the new canonical docs need to be ingested into brik-rag so agents discover them via `brik-rag query "..."`. Follow-up workflow.

## Refs

- brik-bds#712 — drift retirement umbrella
- brik-bds#727 — Phase 1-3 of the drift retirement (in flight)
- brikdesigns#227 — consumer-side migration (depends on #712 resolutions)
- portal #512 / #553 — the rollbacks this vocabulary exists to prevent recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)