### PR TITLE
ci(chromatic): pin chromaui/action to SHA (v13.3.5)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm ci
 
       - name: Run Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@07791f8243f4cb2698bf4d00426baf4b2d1cb7e0  # v13.3.5
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitOnceUploaded: true


### PR DESCRIPTION
## Summary

- Replaces `chromaui/action@latest` with the commit SHA for v13.3.5 in `.github/workflows/chromatic.yml`
- Eliminates the mutable third-party action reference in our CI

## Why

Floating tags are auto-mutable. A compromised upstream release auto-propagates into the runner, which has access to `CHROMATIC_PROJECT_TOKEN` and the full Storybook build. Triggered by the [Chromatic Storybook security advisory](https://www.chromatic.com/blog/storybook-security-advisory/) review (2026-05-25) and the [ReversingLabs GitHub-compromise analysis](https://www.reversinglabs.com/blog/github-compromise-development-ecosystem) (TeamPCP / Shai-Hulud targets mutable refs).

## SHA provenance

\`\`\`
$ gh api repos/chromaui/action/git/tags/30047ab459164cf99ae8f097f6aa5c7ef4fcc869 --jq '{sha: .object.sha, tag: .tag, tagger: .tagger.name, date: .tagger.date}'
{"sha":"07791f8243f4cb2698bf4d00426baf4b2d1cb7e0","tag":"v13","tagger":"Chromatic","date":"2026-01-05T16:04:14Z"}
\`\`\`

Tag message: \`v13.3.5 with automatic upgrades to v13.x.x\`. Tag is unsigned — this is the floor we can establish without a registered signing identity from the upstream.

## Test plan

- [x] Local validation suite (10/10 passed, including Storybook Build)
- [ ] CI Chromatic run on this PR succeeds and uploads the build (proves the pinned SHA still resolves)
- [ ] grep -c '@latest' .github/workflows/chromatic.yml returns 0

Closes brikdesigns/brik-llm#683

🤖 Generated with [Claude Code](https://claude.com/claude-code)