### PR TITLE
security: deprecate pre-Husky local-hook scripts + fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ import '@brikdesigns/bds/styles.css';
 ```bash
 git clone https://github.com/brikdesigns/brik-bds.git
 cd brik-bds
-npm install
-./scripts/install-hooks.sh   # wires up gitleaks pre-commit (run once per clone)
+npm install                  # auto-installs Husky hooks via 'prepare' script
 npm run storybook            # http://localhost:6006
 ```
 
-`install-hooks.sh` symlinks the gitleaks pre-commit scanner into `.git/hooks/pre-commit`. Requires `brew install gitleaks`. brik-bds is a public repo — GitHub's server-side push protection is also enabled, but the pre-commit hook catches issues before the push and is the first line of defense.
+Husky manages git hooks (`.husky/pre-commit` runs gitleaks against the staged diff using the Brik-extended ruleset in `.gitleaks.toml`). Setup is automatic — `npm install` invokes the `prepare` script which configures Husky. Requires `brew install gitleaks` on PATH (the hook gracefully skips if gitleaks isn't installed, but you'll want it for actual coverage).
+
+brik-bds is a public repo — GitHub's server-side push protection is also enabled, and CI runs gitleaks independently on every PR (`.github/workflows/gitleaks.yml`, blocks on findings). The local Husky hook is the first line of defense; CI is the airtight gate.
 
 ## Development workflows
 

--- a/scripts/git-hooks/pre-commit-gitleaks.sh
+++ b/scripts/git-hooks/pre-commit-gitleaks.sh
@@ -1,20 +1,24 @@
 #!/usr/bin/env bash
 # Pre-commit hook: scan staged content for leaked secrets via gitleaks.
 #
-# Install (per clone, since hooks aren't tracked):
-#   ./scripts/install-hooks.sh
-# or manually:
-#   ln -sf ../../scripts/git-hooks/pre-commit-gitleaks.sh .git/hooks/pre-commit
+# DEPRECATED 2026-05-24 — gitleaks now runs via Husky's .husky/pre-commit
+# (auto-installed by `npm install` via the package.json `prepare` script).
+# This standalone script is kept only for environments without Husky or
+# legacy clones that already symlinked it.
+#
+# Do NOT run scripts/install-hooks.sh — it would overwrite Husky's hook
+# and lose any non-gitleaks checks Husky also runs.
 #
 # Bypass (use sparingly, with intent):
 #   git commit --no-verify
 #
 # Bypassing is itself a signal — log it. Pre-commit is one of three layers
 # (pre-commit + GitHub push protection + secret scanning). All three matter.
-# Modeled on brik-llm/scripts/git-hooks/pre-commit-gitleaks.sh; the
-# Brik-extended ruleset in .gitleaks.toml stays in sync across repos.
 
 set -euo pipefail
+
+# Emit deprecation notice on stderr so legacy symlink users see it on every commit.
+echo "note: scripts/git-hooks/pre-commit-gitleaks.sh is deprecated. Husky (.husky/pre-commit) is now canonical; runs gitleaks the same way." >&2
 
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "pre-commit: gitleaks not installed — run: brew install gitleaks" >&2

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
-# install-hooks.sh — Wire up the per-clone gitleaks pre-commit hook.
+# install-hooks.sh — DEPRECATED 2026-05-24.
 #
-# Run once per fresh clone. Symlinks scripts/git-hooks/pre-commit-gitleaks.sh
-# into .git/hooks/pre-commit. If .git/hooks/pre-commit already exists,
-# refuses to overwrite without --force.
+# This script predates the Husky migration. Husky now manages all git hooks
+# in this repo (see `.husky/pre-commit`) and is auto-installed by
+# `npm install` via the `prepare` script in package.json. Running this
+# script would clobber Husky's hook with a gitleaks-only one, losing any
+# additional checks Husky coordinates.
 #
-# Usage:
-#   ./scripts/install-hooks.sh             # idempotent install
-#   ./scripts/install-hooks.sh --force     # overwrite an existing hook
+# If you reached this script via the README: the README has been updated
+# (PR landing 2026-05-24). Pull main and the install-hooks.sh step is gone.
+#
+# Canonical setup is now just:
+#   git clone ...
+#   cd brik-bds
+#   npm install      # Husky auto-installs .husky/pre-commit (gitleaks runs on commit)
 
 set -euo pipefail
 
+echo "✗ scripts/install-hooks.sh is DEPRECATED." >&2
+echo "  Husky (.husky/pre-commit) now manages git hooks; auto-installed via 'npm install'." >&2
+echo "  Running this script would overwrite Husky's hook with a gitleaks-only one." >&2
+echo "  No action needed — Husky is already wired up if you've run 'npm install'." >&2
+exit 1
+
+# Legacy implementation retained below for reference; unreachable after the exit 1 above.
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 HOOK_TARGET="../../scripts/git-hooks/pre-commit-gitleaks.sh"
 HOOK_LINK="$REPO_ROOT/.git/hooks/pre-commit"


### PR DESCRIPTION
## Summary

brik-bds README §Getting started still told contributors to run `./scripts/install-hooks.sh` — a pre-Husky script that would clobber `.husky/pre-commit` with a gitleaks-only symlink and lose whatever else Husky coordinates. This PR fixes the README, deprecates the two obsolete scripts, and makes `install-hooks.sh` fail-safe so anyone following stale docs (or copy-paste) sees what changed.

## Why this is a security PR

Wrong setup instructions → contributors run them → their local hook setup ends up in an inconsistent state. The 2026-05-24 cross-repo gitleaks audit (brik-llm PRs #635 + #643) surfaced this drift between docs and reality. Coverage isn't lost — Husky's hook already runs gitleaks correctly — but the docs were actively misleading.

## What changed

| File | Change |
|------|--------|
| `README.md` (§Getting started) | Drop the `./scripts/install-hooks.sh` step. Add a paragraph documenting Husky as the canonical local-hook mechanism (auto-installed via `npm install` → `prepare` script). Note CI gitleaks is the airtight gate. |
| `scripts/install-hooks.sh` | Now exits 1 immediately with a clear deprecation message. Legacy implementation kept below the exit for reference; unreachable. |
| `scripts/git-hooks/pre-commit-gitleaks.sh` | Deprecation banner in header + stderr notice on every invocation. Kept functional for any legacy symlink installs out there; users will see the migration note on every commit. |

## What did NOT change

- `.husky/pre-commit` — already runs gitleaks correctly. Untouched.
- `.gitleaks.toml` — already has Brik-extended ruleset. Untouched.
- `.github/workflows/gitleaks.yml` — CI gate untouched (still blocks on findings).
- `package.json` — `prepare: "husky || true"` was already there.

## Verification

- Husky pre-commit hook ran on the commit for this PR, gitleaks found no leaks (`no leaks found` in commit output)
- `./scripts/install-hooks.sh` now exits 1 with the deprecation message (verified locally)
- README diff shows the misleading instructions are gone

## Context

Part of the 2026-05-24 cross-repo gitleaks audit. Related PRs:

- brikdesigns/brik-llm#635 — untrack `clients (ignore)/` legacy archive (the sweep that surfaced this)
- brikdesigns/brik-llm#643 — move gitleaks into pre-commit framework (brik-llm template, since brik-llm uses pre-commit framework, not Husky)

Different mechanisms (Husky vs pre-commit framework) across repos is fine; both run gitleaks the same way with the same `.gitleaks.toml` rules. The point of this PR is just to make sure brik-bds docs accurately describe what's actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)