### PR TITLE
fix(footer): align bottom-left copyright + bottom-links text baselines

### DIFF
--- a/components/ui/Footer/Footer.css
+++ b/components/ui/Footer/Footer.css
@@ -160,9 +160,16 @@
   font-family: var(--font-family-body);
   font-size: var(--body-xs);
   font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-tight);
   margin: 0;
 }
 
+/* font-size + line-height pinned on the UL itself so its line-box matches
+ * .bds-footer__copyright. Without this, the UL inherits body's 16px and
+ * gets a 24px line-box while its <li> children (--body-xs ≈ 11.54px) sit
+ * in a 17.31px box. align-items: center on the parent keeps the bounding
+ * boxes centered, but the asymmetric line-boxes drift the text baselines
+ * — copyright ends up visibly higher than the link row. */
 .bds-footer__bottom-links {
   list-style: none;
   display: flex;
@@ -171,12 +178,15 @@
   gap: var(--gap-sm);
   padding: 0;
   margin: 0;
+  font-size: var(--body-xs);
+  line-height: var(--font-line-height-tight);
 }
 
 .bds-footer__bottom-link {
   font-family: var(--font-family-body);
   font-size: var(--body-xs);
   font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-tight);
   text-decoration: none;
   transition: opacity var(--duration-fast) var(--ease-out);
 }
@@ -188,6 +198,7 @@
 .bds-footer__bottom-sep {
   font-family: var(--font-family-body);
   font-size: var(--body-xs);
+  line-height: var(--font-line-height-tight);
   user-select: none;
 }
 


### PR DESCRIPTION
## Summary

`.bds-footer__bottom-left` is a flex container (`align-items: center`) with two children whose **line-boxes are asymmetric** — the bounding-box centers line up but the inner text baselines drift, so the copyright line sits visibly higher than the link row.

| Child | Font-size | Line-height | Box height |
|---|---|---|---|
| `<p class=".bds-footer__copyright">` (before) | `--body-xs` (≈ 11.54px) | `normal` | 17.31px |
| `<ul class=".bds-footer__bottom-links">` (before) | inherited 16px (body default) | `normal` | **24.00px** |
| Both (after) | `--body-xs` | `--font-line-height-tight` | **12.69px** ✅ |

## Fix

Pin `font-size` + `line-height` on the UL itself, and add matching `line-height` to `.bds-footer__copyright`, `.bds-footer__bottom-link`, and `.bds-footer__bottom-sep` so a future change to font-family / weight on the children can't re-introduce the asymmetry through a different `normal` ratio.

Inline comment in [Footer.css](components/ui/Footer/Footer.css) documents the failure mode so the next contributor doesn't think the new declarations are stylistic preference.

## Closes

5c carryover from the footer-surface session (PR [#779](https://github.com/brikdesigns/brik-bds/pull/779) → 5a; PR [#781](https://github.com/brikdesigns/brik-bds/pull/781) → 5b). brikdesigns consumer bump (#6) follows after BDS release ships 5a + 5b + 5c.

## Consumer sync plan

- [ ] brikdesigns: covered by the planned BDS bump (#6); no extra work — site uses the standard BDS Footer.
- [ ] Portal / renew-pms: no action — neither surface uses BDS Footer's `bottomLinks` slot today, behavior unchanged.

## Test plan

- [x] `npm run validate:full` — all 10 checks pass (token / jsdoc / canonical / axes / typecheck / Storybook build)
- [x] Visual verification in Storybook (Sections › footer › Patterns › "Full marketing footer"): copyright + link row now share a baseline; computed line-box heights match (12.69px / 12.69px)
- [x] No new tokens introduced — uses existing `--body-xs` + `--font-line-height-tight`

Generated with [Claude Code](https://claude.ai/code)