### PR TITLE
refactor(service-tag): rename ServiceCategory type → ServiceLine

### DIFF
--- a/blueprints/proposals/services_3col_card_grid.md
+++ b/blueprints/proposals/services_3col_card_grid.md
@@ -60,7 +60,7 @@ interface ServiceCardItem {
   href: string;                    // Learn more target
   description?: string;            // body, optional
   imageUrl?: string;               // top image, optional
-  badge?: ServiceCategory;         // resolves ServiceTag icon
+  badge?: ServiceLine;             // resolves ServiceTag icon
   hasOptions?: boolean;            // shows "Has Options" badge
 }
 

--- a/components/ui/ServiceTag/ServiceTag.stories.tsx
+++ b/components/ui/ServiceTag/ServiceTag.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ServiceTag } from './ServiceTag';
 import { categoryConfig } from './service-config';
-import type { ServiceCategory } from './service-config';
+import type { ServiceLine } from './service-config';
 
 /* ─── Meta ────────────────────────────────────────────────────── */
 
@@ -56,10 +56,10 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
 
 /* ─── Shared data ─────────────────────────────────────────────── */
 
-const categories = Object.keys(categoryConfig) as ServiceCategory[];
+const categories = Object.keys(categoryConfig) as ServiceLine[];
 
 // One representative service per category for icon-text and icon stories
-const categoryServices: Record<ServiceCategory, { serviceName: string; label: string }> = {
+const categoryServices: Record<ServiceLine, { serviceName: string; label: string }> = {
   brand:       { serviceName: 'Brand Identity Bundle',                         label: 'Brand Design' },
   marketing:   { serviceName: 'Custom Standard Web Development and Design',    label: 'Marketing Design' },
   information: { serviceName: 'Information Design',                            label: 'Information Design' },
@@ -68,7 +68,7 @@ const categoryServices: Record<ServiceCategory, { serviceName: string; label: st
 };
 
 // Full service list for catalog stories
-const allServices: Record<ServiceCategory, { serviceName: string; label: string }[]> = {
+const allServices: Record<ServiceLine, { serviceName: string; label: string }[]> = {
   brand: [
     { serviceName: 'Brand Business Card',                                    label: 'Business Card' },
     { serviceName: 'Brand Identity Bundle',                                  label: 'Brand Design' },

--- a/components/ui/ServiceTag/ServiceTag.tsx
+++ b/components/ui/ServiceTag/ServiceTag.tsx
@@ -3,7 +3,7 @@ import { bdsClass } from '../../utils';
 import {
   categoryConfig,
   getServiceIconPath,
-  type ServiceCategory,
+  type ServiceLine,
   type ServiceBadgeSize,
 } from './service-config';
 import './ServiceTag.css';
@@ -11,8 +11,8 @@ import './ServiceTag.css';
 export type ServiceTagVariant = 'text' | 'icon-text' | 'icon';
 
 export interface ServiceTagProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'children'> {
-  /** Service category — determines color and default label */
-  category: ServiceCategory;
+  /** Service line — determines color and default label */
+  category: ServiceLine;
   /** Display variant. Default: 'text' */
   variant?: ServiceTagVariant;
   /** Size variant. Default: 'md' */

--- a/components/ui/ServiceTag/index.ts
+++ b/components/ui/ServiceTag/index.ts
@@ -4,4 +4,4 @@ export type { ServiceTagProps, ServiceTagVariant } from './ServiceTag';
 
 // Shared service-tag domain config — re-exported for consumer convenience
 export { categoryConfig, serviceIconOverrides, normalizeServiceName, getServiceIconPath } from './service-config';
-export type { ServiceCategory, ServiceBadgeSize } from './service-config';
+export type { ServiceLine, ServiceCategory, ServiceBadgeSize } from './service-config';

--- a/components/ui/ServiceTag/service-config.ts
+++ b/components/ui/ServiceTag/service-config.ts
@@ -4,7 +4,14 @@
  * component (removed in #572; dir renamed in #731).
  */
 
-export type ServiceCategory = 'brand' | 'marketing' | 'information' | 'product' | 'service';
+export type ServiceLine = 'brand' | 'marketing' | 'information' | 'product' | 'service';
+
+/**
+ * @deprecated Use `ServiceLine` instead. Kept as a type alias for one
+ * deprecation cycle so existing consumers continue to compile; remove after
+ * portal + brikdesigns have migrated.
+ */
+export type ServiceCategory = ServiceLine;
 
 /**
  * Size scale shared with ServiceTag. Kept as `ServiceBadgeSize` for
@@ -13,7 +20,7 @@ export type ServiceCategory = 'brand' | 'marketing' | 'information' | 'product' 
  */
 export type ServiceBadgeSize = 'sm' | 'md' | 'lg';
 
-export const categoryConfig: Record<ServiceCategory, { token: string; label: string }> = {
+export const categoryConfig: Record<ServiceLine, { token: string; label: string }> = {
   brand: { token: 'yellow', label: 'Brand' },
   marketing: { token: 'green', label: 'Marketing' },
   information: { token: 'blue', label: 'Information' },
@@ -72,7 +79,7 @@ export function normalizeServiceName(name: string): string {
   return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
 }
 
-export function getServiceIconPath(category: ServiceCategory, serviceName: string): string {
+export function getServiceIconPath(category: ServiceLine, serviceName: string): string {
   if (serviceIconOverrides[serviceName]) {
     return `/icons/${category}/${serviceIconOverrides[serviceName]}.svg`;
   }

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -77,7 +77,7 @@ export interface BlueprintSection {
      */
     readonly href?: string;
     readonly imageUrl?: string;
-    /** ServiceCategory slug — see `ServiceTag` props in `@brikdesigns/bds`. */
+    /** ServiceLine slug — see `ServiceTag` props in `@brikdesigns/bds`. */
     readonly category?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
     readonly hasOptions?: boolean;
     /**

--- a/content-system/blueprints/react/Features3ColBrandedDark.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.tsx
@@ -42,7 +42,7 @@
  *
  * @summary Dark section, 3-col grid of brand-colored cards (per-audience scope binding).
  */
-import { Card, ServiceTag, Stack, type ServiceCategory } from '../../../components';
+import { Card, ServiceTag, Stack, type ServiceLine } from '../../../components';
 
 import type { BlueprintProps } from '../astro/types';
 import './Features3ColBrandedDark.css';
@@ -117,7 +117,7 @@ export function Features3ColBrandedDark({ section }: Props) {
                           aria-hidden="true"
                         >
                           <ServiceTag
-                            category={audience as ServiceCategory}
+                            category={audience as ServiceLine}
                             variant="icon"
                             size="lg"
                             serviceName={item.title}

--- a/content-system/blueprints/react/Services3ColCardGrid.tsx
+++ b/content-system/blueprints/react/Services3ColCardGrid.tsx
@@ -22,7 +22,7 @@ import {
   Frame,
   Grid,
   ServiceTag,
-  type ServiceCategory,
+  type ServiceLine,
 } from '../../../components';
 
 import type { BlueprintProps } from '../astro/types';
@@ -46,7 +46,7 @@ export function Services3ColCardGrid({ section }: Props) {
         style={{ listStyle: 'none', margin: 0, padding: 0 }}
       >
         {section.items.map((item, idx) => {
-          const category = (item.category ?? null) as ServiceCategory | null;
+          const category = (item.category ?? null) as ServiceLine | null;
           return (
             <li
               key={`${section.sectionKey}-${idx}`}


### PR DESCRIPTION
## Summary

Renames the canonical type `ServiceCategory` → `ServiceLine` to align with the business / DB / URL vocabulary (`service_lines` table, `/services/[serviceLineSlug]`). Preserves `ServiceCategory` as a `@deprecated` alias of `ServiceLine` for one deprecation cycle so brikdesigns + portal can migrate independently without flag-day coupling.

**Coordinated with [brikdesigns#279](https://github.com/brikdesigns/brikdesigns/issues/279).**

### What changed
- `components/ui/ServiceTag/service-config.ts` — `ServiceLine` is now canonical; `ServiceCategory` retained as `@deprecated` alias
- `components/ui/ServiceTag/index.ts` — re-exports both names
- Internal BDS callers (ServiceTag.tsx, stories, `Features3ColBrandedDark`, `Services3ColCardGrid`, astro types, proposal doc) now reference `ServiceLine` directly
- `categoryConfig` and `getServiceIconPath` value identifiers unchanged — consumer-side cohesion lives in brikdesigns/portal sweeps per the issue scope

### Backwards compat
- Existing consumers importing `ServiceCategory` continue to compile unchanged (alias is identical at the structural level: `'brand' | 'marketing' | 'information' | 'product' | 'service'`)
- IDEs will show the `@deprecated` strike-through on `ServiceCategory` references so downstream sweeps get a visible nudge
- The alias should be removed in a follow-up release once portal + brikdesigns confirm zero remaining `ServiceCategory` imports

## Consumer sync plan
- [ ] Publish patch release of `@brikdesigns/bds`
- [ ] brikdesigns: bump BDS + rename sweep per brikdesigns#279 step 2
- [ ] brik-client-portal: bump BDS + rename sweep per brikdesigns#279 step 3
- [ ] Follow-up BDS PR: drop the deprecated `ServiceCategory` alias once both consumers are clean

## Test plan
- [x] `npm run validate:full` — all 10 checks pass (Token Lint, JSDoc, Grid, Theme, Blueprints, BCS Vocab, Canonical Tokens, Component Axes, TypeScript, Storybook Build)
- [x] `npx vitest run components/ui/ServiceTag/` — 3 files / 8 tests pass
- [x] `npm run build:lib` succeeds; built `.d.ts` files expose both `ServiceLine` (canonical) and `ServiceCategory` (alias)
- [x] Storybook skipped per `SKIP_STORY_CHECK=1` — diff is purely a TS type rename, no rendered output change
- ⚠️ Pre-existing `Radio.stories.tsx` test failure on `main` — unrelated to this PR, confirmed by re-running on bare `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)