### PR TITLE
chore(release): 0.74.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.73.0",
+      "version": "0.74.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Single-feature release: `FileCard` component (#738, closes #729) — populated state for CMS uploaders, composes alongside `FileUploader`.

After merge, tag `v0.74.0` from `main` to trigger publish.

## Post-merge sequence (manual)

```bash
git -C /Users/nickstanerson/Documents/GitHub/brik/brik-bds checkout main
git pull --ff-only
git tag v0.74.0
git push origin v0.74.0
```

## Consumer bump unblocked

- brik-client-portal — `npm install @brikdesigns/bds@0.74.0` enables the #816 retrofit (compose BDS `FileUploader` + `FileCard`, thread `aspectRatio` slug)

## Test plan

- [x] `package.json` version matches title
- [x] `npm version minor --no-git-tag-version` ran clean (lockfile updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)