### PR TITLE
feat(footer): --bds-footer-surface component-local slot

### DIFF
--- a/components/ui/Footer/Footer.css
+++ b/components/ui/Footer/Footer.css
@@ -5,9 +5,16 @@
  * Token reference:
  * - --surface-primary (default bg)
  * - --surface-brand-primary (brand bg)
+ * - --surface-inverse (inverse bg — default value of --bds-footer-surface)
  * - --border-secondary (borders)
  * - --padding-xl, --padding-lg, --padding-md
  * - --gap-xl, --gap-lg, --gap-md, --gap-sm
+ *
+ * Component-local custom property (per BDS lint convention: --bds-* slots
+ * are component-owned, not canonical tokens):
+ * - --bds-footer-surface — bg for variant="inverse". Defaults to
+ *   var(--surface-inverse). Override from a parent (e.g. :root) to pin
+ *   the inverse footer to a fixed color across light + dark themes.
  */
 
 /* ─── Container ───────────────────────────────────────────────── */
@@ -40,8 +47,15 @@
   background-color: var(--surface-brand-primary);
 }
 
+/* The fallback chain `var(--bds-footer-surface, var(--surface-inverse))` is
+   deliberate — declaring `--bds-footer-surface: var(--surface-inverse)` on
+   `.bds-footer` would create a local re-declaration that blocks any
+   :root-level override from inheriting (the local default wins over the
+   inherited value). Using the fallback syntax means a consumer override
+   set on `:root` (or any parent) cascades into the footer cleanly, and
+   absent any override the existing inverse behavior is preserved. */
 .bds-footer--inverse {
-  background-color: var(--surface-inverse);
+  background-color: var(--bds-footer-surface, var(--surface-inverse));
 }
 
 /* ─── Top section: logo + columns ─────────────────────────────── */

--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -140,6 +140,19 @@ export const Variants: Story = {
         />
       </div>
 
+      <div style={{ '--bds-footer-surface': 'var(--color-grayscale-darkest)' } as React.CSSProperties}>
+        <SectionLabel>
+          Inverse + `--bds-footer-surface` override (pinned to grayscale-darkest across themes)
+        </SectionLabel>
+        <Footer
+          logo={<LogoPlaceholder />}
+          tagline="Building better digital experiences for small businesses."
+          columns={sampleColumns}
+          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
+          variant="inverse"
+        />
+      </div>
+
       <div>
         <SectionLabel>With social links</SectionLabel>
         <Footer


### PR DESCRIPTION
Adds a component-local custom property on .bds-footer (read by .bds-footer--inverse via var() fallback) so consumers can pin the inverse footer surface to a fixed color across light + dark themes. Default behavior unchanged.

See commit message for the var()-fallback implementation rationale and the cascade gotcha caught during Storybook verification.

Generated to unblock brikdesigns#TBD which will set --bds-footer-surface: var(--color-grayscale-darkest) in :root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)