### PR TITLE
width: tokens

### DIFF
--- a/docs-site/content/docs/primitives/size.mdx
+++ b/docs-site/content/docs/primitives/size.mdx
@@ -5,47 +5,81 @@ description: Dimensional constraints for containers, breakpoints, and elements.
 
 import { sizeScale } from '@bds-tokens';
 
-Size tokens define dimensional constraints — how big things can be, where the layout breaks, what hero heights to clamp.
+Size tokens define dimensional constraints — how big things can be, where the layout breaks, and how wide content columns sit within a viewport.
 
 ## Size scale (primitives)
 
 <SpacingScale scale={sizeScale} prefix="--size" />
 
-## Semantic size tokens
+## Content widths
 
-### Container sizes
+Max-width values for content containers. Apply to wrapper elements with `max-width` to prevent lines from growing too wide at large viewport sizes.
 
-Width constraints for content containers. Pair with `max-width` to bound page-level content.
+| Token | CSS Variable | Value | Use for |
+|---|---|---|---|
+| Narrow | `--content-width-narrow` | 640px | Prose, reading columns, focused forms |
+| Default | `--content-width-default` | 800px | Standard body sections |
+| Wide | `--content-width-wide` | 1024px | Feature sections, content grids |
+| XL | `--content-width-xl` | 1280px | Hero bands, wide layouts |
+| Full | `--content-width-full` | 100% | Full-bleed (use sparingly) |
 
-| Token | CSS Variable | Value |
+```css
+.content-section {
+  max-width: var(--content-width-default);
+  margin-inline: auto;
+}
+```
+
+## Screen breakpoints
+
+BDS defines five canonical breakpoints. The CSS custom properties (`--breakpoint-*`) are provided for Figma/documentation reference. **For CSS `@media` rules, import the `breakpoints` constant from `@bds-tokens`** — CSS custom properties cannot be used inside `@media()`.
+
+| Name | CSS Variable | Value |
 |---|---|---|
-| Full width | `--container-size-full-width` | 100% |
-| Three-quarter | `--container-size-three-quarter-width` | 75% |
-| Two-third | `--container-size-two-third-width` | 66% |
-| Half | `--container-size-half-width` | 50% |
-| One-third | `--container-size-one-third-width` | 33% |
-| Quarter | `--container-size-quarter-width` | 25% |
+| Mobile | `--breakpoint-mobile` | 320px |
+| Tablet | `--breakpoint-tablet` | 768px |
+| Desktop | `--breakpoint-desktop` | 1024px |
+| Wide | `--breakpoint-wide` | 1280px |
+| Wider | `--breakpoint-wider` | 1440px |
 
-### Screen breakpoints
+<Callout type="warn">
+`--breakpoint-web` (1200px) is a legacy Figma-sourced value kept for backward compatibility. Prefer the canonical names above in new work.
+</Callout>
 
-Used in CSS media queries and responsive container sizing.
+### Using breakpoints in CSS
 
-| Token | CSS Variable | Value |
-|---|---|---|
-| Wider | `--screen-size-wider` | 1440px |
-| Wide | `--screen-size-wide` | 1280px |
-| Desktop | `--screen-size-desktop` | 1080px |
-| Tablet | `--screen-size-tablet` | 768px |
-| Mobile | `--screen-size-mobile` | 320px |
+```tsx
+import { breakpoints } from '@bds-tokens';
 
-### Hero constraints
+// In a CSS-in-JS context
+const styles = {
+  [`@media (min-width: ${breakpoints.desktop})`]: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 2fr',
+  },
+};
+```
 
-| Token | CSS Variable | Value |
-|---|---|---|
-| Max hero height | `--container-size-max-hero-height` | 100vh |
-| Max hero width | `--container-size-max-hero-width` | 100vw |
+```css
+/* In plain CSS — hardcode the value, comment the token name */
+@media (min-width: 1024px) { /* --breakpoint-desktop */
+  .sidebar-layout {
+    display: grid;
+  }
+}
+```
 
-### Element sizes
+### Using breakpoints in JavaScript
+
+```ts
+import { breakpoints } from '@bds-tokens';
+
+const isDesktop = window.matchMedia(
+  `(min-width: ${breakpoints.desktop})`
+).matches;
+```
+
+## Element sizes
 
 Semantic size tokens follow the same tiny-to-huge scale as spacing — for icons, dots, indicators.
 

--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -300,6 +300,24 @@
   --text-service-back-office-on-light: var(--color-orange-darkest);
   --text-service-back-office-on-dark: var(--color-orange-lightest);
 
+  /* ── Layout width tokens ──
+     Content column max-widths — use with `max-width` on container elements.
+     These are NOT screen breakpoints; they constrain content within a viewport.
+     For media queries, use the `breakpoints` constant from @bds-tokens (index.ts) —
+     CSS custom properties cannot be used inside @media rules. */
+  --content-width-narrow:   640px;  /* prose, reading columns, focused forms */
+  --content-width-default:  800px;  /* standard body sections */
+  --content-width-wide:    1024px;  /* feature sections, grids */
+  --content-width-xl:      1280px;  /* hero bands, wide layouts */
+  --content-width-full:     100%;   /* full-bleed (use sparingly — prefer explicit widths) */
+
+  /* Breakpoint reference values — supplement figma-tokens.css --breakpoint-mobile/tablet/web.
+     These CSS vars are for Figma/documentation reference only.
+     Use `breakpoints` TS export from @bds-tokens for actual @media query values. */
+  --breakpoint-desktop:    1024px;
+  --breakpoint-wide:       1280px;
+  --breakpoint-wider:      1440px;
+
   /* ── Border-width semantic aliases (mode-catalog names) ──
      The borderWidth mode catalog (websites/shared/MODE-ARCHITECTURE.md) names
      picks "thin / standard / bold". Without aliases at these names, client

--- a/tokens/index.ts
+++ b/tokens/index.ts
@@ -476,6 +476,45 @@ export const semanticSpace = {
   "input": "var(--space-200)"
 } as const;
 
+/**
+ * Breakpoint values for use in CSS @media queries.
+ * CSS custom properties (--breakpoint-*) cannot be used inside @media rules —
+ * use these TS constants instead.
+ *
+ * @example
+ * import { breakpoints } from '@bds-tokens';
+ * const isMobile = window.matchMedia(`(max-width: ${breakpoints.tablet})`).matches;
+ *
+ * @example (styled-components / emotion)
+ * const styles = css`
+ *   @media (min-width: ${breakpoints.desktop}) { ... }
+ * `;
+ */
+export const breakpoints = {
+  mobile:  '320px',
+  tablet:  '768px',
+  desktop: '1024px',
+  wide:    '1280px',
+  wider:   '1440px',
+} as const;
+
+export type Breakpoint = keyof typeof breakpoints;
+
+/**
+ * Content column max-widths.
+ * Use with `max-width` on container elements to constrain readable content width.
+ * Maps to the --content-width-* CSS custom properties in gap-fills.css.
+ */
+export const contentWidths = {
+  narrow:  '640px',
+  default: '800px',
+  wide:    '1024px',
+  xl:      '1280px',
+  full:    '100%',
+} as const;
+
+export type ContentWidth = keyof typeof contentWidths;
+
 // Theme registry — consumer entry point for adding client themes to the
 // Contrast Compliance audit (and future multi-theme probes). See
 // ./theme-registry for usage.


### PR DESCRIPTION
## Summary
- fix(a11y): breadcrumb current + pricing-card period use --text-secondary (closes #765) (#766)
- security: deprecate pre-Husky local-hook scripts + fix README (#767)
- feat(tokens): add content-width + breakpoint tokens and fix size docs

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)