### PR TITLE
chore(release): 0.73.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.72.0",
+  "version": "0.73.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.72.0",
+      "version": "0.73.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.72.0",
+  "version": "0.73.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Bundle 10 commits since v0.72.0 into a single minor release. After merge, tag `v0.73.0` from `main` to trigger publish to GitHub Packages.

## What's in

**Breaking removals** (deprecated since prior versions; consumers must migrate before upgrade):
- AlertBanner → Banner (#728, closes #725)
- ServiceBadge → ServiceTag (#730, closes #572; dir rename #733)

**Features:**
- Canonical `--aspect-*` token family + Frame slug API (#734, closes #486)
- AnimatedIcon stories + MDX (#732, closes #726)

**Tokens / tooling:**
- Retire references to orphan `--brand-{tier}` tokens (#727)
- bds-manifest storybook_url emits real story IDs (#724, closes #722)

**Storybook / docs:**
- #629 post-flatten audit corrections (#720)
- ADR-006 Part A table top-up — 14 net-new members (#721)
- Stale code comment refresh (#735, closes #723)

## Convention note

`0.x.y` repo — minor bump for everything is consistent with prior cadence (`0.69.0 → 0.70.0 → 0.71.0 → 0.71.1 → 0.72.0`). The breaking removals strictly justify a major in 1.0+ land, but the repo isn't signaling stability yet.

## Post-merge sequence (manual)

```bash
git -C /Users/nickstanerson/Documents/GitHub/brik/brik-bds checkout main
git pull --ff-only
git tag v0.73.0
git push origin v0.73.0
```

`Release` workflow at `.github/workflows/release.yml` fires on the tag push: validates version match, runs lint-tokens + lint-jsdoc + validate:blueprints + typecheck, then `npm publish` (prepublishOnly rebuilds `dist/`).

## Consumer bumps follow (separate PRs)

- brik-client-portal — `npm install @brikdesigns/bds@0.73.0`
- brikdesigns — same; unblocks #197 Frame adoption
- renew-pms / freedom-client-portal — same when those consumers next touch BDS

## Test plan

- [x] `package.json` version matches title
- [x] `npm version minor --no-git-tag-version` ran clean (lockfile updated)
- [ ] Reviewer confirms no stragglers depend on AlertBanner / ServiceBadge in consuming repos before tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)