### PR TITLE
chore(release): 0.77.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.76.0",
+      "version": "0.77.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Single-commit release — publishes the deprecated `ServiceCategory` alias removal from [#774](https://github.com/brikdesigns/brik-bds/pull/774).

### Commits since v0.76.0

```
1364899 refactor(service-tag): drop deprecated ServiceCategory alias (#774)
```

### Semver framing

Minor bump per **pre-1.0 convention**: removing a public export is a breaking change, but:

- The alias was `@deprecated` in 0.76.0 (#772) — IDE strike-through warned consumers
- Zero remaining consumers across the three known BDS consumers:
  - brik-client-portal — [portal#894](https://github.com/brikdesigns/brik-client-portal/pull/894) merged 2026-05-25
  - brikdesigns — [brikdesigns#281](https://github.com/brikdesigns/brikdesigns/pull/281) merged to staging 2026-05-25
  - renew-pms — never referenced the type (verified via `rg`)
- One-cycle deprecation window honoured (0.76.0 → 0.77.0)

## Post-merge sequence (manual)

```bash
git -C /Users/nickstanerson/Documents/Github/brik/brik-bds checkout main
git pull --ff-only
git tag -a -s v0.77.0 -m "v0.77.0"
git push origin v0.77.0
```

Tag push triggers `.github/workflows/release.yml` → publishes to GitHub Packages.

## Consumer impact

- **Breaking** for any external consumer still importing `ServiceCategory` from `@brikdesigns/bds`. Workspace consumers are all clean; no Brik-side action required.
- The canonical `ServiceLine` type (shipped in 0.76.0) is the migration target.

## Test plan

- [x] `package.json` version matches title (`0.77.0`)
- [x] `npm version minor --no-git-tag-version` updated lockfile cleanly
- [x] Pre-push `validate:full` green on this branch (10/10 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)