### PR TITLE
chore(release): 0.76.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.75.0",
+      "version": "0.76.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Cuts **0.76.0** — a 10-commit release since 0.75.0. Minor bump per semver (two `feat(tokens)` PRs).

### Commits since v0.75.0

```
532640a refactor(service-tag): rename ServiceCategory → ServiceLine (#772)
3d5b5b3 feat(tokens/button): tokenise Button.css sizing + icon-2xs/2xl (#770)
ef60975 feat(tokens): wire multi-Library Style Dictionary pull pipeline (#769)
62bc828 feat(tokens): add content-width + breakpoint tokens (#768)
712f405 security: deprecate pre-Husky local-hook scripts (#767)
59b3f8f fix(a11y): breadcrumb + pricing-card → --text-secondary (#766)
ae1e333 fix(button): tokenise hardcoded sizing (#757)
83e2bb7 security: add gitleaks pre-commit hook (#756)
d46062f chore(tokens): retire theme.{brik,blue}.* + brand.{tier} orphans (#753)
4c2c15a chore(deps): qs 6.15.0 → 6.15.2 (#759)
```

**No breaking changes.** The ServiceTag type rename in #772 ships with a `@deprecated` `ServiceCategory` alias so existing consumers compile unchanged.

## Post-merge sequence (manual)

```bash
git -C /Users/nickstanerson/Documents/Github/brik/brik-bds checkout main
git pull --ff-only
git tag -a -s v0.76.0 -m "v0.76.0"
git push origin v0.76.0
```

The tag push triggers `.github/workflows/release.yml` → publishes to GitHub Packages.

## Consumer bump unblocked

- **brikdesigns** — completes [brikdesigns#279](https://github.com/brikdesigns/brikdesigns/issues/279) step 2 (rename sweep: route param, query functions, variables, `mapCategorySlug` → `mapServiceLineSlug`, `ServiceCard` prop). Also picks up token additions (#768, #770) and a11y fix (#766).
- **brik-client-portal** — completes brikdesigns#279 step 3 (consume `ServiceLine` type; drop `ServiceCategory` imports).
- **renew-pms** — submodule bump; no new feature consumers required.

## Test plan

- [x] `package.json` version matches title (`0.76.0`)
- [x] `npm version minor --no-git-tag-version` updated lockfile cleanly
- [x] Pre-push `validate:full` green on this branch (10/10 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)