### PR TITLE
chore(release): 0.78.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.78.0",
+      "version": "0.78.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Patch bump for #789 (hero blueprint surface-family fix).

## Why patch (not minor)

Per `docs/RELEASE.md` semver rubric: patch = "bug fix, no API change". #789 swapped a CSS token reference inside an existing component — same component, same props, same exports, same `data-audience` attribute. The semantic family was wrong; the fix is wholly inside the existing component's stylesheet.

The visible color shift on consumer pages is significant, but visibility ≠ API change. Consumers don't need to update any code; running `npm install @brikdesigns/bds@0.78.1` is sufficient.

## After merge

```bash
git pull --ff-only
git tag -s v0.78.1 -m 'Release 0.78.1'
git push origin v0.78.1
```

The Release workflow validates package.json ↔ tag match and publishes to GitHub Packages.

## Consumer bump

`brikdesigns/task/services-cms-ui-cleanup` is held waiting on this release. After publish, that branch bumps to 0.78.1 and opens against `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)