### PR TITLE
feat(service-tag): add back-office as canonical ServiceLine, deprecate service

### DIFF
--- a/components/ui/Breadcrumb/Breadcrumb.css
+++ b/components/ui/Breadcrumb/Breadcrumb.css
@@ -47,9 +47,9 @@
  * [data-audience='X'] subtree, scoped to .bds-breadcrumb only so
  * other secondary text on the page is unaffected.
  *
- * `data-audience='service'` resolves to the back-office hue per the
- * #563 token rename (audience attribute kept "service" for
- * component-API compat; underlying tokens are *-back-office-*).
+ * `data-audience='back-office'` is canonical; `data-audience='service'` is a
+ * @deprecated alias kept for compat during the cross-repo rename. Both resolve
+ * to the back-office hue (underlying tokens are *-back-office-*).
  * Same mapping as HeroSplitImageCardOverlay.
  *
  * Pattern: rebind canonical generic tokens (--text-secondary,
@@ -77,6 +77,13 @@
   --text-muted: var(--text-service-product);
 }
 
+[data-audience='back-office'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-back-office);
+  --text-muted: var(--text-service-back-office);
+}
+
+/* @deprecated alias of [data-audience='back-office'] — remove with the
+   `service` ServiceLine member in a future major. */
 [data-audience='service'] .bds-breadcrumb {
   --text-secondary: var(--text-service-back-office);
   --text-muted: var(--text-service-back-office);

--- a/components/ui/Breadcrumb/Breadcrumb.stories.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.stories.tsx
@@ -180,7 +180,8 @@ const AUDIENCES = [
   { id: 'marketing', label: 'Marketing (green)' },
   { id: 'information', label: 'Information (blue)' },
   { id: 'product', label: 'Product (purple)' },
-  { id: 'service', label: 'Service / back-office (orange)' },
+  { id: 'back-office', label: 'Back Office (orange)' },
+  { id: 'service', label: 'Service — @deprecated alias of back-office (orange)' },
 ] as const;
 
 /** @summary Service-line tinting via [data-audience] cascade */

--- a/components/ui/ServiceTag/ServiceTag.css
+++ b/components/ui/ServiceTag/ServiceTag.css
@@ -44,9 +44,10 @@
 .bds-service-tag--marketing   { background-color: var(--background-service-marketing);   color: var(--text-service-marketing); }
 .bds-service-tag--information { background-color: var(--background-service-information); color: var(--text-service-information); }
 .bds-service-tag--product     { background-color: var(--background-service-product);     color: var(--text-service-product); }
-/* `--service` class modifier refers to the back-office service line; tokens were
-   renamed `service-service` → `service-back-office` in #563. Class kept stable
-   for component prop-API compat; follow-up may rename the modifier separately. */
+.bds-service-tag--back-office { background-color: var(--background-service-back-office); color: var(--text-service-back-office); }
+/* `--service` is the @deprecated alias of `--back-office` (kept for prop-API
+   compat during the cross-repo rename). Same back-office tokens; remove with
+   the `service` ServiceLine member in a future major. */
 .bds-service-tag--service     { background-color: var(--background-service-back-office); color: var(--text-service-back-office); }
 
 /* ─── Icon ───────────────────────────────────────────────────── */

--- a/components/ui/ServiceTag/ServiceTag.stories.tsx
+++ b/components/ui/ServiceTag/ServiceTag.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof ServiceTag> = {
   argTypes: {
     category: {
       control: 'select',
-      options: ['brand', 'marketing', 'information', 'product', 'service'],
+      options: ['brand', 'marketing', 'information', 'product', 'back-office', 'service'],
     },
     variant: {
       control: 'select',
@@ -64,8 +64,28 @@ const categoryServices: Record<ServiceLine, { serviceName: string; label: string
   marketing:   { serviceName: 'Custom Standard Web Development and Design',    label: 'Marketing Design' },
   information: { serviceName: 'Information Design',                            label: 'Information Design' },
   product:     { serviceName: 'Product Design Systems',                        label: 'Product Design' },
+  'back-office': { serviceName: 'Digital File Organization',                   label: 'Back Office' },
+  // @deprecated alias of 'back-office'
   service:     { serviceName: 'Digital File Organization',                     label: 'Back Office' },
 };
+
+// Back-office catalog — shared by the canonical `back-office` key and its
+// @deprecated `service` alias below (avoids duplicating the list).
+const backOfficeServices: { serviceName: string; label: string }[] = [
+  { serviceName: 'Software and Subscription Audit',                        label: 'Audit' },
+  { serviceName: 'Software Automation Setup',                              label: 'Automated Workflow' },
+  { serviceName: 'Automated Workflow and AI Integration',                  label: 'Automation & AI' },
+  { serviceName: 'Standard Operating Procedures (SOP) Creation',          label: 'Business Solutions' },
+  { serviceName: 'Back Office Consulting',                                 label: 'Consulting' },
+  { serviceName: 'CRM Setup and Data Cleanup',                             label: 'CRM & Data' },
+  { serviceName: 'Back Office Customer Support',                           label: 'Customer Support' },
+  { serviceName: 'Back Office Design',                                     label: 'Design' },
+  { serviceName: 'Digital File Organization',                              label: 'File Organization' },
+  { serviceName: 'Customer Journey Mapping',                               label: 'Journey Mapping' },
+  { serviceName: 'Back Office Software Audit',                             label: 'Software Audit' },
+  { serviceName: 'Back Office SOP Creation',                               label: 'SOP Creation' },
+  { serviceName: 'Back Office Training Setup',                             label: 'Training Setup' },
+];
 
 // Full service list for catalog stories
 const allServices: Record<ServiceLine, { serviceName: string; label: string }[]> = {
@@ -108,21 +128,9 @@ const allServices: Record<ServiceLine, { serviceName: string; label: string }[]>
     { serviceName: 'Product Design',                                         label: 'Design' },
     { serviceName: 'Product Enterprise Design',                              label: 'Enterprise Design' },
   ],
-  service: [
-    { serviceName: 'Software and Subscription Audit',                        label: 'Audit' },
-    { serviceName: 'Software Automation Setup',                              label: 'Automated Workflow' },
-    { serviceName: 'Automated Workflow and AI Integration',                  label: 'Automation & AI' },
-    { serviceName: 'Standard Operating Procedures (SOP) Creation',          label: 'Business Solutions' },
-    { serviceName: 'Back Office Consulting',                                 label: 'Consulting' },
-    { serviceName: 'CRM Setup and Data Cleanup',                             label: 'CRM & Data' },
-    { serviceName: 'Back Office Customer Support',                           label: 'Customer Support' },
-    { serviceName: 'Back Office Design',                                     label: 'Design' },
-    { serviceName: 'Digital File Organization',                              label: 'File Organization' },
-    { serviceName: 'Customer Journey Mapping',                               label: 'Journey Mapping' },
-    { serviceName: 'Back Office Software Audit',                             label: 'Software Audit' },
-    { serviceName: 'Back Office SOP Creation',                               label: 'SOP Creation' },
-    { serviceName: 'Back Office Training Setup',                             label: 'Training Setup' },
-  ],
+  'back-office': backOfficeServices,
+  // @deprecated alias of 'back-office'
+  service: backOfficeServices,
 };
 
 /* ═══════════════════════════════════════════════════════════════
@@ -331,7 +339,7 @@ export const Patterns: Story = {
           {[
             { category: 'marketing' as const, name: 'Website Design & Development',  label: 'Marketing Design' },
             { category: 'brand' as const,     name: 'Logo Design & Brand Guidelines', label: 'Brand' },
-            { category: 'service' as const,   name: 'CRM Setup & Data Cleanup',       label: 'Back Office' },
+            { category: 'back-office' as const,   name: 'CRM Setup & Data Cleanup',       label: 'Back Office' },
             { category: 'information' as const, name: 'Print Collateral',             label: 'Information Design' },
             { category: 'product' as const,   name: 'Design Systems & Libraries',     label: 'Product Design' },
           ].map(({ category, name, label }, i) => (
@@ -362,7 +370,7 @@ export const Patterns: Story = {
           {[
             { category: 'marketing' as const,   serviceName: 'Custom Standard Web Development and Design', label: 'Website Design & Development' },
             { category: 'brand' as const,        serviceName: 'Brand Identity Bundle',                     label: 'Brand Identity Bundle' },
-            { category: 'service' as const,      serviceName: 'CRM Setup and Data Cleanup',                label: 'CRM Setup & Data Cleanup' },
+            { category: 'back-office' as const,      serviceName: 'CRM Setup and Data Cleanup',                label: 'CRM Setup & Data Cleanup' },
             { category: 'information' as const,  serviceName: 'Print Design',                              label: 'Print Collateral' },
             { category: 'product' as const,      serviceName: 'Product Design Systems',                    label: 'Design Systems' },
           ].map(({ category, serviceName, label }, i) => (
@@ -390,7 +398,7 @@ export const Patterns: Story = {
           {[
             { category: 'marketing' as const, serviceName: 'Custom Standard Web Development and Design', label: 'Website Design & Development' },
             { category: 'brand' as const, serviceName: 'Brand Identity Bundle', label: 'Logo Design & Brand Guidelines' },
-            { category: 'service' as const, serviceName: 'CRM Setup and Data Cleanup', label: 'CRM Setup & Data Cleanup' },
+            { category: 'back-office' as const, serviceName: 'CRM Setup and Data Cleanup', label: 'CRM Setup & Data Cleanup' },
             { category: 'information' as const, serviceName: 'Print Design', label: 'Print Design & Collateral' },
             { category: 'product' as const, serviceName: 'Product Design Systems', label: 'Design Systems & Libraries' },
           ].map(({ category, serviceName, label }) => (

--- a/components/ui/ServiceTag/service-config.ts
+++ b/components/ui/ServiceTag/service-config.ts
@@ -4,7 +4,14 @@
  * component (removed in #572; dir renamed in #731).
  */
 
-export type ServiceLine = 'brand' | 'marketing' | 'information' | 'product' | 'service';
+/**
+ * Service-line identifier. `back-office` is canonical; `service` is a
+ * **@deprecated** alias kept for non-breaking package-API compat during the
+ * cross-repo rename (the underlying color tokens already use `*-back-office`).
+ * Pass `back-office` in new code — `service` is slated for removal in a future
+ * major version.
+ */
+export type ServiceLine = 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
 
 /**
  * Size scale shared with ServiceTag. Kept as `ServiceBadgeSize` for
@@ -18,6 +25,8 @@ export const categoryConfig: Record<ServiceLine, { token: string; label: string 
   marketing: { token: 'green', label: 'Marketing' },
   information: { token: 'blue', label: 'Information' },
   product: { token: 'purple', label: 'Product' },
+  'back-office': { token: 'orange', label: 'Back Office' },
+  // @deprecated alias of 'back-office' — same orange tokens. Kept for API compat.
   service: { token: 'orange', label: 'Back Office' },
 };
 
@@ -72,13 +81,26 @@ export function normalizeServiceName(name: string): string {
   return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
 }
 
+/**
+ * On-disk icon directory for a service line. The back-office icon assets still
+ * live under `icons/service/` (the filenames are already `back-office-*`); the
+ * physical directory rename is a separate asset migration (tracked follow-up).
+ * Resolve both the canonical `back-office` and the deprecated `service` alias
+ * to that directory until the assets move. Every other line: dir === category.
+ */
+const iconDirOverrides: Partial<Record<ServiceLine, string>> = { 'back-office': 'service' };
+function iconDir(category: ServiceLine): string {
+  return iconDirOverrides[category] ?? category;
+}
+
 export function getServiceIconPath(category: ServiceLine, serviceName: string): string {
+  const dir = iconDir(category);
   if (serviceIconOverrides[serviceName]) {
-    return `/icons/${category}/${serviceIconOverrides[serviceName]}.svg`;
+    return `/icons/${dir}/${serviceIconOverrides[serviceName]}.svg`;
   }
   const normalized = normalizeServiceName(serviceName);
   if (category === 'information') {
-    return `/icons/${category}/info-${normalized.replace('information-', '')}.svg`;
+    return `/icons/${dir}/info-${normalized.replace('information-', '')}.svg`;
   }
-  return `/icons/${category}/${category}-${normalized.replace(`${category}-`, '')}.svg`;
+  return `/icons/${dir}/${category}-${normalized.replace(`${category}-`, '')}.svg`;
 }

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -77,8 +77,9 @@ export interface BlueprintSection {
      */
     readonly href?: string;
     readonly imageUrl?: string;
-    /** ServiceLine slug — see `ServiceTag` props in `@brikdesigns/bds`. */
-    readonly category?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
+    /** ServiceLine slug — see `ServiceTag` props in `@brikdesigns/bds`.
+     * `back-office` is canonical; `service` is a @deprecated alias. */
+    readonly category?: 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
     readonly hasOptions?: boolean;
     /**
      * Audience slug for `data-audience` scope binding. Re-binds canonical
@@ -90,7 +91,7 @@ export interface BlueprintSection {
      * docs (`docs/theming/client-themes`); BDS ships the pattern, not the
      * audience-specific values.
      */
-    readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
+    readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
     /** Alt text for `imageUrl`. Defaults to empty (decorative) when omitted. */
     readonly imageAlt?: string;
   }[];

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -41,11 +41,11 @@
  * mode-aware companion fill consumed by the inverse `<Button>` variant
  * inside the hero, which IS a small bounded component.
  *
- * Note: the `data-audience='service'` attribute value still reads "service"
- * for component-API compat; the underlying tokens were renamed
- * `service-service` → `service-back-office` in #563 (orange line — back
- * office). API-level rename `data-audience` → `data-service-line` is a
- * separate cross-repo follow-up. */
+ * `data-audience='back-office'` is canonical; `data-audience='service'` is a
+ * @deprecated alias kept for component-API compat during the cross-repo
+ * rename. Both bind the orange back-office tokens (`service-back-office`,
+ * renamed from the bug-named `service-service` in #563). API-level rename
+ * `data-audience` → `data-service-line` is a separate cross-repo follow-up. */
 
 .bp-hero-img-card[data-audience='brand'] {
   background: var(--surface-service-brand);
@@ -79,6 +79,15 @@
   --text-on-color-light: var(--color-grayscale-white);
 }
 
+.bp-hero-img-card[data-audience='back-office'] {
+  background: var(--surface-service-back-office);
+  --bp-hero-img-card-headline-color: var(--text-service-back-office);
+  --text-brand-primary: var(--text-service-back-office);
+  --background-inverse: var(--background-service-back-office-inverse);
+  --text-on-color-light: var(--color-grayscale-white);
+}
+
+/* @deprecated alias of [data-audience='back-office']. */
 .bp-hero-img-card[data-audience='service'] {
   background: var(--surface-service-back-office);
   --bp-hero-img-card-headline-color: var(--text-service-back-office);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## What

Completes the rename started by #563 (color tokens `service-service` → `service-back-office`) by making **`back-office` the canonical `ServiceLine` identifier** across the BDS API, with **`service` kept as a non-breaking `@deprecated` alias**.

`service` as a service-line identifier is nebulous — it collides with the general services / service-lines / service-offerings / service-plans vocabulary. This is Phase 1 of a coordinated cross-repo rename (BDS → portal/DB → brikdesigns).

## Changes (additive, non-breaking)

- `ServiceLine` union + `categoryConfig`: add `back-office`; `service` retained, documented `@deprecated` (same orange tokens).
- `getServiceIconPath`: `iconDir()` resolves `back-office` (and the `service` alias) to the existing `icons/service/` dir — the physical icon-dir rename is a deferred asset migration. The canonical `back-office` fallback prefix now matches the on-disk `back-office-*.svg` filenames.
- `ServiceTag.css`: add `.bds-service-tag--back-office`; keep `--service` alias.
- `Breadcrumb.css` + `HeroSplitImageCardOverlay.css`: add `[data-audience='back-office']`; keep `[data-audience='service']` alias.
- Astro blueprint `types.ts`: add `back-office` to `category` / `audience` unions.
- Stories: canonical examples use `back-office`; `service` retained to demo the alias.
- Minor bump **0.80.0 → 0.81.0**.

Tokens already `*-back-office` (no token work).

## Verification

- typecheck, lint-tokens, lint-jsdoc, validate:blueprints, full Storybook build — all clean (10/10 pre-PR checks).
- Storybook (Playwright): `back-office` ServiceTag → orange `rgb(255,173,146)`; `service` alias renders **identical**; `brand` differs. Breadcrumb `[data-audience='back-office']` rebinds `--text-secondary` `#4e1400`; `service` alias identical.
- Tests: ServiceTag/Breadcrumb/HeroSplit pass (1 unrelated `Radio` `toBeVisible` flake).

## Follow-ups (separate PRs)
- Consumers migrate `service` → `back-office`: brik-client-portal (+ DB slug/`service_tag_category` rename), brikdesigns.
- Physical icon-dir rename `icons/service/` → `icons/back-office/`.
- Remove the `service` alias in a future major once consumers are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)