### PR TITLE
feat(card): add preset="display-row" for horizontal single-card sections

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -289,4 +289,90 @@
 .bds-card > .bds-badge {
   align-self: flex-start;
 }
+
+/* ─── Preset: display-row ─────────────────────────────────────── */
+/* Horizontal sibling of `preset="display"`. Image on the left, content
+ * (tag, title, description, action) on the right. Use for single-card
+ * sections where vertical layout wastes horizontal space — Related
+ * Customer Story, Recommended Add-On, featured plan.
+ *
+ * Image column width comes from a CSS variable that the consumer sets
+ * via the named size modifier classes (narrow/standard/wide) OR via
+ * inline style when a custom percentage/length is passed through props.
+ * Collapses to vertical stacking at ≤ 640px so the card stays readable
+ * on narrow viewports without forcing a layout shift higher up.
+ *
+ * Token pairs (paired family ↔ size only — never mix):
+ *   title       — --font-family-heading + --heading-md
+ *   description — --font-family-body + --body-md
+ *   tag         — own typography (component-internal)
+ */
+
+.bds-card--preset-display-row {
+  /* Default column width — overridden by named modifier class or inline
+   * style. `auto` fallback keeps the card sensible if neither is set. */
+  --bds-card-image-width: 35%;
+  display: grid;
+  grid-template-columns: var(--bds-card-image-width) 1fr;
+  gap: var(--gap-lg);
+  padding: var(--padding-lg);
+  background-color: var(--surface-primary);
+  border: var(--border-width-md) solid var(--border-secondary);
+  border-radius: var(--border-radius-md);
+  align-items: stretch;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.bds-card--preset-display-row-narrow   { --bds-card-image-width: 25%; }
+.bds-card--preset-display-row-standard { --bds-card-image-width: 35%; }
+.bds-card--preset-display-row-wide     { --bds-card-image-width: 50%; }
+
+.bds-card__preset-display-row-media {
+  position: relative;
+  display: block;
+  /* Aspect ratio + object-fit owned by the consumer's <Frame> wrapper. */
+}
+
+.bds-card__preset-display-row-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  min-width: 0;
+}
+
+.bds-card__preset-display-row-tag {
+  /* Anchor at natural width; do NOT stretch in the column flex. */
+  display: inline-flex;
+  align-self: flex-start;
+}
+
+.bds-card__preset-display-row-title {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-md);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+}
+
+.bds-card__preset-display-row-description {
+  margin: 0;
+  font-family: var(--font-family-body);
+  font-size: var(--body-md);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-primary);
+}
+
+.bds-card__preset-display-row-action {
+  /* Anchor to bottom so the action sits at the card footer regardless of
+   * description length. */
+  margin-top: auto;
+}
+
+@media (max-width: 640px) {
+  .bds-card--preset-display-row {
+    grid-template-columns: 1fr;
+  }
+}
 }

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -38,6 +38,12 @@ The `preset` prop selects the shape. Default (no `preset`) gives a flexible `chi
 
 <Canvas of={Stories.Display} />
 
+### Display-row preset
+
+`preset="display-row"` — horizontal sibling of `preset="display"`. Image on the left, content (tag, title, description, action) on the right. Use for single-card sections where a vertical layout wastes horizontal space: Related Customer Story, Recommended Add-On, featured plan, company-segment overview cards. Toggle `imageWidth` between `narrow` (25%), `standard` (35%, default), and `wide` (50%) — or pass a CSS length / percentage string for a custom column width. Collapses to a vertical stack at ≤ 640px so the card stays readable on narrow viewports.
+
+<Canvas of={Stories.DisplayRow} />
+
 ### Pricing (web)
 
 `PricingCard` — pricing tier with title, price block, feature checklist, and call-to-action. The `highlighted` prop marks the recommended tier with brand surface treatment. Web surface only (`surface-web`).

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -205,6 +205,66 @@ export const Display: Story = {
 };
 
 /**
+ * `preset="display-row"` — horizontal sibling of `preset="display"`. Image
+ * on the left, content (tag, title, description, action) on the right. Use
+ * for single-card sections where a vertical layout wastes horizontal space:
+ * Related Customer Story, Recommended Add-On, featured plan. Toggle
+ * `imageWidth` between `narrow` / `standard` / `wide` (or pass a custom CSS
+ * length / percentage) to size the media column. Collapses to vertical
+ * stacking at ≤ 640px.
+ *
+ * @summary preset="display-row" — horizontal content-grid card
+ */
+export const DisplayRow: Story = {
+  args: {
+    preset: 'display-row',
+    title: 'Web Design Retainer',
+    description:
+      'Ongoing design partnership for teams shipping a steady stream of marketing pages, lifecycle assets, and product UI.',
+    image: (
+      <div
+        style={{
+          aspectRatio: '3 / 2',
+          background: 'var(--surface-secondary)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--text-muted)',
+          height: '100%',
+        }}
+      >
+        Image slot
+      </div>
+    ),
+    tag: <Badge>Marketing</Badge>,
+    action: (
+      <Button variant="primary" size="sm">
+        Learn more
+      </Button>
+    ),
+    imageWidth: 'standard',
+  },
+  argTypes: {
+    variant: { table: { disable: true } },
+    padding: { table: { disable: true } },
+    interactive: { table: { disable: true } },
+    imageWidth: {
+      control: 'select',
+      options: ['narrow', 'standard', 'wide'],
+      description:
+        'Image column width. Named: `narrow` 25%, `standard` 35%, `wide` 50%. Pass a CSS length / percentage string (e.g. `"40%"`) to override.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 720, display: 'flex' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
  * `PricingCard` — web-only pricing tier with price block, feature checklist,
  * and optional highlighted (recommended) state. Component lives in
  * `components/ui/PricingCard/`; story lives here because PricingCard is part

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -4,9 +4,15 @@ import './Card.css';
 
 export type CardVariant = 'outlined' | 'brand' | 'elevated';
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
-export type CardPreset = 'control' | 'summary' | 'display';
+export type CardPreset = 'control' | 'summary' | 'display' | 'display-row';
 export type CardControlActionAlign = 'center' | 'top';
 export type CardSummaryType = 'numeric' | 'price';
+/**
+ * Image-column width for `preset="display-row"`. Named values resolve to
+ * fixed percentages (`narrow` 25%, `standard` 35%, `wide` 50%); pass a CSS
+ * length / percentage string to override (e.g. `"40%"`, `"320px"`).
+ */
+export type CardDisplayRowImageWidth = 'narrow' | 'standard' | 'wide' | (string & {});
 
 export interface CardSummaryTextLink {
   label: string;
@@ -132,11 +138,58 @@ interface CardDisplayPresetProps extends CardBaseProps {
   href?: string;
 }
 
+interface CardDisplayRowPresetProps extends CardBaseProps {
+  /**
+   * Display-row preset — horizontal sibling of `preset="display"`. Image on
+   * the left, content (tag, title, description, action) on the right. Use
+   * for single-card sections where vertical layout wastes horizontal space:
+   * Related Customer Story, Recommended Add-On, featured plan. Collapses
+   * to a vertical stack at ≤ 640px.
+   */
+  preset: 'display-row';
+  /** Card heading. Renders as `<h3>` with `--font-family-heading` + `--heading-md`. */
+  title: string;
+  /** Body copy under the title. Renders as `<p>` with `--font-family-body` + `--body-md`. */
+  description?: string;
+  /**
+   * Left media slot. Pass a `<Frame>`-wrapped image (or any ReactNode). The
+   * media column owns its own aspect ratio via `<Frame>`; the column width
+   * is controlled by `imageWidth`.
+   */
+  image?: ReactNode;
+  /**
+   * Inline category indicator rendered above the title. Pass a
+   * `<ServiceTag>` for services, a `<Tag>` for blog categories, a date
+   * pill for stories, etc. Justified `flex-start` (does not stretch).
+   */
+  tag?: ReactNode;
+  /**
+   * Trailing action — typically a `<LinkButton>` or `<Button>`. Anchored
+   * to the bottom of the body column via `margin-top: auto` so the title
+   * + description stay top-aligned while the action sits at the card
+   * footer.
+   */
+  action?: ReactNode;
+  /**
+   * Image column width. Named values: `narrow` (25%), `standard` (35%,
+   * default), `wide` (50%). Any other string passes through as the CSS
+   * column-width value (e.g. `"40%"`, `"320px"`).
+   */
+  imageWidth?: CardDisplayRowImageWidth;
+  /**
+   * Render the card itself as an `<a>` when set — turns the whole card
+   * into a single clickable target. Use when `action` is not set and the
+   * card itself is the navigation affordance.
+   */
+  href?: string;
+}
+
 export type CardProps =
   | CardDefaultProps
   | CardControlPresetProps
   | CardSummaryPresetProps
-  | CardDisplayPresetProps;
+  | CardDisplayPresetProps
+  | CardDisplayRowPresetProps;
 
 function formatSummaryValue(value: string | number, type: CardSummaryType): string {
   if (typeof value === 'string') return value;
@@ -203,8 +256,13 @@ export function Card(props: CardProps) {
   if (props.preset === 'display') {
     return renderDisplayPreset(props);
   }
+  if (props.preset === 'display-row') {
+    return renderDisplayRowPreset(props);
+  }
   return renderDefault(props);
 }
+
+const NAMED_IMAGE_WIDTHS: ReadonlySet<string> = new Set(['narrow', 'standard', 'wide']);
 
 function renderDefault({
   variant = 'outlined',
@@ -384,6 +442,76 @@ function renderDisplayPreset({
 
   return (
     <div className={classes} style={style} {...rest}>
+      {body}
+    </div>
+  );
+}
+
+function renderDisplayRowPreset({
+  title,
+  description,
+  image,
+  tag,
+  action,
+  imageWidth = 'standard',
+  href,
+  className,
+  style,
+  preset: _preset,
+  ...rest
+}: CardDisplayRowPresetProps) {
+  const isNamed = NAMED_IMAGE_WIDTHS.has(imageWidth);
+  const classes = bdsClass(
+    'bds-card',
+    'bds-card--preset-display-row',
+    isNamed && `bds-card--preset-display-row-${imageWidth}`,
+    href && 'bds-card--link',
+    className,
+  );
+
+  // Custom (non-named) imageWidth string drives the CSS variable directly;
+  // named widths are class-based so they compose cleanly with theming. The
+  // `as React.CSSProperties` cast accommodates the CSS-variable property
+  // name (TS doesn't model arbitrary `--*` keys on CSSProperties).
+  const inlineStyle = isNamed
+    ? style
+    : { ...(style ?? {}), ['--bds-card-image-width' as string]: imageWidth };
+
+  const body = (
+    <>
+      {image && (
+        <div className="bds-card__preset-display-row-media">{image}</div>
+      )}
+      <div className="bds-card__preset-display-row-body">
+        {tag && (
+          <span className="bds-card__preset-display-row-tag">{tag}</span>
+        )}
+        <h3 className="bds-card__preset-display-row-title">{title}</h3>
+        {description && (
+          <p className="bds-card__preset-display-row-description">{description}</p>
+        )}
+        {action && (
+          <div className="bds-card__preset-display-row-action">{action}</div>
+        )}
+      </div>
+    </>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        className={classes}
+        style={inlineStyle as React.CSSProperties}
+        {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+      >
+        {body}
+      </a>
+    );
+  }
+
+  return (
+    <div className={classes} style={inlineStyle as React.CSSProperties} {...rest}>
       {body}
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #592.

Horizontal sibling of `preset="display"` — image left, content right (tag, title, description, action). Sized via `imageWidth`: `narrow` (25%), `standard` (35%, default), `wide` (50%), or a custom CSS length/percentage string that drives `--bds-card-image-width` directly. Collapses to a vertical stack at ≤ 640px so the card stays readable on narrow viewports without a layout shift higher up.

Used by single-card sections where a vertical layout wastes horizontal space (Related Customer Story, Recommended Add-On, featured plan, and company-segment overview cards on brikdesigns/customers — see brikdesigns#311).

## API

```tsx
<Card
  preset="display-row"
  imageWidth="standard"        // 'narrow' | 'standard' | 'wide' | string
  image={<Frame ratio="3-2"><Image ... /></Frame>}
  tag={<Badge>Marketing</Badge>}
  title="Web Design Retainer"
  description="…"
  action={<LinkButton>Learn more</LinkButton>}
/>
```

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint-tokens` passes (0 errors)
- [x] `npm run lint-jsdoc` passes
- [x] `npm run build-storybook` passes (full 10-check validation suite)
- [x] `npm run test` — Card.stories.tsx clean (only pre-existing Radio failure remains, unrelated)
- [ ] Visual verification in Storybook on the new `DisplayRow` story
- [ ] Mobile (≤ 640px) responsive collapse to vertical stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)