### PR TITLE
chore(release): 0.79.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.78.1",
+      "version": "0.79.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Minor bump for #793 — `Card preset="display-row"` (closes #592).

## Why minor (not patch)

Per `docs/RELEASE.md` semver rubric: minor = "new component or new prop on existing component". #793 adds a new preset value (`display-row`) plus a new `imageWidth` prop on `Card` — additive, no API change to existing presets.

## After merge

```bash
git pull --ff-only
git tag -a -s v0.79.0 -m 'Release 0.79.0'
git push origin v0.79.0
```

The Release workflow validates package.json ↔ tag match and publishes to GitHub Packages.

## Consumer bump

`brikdesigns` segment-card local compose is the first consumer ready to swap to the new preset (TODO marker referencing #592 already in the codebase). After publish, a follow-up brikdesigns PR bumps to `0.79.0` and replaces the local compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)