### PR TITLE
feat(hooks): auto-ingest .claude/standards/*.md on commit (#744)

### DIFF
--- a/.claude/skills/component-build/SKILL.md
+++ b/.claude/skills/component-build/SKILL.md
@@ -48,7 +48,7 @@ brik-rag query "Button IconButton sizing 4 point grid table cell" --workflow-typ
 brik-rag query "anti-patterns font-family role var() raw" --workflow-type component-build --top-k 3
 ```
 
-Parse the JSON output, apply the relevant rules to the edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/ingest-component-build-standard.sh` once, then retry.
+Parse the JSON output, apply the relevant rules to the edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/run-standards-ingest.sh --all` once to bootstrap, then retry.
 
 ## If you get a conflict between the standard and existing content
 
@@ -56,4 +56,4 @@ The standard is canon, and the canon-CSS sources it references ([SLOT-ALLOWLIST.
 
 ## How to update the standard itself
 
-Edit `brik-bds/.claude/standards/component-build.md`, bump `last-verified`, re-run `scripts/ingest-component-build-standard.sh`. The skill picks up the new content on the next retrieval — no skill file change needed.
+Edit `brik-bds/.claude/standards/component-build.md`, bump `last-verified`, then commit — the pre-commit hook auto-ingests changed standards into brik-rag (brik-bds#744). The skill picks up the new content on the next retrieval; no skill file change needed.

--- a/.claude/skills/fumadocs-content-standard/SKILL.md
+++ b/.claude/skills/fumadocs-content-standard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fumadocs-content-standard
-description: Retrieve the canonical Fumadocs writing standard from brik-rag before authoring or editing MDX in docs-site/content/docs. Covers frontmatter shape, IA decision tree (page vs section vs callout vs cross-link), heading depth, voice pointer, and anti-patterns. Source of truth lives at brik-bds/.claude/standards/fumadocs-content-standard.md; this skill fetches the ingested copy from brik-rag so guidance loads at edit time without re-reading the markdown.
+description: Retrieve the canonical Fumadocs writing standard from brik-rag before authoring or editing MDX in docs-site/content/docs. Covers frontmatter shape, IA decision tree (page vs section vs callout vs cross-link), heading depth, voice pointer, and anti-patterns. Source of truth lives at brik-bds/.claude/standards/fumadocs-content.md; this skill fetches the ingested copy from brik-rag so guidance loads at edit time without re-reading the markdown.
 triggers:
   - About to create a new .mdx file under docs-site/content/docs/
   - About to edit an existing .mdx file under docs-site/content/docs/
@@ -12,7 +12,7 @@ last-verified: 2026-05-11
 
 # fumadocs-content-standard — Retrieve the docs-site writing standard via brik-rag
 
-The canonical rules for `docs-site/content/docs/**/*.mdx` live in `brik-bds/.claude/standards/fumadocs-content-standard.md` and are ingested into brik-rag. Auto-retrieve before authoring or editing MDX so the standard loads into context at edit time.
+The canonical rules for `docs-site/content/docs/**/*.mdx` live in `brik-bds/.claude/standards/fumadocs-content.md` and are ingested into brik-rag. Auto-retrieve before authoring or editing MDX so the standard loads into context at edit time.
 
 ## When to invoke
 
@@ -44,7 +44,7 @@ brik-rag query "fumadocs IA decision tree page section callout" --workflow-type 
 brik-rag query "fumadocs anti-patterns" --workflow-type fumadocs-standard --top-k 3
 ```
 
-Parse the JSON output, apply the relevant rules to the MDX edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/ingest-fumadocs-standard.sh` once, then retry.
+Parse the JSON output, apply the relevant rules to the MDX edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/run-standards-ingest.sh --all` once to bootstrap, then retry.
 
 ## If you get a conflict between the standard and existing content
 
@@ -52,4 +52,4 @@ The standard is canon. Existing MDX that violates it is legacy — flag the inco
 
 ## How to update the standard itself
 
-Edit `brik-bds/.claude/standards/fumadocs-content-standard.md`, bump `last-verified`, re-run `scripts/ingest-fumadocs-standard.sh`. The skill picks up the new content on the next retrieval — no skill file change needed.
+Edit `brik-bds/.claude/standards/fumadocs-content.md`, bump `last-verified`, then commit — the pre-commit hook auto-ingests changed standards into brik-rag (brik-bds#744). The skill picks up the new content on the next retrieval; no skill file change needed.

--- a/.claude/skills/storybook-mdx-recipe/SKILL.md
+++ b/.claude/skills/storybook-mdx-recipe/SKILL.md
@@ -46,7 +46,7 @@ brik-rag query "ADR-006 ADR-007 same words different layers" --workflow-type sto
 brik-rag query "MDX acceptance criteria lint storybook recipe" --workflow-type storybook-mdx-recipe --top-k 3
 ```
 
-Parse the JSON output, apply the relevant rules to the edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/ingest-storybook-mdx-recipe-standard.sh` once, then retry.
+Parse the JSON output, apply the relevant rules to the edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/run-standards-ingest.sh --all` once to bootstrap, then retry.
 
 ## Lint is the gate
 
@@ -58,4 +58,4 @@ The standard + the lint are canon. Existing MDX pages that violate them are lega
 
 ## How to update the standard itself
 
-Edit `brik-bds/.claude/standards/storybook-mdx-recipe.md`, bump `last-verified`, re-run `scripts/ingest-storybook-mdx-recipe-standard.sh`. The skill picks up the new content on the next retrieval — no skill file change needed. **If the change is material** (new required section, change in section order, change to acceptance criteria), also amend ADR-007 and update `scripts/lint-storybook-recipe.js`.
+Edit `brik-bds/.claude/standards/storybook-mdx-recipe.md`, bump `last-verified`, then commit — the pre-commit hook auto-ingests changed standards into brik-rag (brik-bds#744). The skill picks up the new content on the next retrieval; no skill file change needed. **If the change is material** (new required section, change in section order, change to acceptance criteria), also amend ADR-007 and update `scripts/lint-storybook-recipe.js`.

--- a/.claude/skills/storybook-story-shape/SKILL.md
+++ b/.claude/skills/storybook-story-shape/SKILL.md
@@ -49,7 +49,7 @@ brik-rag query "sidebar taxonomy components subcategory" --workflow-type storybo
 brik-rag query "storybook 9 imports framework package" --workflow-type storybook-story-shape --top-k 3
 ```
 
-Parse the JSON output, apply the relevant rules to the edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/ingest-storybook-story-shape-standard.sh` once, then retry.
+Parse the JSON output, apply the relevant rules to the edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/run-standards-ingest.sh --all` once to bootstrap, then retry.
 
 ## If you get a conflict between the standard and existing content
 
@@ -57,4 +57,4 @@ The standard is canon. Existing `*.stories.tsx` files that violate it are legacy
 
 ## How to update the standard itself
 
-Edit `brik-bds/.claude/standards/storybook-story-shape.md`, bump `last-verified`, re-run `scripts/ingest-storybook-story-shape-standard.sh`. The skill picks up the new content on the next retrieval — no skill file change needed.
+Edit `brik-bds/.claude/standards/storybook-story-shape.md`, bump `last-verified`, then commit — the pre-commit hook auto-ingests changed standards into brik-rag (brik-bds#744). The skill picks up the new content on the next retrieval; no skill file change needed.

--- a/.claude/skills/storybook-toolbar-globals/SKILL.md
+++ b/.claude/skills/storybook-toolbar-globals/SKILL.md
@@ -46,7 +46,7 @@ brik-rag query "client-sim font audit theme decorator" --workflow-type storybook
 brik-rag query "ADR-010 Q1 toolbar global never story export" --workflow-type storybook-toolbar-globals --top-k 3
 ```
 
-Parse the JSON output, apply the relevant rules to the edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/ingest-storybook-toolbar-globals-standard.sh` once, then retry.
+Parse the JSON output, apply the relevant rules to the edit. If the query returns no results, the standard has not been ingested — run `brik-bds/scripts/run-standards-ingest.sh --all` once to bootstrap, then retry.
 
 ## The first-yes rule
 
@@ -58,4 +58,4 @@ The standard is canon. If the wired globals in `.storybook/preview.tsx` and the 
 
 ## How to update the standard itself
 
-Edit `brik-bds/.claude/standards/storybook-toolbar-globals.md`, bump `last-verified`, re-run `scripts/ingest-storybook-toolbar-globals-standard.sh`. Add a row to the "Wired today" table when a new axis lands. **Update ADR-010 only if the rule itself changes** — adding a wired axis doesn't require an ADR amendment.
+Edit `brik-bds/.claude/standards/storybook-toolbar-globals.md`, bump `last-verified`, then commit — the pre-commit hook auto-ingests changed standards into brik-rag (brik-bds#744). Add a row to the "Wired today" table when a new axis lands. **Update ADR-010 only if the rule itself changes** — adding a wired axis doesn't require an ADR amendment.

--- a/.claude/standards/component-build.md
+++ b/.claude/standards/component-build.md
@@ -472,8 +472,8 @@ Two minor releases is the Carbon-aligned default — long enough for downstream 
 ## When this standard updates
 
 1. Edit this file (the source of truth)
-2. Re-run `scripts/ingest-component-build-standard.sh` to push to brik-rag
-3. Bump `last-verified` in frontmatter
+2. Bump `last-verified` in frontmatter
+3. Stage + commit — the pre-commit hook auto-ingests changed standards into brik-rag and updates `scripts/.standards-hashes` (brik-bds#744). CI verifies the hash matches on every PR.
 4. Note the change in the PR description
 
 The skill auto-retrieves on `components/ui/**/*.{tsx,css}` edits — no other propagation needed.

--- a/.claude/standards/fumadocs-content.md
+++ b/.claude/standards/fumadocs-content.md
@@ -117,8 +117,8 @@ Adding a new Fumadocs UI component (tabs, accordions, custom MDX components) is 
 ## When this standard updates
 
 1. Edit this file (the source of truth)
-2. Re-run `scripts/ingest-fumadocs-standard.sh` to push to brik-rag
-3. Bump `last-verified` in frontmatter
+2. Bump `last-verified` in frontmatter
+3. Stage + commit — the pre-commit hook auto-ingests changed standards into brik-rag and updates `scripts/.standards-hashes` (brik-bds#744). CI verifies the hash matches on every PR.
 4. Note the change in the PR description
 
 The skill auto-retrieves on `.mdx` edits — no other propagation needed.

--- a/.claude/standards/storybook-mdx-recipe.md
+++ b/.claude/standards/storybook-mdx-recipe.md
@@ -253,9 +253,9 @@ See [ADR-007 §Narrative MDX migration disposition](../../docs/adrs/ADR-007-stor
 ## When this standard updates
 
 1. Edit this file (the source of truth)
-2. Re-run `scripts/ingest-storybook-mdx-recipe-standard.sh` to push to brik-rag
-3. Bump `last-verified` in frontmatter
+2. Bump `last-verified` in frontmatter
+3. Stage + commit — the pre-commit hook auto-ingests changed standards into brik-rag and updates `scripts/.standards-hashes` (brik-bds#744). CI verifies the hash matches on every PR.
 4. **If the change is material** (new required section, change in section order, change to acceptance criteria): also amend [ADR-007](../../docs/adrs/ADR-007-storybook-page-recipe.md) and update `scripts/lint-storybook-recipe.js`
-5. **If the change is minor wording**: just this file + ingestion script
+5. **If the change is minor wording**: just this file
 
 The skill auto-retrieves on `*.mdx` edits — no other propagation needed.

--- a/.claude/standards/storybook-story-shape.md
+++ b/.claude/standards/storybook-story-shape.md
@@ -406,8 +406,8 @@ If you find yourself wanting to "clean up" an existing file's `export const Vari
 ## When this standard updates
 
 1. Edit this file (the source of truth)
-2. Re-run `scripts/ingest-storybook-story-shape-standard.sh` to push to brik-rag
-3. Bump `last-verified` in frontmatter
+2. Bump `last-verified` in frontmatter
+3. Stage + commit — the pre-commit hook auto-ingests changed standards into brik-rag and updates `scripts/.standards-hashes` (brik-bds#744). CI verifies the hash matches on every PR.
 4. Note the change in the PR description
 
 The skill auto-retrieves on `*.stories.tsx` edits — no other propagation needed.

--- a/.claude/standards/storybook-toolbar-globals.md
+++ b/.claude/standards/storybook-toolbar-globals.md
@@ -121,14 +121,14 @@ Stories MAY read `context.globals.*` if they need to adapt their render to the c
 3. If a *third-party* addon is needed (not built into Storybook core), register it in `.storybook/main.ts` `addons` array
 4. Add a row to the "Wired today" table in this file
 5. Bump `last-verified` in frontmatter
-6. Re-run `scripts/ingest-storybook-toolbar-globals-standard.sh`
+6. Stage + commit — the pre-commit hook auto-ingests changed standards into brik-rag (brik-bds#744)
 7. Update ADR-010 only if the rule itself changes — adding a wired axis doesn't require an ADR amendment
 
 ## When this standard updates
 
 1. Edit this file (the source of truth)
-2. Re-run `scripts/ingest-storybook-toolbar-globals-standard.sh` to push to brik-rag
-3. Bump `last-verified` in frontmatter
+2. Bump `last-verified` in frontmatter
+3. Stage + commit — the pre-commit hook auto-ingests changed standards into brik-rag and updates `scripts/.standards-hashes` (brik-bds#744). CI verifies the hash matches on every PR.
 4. Note the change in the PR description
 
 The skill auto-retrieves on `.storybook/preview.tsx` and `.storybook/main.ts` edits — no other propagation needed.

--- a/.github/workflows/standards-rag-drift-check.yml
+++ b/.github/workflows/standards-rag-drift-check.yml
@@ -1,0 +1,59 @@
+name: Standards RAG Drift Check
+
+# Fails when a .claude/standards/*.md change in the PR diff is not accompanied
+# by a matching update to scripts/.standards-hashes. Catches edits that
+# bypassed the local auto-ingest hook (web UI commits, --no-verify, forks).
+#
+# CI does NOT re-ingest into brik-rag — that requires brik-rag CLI + secrets
+# the GitHub Action does not have. The hash file is the contract: locally the
+# pre-commit hook runs the paired ingest and stages the hash; CI verifies the
+# hash matches the standards content.
+#
+# Issue: brikdesigns/brik-bds#744
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.claude/standards/**'
+      - 'scripts/.standards-hashes'
+      - 'scripts/run-standards-ingest.sh'
+      - 'scripts/ingest-*-standard.sh'
+      - 'scripts/audit/standards-rag-drift.sh'
+  push:
+    branches:
+      - main
+    paths:
+      - '.claude/standards/**'
+      - 'scripts/.standards-hashes'
+
+concurrency:
+  group: standards-rag-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve base + head SHAs
+        id: shas
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "base=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pairing audit (every standard has a paired ingest script)
+        run: scripts/run-standards-ingest.sh --check
+
+      - name: Drift check
+        run: scripts/audit/standards-rag-drift.sh --ci --base "${{ steps.shas.outputs.base }}" --head "${{ steps.shas.outputs.head }}"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -111,6 +111,23 @@ fi
 # Typecheck always runs (fast, catches real errors)
 npm run typecheck
 
+# ── Standards auto-ingest (brik-bds#744) ──
+# When .claude/standards/*.md is staged, run the paired ingest-<name>-standard.sh
+# so brik-rag never falls behind a committed edit. The runner updates
+# scripts/.standards-hashes; we auto-stage it so the hash always travels with
+# the standard. CI uses scripts/audit/standards-rag-drift.sh --ci to catch
+# web-UI / --no-verify edits that bypassed this hook.
+STAGED_STANDARDS=$(git diff --cached --name-only --diff-filter=ACM -- '.claude/standards/*.md')
+if [ -n "$STAGED_STANDARDS" ]; then
+  echo "📚 Auto-ingesting changed standards into brik-rag..."
+  if ! scripts/run-standards-ingest.sh $STAGED_STANDARDS; then
+    echo ""
+    echo "   Standards ingest failed. Resolve the error above before committing."
+    exit 1
+  fi
+  git add scripts/.standards-hashes
+fi
+
 # ── Anti-slop CRITICAL check ──
 # Blocks commits that introduce silent bugs on staged files:
 #   - empty catch blocks

--- a/scripts/.standards-hashes
+++ b/scripts/.standards-hashes
@@ -1,0 +1,5 @@
+2df70ed0eadc26c515150c279de04b5f0afcef4079d660db4f043aa301d8f8f8  .claude/standards/component-build.md
+79f34fe82693d85f7f39a2fec4160b945004e4a270ea331a2495ea1272a321b9  .claude/standards/storybook-mdx-recipe.md
+8caeddca93778c57a56b5f404e1460293e97fa02f6f01eb4057c43a9f1c07249  .claude/standards/storybook-story-shape.md
+aa041ded08faa66658d0b8e3d5c09216fd6bf72a622c125b185714a976ec0305  .claude/standards/fumadocs-content.md
+b4db3ec98bb1dec16b509c5a400fe5e465fd3840d36f549c0da1b0669b72b1ea  .claude/standards/storybook-toolbar-globals.md

--- a/scripts/audit/standards-rag-drift.sh
+++ b/scripts/audit/standards-rag-drift.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# standards-rag-drift.sh — Block commits/PRs that edit .claude/standards/*.md
+# without updating the paired brik-rag corpus.
+#
+# Adapted from brik-llm's scripts/audit/coding-standards-rag-drift.sh — same
+# hash-file pattern, generalised to the multi-file standards set.
+#
+# Local: pre-commit hook runs `scripts/run-standards-ingest.sh` on the staged
+# set, which auto-updates `scripts/.standards-hashes`. This drift check
+# verifies the hash file in the PR matches the standards content — catches
+# web-UI edits, --no-verify bypasses, and forks where the local hook never
+# ran.
+#
+# Modes:
+#   --check                 Read-only: compare working-tree standards against
+#                           the recorded hash file. Exit 1 on any drift.
+#   --staged                Pre-commit defensive check: if a standard is
+#                           staged but the hash file is not (or the staged
+#                           hash file doesn't match staged standards), fail.
+#                           Belt-and-suspenders alongside run-standards-ingest.
+#   --ci --base <sha> --head <sha>
+#                           PR-gate mode. If any .claude/standards/*.md
+#                           changed in <base>..<head>, fail unless the hash
+#                           file in <head> matches the standards in <head>.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+STANDARDS_DIR="$REPO_ROOT/.claude/standards"
+HASH_FILE_REL="scripts/.standards-hashes"
+HASH_FILE="$REPO_ROOT/$HASH_FILE_REL"
+
+MODE="check"
+BASE=""
+HEAD=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check)   MODE="check";  shift ;;
+    --staged)  MODE="staged"; shift ;;
+    --ci)      MODE="ci";     shift ;;
+    --base)    BASE="$2";     shift 2 ;;
+    --head)    HEAD="$2";     shift 2 ;;
+    -h|--help) sed -n '2,24p' "$0"; exit 0 ;;
+    *)         echo "standards-rag-drift: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Compute the canonical hash-line for one standard.
+compute_line() {
+  local path="$1"
+  local rel="${path#$REPO_ROOT/}"
+  local h
+  h="$(shasum -a 256 "$path" | awk '{print $1}')"
+  printf '%s  %s\n' "$h" "$rel"
+}
+
+# Compute expected hash file body for working tree.
+compute_expected() {
+  for f in "$STANDARDS_DIR"/*.md; do
+    [ -f "$f" ] || continue
+    compute_line "$f"
+  done | sort
+}
+
+if [ "$MODE" = "check" ]; then
+  if [ ! -f "$HASH_FILE" ]; then
+    echo "ERROR: standards-rag-drift — hash file missing: $HASH_FILE_REL" >&2
+    echo "  Bootstrap: scripts/run-standards-ingest.sh --all && git add $HASH_FILE_REL" >&2
+    exit 1
+  fi
+
+  EXPECTED="$(compute_expected)"
+  RECORDED="$(cat "$HASH_FILE")"
+
+  if [ "$EXPECTED" = "$RECORDED" ]; then
+    echo "standards-rag-drift: OK ($(echo "$EXPECTED" | wc -l | tr -d ' ') standards)" >&2
+    exit 0
+  fi
+
+  echo "" >&2
+  echo "ERROR: standards-rag-drift — recorded hashes do not match working tree." >&2
+  echo "" >&2
+  diff <(echo "$RECORDED") <(echo "$EXPECTED") >&2 || true
+  echo "" >&2
+  echo "Fix: scripts/run-standards-ingest.sh --all && git add $HASH_FILE_REL" >&2
+  exit 1
+fi
+
+if [ "$MODE" = "staged" ]; then
+  STAGED="$(git diff --cached --name-only --diff-filter=ACMR || true)"
+
+  STANDARDS_STAGED=0
+  HASH_STAGED=0
+  echo "$STAGED" | grep -qE '^\.claude/standards/.*\.md$' && STANDARDS_STAGED=1
+  echo "$STAGED" | grep -qx "$HASH_FILE_REL" && HASH_STAGED=1
+
+  if [ "$STANDARDS_STAGED" = "0" ]; then
+    exit 0
+  fi
+
+  if [ "$HASH_STAGED" = "0" ]; then
+    echo "" >&2
+    echo "ERROR: standards-rag-drift — .claude/standards/*.md is staged but $HASH_FILE_REL is not." >&2
+    echo "" >&2
+    echo "The pre-commit hook normally auto-stages the hash file after running" >&2
+    echo "the paired ingest. If you arrived here, the runner did not complete." >&2
+    echo "Re-run manually:" >&2
+    echo "  scripts/run-standards-ingest.sh \$(git diff --cached --name-only --diff-filter=ACM -- '.claude/standards/*.md')" >&2
+    echo "  git add $HASH_FILE_REL" >&2
+    exit 1
+  fi
+
+  # Both staged — verify the staged hash file matches the staged standards.
+  TMP="$(mktemp)"
+  trap 'rm -f "$TMP"' EXIT
+  for f in "$STANDARDS_DIR"/*.md; do
+    [ -f "$f" ] || continue
+    REL="${f#$REPO_ROOT/}"
+    # Prefer staged blob if the standard itself was staged; fall back to working tree.
+    if git ls-files --cached --error-unmatch "$REL" >/dev/null 2>&1; then
+      H="$(git show ":$REL" 2>/dev/null | shasum -a 256 | awk '{print $1}')"
+    else
+      H="$(shasum -a 256 "$f" | awk '{print $1}')"
+    fi
+    printf '%s  %s\n' "$H" "$REL" >> "$TMP"
+  done
+  STAGED_EXPECTED="$(sort < "$TMP")"
+  STAGED_RECORDED="$(git show ":$HASH_FILE_REL" 2>/dev/null || true)"
+
+  if [ "$STAGED_EXPECTED" != "$STAGED_RECORDED" ]; then
+    echo "" >&2
+    echo "ERROR: standards-rag-drift — staged hash file does not match staged standards." >&2
+    echo "" >&2
+    diff <(echo "$STAGED_RECORDED") <(echo "$STAGED_EXPECTED") >&2 || true
+    echo "" >&2
+    echo "Re-run: scripts/run-standards-ingest.sh \$(git diff --cached --name-only --diff-filter=ACM -- '.claude/standards/*.md')" >&2
+    echo "        git add $HASH_FILE_REL" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+if [ "$MODE" = "ci" ]; then
+  if [ -z "$BASE" ] || [ -z "$HEAD" ]; then
+    echo "standards-rag-drift: --ci requires --base <sha> --head <sha>" >&2
+    exit 2
+  fi
+
+  CHANGED_FILES="$(git diff --name-only "$BASE".."$HEAD" || true)"
+  STANDARDS_CHANGED=0
+  echo "$CHANGED_FILES" | grep -qE '^\.claude/standards/.*\.md$' && STANDARDS_CHANGED=1
+
+  if [ "$STANDARDS_CHANGED" = "0" ]; then
+    echo "standards-rag-drift: no standards changes in $BASE..$HEAD" >&2
+    exit 0
+  fi
+
+  # Build expected hash body from HEAD blobs.
+  TMP="$(mktemp)"
+  trap 'rm -f "$TMP"' EXIT
+  while IFS= read -r REL; do
+    case "$REL" in
+      .claude/standards/*.md) ;;
+      *) continue ;;
+    esac
+    H="$(git show "$HEAD:$REL" 2>/dev/null | shasum -a 256 | awk '{print $1}')"
+    printf '%s  %s\n' "$H" "$REL" >> "$TMP"
+  done < <(git ls-tree -r --name-only "$HEAD" -- .claude/standards | grep -E '\.md$')
+  HEAD_EXPECTED="$(sort < "$TMP")"
+  HEAD_RECORDED="$(git show "$HEAD:$HASH_FILE_REL" 2>/dev/null || true)"
+
+  if [ "$HEAD_EXPECTED" = "$HEAD_RECORDED" ]; then
+    echo "standards-rag-drift: OK ($(echo "$HEAD_EXPECTED" | wc -l | tr -d ' ') standards)" >&2
+    exit 0
+  fi
+
+  echo "" >&2
+  echo "ERROR: standards-rag-drift — hash file in $HEAD does not match standards in $HEAD." >&2
+  echo "" >&2
+  diff <(echo "$HEAD_RECORDED") <(echo "$HEAD_EXPECTED") >&2 || true
+  echo "" >&2
+  echo "Likely cause: a .claude/standards/*.md was edited via the GitHub web UI" >&2
+  echo "or with --no-verify, bypassing the local auto-ingest hook." >&2
+  echo "" >&2
+  echo "Fix locally then push:" >&2
+  echo "  git pull --ff-only" >&2
+  echo "  scripts/run-standards-ingest.sh --all" >&2
+  echo "  git add $HASH_FILE_REL && git commit -m 'chore(standards): refresh ingest hashes'" >&2
+  echo "  git push" >&2
+  echo "::error::standards-rag-drift: hash file out of sync with standards"
+  exit 1
+fi
+
+echo "standards-rag-drift: no mode specified (try --check / --staged / --ci)" >&2
+exit 2

--- a/scripts/ingest-fumadocs-content-standard.sh
+++ b/scripts/ingest-fumadocs-content-standard.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# ingest-fumadocs-standard.sh — push the Fumadocs writing standard into brik-rag.
+# ingest-fumadocs-content-standard.sh — push the Fumadocs writing standard into brik-rag.
 #
-# Source of truth: .claude/standards/fumadocs-content-standard.md
+# Source of truth: .claude/standards/fumadocs-content.md
 # Destination: brik-rag memory corpus (type=reference, project=brik-bds)
 #
 # Re-runnable: each invocation re-ingests the latest content. Run after editing
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-STANDARD_FILE="$REPO_ROOT/.claude/standards/fumadocs-content-standard.md"
+STANDARD_FILE="$REPO_ROOT/.claude/standards/fumadocs-content.md"
 
 if [[ ! -f "$STANDARD_FILE" ]]; then
   echo "error: standard markdown not found at $STANDARD_FILE" >&2
@@ -38,7 +38,7 @@ echo "▸ Ingesting fumadocs-writing-standard ($(echo "$BODY" | wc -l | tr -d ' 
 
 brik-rag remember \
   --name "fumadocs-writing-standard" \
-  --description "Canonical Fumadocs MDX writing standard for brik-bds docs-site — frontmatter shape, IA decision tree (page/section/callout/cross-link), heading depth cap, voice pointer, anti-patterns. Source: brik-bds/.claude/standards/fumadocs-content-standard.md" \
+  --description "Canonical Fumadocs MDX writing standard for brik-bds docs-site — frontmatter shape, IA decision tree (page/section/callout/cross-link), heading depth cap, voice pointer, anti-patterns. Source: brik-bds/.claude/standards/fumadocs-content.md" \
   --type reference \
   --project brik-bds \
   --human \

--- a/scripts/run-standards-ingest.sh
+++ b/scripts/run-standards-ingest.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# run-standards-ingest.sh — auto-ingest paired BDS standards into brik-rag.
+#
+# Pairing rule (glob-driven, not table-driven):
+#   .claude/standards/<name>.md  ↔  scripts/ingest-<name>-standard.sh
+#
+# Missing pair = hard fail. A future standard added without a paired script
+# fails this gate at commit time, so brik-rag never falls behind a committed
+# edit (the failure mode brik-bds#744 was filed to close).
+#
+# Usage:
+#   run-standards-ingest.sh <standard-path> [<standard-path>...]
+#                            Ingest only the listed standards.
+#                            Called by .husky/pre-commit with the staged set.
+#   run-standards-ingest.sh --all
+#                            Ingest every .claude/standards/*.md. Bootstrap
+#                            + manual full refresh.
+#   run-standards-ingest.sh --check
+#                            Verify every standard has a paired script; do
+#                            not run ingest. CI-side pairing audit.
+#
+# After successful ingest, writes scripts/.standards-hashes (one line per
+# standard, sorted). Pre-commit auto-stages it so the hash always travels
+# with the standard. CI uses scripts/audit/standards-rag-drift.sh against
+# this same file to catch web-UI / --no-verify edits.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+STANDARDS_DIR="$REPO_ROOT/.claude/standards"
+INGEST_DIR="$REPO_ROOT/scripts"
+HASH_FILE="$REPO_ROOT/scripts/.standards-hashes"
+
+MODE="run"
+case "${1:-}" in
+  --check) MODE="check"; shift ;;
+  --all)   MODE="all";   shift ;;
+  -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
+esac
+
+TARGETS=()
+if [ "$MODE" = "all" ] || [ "$MODE" = "check" ]; then
+  for f in "$STANDARDS_DIR"/*.md; do
+    [ -f "$f" ] && TARGETS+=("$f")
+  done
+else
+  if [ $# -eq 0 ]; then
+    echo "run-standards-ingest: no targets and not --all/--check" >&2
+    echo "  Pass one or more .claude/standards/*.md paths, or use --all." >&2
+    exit 2
+  fi
+  for arg in "$@"; do
+    case "$arg" in
+      /*) f="$arg" ;;
+      *)  f="$REPO_ROOT/$arg" ;;
+    esac
+    TARGETS+=("$f")
+  done
+fi
+
+# brik-rag CLI is required for --run / --all (the actual ingest). --check
+# only verifies pairing on disk, so it skips this requirement.
+if [ "$MODE" != "check" ]; then
+  if ! command -v brik-rag >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: brik-rag CLI not on PATH." >&2
+    echo "  Expected: ~/.local/bin/claude-tools/brik-rag" >&2
+    echo "  Install (one-time):" >&2
+    echo "    ln -s \"\$HOME/Documents/Github/brik/brik-llm/scripts/rag/brik-rag\" \\" >&2
+    echo "          \"\$HOME/.local/bin/claude-tools/brik-rag\"" >&2
+    echo "" >&2
+    echo "  Credentials live in ~/.secrets/brik-rag.env (the CLI sources them)." >&2
+    exit 1
+  fi
+fi
+
+FAILED=0
+for STANDARD in "${TARGETS[@]}"; do
+  if [ ! -f "$STANDARD" ]; then
+    echo "run-standards-ingest: standard not found: $STANDARD" >&2
+    FAILED=1
+    continue
+  fi
+
+  BASENAME="$(basename "$STANDARD" .md)"
+  PAIRED_SCRIPT="$INGEST_DIR/ingest-${BASENAME}-standard.sh"
+
+  if [ ! -x "$PAIRED_SCRIPT" ]; then
+    echo "" >&2
+    echo "ERROR: unpaired standard: ${STANDARD#$REPO_ROOT/}" >&2
+    echo "  Expected paired script: ${PAIRED_SCRIPT#$REPO_ROOT/}" >&2
+    echo "  Convention: .claude/standards/<name>.md ↔ scripts/ingest-<name>-standard.sh" >&2
+    echo "  Add the paired ingest script before committing this standard." >&2
+    echo "" >&2
+    FAILED=1
+    continue
+  fi
+
+  if [ "$MODE" = "check" ]; then
+    continue
+  fi
+
+  echo "▸ Ingesting ${STANDARD#$REPO_ROOT/} → ${PAIRED_SCRIPT#$REPO_ROOT/}"
+  if ! "$PAIRED_SCRIPT"; then
+    echo "" >&2
+    echo "ERROR: ingest failed: ${PAIRED_SCRIPT#$REPO_ROOT/}" >&2
+    FAILED=1
+    continue
+  fi
+done
+
+if [ "$FAILED" = "1" ]; then
+  exit 1
+fi
+
+if [ "$MODE" = "check" ]; then
+  exit 0
+fi
+
+# Recompute and write all hashes so the file always reflects full state,
+# never a partial mid-run. Sorted for stable diffs.
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+for f in "$STANDARDS_DIR"/*.md; do
+  [ -f "$f" ] || continue
+  H="$(shasum -a 256 "$f" | awk '{print $1}')"
+  REL="${f#$REPO_ROOT/}"
+  printf '%s  %s\n' "$H" "$REL" >> "$TMP"
+done
+sort "$TMP" > "$HASH_FILE"
+echo "✓ Updated ${HASH_FILE#$REPO_ROOT/}"
+
+exit 0


### PR DESCRIPTION
## Summary

Pre-commit hook + CI drift check that close the human-memory dependency between editing a `.claude/standards/<name>.md` and re-running its paired `ingest-<name>-standard.sh`. After this lands, every commit that changes a standard auto-ingests it into brik-rag; CI rejects PRs where a standard moved without the hash file moving with it.

## What changes

| File | Kind | Purpose |
| --- | --- | --- |
| `scripts/run-standards-ingest.sh` | new | Glob-driven runner — for each `.claude/standards/<name>.md`, runs `scripts/ingest-<name>-standard.sh`. Unpaired = hard fail. Updates `scripts/.standards-hashes` at the end. |
| `scripts/audit/standards-rag-drift.sh` | new | Hash-file guard adapted from brik-llm's `coding-standards-rag-drift.sh`. Modes: `--check`, `--staged`, `--ci --base --head`. |
| `scripts/.standards-hashes` | new | One sorted SHA256 per standard. Auto-staged by the hook so it always travels with the standard. |
| `.github/workflows/standards-rag-drift-check.yml` | new | PR gate — runs drift check against `<base>..<head>`. Does NOT re-ingest in CI (no brik-rag CLI / secrets); the hash file is the contract. |
| `.husky/pre-commit` | modified | Added 11-line block between typecheck and anti-slop that runs the runner on staged standards and auto-stages the hash file. |
| `.claude/standards/fumadocs-content-standard.md` → `fumadocs-content.md` | renamed | Basename conformance for the glob pairing rule. |
| `scripts/ingest-fumadocs-standard.sh` → `ingest-fumadocs-content-standard.sh` | renamed | Same. |
| `.claude/standards/*.md` × 5 | modified | Footer: removed manual "re-run the script" instruction (AC6). |
| `.claude/skills/*/SKILL.md` × 5 | modified | Same footer cleanup + bootstrap line redirected to `run-standards-ingest.sh --all`. |

## Pairing rule (glob-driven)

```
.claude/standards/<name>.md  ↔  scripts/ingest-<name>-standard.sh
```

Per the issue body: \"glob-driven, not table-driven, so a future standard added without script wiring fails loudly at commit time.\" The rule required two renames so all five standards map cleanly (`fumadocs-content-standard.md` was the outlier — its basename already contained `-standard` while peers did not).

## Why hash-file CI, not in-CI ingest

CI doesn't have the brik-rag CLI installed or the Voyage / Supabase secrets — installing both for every PR run is heavy. The hash-file contract from `brik-llm/scripts/audit/coding-standards-rag-drift.sh` is proven: locally the pre-commit hook runs the paired ingest and stages the hash; CI verifies the hash matches the standards content. A web-UI edit or `--no-verify` bypass leaves the hash unsync'd → CI fails with the exact fix-locally-then-push runbook.

## Acceptance criteria

- [x] Husky pre-commit runs the paired script for any changed `.claude/standards/*.md` file
- [x] Hook fails (blocks commit) when (a) a standard has no paired script, or (b) the script run fails
- [x] Hook is fast — only the changed file's paired script runs, not all 5
- [x] Honors `~/.secrets/brik-rag.env` (the brik-rag CLI self-sources)
- [x] CI parity workflow catches web-UI / --no-verify / fork bypasses
- [x] Standards + SKILLs no longer instruct manual re-run

## End-to-end test

This PR's first commit (`288c2fc`) WAS the end-to-end test: the staged set included all 5 standards (footer updates). The hook fired, ran all 5 paired ingest scripts, updated `scripts/.standards-hashes`, and auto-staged it. Commit completed cleanly.

```
📚 Auto-ingesting changed standards into brik-rag...
▸ Ingesting .claude/standards/component-build.md → scripts/ingest-component-build-standard.sh
...
▸ Ingesting .claude/standards/storybook-toolbar-globals.md → scripts/ingest-storybook-toolbar-globals-standard.sh
✓ Updated scripts/.standards-hashes
```

Post-commit verification:

```
$ scripts/audit/standards-rag-drift.sh --check
standards-rag-drift: OK (5 standards)
```

## Out of scope

- Migrating `.claude/standards/*.md` to a different ingest pathway — issue body validated 2026-05-18 that the memory corpus is the correct owner per the brik-bds#601 / brik-llm#473 migration
- Auto-ingest for `.claude/skills/*/SKILL.md` — different corpus (`agent-skills`), different lifecycle, separate concern (brik-llm#511; landed via brik-llm#516)
- Installing the brik-rag CLI inside CI — explicitly punted to keep PR cost low; the hash-file contract is the parity mechanism

## Test plan

- [x] `scripts/run-standards-ingest.sh --check` (pairing audit) passes
- [x] `scripts/run-standards-ingest.sh --all` bootstraps `.standards-hashes` from current content
- [x] `scripts/audit/standards-rag-drift.sh --check` passes after bootstrap
- [x] `git commit` on this PR triggered the hook + ran all 5 ingest scripts + updated hash + auto-staged hash
- [x] `npm run typecheck` passes
- [ ] CI `Standards RAG Drift Check` workflow passes on this PR (verifies in real CI)

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)