### PR TITLE
refactor(service-tag): drop deprecated ServiceCategory alias

### DIFF
--- a/components/ui/ServiceTag/index.ts
+++ b/components/ui/ServiceTag/index.ts
@@ -4,4 +4,4 @@ export type { ServiceTagProps, ServiceTagVariant } from './ServiceTag';
 
 // Shared service-tag domain config — re-exported for consumer convenience
 export { categoryConfig, serviceIconOverrides, normalizeServiceName, getServiceIconPath } from './service-config';
-export type { ServiceLine, ServiceCategory, ServiceBadgeSize } from './service-config';
+export type { ServiceLine, ServiceBadgeSize } from './service-config';

--- a/components/ui/ServiceTag/service-config.ts
+++ b/components/ui/ServiceTag/service-config.ts
@@ -7,13 +7,6 @@
 export type ServiceLine = 'brand' | 'marketing' | 'information' | 'product' | 'service';
 
 /**
- * @deprecated Use `ServiceLine` instead. Kept as a type alias for one
- * deprecation cycle so existing consumers continue to compile; remove after
- * portal + brikdesigns have migrated.
- */
-export type ServiceCategory = ServiceLine;
-
-/**
  * Size scale shared with ServiceTag. Kept as `ServiceBadgeSize` for
  * non-breaking package-API stability; structurally identical to a future
  * `ServiceTagSize` if the dir is renamed.


### PR DESCRIPTION
## Summary

Closes the cross-repo `category → serviceLine` rename agreed in brikdesigns#279 — drops the `@deprecated ServiceCategory = ServiceLine` alias that was added in [#772](https://github.com/brikdesigns/brik-bds/pull/772) as a one-cycle migration bridge.

| Consumer | State | Latest |
|---|---|---|
| brik-client-portal | ✅ All casts use `ServiceLine` | [portal#894](https://github.com/brikdesigns/brik-client-portal/pull/894) merged |
| brikdesigns | ✅ All imports use `ServiceLine` | [brikdesigns#281](https://github.com/brikdesigns/brikdesigns/pull/281) merged to staging |
| renew-pms | ✅ Never referenced the type | (no PR needed) |

Verified clean across all three consumers via `rg -l 'ServiceCategory'` immediately before opening this PR.

## What changed

- `components/ui/ServiceTag/service-config.ts` — drop `export type ServiceCategory = ServiceLine` (+ its `@deprecated` block)
- `components/ui/ServiceTag/index.ts` — drop `ServiceCategory` from the re-exports

2 files changed, +1 / -8 lines.

## Semver framing

Strictly speaking this removes a public export, which is a breaking change. Two reasons it's appropriate here:

1. **Pre-1.0 convention** — minor bumps signal breaking changes pre-1.0; the alias was `@deprecated` in v0.76.0, IDE strike-through warned consumers, and every known consumer has migrated.
2. **No internal call sites** — the alias was a forward-compatible re-export. Anything still importing `ServiceCategory` from `@brikdesigns/bds` was running on the deprecation warning, not on behavior.

Recommend bundling this into the next minor (0.77.0) when the release PR is cut.

## Verification

- [x] `npm run validate:full` — all 10 checks pass (Token Lint, JSDoc, Grid, Theme, Blueprints, BCS Vocab, Canonical Tokens, Component Axes, TypeScript, Storybook Build)
- [x] `rg ServiceCategory .` in this branch — zero results
- [x] Consumer verification across portal + brikdesigns + renew-pms — zero references
- [x] Pre-push hook ran a full `validate:full` re-check before push — all 10 pass

## Out of scope

- Version bump — handled separately per BDS convention (`chore(release): 0.77.0` PR bundles unreleased commits)
- Any other deprecated aliases (`ServiceBadgeSize` etc. remain canonical as documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)