### PR TITLE
feat(breadcrumb): [data-audience] cascade rebinds canonical text tokens

### DIFF
--- a/components/ui/Breadcrumb/Breadcrumb.css
+++ b/components/ui/Breadcrumb/Breadcrumb.css
@@ -41,4 +41,44 @@
   line-height: var(--font-line-height-tight);
   padding: 0 var(--padding-tiny);
 }
+
+/* ─── Audience cascade — service-line tinting ────────────────────
+ * Re-binds canonical --text-secondary / --text-muted inside each
+ * [data-audience='X'] subtree, scoped to .bds-breadcrumb only so
+ * other secondary text on the page is unaffected.
+ *
+ * `data-audience='service'` resolves to the back-office hue per the
+ * #563 token rename (audience attribute kept "service" for
+ * component-API compat; underlying tokens are *-back-office-*).
+ * Same mapping as HeroSplitImageCardOverlay.
+ *
+ * Pattern: rebind canonical generic tokens (--text-secondary,
+ * --text-muted) — never introduce scoped hierarchy modifiers like
+ * --text-service-X-muted (forbidden by BDS naming canon: scoped
+ * tokens carry context modifiers only, not hierarchy). */
+
+[data-audience='brand'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-brand);
+  --text-muted: var(--text-service-brand);
+}
+
+[data-audience='marketing'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-marketing);
+  --text-muted: var(--text-service-marketing);
+}
+
+[data-audience='information'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-information);
+  --text-muted: var(--text-service-information);
+}
+
+[data-audience='product'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-product);
+  --text-muted: var(--text-service-product);
+}
+
+[data-audience='service'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-back-office);
+  --text-muted: var(--text-service-back-office);
+}
 }

--- a/components/ui/Breadcrumb/Breadcrumb.mdx
+++ b/components/ui/Breadcrumb/Breadcrumb.mdx
@@ -29,6 +29,20 @@ Real-world usage: page headers and settings navigation.
 
 <Canvas of={Stories.Patterns} />
 
+## Audience cascade
+
+When a breadcrumb sits inside a `[data-audience='X']` subtree, the
+current page label and separators rebind canonical `--text-secondary`
+and `--text-muted` to the matching `--text-service-{name}` value
+(`brand`, `marketing`, `information`, `product`, and `service` → back-office).
+
+The component itself stays scope-blind — only the cascade block in
+`Breadcrumb.css` knows about audiences. Consumers set `data-audience`
+on any ancestor (page wrapper, hero card, sidebar column) and the
+breadcrumb inside picks up the hue.
+
+<Canvas of={Stories.AudienceCascade} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/Breadcrumb/Breadcrumb.stories.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.stories.tsx
@@ -164,3 +164,41 @@ export const Patterns: Story = {
     </Stack>
   ),
 };
+
+/* ═══════════════════════════════════════════════════════════════
+   4. AUDIENCE CASCADE — service-line tinting via [data-audience]
+   ═══════════════════════════════════════════════════════════════ */
+
+// The breadcrumb stays scope-blind — __current reads --text-secondary
+// and __separator reads --text-muted as always. When the breadcrumb
+// sits inside a [data-audience='X'] subtree, Breadcrumb.css rebinds
+// those two canonical tokens to --text-service-{name} so the current
+// page label + separators pick up the audience hue. The 'service'
+// audience maps to the back-office token set per the #563 rename.
+const AUDIENCES = [
+  { id: 'brand', label: 'Brand (yellow)' },
+  { id: 'marketing', label: 'Marketing (green)' },
+  { id: 'information', label: 'Information (blue)' },
+  { id: 'product', label: 'Product (purple)' },
+  { id: 'service', label: 'Service / back-office (orange)' },
+] as const;
+
+/** @summary Service-line tinting via [data-audience] cascade */
+export const AudienceCascade: Story = {
+  render: () => (
+    <Stack>
+      {AUDIENCES.map(({ id, label }) => (
+        <div key={id} data-audience={id}>
+          <SectionLabel>{`[data-audience='${id}'] — ${label}`}</SectionLabel>
+          <Breadcrumb
+            items={[
+              { label: 'Home', href: '#' },
+              { label: 'Services', href: '#' },
+              { label: 'Detail page' },
+            ]}
+          />
+        </div>
+      ))}
+    </Stack>
+  ),
+};


### PR DESCRIPTION
## Summary

When a `.bds-breadcrumb` sits inside a `[data-audience='X']` subtree (brand / marketing / information / product / service), rebind canonical `--text-secondary` and `--text-muted` to the matching `--text-service-{name}` value so the current page label + separators pick up the audience hue.

The `data-audience='service'` value maps to the back-office token set per the [#563](https://github.com/brikdesigns/brik-bds/issues/563) rename (audience attribute kept "service" for component-API compat; underlying tokens are `*-back-office-*`). Same mapping as `HeroSplitImageCardOverlay`.

## Naming canon

Stays inside BDS naming canon: **scoped tokens carry context modifiers only, never hierarchy**. No `--text-service-X-muted` invented — the consumer-facing behavior is achieved by rebinding canonical generic tokens within the cascade scope. Surgical blast radius: the rebind is scoped to `.bds-breadcrumb`, so other secondary text on the page is unaffected.

This closes the `#5b` carryover item from the footer-surface session (PR [#779](https://github.com/brikdesigns/brik-bds/pull/779)). The brikdesigns consumer bump follows once `#5c` (footer bottom-left alignment) lands and a new BDS is published.

## Files

- `components/ui/Breadcrumb/Breadcrumb.css` — `[data-audience='X'] .bds-breadcrumb { --text-secondary / --text-muted }` for 5 audiences
- `components/ui/Breadcrumb/Breadcrumb.stories.tsx` — new `AudienceCascade` story rendering the breadcrumb under each subtree
- `components/ui/Breadcrumb/Breadcrumb.mdx` — Audience cascade section + Canvas

## Consumer sync plan

- [ ] brikdesigns: wire `data-audience` on service-line page wrapper (deferred to brikdesigns bump after BDS release)
- [ ] Portal / renew-pms: no action — these surfaces don't ship `data-audience`, breadcrumb defaults unchanged.

## Test plan

- [x] `npm run validate:full` — all 10 checks pass (token / jsdoc / canonical / axes / typecheck / storybook build)
- [x] Visual verification in Storybook — each audience's `current` + `/` computed color matches its `--color-{hue}-darkest` (brand=#634716 / marketing=#2a5542 / information=#314952 / product=#362d48 / service=#4e1400)
- [x] Link color stays scope-blind on `--text-brand-primary` (poppy in default theme) — only `current` + `separator` re-bind.

## Knowledge capture

Surfaced and codified the canon rule on first attempt: scoped tokens (`--text-service-marketing-*`) take **context** modifiers (`-on-light`, `-on-dark`) but never **hierarchy** modifiers (`-muted`, `-secondary`, `-primary`). The original punch-list proposal (`--text-service-{audience}-muted`) would have repeated the portal #512/#553 parallel-taxonomy failure mode.

Generated with [Claude Code](https://claude.ai/code)