### PR TITLE
feat(lint-tokens): add Rule 5 — token-family ↔ property pairing (closes #578)

### DIFF
--- a/components/ui/ActivityTimeline/ActivityTimeline.css
+++ b/components/ui/ActivityTimeline/ActivityTimeline.css
@@ -66,7 +66,7 @@
   width: 2px; /* bds-lint-ignore — hairline connector */
   flex: 1;
   min-height: 20px; /* bds-lint-ignore — minimum connector height */
-  background-color: var(--border-muted);
+  background-color: var(--border-muted); /* bds-lint-ignore token-family — hairline connector rendered as 1px background; see #777 */
 }
 
 /* ─── Content ────────────────────────────────────────────────── */

--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -30,12 +30,12 @@
 }
 
 .bds-board::-webkit-scrollbar-thumb {
-  background-color: var(--border-muted);
+  background-color: var(--border-muted); /* bds-lint-ignore token-family — scrollbar thumb shares border hue; see #777 */
   border-radius: var(--border-radius-pill);
 }
 
 .bds-board:hover::-webkit-scrollbar-thumb {
-  background-color: var(--border-secondary);
+  background-color: var(--border-secondary); /* bds-lint-ignore token-family — scrollbar thumb shares border hue; see #777 */
 }
 
 /* ─── Board column ────────────────────────────────────── */

--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -125,7 +125,7 @@
 .bds-button--danger-outline {
   background-color: transparent;
   color: var(--text-accent-red);
-  border-color: var(--text-accent-red);
+  border-color: var(--border-negative);
 }
 
 .bds-button--danger-ghost {
@@ -276,12 +276,12 @@
 .bds-button--danger-outline:focus-visible,
 .bds-button--danger-ghost:focus-visible,
 .bds-button--destructive:focus-visible {
-  outline-color: var(--text-negative);
+  outline-color: var(--border-negative);
 }
 
 /* Positive: green focus ring */
 .bds-button--positive:focus-visible {
-  outline-color: var(--text-positive);
+  outline-color: var(--border-positive);
 }
 
 /* ─── Loading State ───────────────────────────────────────────── */

--- a/components/ui/CardTestimonial/CardTestimonial.css
+++ b/components/ui/CardTestimonial/CardTestimonial.css
@@ -93,6 +93,6 @@
   gap: var(--gap-md);
   font-size: var(--heading-lg);
   line-height: var(--font-line-height-snug);
-  color: var(--background-warning);
+  color: var(--text-warning);
 }
 }

--- a/components/ui/DatePicker/DatePicker.css
+++ b/components/ui/DatePicker/DatePicker.css
@@ -62,7 +62,7 @@
 }
 
 .bds-date-picker__trigger--error {
-  border-color: var(--color-system-red);
+  border-color: var(--border-negative);
 }
 
 .bds-date-picker__trigger--disabled {

--- a/components/ui/FileUploader/FileUploader.css
+++ b/components/ui/FileUploader/FileUploader.css
@@ -52,7 +52,7 @@
 }
 
 .bds-file-uploader__dropzone--error {
-  border-color: var(--text-negative);
+  border-color: var(--border-negative);
 }
 
 /* ─── Icon ────────────────────────────────────────────────────── */

--- a/components/ui/Meter/Meter.css
+++ b/components/ui/Meter/Meter.css
@@ -60,15 +60,15 @@
 
 /* Status colors */
 .bds-meter__fill--positive {
-  background-color: var(--color-system-green);
+  background-color: var(--background-positive);
 }
 
 .bds-meter__fill--warning {
-  background-color: var(--color-system-yellow);
+  background-color: var(--background-warning);
 }
 
 .bds-meter__fill--error {
-  background-color: var(--color-system-red);
+  background-color: var(--background-negative);
 }
 
 .bds-meter__fill--neutral {

--- a/components/ui/ProgressStepper/ProgressStepper.css
+++ b/components/ui/ProgressStepper/ProgressStepper.css
@@ -154,7 +154,7 @@
 }
 
 .bds-progress-stepper__connector--incomplete {
-  background-color: var(--border-secondary);
+  background-color: var(--border-secondary); /* bds-lint-ignore token-family — connector line styled as 2px background; see #777 */
 }
 
 /* ─── Dots variant ───────────────────────────────────────────── */
@@ -178,7 +178,7 @@
 }
 
 .bds-progress-stepper__dot--inactive {
-  background-color: var(--border-secondary);
+  background-color: var(--border-secondary); /* bds-lint-ignore token-family — inactive dot shares border-secondary hue; see #777 */
   opacity: 1;
 }
 

--- a/components/ui/Select/Select.css
+++ b/components/ui/Select/Select.css
@@ -118,16 +118,16 @@
 
 /* Error state */
 .bds-select--error {
-  border-color: var(--text-negative);
+  border-color: var(--border-negative);
 }
 
 .bds-select--error:hover:not(:disabled) {
-  border-color: var(--text-negative);
+  border-color: var(--border-negative);
 }
 
 .bds-select--error:focus,
 .bds-select--error:focus-visible {
-  border-color: var(--text-negative);
+  border-color: var(--border-negative);
   box-shadow: 0 0 0 1px var(--text-negative);
 }
 

--- a/components/ui/Slider/Slider.css
+++ b/components/ui/Slider/Slider.css
@@ -40,7 +40,7 @@
 .bds-slider-input::-moz-range-track {
   height: var(--bds-slider-track-height, 6px);
   border-radius: 999px;
-  background: var(--border-secondary);
+  background: var(--border-secondary); /* bds-lint-ignore token-family — slider track styled with border-family hue; see #777 */
   border: none;
 }
 
@@ -90,12 +90,12 @@
 }
 
 .bds-slider-input:disabled::-webkit-slider-thumb {
-  background: var(--border-secondary);
+  background: var(--border-secondary); /* bds-lint-ignore token-family — disabled thumb shares border hue; see #777 */
   border-color: var(--border-secondary);
 }
 
 .bds-slider-input:disabled::-moz-range-thumb {
-  background: var(--border-secondary);
+  background: var(--border-secondary); /* bds-lint-ignore token-family — disabled thumb shares border hue; see #777 */
   border-color: var(--border-secondary);
 }
 }

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -205,7 +205,7 @@
 .bds-task-console .bds-task-console__icon--in-progress {
   width: var(--icon-lg);
   height: var(--icon-lg);
-  border-color: var(--surface-muted);
+  border-color: var(--surface-muted); /* bds-lint-ignore token-family — spinner track uses surface-muted hue; see #777 */
   border-top-color: var(--border-brand-primary);
 }
 

--- a/components/ui/Testimonial/Testimonial.css
+++ b/components/ui/Testimonial/Testimonial.css
@@ -93,6 +93,6 @@
   gap: var(--gap-md);
   font-size: var(--heading-lg);
   line-height: var(--font-line-height-snug);
-  color: var(--background-warning);
+  color: var(--text-warning);
 }
 }

--- a/components/ui/TimePicker/TimePicker.css
+++ b/components/ui/TimePicker/TimePicker.css
@@ -67,11 +67,11 @@
 }
 
 .bds-time-picker__trigger--error {
-  border-color: var(--color-system-red);
+  border-color: var(--border-negative);
 }
 
 .bds-time-picker__trigger--error:hover:not(:disabled) {
-  border-color: var(--color-system-red);
+  border-color: var(--border-negative);
 }
 
 .bds-time-picker__trigger--disabled {

--- a/docs/TOKEN-PR-CHECKLIST.md
+++ b/docs/TOKEN-PR-CHECKLIST.md
@@ -21,11 +21,51 @@ Never combine theme changes + component fixes + submodule sync in a single PR. E
 
 | Check | What it catches |
 |-------|----------------|
-| `lint-tokens.js --errors-only` | Primitive tokens in component CSS, hardcoded values, unknown vars |
+| `lint-tokens.js --errors-only` | Primitive tokens in component CSS, hardcoded values, unknown vars, **wrong-family token in property slot (see table below)** |
 | `token-audit.sh` (consuming projects) | Raw hex, hardcoded px, raw `var()` strings in style props, wrong element types |
 | Tier 2 hex scan | Raw hex values in the semantic section of theme files |
 
 All three must pass before the PR is ready for review.
+
+---
+
+## Token-family ↔ property pairing
+
+Even when a token name resolves to the visually right hue, the **family** must match the property's slot. Mixing them up was the failure mode behind portal #512 / #553 (rolled back) and brikdesigns #99 — caught only in browser review. `lint-tokens.js` Rule 5 now enforces this as a hard gate.
+
+| Property | Allowed token families |
+|---|---|
+| `background-color`, `background` | `--background-*`, `--surface-*` |
+| `color` | `--text-*`, `--color-*` (primitives) |
+| `border-color`, `border-{side}-color` | `--border-*`, `--background-*` (fill-matching borders) |
+| `outline-color` | `--border-*` |
+
+Custom-property declarations inherit the allowlist of their LHS prefix family — e.g. `--background-inverse: var(--text-foo)` fails because `--background-*` declarations follow the `background-color` rule, which doesn't include the text family.
+
+**TSX inline styles follow the same rule** — `style={{ backgroundColor: 'var(--text-service-marketing)' }}` is the canonical failure case.
+
+**Escape hatch:** when a cross-family alias is intentional (e.g. a divider line rendered as a 1px `background-color` of `--border-muted`), add an inline `bds-lint-ignore token-family — <reason>` comment and link to a tracking issue. The comment must justify the design intent, not silently suppress the rule.
+
+### Examples
+
+```css
+/* ✅ Pass — same family */
+background-color: var(--background-primary);
+color: var(--text-primary);
+border-color: var(--border-negative);
+
+/* ✅ Pass — border allows fill-matching --background-* */
+border-color: var(--background-brand-primary);
+
+/* ❌ Fail — text family in background slot */
+background-color: var(--text-service-marketing);
+
+/* ❌ Fail — background family in text slot */
+color: var(--background-warning);
+
+/* ❌ Fail — text family in border slot (use --border-negative instead) */
+border-color: var(--text-negative);
+```
 
 ---
 

--- a/scripts/__tests__/lint-tokens-family.test.mjs
+++ b/scripts/__tests__/lint-tokens-family.test.mjs
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+// Integration tests for Rule 5 (token-family pairing) in scripts/lint-tokens.js.
+// The linter is a CLI; we exercise it via --json mode against temp-dir fixtures
+// to avoid coupling the test to the script's internal CommonJS structure.
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
+const LINTER = resolve(REPO_ROOT, 'scripts', 'lint-tokens.js');
+
+function runLinter({ tsxFiles = [], cssFiles = [] }) {
+  const args = ['--json', '--errors-only'];
+  if (tsxFiles.length > 0) args.push('--files', ...tsxFiles);
+  if (cssFiles.length > 0) args.push('--css-files', ...cssFiles);
+  const result = spawnSync('node', [LINTER, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  // JSON output is on stdout regardless of exit code.
+  const payload = JSON.parse(result.stdout);
+  return payload.violations.filter((v) => v.rule === 'token-family');
+}
+
+describe('lint-tokens Rule 5 (token-family pairing)', () => {
+  let tmpDir;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bds-lint-family-'));
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('fires on the canonical failure example from #578 (TSX inline style)', () => {
+    const file = join(tmpDir, 'Failure.tsx');
+    writeFileSync(file, `
+      export function Failure() {
+        return <span style={{ backgroundColor: 'var(--text-service-marketing)' }} />;
+      }
+    `);
+    const violations = runLinter({ tsxFiles: [file] });
+    expect(violations.length).toBe(1);
+    expect(violations[0].message).toMatch(/backgroundColor.*--text-service-marketing/);
+    expect(violations[0].message).toMatch(/text-family token in background slot/);
+  });
+
+  it('fires on CSS property using wrong-family token (background-color: var(--text-*))', () => {
+    const file = join(tmpDir, 'Failure.css');
+    writeFileSync(file, `
+      .x { background-color: var(--text-service-marketing); }
+    `);
+    const violations = runLinter({ cssFiles: [file] });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(/text-family token in background slot/);
+  });
+
+  it('fires on custom-property declaration using wrong-family value', () => {
+    const file = join(tmpDir, 'Decl.css');
+    writeFileSync(file, `
+      .x { --background-inverse: var(--text-service-marketing); }
+    `);
+    const violations = runLinter({ cssFiles: [file] });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(/--background-inverse.*--text-service-marketing/);
+  });
+
+  it('fires on border-color: var(--text-*) and outline-color: var(--text-*)', () => {
+    const file = join(tmpDir, 'BorderOutline.css');
+    writeFileSync(file, `
+      .a { border-color: var(--text-negative); }
+      .b { outline-color: var(--text-positive); }
+    `);
+    const violations = runLinter({ cssFiles: [file] });
+    expect(violations).toHaveLength(2);
+    expect(violations.map((v) => v.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/text-family token in border slot/),
+        expect.stringMatching(/text-family token in outline slot/),
+      ]),
+    );
+  });
+
+  it('passes ServiceTag-style canonical pairings (--background-service-* + --text-service-*)', () => {
+    const file = join(tmpDir, 'ServiceTagLike.css');
+    writeFileSync(file, `
+      .bds-service-tag--brand {
+        background-color: var(--background-service-brand);
+        color: var(--text-service-brand);
+      }
+    `);
+    const violations = runLinter({ cssFiles: [file] });
+    expect(violations).toEqual([]);
+  });
+
+  it('passes canonical same-family custom-property override (--background-inverse: var(--background-primary))', () => {
+    const file = join(tmpDir, 'SafeDecl.css');
+    writeFileSync(file, `
+      .x { --background-inverse: var(--background-primary); }
+    `);
+    const violations = runLinter({ cssFiles: [file] });
+    expect(violations).toEqual([]);
+  });
+
+  it('honours bds-lint-ignore on the same line', () => {
+    const file = join(tmpDir, 'Ignored.css');
+    writeFileSync(file, `
+      .x { background-color: var(--border-muted); /* bds-lint-ignore token-family */ }
+    `);
+    const violations = runLinter({ cssFiles: [file] });
+    expect(violations).toEqual([]);
+  });
+
+  it('does not fire on border CSS shorthand (out of scope — bundles width/style)', () => {
+    const file = join(tmpDir, 'Shorthand.css');
+    writeFileSync(file, `
+      .x { border: 1px solid var(--text-negative); }
+    `);
+    const violations = runLinter({ cssFiles: [file] });
+    expect(violations).toEqual([]);
+  });
+});

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -4,11 +4,14 @@
  * BDS Token Validation Linter
  *
  * Validates CSS variable usage in BDS components against Style Dictionary token outputs.
- * Catches four types of violations:
+ * Catches five types of violations:
  *   1. Primitive token usage (use semantic tokens instead)
  *   2. Hardcoded CSS values (use tokens)
  *   3. Unknown tokens (typos or non-existent variables)
  *   4. Spacing values not aligned to 4-point grid (see https://design.brikdesigns.com/docs/primitives/spacing)
+ *   5. Token-family pairing mismatch — a token used in a property whose family
+ *      it doesn't belong to (e.g. background-color: var(--text-*)). See
+ *      docs/TOKEN-PR-CHECKLIST.md for the property↔family table.
  *
  * Usage:
  *   node scripts/lint-tokens.js              # full report (errors + warnings)
@@ -168,6 +171,108 @@ const LINE_ALLOWLIST = [
   'background: \'transparent\'',
   'backgroundColor: \'transparent\'',
 ];
+
+// ---------------------------------------------------------------------------
+// Token-family pairing rules (Rule 5)
+// ---------------------------------------------------------------------------
+// Each CSS property is paired with the set of token-family prefixes whose
+// values are semantically appropriate. Wrong-family usage was the failure
+// mode behind portal #512 / #553 (rolled back) and brikdesigns #99 (caught
+// in browser review).
+//
+// Custom-property declarations (e.g. `--background-inverse: var(...)`)
+// inherit the rule of the LHS prefix family — see CUSTOM_PROP_TO_RULE.
+//
+// Documented at docs/TOKEN-PR-CHECKLIST.md.
+
+const TOKEN_FAMILY_RULES = {
+  'background-color': {
+    allowed: ['--background-', '--surface-'],
+    label: 'background',
+    suggestion: 'use a --background-* or --surface-* token',
+  },
+  'background': {
+    allowed: ['--background-', '--surface-'],
+    label: 'background',
+    suggestion: 'use a --background-* or --surface-* token',
+  },
+  'color': {
+    allowed: ['--text-', '--color-'],
+    label: 'text',
+    suggestion: 'use a --text-* token or a --color-* primitive',
+  },
+  'border-color': {
+    allowed: ['--border-', '--background-'],
+    label: 'border',
+    suggestion: 'use a --border-* token (or matching --background-* for fill-style borders)',
+  },
+  'border-top-color': {
+    allowed: ['--border-', '--background-'],
+    label: 'border',
+    suggestion: 'use a --border-* token',
+  },
+  'border-bottom-color': {
+    allowed: ['--border-', '--background-'],
+    label: 'border',
+    suggestion: 'use a --border-* token',
+  },
+  'border-left-color': {
+    allowed: ['--border-', '--background-'],
+    label: 'border',
+    suggestion: 'use a --border-* token',
+  },
+  'border-right-color': {
+    allowed: ['--border-', '--background-'],
+    label: 'border',
+    suggestion: 'use a --border-* token',
+  },
+  'outline-color': {
+    allowed: ['--border-'],
+    label: 'outline',
+    suggestion: 'use a --border-* token',
+  },
+};
+
+// TSX inline-style camelCase → kebab-case for properties in TOKEN_FAMILY_RULES.
+const TSX_STYLE_PROP_TO_CSS = {
+  backgroundColor: 'background-color',
+  background: 'background',
+  color: 'color',
+  borderColor: 'border-color',
+  borderTopColor: 'border-top-color',
+  borderBottomColor: 'border-bottom-color',
+  borderLeftColor: 'border-left-color',
+  borderRightColor: 'border-right-color',
+  outlineColor: 'outline-color',
+};
+
+// CSS custom-property declaration prefixes that inherit a TOKEN_FAMILY_RULES
+// allowlist. Lets the rule fire on `--background-foo: var(--text-bar)` too.
+const CUSTOM_PROP_TO_RULE = {
+  '--background-': 'background-color',
+  '--surface-': 'background-color',
+  '--text-': 'color',
+  '--border-': 'border-color',
+};
+
+// Token prefixes the family-pairing rule recognises. Values pointing to other
+// prefixes (e.g. --bds-*, --font-*, --space-*) are out of scope.
+const FAMILY_PREFIXES_FOR_VALUES = [
+  '--background-', '--surface-', '--text-', '--border-', '--color-',
+];
+
+function classifyTokenFamily(tokenName) {
+  for (const prefix of FAMILY_PREFIXES_FOR_VALUES) {
+    if (tokenName.startsWith(prefix)) return prefix;
+  }
+  return null;
+}
+
+function tokenFamilyMatchesAllowlist(tokenName, allowed) {
+  const family = classifyTokenFamily(tokenName);
+  if (family === null) return true; // unknown family — out of scope; Rule 3 handles unknown tokens
+  return allowed.includes(family);
+}
 
 // ---------------------------------------------------------------------------
 // Token parser — reads Webflow CSS and extracts all valid custom properties
@@ -560,6 +665,85 @@ function checkGridCompliance(line, lineNum, file) {
   return violations;
 }
 
+/**
+ * Rule 5: Token-family pairing
+ *
+ * Flags `var(--TOKEN)` uses where the token's family doesn't match the
+ * property's allowlist. Three usage shapes are checked:
+ *
+ *   • CSS property in a rule body:        background-color: var(--text-foo);
+ *   • CSS custom-property declaration:    --background-inverse: var(--text-foo);
+ *   • TSX inline-style object:            style={{ backgroundColor: 'var(--text-foo)' }}
+ *
+ * Skips lines with `bds-lint-ignore` (escape hatch for cross-family aliases
+ * that are intentional — e.g. hue-sharing across families).
+ */
+function checkTokenFamilyPairing(line, lineNum, file, isComponent) {
+  const violations = [];
+
+  const trimmed = line.trim();
+  if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+    return violations;
+  }
+  if (line.includes('bds-lint-ignore')) return violations;
+
+  const isTsx = /\.tsx?$/.test(file);
+  const isCss = /\.css$/.test(file);
+
+  function pushViolation(prop, tokenName, ruleKey, column) {
+    const rule = TOKEN_FAMILY_RULES[ruleKey];
+    if (!rule) return;
+    if (tokenFamilyMatchesAllowlist(tokenName, rule.allowed)) return;
+    violations.push({
+      rule: 'token-family',
+      severity: isComponent ? 'error' : 'warning',
+      file,
+      line: lineNum,
+      column: column + 1,
+      message: `"${prop}: var(${tokenName})" — ${classifyTokenFamily(tokenName)?.slice(2, -1) || 'unknown'}-family token in ${rule.label} slot`,
+      suggestion: rule.suggestion,
+    });
+  }
+
+  if (isCss) {
+    // Shape A: standard CSS property `<prop>: var(--token)`
+    // Must match an exact key in TOKEN_FAMILY_RULES (so `border-color`
+    // matches but `border` shorthand doesn't — shorthands bundle width/style
+    // and are out of scope).
+    const propRegex = /(^|[\s;{])(background-color|background|color|border-color|border-top-color|border-bottom-color|border-left-color|border-right-color|outline-color)\s*:\s*var\((--[\w-]+)(?:\s*,[^)]*)?\)/g;
+    let m;
+    while ((m = propRegex.exec(line)) !== null) {
+      pushViolation(m[2], m[3], m[2], m.index + m[1].length);
+    }
+
+    // Shape B: custom-property declaration `<--family-...>: var(--token)`
+    // Only LHS prefixes in CUSTOM_PROP_TO_RULE trigger the rule. Pure
+    // numeric-suffix or skipped prefixes (--bds-*, --font-*, etc.) are
+    // out of scope.
+    const declRegex = /(^|[\s;{])(--[\w-]+)\s*:\s*var\((--[\w-]+)(?:\s*,[^)]*)?\)/g;
+    while ((m = declRegex.exec(line)) !== null) {
+      const lhs = m[2];
+      if (lhs.startsWith('--bds-')) continue;
+      const ruleKey = Object.entries(CUSTOM_PROP_TO_RULE).find(([prefix]) => lhs.startsWith(prefix))?.[1];
+      if (!ruleKey) continue;
+      pushViolation(lhs, m[3], ruleKey, m.index + m[1].length);
+    }
+  }
+
+  if (isTsx) {
+    // Shape C: TSX inline-style object property `<camelProp>: 'var(--token)'`
+    const tsxRegex = /\b(backgroundColor|background|color|borderColor|borderTopColor|borderBottomColor|borderLeftColor|borderRightColor|outlineColor)\s*:\s*['"]var\((--[\w-]+)(?:\s*,[^)]*)?\)['"]/g;
+    let m;
+    while ((m = tsxRegex.exec(line)) !== null) {
+      const cssProp = TSX_STYLE_PROP_TO_CSS[m[1]];
+      if (!cssProp) continue;
+      pushViolation(m[1], m[2], cssProp, m.index);
+    }
+  }
+
+  return violations;
+}
+
 // ---------------------------------------------------------------------------
 // Reporter
 // ---------------------------------------------------------------------------
@@ -657,6 +841,7 @@ function main() {
       allViolations.push(...checkPrimitiveTokens(line, lineNum, file, isComponent));
       allViolations.push(...checkHardcodedValues(line, lineNum, file, isComponent));
       allViolations.push(...checkUnknownTokens(line, lineNum, file, tokens, isComponent));
+      allViolations.push(...checkTokenFamilyPairing(line, lineNum, file, isComponent));
 
       // Rule 4: grid compliance (opt-in via --check-grid)
       if (checkGrid) {
@@ -678,6 +863,8 @@ function main() {
       allViolations.push(...checkPrimitiveTokens(line, lineNum, file, true));
       // Rule 3: unknown token references in CSS (catches stale var() after renames)
       allViolations.push(...checkUnknownTokens(line, lineNum, file, tokens, true));
+      // Rule 5: token-family pairing
+      allViolations.push(...checkTokenFamilyPairing(line, lineNum, file, true));
 
       if (checkGrid) {
         allViolations.push(...checkGridCompliance(line, lineNum, file));


### PR DESCRIPTION
## Summary

Closes #578. Adds **Rule 5** to `scripts/lint-tokens.js` — enforces that each `var(--TOKEN)` reference uses a token whose family matches the property's slot. This catches the failure mode behind portal #512 / #553 (rolled back) and brikdesigns #99 (caught only in browser review): a token name that exists in `dist/tokens.css` but whose family doesn't belong in the property it's applied to.

`validate-token-names` was the **soft** gate; this is the **hard** gate.

## Rule shape

| Property | Allowed families |
|---|---|
| `background-color`, `background` | `--background-*`, `--surface-*` |
| `color` | `--text-*`, `--color-*` (primitives) |
| `border-color`, `border-{side}-color` | `--border-*`, `--background-*` (fill-matching borders) |
| `outline-color` | `--border-*` |

Fires on three usage shapes:
- CSS property in rule body: `background-color: var(--text-foo);`
- CSS custom-property declaration: `--background-inverse: var(--text-foo);` (inherits the rule of the LHS prefix family)
- TSX inline-style object: `style={{ backgroundColor: 'var(--text-foo)' }}`

Escape hatch: `bds-lint-ignore token-family — <reason>` inline comment.

## Pre-existing violations swept in this PR (15 same-hue mechanical swaps)

Verified same-hue per `tokens/figma-tokens.css` — no visual change.

| Component | Before | After |
|---|---|---|
| Button (danger-outline border, focus rings) | `--text-accent-red`, `--text-negative`, `--text-positive` | `--border-negative`, `--border-positive` |
| Select (error states ×3) | `--text-negative` | `--border-negative` |
| FileUploader (error dropzone) | `--text-negative` | `--border-negative` |
| DatePicker, TimePicker (error states ×3) | `--color-system-red` (primitive) | `--border-negative` |
| Meter (status fills ×3) | `--color-system-green/yellow/red` | `--background-positive/warning/negative` |
| Testimonial, CardTestimonial (rating color) | `--background-warning` | `--text-warning` |

## Annotated-but-not-changed (9 design-ambiguous lines → #777)

`bds-lint-ignore token-family — <reason>; see #777` added to:
- ActivityTimeline, Board ×2, ProgressStepper ×2 — divider/connector lines styled as `background-color: var(--border-*)`
- Slider ×3 — track + disabled thumb using `background: var(--border-secondary)`
- TaskConsole spinner — `border-color: var(--surface-muted)`

#777 owns the design call for whether to keep the cross-family alias as documented intent or migrate to new semantic tokens.

## Tests

`scripts/__tests__/lint-tokens-family.test.mjs` — 8 vitest cases:
- Fires on the canonical failure example from #578 (TSX inline style)
- Fires on CSS property + custom-property declaration mismatches
- Fires on `border-color`/`outline-color` with text-family tokens
- ServiceTag-style canonical pairings pass
- Same-family custom-property override passes
- `bds-lint-ignore` honoured
- CSS `border` shorthand out of scope (bundles width/style)

## Docs

`docs/TOKEN-PR-CHECKLIST.md` — new section "Token-family ↔ property pairing" with the table, examples, and escape-hatch policy.

## Follow-ups (out of scope here — one concern per PR)

- **#777** — clean up 9 design-ambiguous violations annotated with `bds-lint-ignore`
- Consumer-linter mirror PRs (to be filed after merge): `brikdesigns`, `brik-client-portal`, `renew-pms` each carry a copy of `lint-tokens.{js,mjs}` that needs Rule 5

## Test plan

- [x] `node scripts/lint-tokens.js --errors-only` — 0 violations across 202 .tsx + 94 .css files
- [x] `npx vitest run scripts/__tests__/` — 78/78 pass (including 8 new family-pairing cases)
- [x] `npm run typecheck` — clean
- [x] `./scripts/pr-checklist.sh` — all automated checks pass
- [x] `npm run validate:full` (pre-push) — 10/10 checks pass (Component Axes, TypeScript, Storybook Build, etc.)
- [ ] Chromatic visual review — verify no visual diff on Button (danger), Select (error), FileUploader (error), DatePicker/TimePicker (error), Meter (status fills), Testimonial (rating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)