### PR TITLE
security: add gitleaks pre-commit hook + .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,96 @@
+# Gitleaks config for brik-bds.
+# Extends the default ruleset with patterns for secrets Brik actually uses,
+# because the default rules miss Anthropic, Notion, and Helicone shapes.
+#
+# Kept in sync with brik-llm/.gitleaks.toml — when one changes the other
+# should too. Allowlist paths are brik-bds-specific.
+#
+# See https://github.com/gitleaks/gitleaks#configuration for syntax.
+# Use via: gitleaks protect --staged --redact --config /path/to/.gitleaks.toml
+
+[extend]
+# Inherit gitleaks' bundled rules (GitHub PAT, generic API key, etc.)
+useDefault = true
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API key (sk-ant-api03-...)"
+regex = '''sk-ant-api(?:01|02|03)-[A-Za-z0-9_\-]{40,}'''
+keywords = ["sk-ant-api"]
+
+[[rules]]
+id = "anthropic-oauth-bearer"
+description = "Anthropic OAuth bearer (claude-cli)"
+regex = '''sk-ant-oat[0-9]{2}-[A-Za-z0-9_\-]{40,}'''
+keywords = ["sk-ant-oat"]
+
+[[rules]]
+id = "notion-integration-token"
+description = "Notion integration token (ntn_...)"
+regex = '''ntn_[A-Za-z0-9]{40,}'''
+keywords = ["ntn_"]
+
+[[rules]]
+id = "slack-bot-token"
+description = "Slack bot token (xoxb-...)"
+regex = '''xoxb-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{20,}'''
+keywords = ["xoxb-"]
+
+[[rules]]
+id = "slack-app-token"
+description = "Slack app-level token (xapp-...)"
+regex = '''xapp-[0-9]+-[A-Z0-9]+-[0-9]+-[a-f0-9]{40,}'''
+keywords = ["xapp-"]
+
+[[rules]]
+id = "slack-user-token"
+description = "Slack user/admin/refresh token (xoxp/xoxa/xoxr/xoxs)"
+regex = '''xox[apsr]-[0-9]{10,}-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{30,}'''
+keywords = ["xoxp-", "xoxa-", "xoxs-", "xoxr-"]
+
+[[rules]]
+id = "helicone-key"
+description = "Helicone API key (sk-helicone-...)"
+regex = '''sk-helicone-[A-Za-z0-9_\-]{20,}'''
+keywords = ["sk-helicone"]
+
+[[rules]]
+id = "voyage-api-key"
+description = "Voyage AI API key (pa-...)"
+regex = '''pa-[A-Za-z0-9]{40,}'''
+keywords = ["pa-"]
+
+# ── Allowlist ───────────────────────────────────────────────────────────────
+# Files known to contain placeholder/test values or secret-shape regexes for
+# detection (not real secrets).
+
+[allowlist]
+description = "Globally allowlisted paths"
+paths = [
+  '''(.*/)?\.env\.example$''',
+  '''(.*/)?\.env\.template$''',
+  '''(.*/)?CLAUDE\.md$''',
+  '''(.*/)?\.gitleaks\.toml$''',
+  # Hardcoded Notion database IDs (36-char hex+hyphen UUIDs); not secrets,
+  # but the variable name contains "TOKENS" which triggers the generic
+  # api-key rule. Verified non-secret 2026-05-19.
+  '''(.*/)?scripts/populate-notion-tokens\.js$''',
+  # npm dependency manifest — version pins occasionally match generic-api-key
+  # entropy thresholds (e.g. "10.3.6" with surrounding context).
+  '''(.*/)?package\.json$''',
+  # Figma-derived token metadata — theme names + token counts are flagged
+  # by generic-api-key but are not credentials.
+  '''(.*/)?design-tokens/metadata\.json$''',
+  '''(.*/)?updates/.*/design-tokens/metadata\.json$''',
+]
+
+# ── Webflow v1 token shape: 64-char hex assigned to API_TOKEN-like variable.
+# Catches the pattern that triggered the 2026-01-13 historical leak
+# (publish-webflow.js / publish-webflow-test.js) which slipped past GitHub
+# server-side scanning. Generic-api-key already catches this shape, but a
+# named rule produces a clearer finding in CI/hook output.
+[[rules]]
+id = "webflow-v1-api-token"
+description = "Webflow API v1 token assigned to a credential-shaped variable (64-char hex)"
+regex = '''(?i)(?:api[_-]?token|webflow[_-]?(?:api[_-]?)?(?:token|key))\s*=\s*['"`]([0-9a-f]{64})['"`]'''
+keywords = ["api_token", "API_TOKEN", "webflow"]

--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ import '@brikdesigns/bds/styles.css';
 git clone https://github.com/brikdesigns/brik-bds.git
 cd brik-bds
 npm install
-npm run storybook    # http://localhost:6006
+./scripts/install-hooks.sh   # wires up gitleaks pre-commit (run once per clone)
+npm run storybook            # http://localhost:6006
 ```
+
+`install-hooks.sh` symlinks the gitleaks pre-commit scanner into `.git/hooks/pre-commit`. Requires `brew install gitleaks`. brik-bds is a public repo — GitHub's server-side push protection is also enabled, but the pre-commit hook catches issues before the push and is the first line of defense.
 
 ## Development workflows
 

--- a/scripts/git-hooks/pre-commit-gitleaks.sh
+++ b/scripts/git-hooks/pre-commit-gitleaks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Pre-commit hook: scan staged content for leaked secrets via gitleaks.
+#
+# Install (per clone, since hooks aren't tracked):
+#   ./scripts/install-hooks.sh
+# or manually:
+#   ln -sf ../../scripts/git-hooks/pre-commit-gitleaks.sh .git/hooks/pre-commit
+#
+# Bypass (use sparingly, with intent):
+#   git commit --no-verify
+#
+# Bypassing is itself a signal — log it. Pre-commit is one of three layers
+# (pre-commit + GitHub push protection + secret scanning). All three matter.
+# Modeled on brik-llm/scripts/git-hooks/pre-commit-gitleaks.sh; the
+# Brik-extended ruleset in .gitleaks.toml stays in sync across repos.
+
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "pre-commit: gitleaks not installed — run: brew install gitleaks" >&2
+  exit 1
+fi
+
+# --staged scans the staged diff against the Brik-extended ruleset.
+# --no-banner keeps the hook output tight.
+# --redact ensures any finding is shown without echoing the matched secret.
+# Resolve repo root so the hook works from any working directory.
+repo_root=$(git rev-parse --show-toplevel)
+config_arg=""
+if [ -f "$repo_root/.gitleaks.toml" ]; then
+  config_arg="--config $repo_root/.gitleaks.toml"
+fi
+gitleaks protect --staged --redact --no-banner --verbose $config_arg

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# install-hooks.sh — Wire up the per-clone gitleaks pre-commit hook.
+#
+# Run once per fresh clone. Symlinks scripts/git-hooks/pre-commit-gitleaks.sh
+# into .git/hooks/pre-commit. If .git/hooks/pre-commit already exists,
+# refuses to overwrite without --force.
+#
+# Usage:
+#   ./scripts/install-hooks.sh             # idempotent install
+#   ./scripts/install-hooks.sh --force     # overwrite an existing hook
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_TARGET="../../scripts/git-hooks/pre-commit-gitleaks.sh"
+HOOK_LINK="$REPO_ROOT/.git/hooks/pre-commit"
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "✗ gitleaks not on PATH — install first:" >&2
+  echo "    brew install gitleaks" >&2
+  exit 1
+fi
+
+force=0
+if [ "${1:-}" = "--force" ]; then
+  force=1
+fi
+
+if [ -e "$HOOK_LINK" ] && [ "$force" -ne 1 ]; then
+  current=$(readlink "$HOOK_LINK" 2>/dev/null || echo "<regular file>")
+  if [ "$current" = "$HOOK_TARGET" ]; then
+    echo "✓ pre-commit hook already wired to gitleaks (no change)."
+    exit 0
+  fi
+  echo "✗ $HOOK_LINK already exists (points to: $current)" >&2
+  echo "  Re-run with --force to replace, or remove it first." >&2
+  exit 1
+fi
+
+ln -sf "$HOOK_TARGET" "$HOOK_LINK"
+echo "✓ Installed gitleaks pre-commit hook → $HOOK_LINK"
+echo "  To bypass on a single commit (sparingly): git commit --no-verify"


### PR DESCRIPTION
## Summary

brik-bds is a **PUBLIC** repo. Server-side secret-scanning + push-protection are already on (verified via the org API), but there was no local pre-commit gate — meaning a leaked secret would only be caught at push time. This adds the missing first line of defense, modeled on the brik-llm setup.

## What this adds

- `scripts/git-hooks/pre-commit-gitleaks.sh` — runs `gitleaks protect --staged --redact` against the Brik-extended ruleset before each commit.
- `scripts/install-hooks.sh` — one-shot symlink installer (`.git/hooks/` isn't tracked, so this is per-clone). Idempotent; refuses to overwrite an existing hook without `--force`.
- `.gitleaks.toml` — extends gitleaks' defaults with Brik-specific patterns (Anthropic, Notion, Slack, Helicone, Voyage) plus a new `webflow-v1-api-token` rule (see below). Allowlist scoped to brik-bds-specific false-positive paths.
- README.md — `./scripts/install-hooks.sh` added to dev quickstart.

## `webflow-v1-api-token` rule — historical leak surfaced ⚠

A full-history gitleaks scan surfaced a **64-char hex value literally assigned to `API_TOKEN`** in two historical files:
- `js/publish-webflow.js` (line 4) at commit `ee0e964` (2026-01-13)
- `js/publish-webflow-test.js` (line 3) at the same commit

Both files are removed from HEAD, but the blobs persist in this **public** repo's git history. Shape matches Webflow API v1 tokens. **GitHub's server-side scanner did not flag it** (Webflow v1 isn't in their curated pattern set). The new `webflow-v1-api-token` rule (added in this PR) catches this shape going forward — but the existing historical leak is real exposure.

**Out of scope for this PR**: rotating the leaked Webflow token. That's a real-exposure trigger per the brik-secrets doctrine and requires operator-driven provider-side action. Surfaced separately in the parent thread for the operator to decide which Webflow purpose (likely `webflow-brikdesigns` or `webflow-templates`) maps to that token.

## False positives surfaced + allowlisted

History scan found 11 `generic-api-key` matches. All were false positives:

| File | Why it false-fired |
|---|---|
| `design-tokens/metadata.json` | `tokenCount` integers + theme names like `"theme-3"`, `"theme-7"` |
| `package.json` | npm dependency version pins |
| `scripts/populate-notion-tokens.js` | hardcoded 36-char hex+hyphen Notion database IDs (not secrets — Notion DB IDs are public; the secret is `NOTION_TOKEN` which is loaded from env correctly) |
| `js/publish-webflow*.js` | gone from HEAD; the new `webflow-v1-api-token` rule would catch reintroduction |

Each false-positive path is allowlisted by path with an inline comment explaining the rationale.

## Server-side state (verified 2026-05-19)

- ✓ GitHub secret-scanning enabled
- ✓ Push-protection enabled
- This PR adds the local pre-commit layer for defense in depth.

## Verification

- [x] `gitleaks detect --no-git` on the worktree returns "no leaks found"
- [x] `.gitleaks.toml` parses cleanly
- [x] `install-hooks.sh` is idempotent (re-run with no args = no-op message; with `--force` overwrites)
- [x] Pre-commit hook runs gitleaks in the existing pre-commit chain (verified — the commit creating this PR ran `gitleaks` and reported "no leaks found")

## Post-merge

Each developer clones brik-bds runs once:
```bash
./scripts/install-hooks.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)