### PR TITLE
chore(release): 0.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.74.0",
+      "version": "0.75.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Two-feature release — the **read/edit canon Path A** pair:

- **#749 (closes #745)** — Sheet `viewDetailsAction` + `editTarget`, PageHeader `mode` (read/edit symmetry with Sheet, forward-compatible with #404's compound `<Page>` API).
- **#751 (closes #746)** — `TableActionsCell` subcomponent + cell-level click rules; docs-site `table.mdx` gains the no-row-click canon callout.

Additive only — no breaking changes. Both PRs went green through \`validate:full\` (10-check pre-push suite) before merge.

After merge, tag \`v0.75.0\` from \`main\` to trigger publish.

## Post-merge sequence (manual)

\`\`\`bash
git -C /Users/nickstanerson/Documents/GitHub/brik/brik-bds checkout main
git pull --ff-only
git tag v0.75.0
git push origin v0.75.0
\`\`\`

## Consumer bump unblocked

- **brik-client-portal** — \`npm install @brikdesigns/bds@0.75.0\` enables the [Settings IA migration](https://github.com/brikdesigns/brik-client-portal/blob/staging/.claude/references/settings-ia.md#migration-current-state--contract) per-table sweep starting with \`/settings/services\` (#768 → kill \`onRowClick\` + wire \`Sheet.mode\` + \`TableActionsCell\`, then split into read/edit routes).
- **renew-pms** — \`PageHeader.mode\` available for the bimodal settings pages (no current consumer, additive).
- **brikdesigns marketing site** — no relevant changes (catalog/CMS-only).

## Test plan

- [x] \`package.json\` version matches title (\`0.75.0\`)
- [x] \`npm version minor --no-git-tag-version\` ran clean (lockfile updated)
- [x] Pre-push \`validate:full\` green on this branch (10/10 checks)