### PR TITLE
feat(card): add `extras` slot to preset="display-row"

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -364,6 +364,16 @@
   color: var(--text-primary);
 }
 
+.bds-card__preset-display-row-extras {
+  /* Generic supporting-content slot rendered between description and
+   * action. The consumer owns the rendered markup (bullet list, pill
+   * row, gallery, etc.); this wrapper exists only to give the slot a
+   * stable position in the column flex and to preserve gap rhythm. */
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+}
+
 .bds-card__preset-display-row-action {
   /* Anchor to bottom so the action sits at the card footer regardless of
    * description length. */

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -40,7 +40,7 @@ The `preset` prop selects the shape. Default (no `preset`) gives a flexible `chi
 
 ### Display-row preset
 
-`preset="display-row"` — horizontal sibling of `preset="display"`. Image on the left, content (tag, title, description, action) on the right. Use for single-card sections where a vertical layout wastes horizontal space: Related Customer Story, Recommended Add-On, featured plan, company-segment overview cards. Toggle `imageWidth` between `narrow` (25%), `standard` (35%, default), and `wide` (50%) — or pass a CSS length / percentage string for a custom column width. Collapses to a vertical stack at ≤ 640px so the card stays readable on narrow viewports.
+`preset="display-row"` — horizontal sibling of `preset="display"`. Image on the left, content (tag, title, description, optional `extras`, action) on the right. Use for single-card sections where a vertical layout wastes horizontal space: Related Customer Story, Recommended Add-On, featured plan, company-segment overview cards. Toggle `imageWidth` between `narrow` (25%), `standard` (35%, default), and `wide` (50%) — or pass a CSS length / percentage string for a custom column width. The `extras` slot accepts any ReactNode (bullet list, pill row, supporting meta) and renders between `description` and `action`; use it when the single-paragraph `description` is too narrow for the content shape. Collapses to a vertical stack at ≤ 640px so the card stays readable on narrow viewports.
 
 <Canvas of={Stories.DisplayRow} />
 

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -206,12 +206,14 @@ export const Display: Story = {
 
 /**
  * `preset="display-row"` — horizontal sibling of `preset="display"`. Image
- * on the left, content (tag, title, description, action) on the right. Use
- * for single-card sections where a vertical layout wastes horizontal space:
- * Related Customer Story, Recommended Add-On, featured plan. Toggle
- * `imageWidth` between `narrow` / `standard` / `wide` (or pass a custom CSS
- * length / percentage) to size the media column. Collapses to vertical
- * stacking at ≤ 640px.
+ * on the left, content (tag, title, description, optional `extras`, action)
+ * on the right. Use for single-card sections where a vertical layout wastes
+ * horizontal space: Related Customer Story, Recommended Add-On, featured
+ * plan, company-segment overview. Toggle `imageWidth` between `narrow` /
+ * `standard` / `wide` (or pass a custom CSS length / percentage) to size
+ * the media column. The `extras` slot lets the consumer drop in any
+ * supporting content (bullet list, pill row, gallery) between description
+ * and action. Collapses to vertical stacking at ≤ 640px.
  *
  * @summary preset="display-row" — horizontal content-grid card
  */
@@ -237,6 +239,16 @@ export const DisplayRow: Story = {
       </div>
     ),
     tag: <Badge>Marketing</Badge>,
+    extras: (
+      <>
+        <p style={{ margin: 0, fontWeight: 600 }}>Great fit for:</p>
+        <ul style={{ margin: 0, paddingInlineStart: '1.25rem' }}>
+          <li>Marketing leads shipping multiple campaigns a month</li>
+          <li>Founders who need brand + landing pages in lockstep</li>
+          <li>Teams without a full-time designer</li>
+        </ul>
+      </>
+    ),
     action: (
       <Button variant="primary" size="sm">
         Learn more

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -164,6 +164,15 @@ interface CardDisplayRowPresetProps extends CardBaseProps {
    */
   tag?: ReactNode;
   /**
+   * Optional content block rendered between `description` and `action`.
+   * Use for structured supporting content that doesn't fit the single-
+   * paragraph `description` slot — bullet lists ("Great fit for: …"),
+   * feature pills, supporting meta, or a small inline gallery. Receives
+   * no internal styling beyond a flex-column wrapper; the consumer owns
+   * the rendered markup.
+   */
+  extras?: ReactNode;
+  /**
    * Trailing action — typically a `<LinkButton>` or `<Button>`. Anchored
    * to the bottom of the body column via `margin-top: auto` so the title
    * + description stay top-aligned while the action sits at the card
@@ -452,6 +461,7 @@ function renderDisplayRowPreset({
   description,
   image,
   tag,
+  extras,
   action,
   imageWidth = 'standard',
   href,
@@ -489,6 +499,9 @@ function renderDisplayRowPreset({
         <h3 className="bds-card__preset-display-row-title">{title}</h3>
         {description && (
           <p className="bds-card__preset-display-row-description">{description}</p>
+        )}
+        {extras && (
+          <div className="bds-card__preset-display-row-extras">{extras}</div>
         )}
         {action && (
           <div className="bds-card__preset-display-row-action">{action}</div>


### PR DESCRIPTION
## Summary

Adds an optional `extras` slot to `Card preset="display-row"`, rendered between `description` and `action`. Accepts any ReactNode (bullet list, pill row, supporting meta) — the consumer owns the rendered markup; the BDS wrapper just preserves flex-column gap rhythm.

## Why

Surfaced while migrating brikdesigns/customers segment-card from a local horizontal compose to `preset="display-row"` (the original consumer goal of #592 / #793). The preset's single-paragraph `description` slot was too narrow for the card's 5-block structure (eyebrow + title + desc + **fits bullet list** + CTA). Two bad options without this slot:

1. Drop the fits list — loses meaningful content per segment.
2. Smush list HTML into `description` — breaks the `string`-typed prop.

`extras` lets the segment-card swap cleanly, and gives future single-card sections (Related Customer Story, Recommended Add-On, featured plan) the same affordance for supporting meta.

## API

```tsx
<Card
  preset="display-row"
  title="…"
  description="…"
  extras={
    <>
      <p style={{ margin: 0, fontWeight: 600 }}>Great fit for:</p>
      <ul>…</ul>
    </>
  }
  action={<LinkButton>…</LinkButton>}
/>
```

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint-tokens` passes (0 errors)
- [x] `npm run lint-jsdoc` passes
- [ ] Storybook `DisplayRow` story visual verification (extras slot renders between description and CTA)
- [ ] Mobile (≤ 640px) responsive collapse still works with extras present

## Release plan

New prop on existing component → **minor** bump per docs/RELEASE.md rubric → cuts as 0.80.0. brikdesigns consumer PR follows the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)