### PR TITLE
fix(a11y): breadcrumb current + pricing-card period --text-muted → --text-secondary (closes #765)

### DIFF
--- a/components/ui/Breadcrumb/Breadcrumb.css
+++ b/components/ui/Breadcrumb/Breadcrumb.css
@@ -27,7 +27,7 @@
   font-size: var(--label-sm);
   font-weight: var(--font-weight-semi-bold);
   line-height: var(--font-line-height-tight);
-  color: var(--text-muted);
+  color: var(--text-secondary);
   text-transform: capitalize;
   cursor: default;
 }

--- a/components/ui/PricingCard/PricingCard.css
+++ b/components/ui/PricingCard/PricingCard.css
@@ -63,7 +63,7 @@
   font-family: var(--font-family-body);
   font-size: var(--body-sm);
   font-weight: var(--font-weight-regular);
-  color: var(--text-muted);
+  color: var(--text-secondary);
 }
 
 /* ─── Description ─────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- `Breadcrumb.css` — `.bds-breadcrumb__current`: `--text-muted` → `--text-secondary`
- `PricingCard.css` — `.bds-pricing-card__period`: `--text-muted` → `--text-secondary`

`--text-muted` resolves to `#828282` (3.84:1 on `--surface-primary`) — fails WCAG AA for normal text. `--text-secondary` resolves to `#5a5a5a` (7.4:1 on white) — passes AA at all sizes.

The breadcrumb separator also uses `--text-muted` but was not flagged by the axe scanner (axe doesn't evaluate decorative separators as text); left unchanged to avoid scope creep.

## Downstream impact

Once merged + published, brikdesigns can bump the dep and remove 5 remaining entries from `tests/a11y/baseline.json`, closing brikdesigns#40.

## Test plan
- [x] BDS Token Lint pass (validates `--text-secondary` is canonical)
- [x] BDS Canonical Tokens pass
- [ ] Visual check — breadcrumb current text and pricing card period text appear slightly darker than before

🤖 Generated with [Claude Code](https://claude.ai/code)