### PR TITLE
chore(release): 0.78.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.77.0",
+      "version": "0.78.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Batched release for the **5a / 5b / 5c carryover** from the footer-surface session.

### Commits since v0.77.0

```
0680b59 feat(lint-tokens): Rule 5 — token-family ↔ property pairing (#778)
b9dccb1 feat(footer): --bds-footer-surface component-local slot (#779)       [5a]
95bc347 feat(breadcrumb): [data-audience] cascade rebinds canonical text tokens (#781)  [5b]
606501f fix(footer): align bottom-left copyright + bottom-links text baselines (#782)   [5c]
```

### Semver framing

**Minor bump (0.77.0 → 0.78.0).** Three feature commits + one fix; no API removals, no token renames, no breaking changes.

- `#779` adds a new component-local slot (`--bds-footer-surface`) — additive
- `#781` adds 5 new `[data-audience='X'] .bds-breadcrumb` cascade blocks — additive, scope-blind components stay unchanged
- `#782` fixes the `.bds-footer__bottom-left` baseline offset — defensive hygiene
- `#778` adds linter Rule 5 (internal tooling, no public API)

### Post-merge sequence (manual)

```bash
git -C /Users/nickstanerson/Documents/Github/brik/brik-bds checkout main
git pull --ff-only
git tag -a -s v0.78.0 -m "v0.78.0"
git push origin v0.78.0
```

Tag push triggers [`.github/workflows/release.yml`](.github/workflows/release.yml) → publishes to GitHub Packages.

## Consumer impact

- **brikdesigns** — unblocks the [#6 carryover](https://github.com/brikdesigns/brik-bds/pull/779) (BDS bump + `:root { --bds-footer-surface: var(--color-grayscale-darkest); }` in `globals.css` + drop legacy `.bds-footer` border workaround + wire `data-audience` on service-line page wrapper)
- **portal / renew-pms** — no required action. Neither surface ships `data-audience` today; breadcrumb behavior unchanged. Both can bump at leisure.

## Test plan

- [x] `package.json` version matches title (`0.78.0`)
- [x] `npm version minor --no-git-tag-version` updated lockfile cleanly
- [x] Each of #779, #781, #782 was independently validated on green CI before merge

Generated with [Claude Code](https://claude.ai/code)