### PR TITLE
chore(release): 0.80.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.79.0",
+      "version": "0.80.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Minor bump for #795 — `extras` slot on `Card preset="display-row"`.

## Why minor (not patch)

Per `docs/RELEASE.md` semver rubric: minor = "new prop on existing component". #795 adds an `extras?: ReactNode` slot — additive, no API change to existing presets or props.

## Why minor when 0.79.0 just shipped

#795 closes a real consumer-blocking gap discovered the same day 0.79.0 published. The brikdesigns segment-card swap from local compose → `preset="display-row"` (the original goal of #592) lost its "Great fit for:" bullet list because `description` is typed as `string`. Rather than degrade the content or block the consumer, the `extras` slot makes the preset rich enough for the consumer's card shape (and any future single-card section with structured supporting content).

## After merge

```bash
git pull --ff-only
git tag -a -s v0.80.0 -m 'Release 0.80.0'
git push origin v0.80.0
```

The Release workflow validates `package.json` ↔ tag match and publishes to GitHub Packages.

## Consumer bump

brikdesigns segment-card swap follows in a single PR (BDS dep bump + local-compose → preset migration). The brikdesigns worktree is held ready to install `0.80.0` and do the swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)