### PR TITLE
feat(components): FileCard — populated state for CMS uploaders (closes #729)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -340,7 +340,7 @@ const preview: Preview = {
           ],
           // 6-bucket flat taxonomy per ADR-006 Part A (2026-05-16) + #629
           'Components',
-          ['address-input', 'avatar', 'badge', 'badge-group', 'banner', 'button', 'button-group', 'checkbox', 'chip', 'completion-toggle', 'counter', 'divider', 'dot', 'empty-state', 'file-uploader', 'filter-bar', 'filter-button', 'filter-toggle', 'icons', 'marketing-illustration', 'meter', 'modal', 'multi-select', 'pagination', 'password-input', 'popover', 'progress-bar', 'progress-circle', 'radio', 'segmented-control', 'select', 'service-tag', 'skeleton', 'slider', 'spinner', 'stepper', 'switch', 'tag', 'tag-group', 'text-area', 'text-input', 'text-link', 'toast', 'tooltip', '*'],
+          ['address-input', 'avatar', 'badge', 'badge-group', 'banner', 'button', 'button-group', 'checkbox', 'chip', 'completion-toggle', 'counter', 'divider', 'dot', 'empty-state', 'file-card', 'file-uploader', 'filter-bar', 'filter-button', 'filter-toggle', 'icons', 'marketing-illustration', 'meter', 'modal', 'multi-select', 'pagination', 'password-input', 'popover', 'progress-bar', 'progress-circle', 'radio', 'segmented-control', 'select', 'service-tag', 'skeleton', 'slider', 'spinner', 'stepper', 'switch', 'tag', 'tag-group', 'text-area', 'text-input', 'text-link', 'toast', 'tooltip', '*'],
           'Containers',
           [
             'accordion',

--- a/components/icons.ts
+++ b/components/icons.ts
@@ -13,6 +13,7 @@ export const CaretRight = 'ph:caret-right';
 export const MagnifyingGlass = 'ph:magnifying-glass';
 export const MapPin = 'ph:map-pin';
 export const CloudArrowUp = 'ph:cloud-arrow-up';
+export const ArrowSquareOut = 'ph:arrow-square-out';
 export const CheckCircle = 'ph:check-circle';
 export const Circle = 'ph:circle';
 export const WarningCircle = 'ph:warning-circle';

--- a/components/ui/FileCard/FileCard.css
+++ b/components/ui/FileCard/FileCard.css
@@ -1,0 +1,181 @@
+@layer bds-components {
+/**
+ * BDS FileCard
+ *
+ * Token reference:
+ * - --surface-primary (card body)
+ * - --surface-muted (preview backdrop)
+ * - --surface-secondary-hover (action button hover)
+ * - --border-secondary (card border)
+ * - --border-radius-md
+ * - --padding-sm, --padding-md
+ * - --gap-tiny, --gap-xs, --gap-sm, --gap-md
+ * - --text-primary, --text-secondary
+ * - --text-brand-primary (open-in-new-tab link)
+ * - --aspect-* (preview thumbnail aspect-ratio)
+ */
+
+/* ─── Wrapper ─────────────────────────────────────────────────── */
+
+.bds-file-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  width: 100%;
+}
+
+.bds-file-card--disabled {
+  opacity: 0.6;
+}
+
+/* ─── Card surface ────────────────────────────────────────────── */
+
+.bds-file-card__card {
+  display: flex;
+  align-items: stretch;
+  background-color: var(--surface-primary);
+  border: var(--border-width-sm) solid var(--border-secondary);
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ─── Preview thumbnail ───────────────────────────────────────── */
+/* Preview box has a fixed width and an aspect-ratio modifier that drives
+   the height. Image/SVG previews fill the box via object-fit: cover; icon
+   previews center a Phosphor glyph. */
+
+.bds-file-card__preview-link {
+  display: block;
+  text-decoration: none;
+  flex: 0 0 auto;
+}
+
+.bds-file-card__preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--size-1400);
+  background-color: var(--surface-muted);
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+
+.bds-file-card__preview-img,
+.bds-file-card__preview-svg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.bds-file-card__preview-icon {
+  font-size: var(--heading-sm);
+  color: var(--text-secondary);
+}
+
+/* Aspect-ratio modifiers — mirrors Frame's slug vocabulary. */
+.bds-file-card__preview--ratio-1-1   { aspect-ratio: var(--aspect-1-1); }
+.bds-file-card__preview--ratio-3-2   { aspect-ratio: var(--aspect-3-2); }
+.bds-file-card__preview--ratio-2-3   { aspect-ratio: var(--aspect-2-3); }
+.bds-file-card__preview--ratio-4-3   { aspect-ratio: var(--aspect-4-3); }
+.bds-file-card__preview--ratio-3-4   { aspect-ratio: var(--aspect-3-4); }
+.bds-file-card__preview--ratio-16-9  { aspect-ratio: var(--aspect-16-9); }
+.bds-file-card__preview--ratio-9-16  { aspect-ratio: var(--aspect-9-16); }
+.bds-file-card__preview--ratio-21-9  { aspect-ratio: var(--aspect-21-9); }
+.bds-file-card__preview--ratio-square           { aspect-ratio: var(--aspect-square); }
+.bds-file-card__preview--ratio-photo-landscape  { aspect-ratio: var(--aspect-photo-landscape); }
+.bds-file-card__preview--ratio-photo-portrait   { aspect-ratio: var(--aspect-photo-portrait); }
+.bds-file-card__preview--ratio-cinema           { aspect-ratio: var(--aspect-cinema); }
+
+/* ─── Card body — filename + meta + open link ─────────────────── */
+
+.bds-file-card__body {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap-md);
+  padding: var(--padding-sm) var(--padding-md);
+  min-width: 0;
+}
+
+.bds-file-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-tiny);
+  min-width: 0;
+}
+
+.bds-file-card__name {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-snug);
+  color: var(--text-primary);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bds-file-card__metadata {
+  font-family: var(--font-family-body);
+  font-size: var(--body-xs);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.bds-file-card__open {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: var(--label-md);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+
+.bds-file-card__open:hover,
+.bds-file-card__open:focus-visible {
+  color: var(--text-brand-primary);
+}
+
+/* ─── Action row ──────────────────────────────────────────────── */
+
+.bds-file-card__actions {
+  display: flex;
+  gap: var(--gap-xs);
+}
+
+.bds-file-card__action {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-xs);
+  padding: var(--padding-xs) var(--padding-sm);
+  background-color: var(--surface-primary);
+  border: var(--border-width-sm) solid var(--border-secondary);
+  border-radius: var(--border-radius-sm);
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  font-weight: var(--font-weight-regular);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out);
+}
+
+.bds-file-card__action:hover:not(:disabled),
+.bds-file-card__action:focus-visible:not(:disabled) {
+  background-color: var(--surface-secondary-hover);
+}
+
+.bds-file-card__action:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+}

--- a/components/ui/FileCard/FileCard.mdx
+++ b/components/ui/FileCard/FileCard.mdx
@@ -1,0 +1,33 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './FileCard.stories';
+
+<Meta of={Stories} />
+
+# File card
+
+<ComponentLinks slug="file-card" />
+
+Populated state of a file upload — a card surface showing one uploaded asset with preview thumbnail, filename, optional metadata, optional open-in-new-tab link, and an action row with Replace / Delete buttons. Composes alongside `FileUploader` (which owns the empty/dropzone state).
+
+The `aspectRatio` slug consumes the `--aspect-*` token family so CMS uploaders can encode the target image shape once — the same slug feeds `<Frame ratio="…">` on the consumer side.
+
+## Playground
+
+<Canvas of={Stories.Playground} />
+
+## Variants
+
+Preview modes (image, SVG, icon), aspect ratios (1:1 default, 16:9 hero), and action-row presence (Replace, Delete, both, neither, disabled).
+
+<Canvas of={Stories.Variants} />
+
+## Patterns
+
+Composition with `FileUploader` — render `FileUploader` while the slot is empty, then swap to `FileCard` once a file has been uploaded.
+
+<Canvas of={Stories.Patterns} />
+
+## Props
+
+<ArgTypes of={Stories} />

--- a/components/ui/FileCard/FileCard.stories.tsx
+++ b/components/ui/FileCard/FileCard.stories.tsx
@@ -1,0 +1,183 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { FileCard } from './FileCard';
+import { FileUploader } from '../FileUploader/FileUploader';
+
+/* ─── Layout Helpers (story-only) ─────────────────────────────── */
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <div style={{
+    fontFamily: 'var(--font-family-label)',
+    fontSize: 'var(--body-xs)', // bds-lint-ignore
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginBottom: 'var(--gap-md)',
+    color: 'var(--text-muted)',
+  }}>
+    {children}
+  </div>
+);
+
+const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
+);
+
+const SAMPLE_IMAGE = 'https://images.unsplash.com/photo-1503602642458-232111445657?auto=format&fit=crop&w=400&q=80';
+const SAMPLE_SVG = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28"><path fill="%23333" d="M14 4l3 7h7l-5.5 4 2 7L14 18l-6.5 4 2-7L4 11h7z"/></svg>';
+
+/* ─── Meta ────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof FileCard> = {
+  title: 'Components/file-card',
+  component: FileCard,
+  tags: ['surface-shared'],
+  parameters: { layout: 'centered' },
+  decorators: [(Story) => <div style={{ width: 440 }}><Story /></div>],
+} satisfies Meta<typeof FileCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ═══════════════════════════════════════════════════════════════
+   1. PLAYGROUND — Args-based, use Controls panel to explore
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Interactive playground for prop tweaking. */
+export const Playground: Story = {
+  args: {
+    preview: 'image',
+    src: SAMPLE_IMAGE,
+    aspectRatio: '1-1',
+    name: 'hero.jpg',
+    meta: '1600 × 900 • 248 KB',
+    href: SAMPLE_IMAGE,
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   2. VARIANTS — Preview modes + aspect ratios + actions
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary All variants side by side — preview modes, aspect ratios, and action presence. */
+export const Variants: Story = {
+  decorators: [(Story) => <div style={{ width: 480 }}><Story /></div>],
+  render: () => (
+    <Stack>
+      <div>
+        <SectionLabel>Preview: image (1:1)</SectionLabel>
+        <FileCard
+          preview="image"
+          src={SAMPLE_IMAGE}
+          name="profile-photo.jpg"
+          meta="600 × 600 • 142 KB"
+          href={SAMPLE_IMAGE}
+          onReplace={() => {}}
+          onDelete={() => {}}
+        />
+      </div>
+
+      <div>
+        <SectionLabel>Preview: image (16:9 — hero)</SectionLabel>
+        <FileCard
+          preview="image"
+          src={SAMPLE_IMAGE}
+          aspectRatio="16-9"
+          name="hero-banner.jpg"
+          meta="1600 × 900 • 248 KB"
+          href={SAMPLE_IMAGE}
+          onReplace={() => {}}
+          onDelete={() => {}}
+        />
+      </div>
+
+      <div>
+        <SectionLabel>Preview: svg</SectionLabel>
+        <FileCard
+          preview="svg"
+          src={SAMPLE_SVG}
+          name="industry-small-biz-primary.svg"
+          meta="28 × 28 • 673 B"
+          onReplace={() => {}}
+          onDelete={() => {}}
+        />
+      </div>
+
+      <div>
+        <SectionLabel>Preview: icon (non-renderable type)</SectionLabel>
+        <FileCard
+          preview="icon"
+          name="brand-guidelines.pdf"
+          meta="PDF • 2.4 MB"
+          onReplace={() => {}}
+          onDelete={() => {}}
+        />
+      </div>
+
+      <div>
+        <SectionLabel>No actions (read-only display)</SectionLabel>
+        <FileCard
+          preview="image"
+          src={SAMPLE_IMAGE}
+          name="archived-photo.jpg"
+          meta="800 × 600 • 96 KB"
+          href={SAMPLE_IMAGE}
+        />
+      </div>
+
+      <div>
+        <SectionLabel>Disabled</SectionLabel>
+        <FileCard
+          preview="image"
+          src={SAMPLE_IMAGE}
+          name="locked-asset.jpg"
+          meta="400 × 400 • 64 KB"
+          onReplace={() => {}}
+          onDelete={() => {}}
+          disabled
+        />
+      </div>
+    </Stack>
+  ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   3. PATTERNS — Composition with FileUploader
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Common composition with `FileUploader` — empty state vs populated state. */
+export const Patterns: Story = {
+  decorators: [(Story) => <div style={{ width: 480 }}><Story /></div>],
+  render: () => {
+    function UploaderPair() {
+      const [url, setUrl] = useState<string | null>(null);
+      return (
+        <Stack gap="var(--gap-md)">
+          <SectionLabel>Empty + populated states</SectionLabel>
+          {url ? (
+            <FileCard
+              preview="image"
+              src={url}
+              aspectRatio="16-9"
+              name="uploaded.jpg"
+              meta="1600 × 900 • image/jpeg"
+              href={url}
+              onReplace={() => setUrl(null)}
+              onDelete={() => setUrl(null)}
+            />
+          ) : (
+            <FileUploader
+              label="Drop or click to upload"
+              helperText="JPEG · PNG · WebP · AVIF — max 10MB"
+              accept="image/*"
+              onChange={(files) => {
+                const file = files[0];
+                if (file) setUrl(URL.createObjectURL(file));
+              }}
+            />
+          )}
+        </Stack>
+      );
+    }
+    return <UploaderPair />;
+  },
+};

--- a/components/ui/FileCard/FileCard.tsx
+++ b/components/ui/FileCard/FileCard.tsx
@@ -1,0 +1,195 @@
+import { type HTMLAttributes } from 'react';
+import { Icon } from '@iconify/react';
+import { ArrowSquareOut, CloudArrowUp, File as FileIcon, Trash } from '../../icons';
+import { bdsClass } from '../../utils';
+import './FileCard.css';
+
+/**
+ * Preview render modes for `FileCard`. Image and SVG render `src`; icon
+ * renders a generic file-type placeholder for non-renderable types (PDF, ZIP).
+ */
+export type FileCardPreview = 'image' | 'icon' | 'svg';
+
+/**
+ * Aspect-ratio slug applied to the preview thumbnail. Matches `Frame`'s
+ * `ratio` vocabulary — backed by the `--aspect-*` token family.
+ */
+export type FileCardAspectRatio =
+  | '1-1'
+  | '3-2'
+  | '2-3'
+  | '4-3'
+  | '3-4'
+  | '16-9'
+  | '9-16'
+  | '21-9'
+  | 'square'
+  | 'photo-landscape'
+  | 'photo-portrait'
+  | 'cinema';
+
+/**
+ * `FileCard` component props.
+ */
+export interface FileCardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  /** Render mode for the preview thumbnail. */
+  preview: FileCardPreview;
+  /** Source URL for the preview. Required for `preview="image"` and `preview="svg"`; ignored for `preview="icon"`. */
+  src?: string;
+  /** Aspect-ratio slug applied to the preview thumbnail (default `1-1`). Maps to the `--aspect-*` token family. */
+  aspectRatio?: FileCardAspectRatio;
+  /** Filename label (required). */
+  name: string;
+  /** Optional metadata line — typically dimensions / size / mime info. */
+  meta?: string;
+  /** When set, the preview thumbnail becomes a link that opens the file in a new tab. */
+  href?: string;
+  /** Replace action handler. When omitted, the Replace button is not rendered. */
+  onReplace?: () => void;
+  /** Delete action handler. When omitted, the Delete button is not rendered. */
+  onDelete?: () => void;
+  /** Disable action buttons while preserving the visual. */
+  disabled?: boolean;
+  /** Accessible alt text for image / svg previews. Falls back to `name`. */
+  previewAlt?: string;
+}
+
+/**
+ * FileCard — populated state of a file upload.
+ *
+ * Renders one uploaded asset as a card surface: preview thumbnail, filename,
+ * optional metadata line, optional open-in-new-tab link, and an action row
+ * with optional Replace / Delete buttons. Designed to compose alongside
+ * `FileUploader` (which owns the empty/dropzone state).
+ *
+ * Pair with `FileUploader` in the consumer:
+ * - Empty slot → `<FileUploader …>`
+ * - Single populated → `<FileCard …>`
+ * - Multi → list of `FileCard`s + small `FileUploader` for "add more"
+ *
+ * The `aspectRatio` slug consumes the `--aspect-*` token family (BDS #486) so
+ * CMS uploaders can encode the target image shape once — the same slug feeds
+ * `<Frame ratio="…">` on the consumer side.
+ *
+ * @example
+ * ```tsx
+ * <FileCard
+ *   preview="image"
+ *   src="https://cdn.example/hero.jpg"
+ *   aspectRatio="16-9"
+ *   name="hero.jpg"
+ *   meta="1600 × 900 • 248 KB"
+ *   href="https://cdn.example/hero.jpg"
+ *   onReplace={() => openFilePicker()}
+ *   onDelete={() => clearImage()}
+ * />
+ * ```
+ *
+ * @summary Card surface for one uploaded asset — preview, filename, meta, actions.
+ */
+export function FileCard({
+  preview,
+  src,
+  aspectRatio = '1-1',
+  name,
+  meta,
+  href,
+  onReplace,
+  onDelete,
+  disabled = false,
+  previewAlt,
+  className,
+  ...props
+}: FileCardProps) {
+  const altText = previewAlt ?? name;
+  const previewBox = (
+    <span
+      className={bdsClass(
+        'bds-file-card__preview',
+        `bds-file-card__preview--ratio-${aspectRatio}`,
+        `bds-file-card__preview--${preview}`,
+      )}
+      aria-hidden={preview === 'icon' ? true : undefined}
+    >
+      {preview === 'image' && src && (
+        <img className="bds-file-card__preview-img" src={src} alt={altText} />
+      )}
+      {preview === 'svg' && src && (
+        <img className="bds-file-card__preview-svg" src={src} alt={altText} />
+      )}
+      {preview === 'icon' && (
+        <span className="bds-file-card__preview-icon">
+          <Icon icon={FileIcon} />
+        </span>
+      )}
+    </span>
+  );
+
+  return (
+    <div
+      className={bdsClass('bds-file-card', disabled ? 'bds-file-card--disabled' : undefined, className)}
+      {...props}
+    >
+      <div className="bds-file-card__card">
+        {href ? (
+          <a
+            className="bds-file-card__preview-link"
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Open ${name} in new tab`}
+          >
+            {previewBox}
+          </a>
+        ) : (
+          previewBox
+        )}
+        <div className="bds-file-card__body">
+          <div className="bds-file-card__meta">
+            <p className="bds-file-card__name">{name}</p>
+            {meta && <p className="bds-file-card__metadata">{meta}</p>}
+          </div>
+          {href && (
+            <a
+              className="bds-file-card__open"
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Open ${name} in new tab`}
+            >
+              <Icon icon={ArrowSquareOut} />
+            </a>
+          )}
+        </div>
+      </div>
+      {(onReplace || onDelete) && (
+        <div className="bds-file-card__actions">
+          {onReplace && (
+            <button
+              type="button"
+              className="bds-file-card__action"
+              onClick={onReplace}
+              disabled={disabled}
+            >
+              <Icon icon={CloudArrowUp} />
+              <span>Replace</span>
+            </button>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              className="bds-file-card__action"
+              onClick={onDelete}
+              disabled={disabled}
+            >
+              <Icon icon={Trash} />
+              <span>Delete</span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FileCard;

--- a/components/ui/FileCard/index.ts
+++ b/components/ui/FileCard/index.ts
@@ -1,0 +1,2 @@
+export { FileCard, default } from './FileCard';
+export type { FileCardProps, FileCardPreview, FileCardAspectRatio } from './FileCard';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -42,6 +42,7 @@ export * from './Dot';
 export * from './EmptyState';
 export * from './Field';
 export * from './FieldGrid';
+export * from './FileCard';
 export * from './FileUploader';
 export * from './FilterBar';
 export * from './FilterButton';


### PR DESCRIPTION
## Summary

Closes #729. New `FileCard` component representing the **populated state** of a file upload — composes alongside the existing `FileUploader` (dropzone only) to give consumers a complete upload UX.

## Component shape

`components/ui/FileCard/FileCard.tsx`

| Prop | Type | Notes |
| --- | --- | --- |
| `preview` | `'image' \| 'icon' \| 'svg'` | Render mode for the preview thumbnail |
| `src?` | `string` | Source URL — required for `image` / `svg`, ignored for `icon` |
| `aspectRatio?` | slug | Defaults to `1-1`. Maps to `--aspect-*` token family (#486) |
| `name` | `string` | Filename (required) |
| `meta?` | `string` | Dimensions / size / mime info |
| `href?` | `string` | When set, preview becomes a link + open-icon appears |
| `onReplace?` / `onDelete?` | `() => void` | Action handlers — buttons render only if handler provided |
| `disabled?` | `boolean` | Disables action buttons; preserves visual |

## Aspect-ratio contract

The `aspectRatio` slug vocabulary mirrors `Frame.ratio`. CMS uploaders pass the target ratio (e.g. `aspectRatio="16-9"`), the preview thumbnail constrains via `aspect-ratio: var(--aspect-16-9)`, and the same slug feeds `<Frame ratio="16-9">` on the consumer side — producer and consumer encode the shape with one token.

## Composition with `FileUploader`

```tsx
{url ? (
  <FileCard preview="image" src={url} aspectRatio="16-9" name="…" … />
) : (
  <FileUploader onChange={…} />
)}
```

Captured in the `Patterns` story.

## Files

- `components/ui/FileCard/{FileCard.tsx, FileCard.css, FileCard.stories.tsx, FileCard.mdx, index.ts}` — new
- `components/ui/index.ts` — re-export `FileCard`
- `.storybook/preview.tsx` — alphabetical sort position between `empty-state` and `file-uploader`
- `components/icons.ts` — register `ArrowSquareOut` for the open-in-new-tab action

## Validation

- [x] `npm run lint-tokens` — 0 errors (24 pre-existing warnings, unrelated `gap-fill-drift`)
- [x] `npm run lint-jsdoc` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run validate` (lint-tokens + lint-jsdoc + validate:blueprints + typecheck + build-storybook) — passes end-to-end
- [x] `validate:full` (pre-push hook) — passes

## Refs

- #486 — aspect-ratio token family (depends on, shipped in `0.73.0`)
- #681 — Media category umbrella (parent)
- brik-client-portal#816 — first downstream consumer (CMS uploader retrofit lands after this releases)

## Release note

After merge, cut `0.74.0` (minor — new component, no breaking change) so portal can adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)