### PR TITLE
fix(hero-blueprint): use --surface-service-* for hero band

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -199,42 +199,53 @@ const cta = section.cta;
     );
   }
 
-  /* Audience cascade — canonical --*-service-{audience} tokens.
+  /* Service-line cascade — canonical --*-service-{service-line} tokens.
+   *
+   * Background uses the `surface` family (not `background`) because the hero
+   * is a broad page-level container, not a small bounded component — per the
+   * service-token decision tree (`-surface-` for sections/heroes/cards;
+   * `-background-` for badges/tags/pills/buttons). This keeps the hero band
+   * the same shade as section-level surfaces below it on the same page.
+   *
+   * `--background-inverse` stays on the `background` family: it's the
+   * mode-aware companion fill consumed by the inverse `<Button>` variant
+   * inside the hero, which IS a small bounded component.
+   *
    * Note: the `data-audience='service'` attribute value still reads "service"
    * for component-API compat; the underlying tokens were renamed
-   * `service-service` → `service-back-office` in #563 (orange line — back office).
-   * `--background-service-X-secondary` → `--background-service-X-inverse`
-   * (mode-aware companion to the default service bg) from the same issue. */
+   * `service-service` → `service-back-office` in #563 (orange line — back
+   * office). API-level rename `data-audience` → `data-service-line` is a
+   * separate cross-repo follow-up. */
   .bp-hero-img-card[data-audience='brand'] {
-    background: var(--background-service-brand);
+    background: var(--surface-service-brand);
     --bp-hero-img-card-headline-color: var(--text-service-brand);
     --text-brand-primary: var(--text-service-brand);
     --background-inverse: var(--background-service-brand-inverse);
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='marketing'] {
-    background: var(--background-service-marketing);
+    background: var(--surface-service-marketing);
     --bp-hero-img-card-headline-color: var(--text-service-marketing);
     --text-brand-primary: var(--text-service-marketing);
     --background-inverse: var(--background-service-marketing-inverse);
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='information'] {
-    background: var(--background-service-information);
+    background: var(--surface-service-information);
     --bp-hero-img-card-headline-color: var(--text-service-information);
     --text-brand-primary: var(--text-service-information);
     --background-inverse: var(--background-service-information-inverse);
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='product'] {
-    background: var(--background-service-product);
+    background: var(--surface-service-product);
     --bp-hero-img-card-headline-color: var(--text-service-product);
     --text-brand-primary: var(--text-service-product);
     --background-inverse: var(--background-service-product-inverse);
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='service'] {
-    background: var(--background-service-back-office);
+    background: var(--surface-service-back-office);
     --bp-hero-img-card-headline-color: var(--text-service-back-office);
     --text-brand-primary: var(--text-service-back-office);
     --background-inverse: var(--background-service-back-office-inverse);

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -29,15 +29,26 @@
   );
 }
 
-/* ── Audience cascade — canonical --*-service-{audience} tokens.
+/* ── Service-line cascade — canonical --*-service-{service-line} tokens.
+ *
+ * Background uses the `surface` family (not `background`) because the hero
+ * is a broad page-level container, not a small bounded component — per the
+ * service-token decision tree (`-surface-` for sections/heroes/cards;
+ * `-background-` for badges/tags/pills/buttons). This keeps the hero band
+ * the same shade as section-level surfaces below it on the same page.
+ *
+ * `--background-inverse` stays on the `background` family: it's the
+ * mode-aware companion fill consumed by the inverse `<Button>` variant
+ * inside the hero, which IS a small bounded component.
+ *
  * Note: the `data-audience='service'` attribute value still reads "service"
  * for component-API compat; the underlying tokens were renamed
- * `service-service` → `service-back-office` in #563 (orange line — back office).
- * `--background-service-X-secondary` → `--background-service-X-inverse`
- * (mode-aware companion to the default service bg) from the same issue. */
+ * `service-service` → `service-back-office` in #563 (orange line — back
+ * office). API-level rename `data-audience` → `data-service-line` is a
+ * separate cross-repo follow-up. */
 
 .bp-hero-img-card[data-audience='brand'] {
-  background: var(--background-service-brand);
+  background: var(--surface-service-brand);
   --bp-hero-img-card-headline-color: var(--text-service-brand);
   --text-brand-primary: var(--text-service-brand);
   --background-inverse: var(--background-service-brand-inverse);
@@ -45,7 +56,7 @@
 }
 
 .bp-hero-img-card[data-audience='marketing'] {
-  background: var(--background-service-marketing);
+  background: var(--surface-service-marketing);
   --bp-hero-img-card-headline-color: var(--text-service-marketing);
   --text-brand-primary: var(--text-service-marketing);
   --background-inverse: var(--background-service-marketing-inverse);
@@ -53,7 +64,7 @@
 }
 
 .bp-hero-img-card[data-audience='information'] {
-  background: var(--background-service-information);
+  background: var(--surface-service-information);
   --bp-hero-img-card-headline-color: var(--text-service-information);
   --text-brand-primary: var(--text-service-information);
   --background-inverse: var(--background-service-information-inverse);
@@ -61,7 +72,7 @@
 }
 
 .bp-hero-img-card[data-audience='product'] {
-  background: var(--background-service-product);
+  background: var(--surface-service-product);
   --bp-hero-img-card-headline-color: var(--text-service-product);
   --text-brand-primary: var(--text-service-product);
   --background-inverse: var(--background-service-product-inverse);
@@ -69,7 +80,7 @@
 }
 
 .bp-hero-img-card[data-audience='service'] {
-  background: var(--background-service-back-office);
+  background: var(--surface-service-back-office);
   --bp-hero-img-card-headline-color: var(--text-service-back-office);
   --text-brand-primary: var(--text-service-back-office);
   --background-inverse: var(--background-service-back-office-inverse);


### PR DESCRIPTION
## Summary

- `HeroSplitImageCardOverlay` (React + Astro) now uses `--surface-service-{service-line}` on its band background instead of `--background-service-{service-line}`.
- Same color ramp, correct semantic family per the service-token decision tree: `-surface-` is the family for sections / heroes / cards (broad containers); `-background-` is for small bounded components (badges, tags, pills, buttons).
- `--background-inverse` stays on the `background` family — the inverse `<Button>` inside the hero IS a small component, so that mapping is correct.

## Visible effect

Hero band now reads the same shade as section-level surfaces below it on the same page (e.g. the Recommended Add-On band on a brikdesigns service detail page). Previously the hero used the lighter `--background-service-*` shade and the section below used `--surface-service-*`, so the page rendered as two near-miss tints of the same audience color.

## Companion work

- Surfaced via brikdesigns service detail page audit (`task/services-cms-ui-cleanup`). The brikdesigns wrapper around the BDS hero already corrects its own `backgroundColor` to `serviceTokens.surface`; until this PR ships in a published version of `@brikdesigns/bds`, the BDS section itself still paints over the wrapper with the old family, so the visible fix requires this PR.
- Follow-up: brik-bds#788 — API rename `audience` → `serviceLine` across blueprints, props, and `data-audience` attributes. The CSS comments in this PR reference that as a separate cross-repo workstream; `data-audience` selectors are unchanged here.

## Risk

- Chromatic will show audience-tinted heroes shifting from pastel `background-*` to the more-grounded `surface-*` ramp on all 5 service lines. Expected; review the Chromatic diff to confirm the shade matches downstream section surfaces.

## Test plan

- [ ] Chromatic visual review on `HeroSplitImageCardOverlay` stories (all 5 audiences, light + dark mode)
- [ ] After merge + release: bump `@brikdesigns/bds` in `brikdesigns/task/services-cms-ui-cleanup`, deploy preview, verify the hero band matches the Recommended Add-On band on a service detail page (e.g. `/services/back-office/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)