### PR TITLE
feat(file-uploader): validate accept on drag-drop + surface SVG support

### DIFF
--- a/components/ui/FileUploader/FileUploader.stories.tsx
+++ b/components/ui/FileUploader/FileUploader.stories.tsx
@@ -43,8 +43,8 @@ type Story = StoryObj<typeof meta>;
 export const Playground: Story = {
   args: {
     label: 'Drag and drop files here',
-    helperText: 'PDF, JPG, or PNG up to 10MB',
-    accept: '.pdf,.jpg,.png',
+    helperText: 'PDF, JPG, PNG, or SVG up to 10MB',
+    accept: '.pdf,.jpg,.png,.svg',
   },
 };
 
@@ -61,8 +61,18 @@ export const Variants: Story = {
         <SectionLabel>Default</SectionLabel>
         <FileUploader
           label="Drag and drop files here"
-          helperText="PDF, JPG, or PNG up to 10MB"
-          accept=".pdf,.jpg,.png"
+          helperText="PDF, JPG, PNG, or SVG up to 10MB"
+          accept=".pdf,.jpg,.png,.svg"
+        />
+      </div>
+
+      <div>
+        <SectionLabel>SVG icon (single)</SectionLabel>
+        <FileUploader
+          label="Upload an SVG icon"
+          helperText="SVG up to 100KB · for industry / category icons"
+          accept=".svg,image/svg+xml"
+          maxSize={100 * 1024}
         />
       </div>
 

--- a/components/ui/FileUploader/FileUploader.tsx
+++ b/components/ui/FileUploader/FileUploader.tsx
@@ -8,7 +8,7 @@ import './FileUploader.css';
  * FileUploader component props
  */
 export interface FileUploaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
-  /** Accepted file types (e.g., ".pdf,.jpg" or "image/*") */
+  /** Accepted file types (e.g., ".pdf,.svg" or "image/svg+xml" or "image/*") */
   accept?: string;
   /** Allow multiple files */
   multiple?: boolean;
@@ -26,20 +26,41 @@ export interface FileUploaderProps extends Omit<HTMLAttributes<HTMLDivElement>, 
   onChange?: (files: File[]) => void;
 }
 
+// `accept` honors three forms per HTML spec: extension (`.svg`), MIME type
+// (`image/svg+xml`), and MIME wildcard (`image/*`). Browsers only enforce
+// `accept` in the file picker — drag-drop bypasses it — so we check here too.
+function fileMatchesAccept(file: File, accept: string): boolean {
+  const name = file.name.toLowerCase();
+  const type = (file.type || '').toLowerCase();
+  const patterns = accept
+    .split(',')
+    .map((p) => p.trim().toLowerCase())
+    .filter(Boolean);
+  if (patterns.length === 0) return true;
+  return patterns.some((p) => {
+    if (p.startsWith('.')) return name.endsWith(p);
+    if (p.endsWith('/*')) return type.startsWith(p.slice(0, -1));
+    return type === p;
+  });
+}
+
 /**
  * FileUploader - BDS drag-and-drop file upload zone
  *
  * A dropzone that accepts files via drag-and-drop or click-to-browse.
  * Supports file type filtering, size limits, and multiple files.
  *
+ * Validates `accept` and `maxSize` on both click-to-browse and drag-and-drop;
+ * mismatched files are rejected with an inline error.
+ *
  * @example
  * ```tsx
  * <FileUploader
- *   accept="image/*,.pdf"
+ *   accept="image/*,.pdf,.svg"
  *   multiple
  *   maxSize={5 * 1024 * 1024}
  *   label="Upload documents"
- *   helperText="PDF, JPG, PNG up to 5MB"
+ *   helperText="PDF, JPG, PNG, or SVG up to 5MB"
  *   onChange={(files) => console.log(files)}
  * />
  * ```
@@ -67,17 +88,34 @@ export function FileUploader({
 
   const validateFiles = useCallback(
     (files: File[]): File[] => {
-      if (!maxSize) return files;
-      const oversized = files.filter((f) => f.size > maxSize);
-      if (oversized.length > 0) {
-        const maxMB = (maxSize / (1024 * 1024)).toFixed(1);
-        setInternalError(`File(s) exceed ${maxMB}MB limit`);
-        return files.filter((f) => f.size <= maxSize);
+      const errors: string[] = [];
+
+      let valid = files;
+      if (accept && accept.trim()) {
+        const mismatched = valid.filter((f) => !fileMatchesAccept(f, accept));
+        if (mismatched.length > 0) {
+          errors.push(
+            mismatched.length === 1
+              ? `"${mismatched[0].name}" is not a supported file type`
+              : `${mismatched.length} files are not supported file types`,
+          );
+          valid = valid.filter((f) => fileMatchesAccept(f, accept));
+        }
       }
-      setInternalError('');
-      return files;
+
+      if (maxSize) {
+        const oversized = valid.filter((f) => f.size > maxSize);
+        if (oversized.length > 0) {
+          const maxMB = (maxSize / (1024 * 1024)).toFixed(1);
+          errors.push(`File(s) exceed ${maxMB}MB limit`);
+          valid = valid.filter((f) => f.size <= maxSize);
+        }
+      }
+
+      setInternalError(errors.join(' · '));
+      return valid;
     },
-    [maxSize],
+    [accept, maxSize],
   );
 
   const handleFiles = useCallback(

--- a/docs-site/content/docs/components/file-uploader.mdx
+++ b/docs-site/content/docs/components/file-uploader.mdx
@@ -11,6 +11,7 @@ FileUploader is a drag-and-drop drop zone with click-to-browse fallback. Use any
 
 - Document upload (PDF, DOCX, CSV imports)
 - Image uploads (avatars, gallery, before/after photos)
+- SVG icon uploads (industry / category icons in CMS pages)
 - Multi-file batch uploads
 - Any field where the user supplies a file from their device
 
@@ -26,11 +27,29 @@ import { FileUploader } from '@brikdesigns/bds';
 
 ```tsx
 <FileUploader
-  accept=".pdf,.jpg,.png"
-  helperText="PDF, JPG, or PNG up to 10MB"
+  accept=".pdf,.jpg,.png,.svg"
+  helperText="PDF, JPG, PNG, or SVG up to 10MB"
   onChange={(files) => handleFiles(files)}
 />
 ```
+
+### SVG icon (single)
+
+For uploading a single SVG asset — for example, an industry or category icon in a CMS form. The `accept` value combines the extension and MIME type so the browser picker matches across OSes, and the dropzone validates the same patterns on drag-drop.
+
+```tsx
+<FileUploader
+  accept=".svg,image/svg+xml"
+  maxSize={100 * 1024}
+  label="Upload an SVG icon"
+  helperText="SVG up to 100KB"
+  onChange={(files) => setIcon(files[0])}
+/>
+```
+
+<Callout type="warn">
+  **SVGs can contain executable scripts.** FileUploader does not sanitize SVG content. Strip `<script>` tags, event-handler attributes (`onclick`, `onload`, …), and `xlink:href="javascript:..."` on the server before storing or serving the file.
+</Callout>
 
 ### Multiple files with size limit
 


### PR DESCRIPTION
## Summary

- The HTML `accept` attribute only filters the file picker — drag-and-drop bypasses it. `handleFiles()` now applies the same extension / MIME / wildcard checks on dropped files, joining type + size errors with ` · ` in the inline error message.
- Stories + docs now advertise SVG as a first-class type, including a dedicated `SVG icon (single)` variant matched to the brik-client-portal industry-icon upload use case.
- The Fumadocs page adds a security callout noting SVG sanitization is a server-side responsibility — FileUploader does not strip `<script>` tags or event-handler attributes.

## Behavior change

When `accept` is set, mismatched files (drag-drop or picker) are now rejected with an inline error instead of being silently passed to `onChange`. Additive — no consumer migration required and no current downstream consumers (`@brikdesigns/bds` portal/renew/web/{slug} repos do not use FileUploader yet).

## Out of scope (called out so they don't get lost)

- **Server-side SVG sanitization** in brik-client-portal CMS — separate follow-up. Confirmed not in place today; the docs callout flags it.
- **Story-shape modernization** — the file uses legacy `Playground`/`Variants`/`Patterns` exports. Lint (`scripts/lint-storybook-recipe.js`) accepts the current shape; not migrated here per surgical-changes rule.
- **A11y docs drift** — [file-uploader.mdx:105-106](docs-site/content/docs/components/file-uploader.mdx#L105) claims `aria-busy` on the dropzone and `aria-invalid` / `aria-describedby` on errors, but neither is implemented in the component. Pre-existing; not fixed here.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint-tokens` clean (24 warnings pre-existing, unrelated to FileUploader)
- [x] `node scripts/lint-storybook-recipe.js --enforce` clean (84/84 MDX pages conforming)
- [x] `npm test -- components/ui/FileUploader` — 3 portable-stories tests pass
- [x] Storybook visual verification via headless Playwright:
  - Variants story renders all 5 dropzones; new SVG-icon section displays correct label + helper text
  - Dropping a `.txt` into the Playground (`accept=".pdf,.jpg,.png,.svg"`) shows `"oops.txt" is not a supported file type` error
  - Dropping a valid `.svg` clears the error and fires `onChange`
- [x] `./scripts/pr-task.sh` full validation suite — 10/10 checks pass (Token Lint, JSDoc, Grid Audit, Theme Compliance, Blueprint Library, BCS Vocab, Canonical Tokens, Component Axes, TypeScript, Storybook Build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)