### PR TITLE
button: sizing tokens

### DIFF
--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -53,7 +53,7 @@
  */
 
 .bds-button--tiny {
-  height: 24px;
+  height: var(--size-600);
   padding-inline: var(--padding-tiny);
   font-size: var(--label-xs);
   gap: var(--gap-xs);
@@ -61,25 +61,25 @@
 }
 
 .bds-button--sm {
-  height: 32px;
+  height: var(--size-800);
   padding-inline: var(--padding-sm);
   font-size: var(--label-sm);
 }
 
 .bds-button--md {
-  height: 40px;
+  height: var(--size-1000);
   padding-inline: var(--padding-md);
   font-size: var(--label-md);
 }
 
 .bds-button--lg {
-  height: 48px;
+  height: var(--size-1200);
   padding-inline: var(--padding-md);
   font-size: var(--label-lg);
 }
 
 .bds-button--xl {
-  height: 56px;
+  height: var(--size-1400);
   padding-inline: var(--padding-lg);
   font-size: var(--label-xl);
 }
@@ -315,8 +315,8 @@
 
 .bds-button__spinner-icon {
   display: inline-block;
-  width: 16px;  /* md default — scaled per size below */
-  height: 16px;
+  width: var(--icon-sm);  /* md default (16px) — scaled per size below */
+  height: var(--icon-sm);
   border-radius: 50%;
   border-width: var(--border-width-lg);
   border-style: solid;
@@ -328,13 +328,13 @@
 
 /* Size-specific spinner scale — mirrors IconButton icon scale (tiny=12, sm=14, md=16, lg=20, xl=24) */
 .bds-button--tiny .bds-button__spinner-icon {
-  width: 12px;
-  height: 12px;
+  width: var(--size-300);   /* 12px */
+  height: var(--size-300);
 }
 
 .bds-button--sm .bds-button__spinner-icon {
-  width: 14px;
-  height: 14px;
+  width: var(--icon-xs);    /* 14px */
+  height: var(--icon-xs);
 }
 
 .bds-button--lg .bds-button__spinner-icon {
@@ -343,8 +343,8 @@
 }
 
 .bds-button--xl .bds-button__spinner-icon {
-  width: 24px;
-  height: 24px;
+  width: var(--size-600);   /* 24px */
+  height: var(--size-600);
 }
 
 /* Icon buttons: spinner scales with the button's font-size (matches icon 1em × 1em) */
@@ -366,34 +366,34 @@
 .bds-icon-button {
   padding: 0;
   gap: 0;
-  width: 40px;   /* md default */
-  height: 40px;
+  width: var(--size-1000);   /* md default (40px) */
+  height: var(--size-1000);
   flex-shrink: 0;
 }
 
 .bds-icon-button--tiny {
-  width: 24px;
-  height: 24px;
+  width: var(--size-600);    /* 24px */
+  height: var(--size-600);
 }
 
 .bds-icon-button--sm {
-  width: 32px;
-  height: 32px;
+  width: var(--size-800);    /* 32px */
+  height: var(--size-800);
 }
 
 .bds-icon-button--md {
-  width: 40px;
-  height: 40px;
+  width: var(--size-1000);   /* 40px */
+  height: var(--size-1000);
 }
 
 .bds-icon-button--lg {
-  width: 48px;
-  height: 48px;
+  width: var(--size-1200);   /* 48px */
+  height: var(--size-1200);
 }
 
 .bds-icon-button--xl {
-  width: 56px;
-  height: 56px;
+  width: var(--size-1400);   /* 56px */
+  height: var(--size-1400);
 }
 
 .bds-icon-button__icon {
@@ -402,15 +402,15 @@
   justify-content: center;
   width: 1em;
   height: 1em;
-  font-size: 16px;  /* md default */
+  font-size: var(--icon-sm);   /* md default (16px) */
 }
 
 .bds-icon-button--tiny .bds-icon-button__icon {
-  font-size: 12px;
+  font-size: var(--size-300);  /* 12px — no matching icon token at this size */
 }
 
 .bds-icon-button--sm .bds-icon-button__icon {
-  font-size: 16px;
+  font-size: var(--icon-sm);   /* 16px */
 }
 
 .bds-icon-button--lg .bds-icon-button__icon {
@@ -418,7 +418,7 @@
 }
 
 .bds-icon-button--xl .bds-icon-button__icon {
-  font-size: 24px;
+  font-size: var(--size-600);  /* 24px — no matching icon token at this size */
 }
 
 }


### PR DESCRIPTION
## Summary
- docs(adrs): unify canonical first-story name to `Default` (supersedes legacy `Playground`) (#714)
- fix(tokens): AA-clear --text-brand-primary in theme-brand-brik light (#719)
- feat(storybook): #629 post-flatten audit corrections — card-list/card-control/navigation-archetypes (refs #629) (#720)
- docs(adr-006): Part A table top-up — 14 net-new members shipped since 2026-05-16 (refs #629) (#721)
- fix(tooling): bds-manifest storybook_url emits real story IDs (closes #722) (#724)
- chore(tokens): retire references to orphan --brand-{tier} tokens (#727)
- refactor(bds): remove deprecated AlertBanner — Banner is canonical (closes #725) (#728)
- refactor(bds): remove deprecated ServiceBadge — ServiceTag is canonical (closes #572) (#730)
- feat(components): AnimatedIcon stories + MDX (closes #726) (#732)
- refactor(bds): rename components/ui/ServiceBadge/ → components/ui/ServiceTag/ (closes #731) (#733)
- feat(tokens): canonical --aspect-* token family + Frame slug API (closes #486) (#734)
- docs(bds): refresh stale code comments for post-#629 / post-#724 state (closes #723) (#735)
- docs(architecture): lock six-concept token vocabulary + Library architecture + Theming Dimensions (#736)
- chore(release): 0.73.0 (#737)
- feat(components): FileCard — populated state for CMS uploaders (closes #729) (#738)
- chore(release): 0.74.0 (#739)
- chore(claude): align component-build SKILL description to four-tier token anatomy (#740)
- feat(components): read/edit canon for Sheet + PageHeader (closes #745) (#749)
- feat(components): TableActionsCell + cell-level click rules (closes #746) (#751)
- feat(hooks): auto-ingest .claude/standards/*.md on commit (#744) (#750)
- chore(release): 0.75.0 (#752)
- chore(tokens): retire theme.{brik,blue}.* + brand.{tier} orphans (#712 Phase 4) (#753)
- security: add gitleaks pre-commit hook + .gitleaks.toml (#756)
- fix(button): tokenise all hardcoded sizing values in Button.css

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)