### PR TITLE
fix(blueprints): add back-office to section audience union (0.81.1)

### DIFF
--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -123,8 +123,10 @@ export interface BlueprintSection {
    * pattern, not the audience-specific values.
    *
    * Additive, optional — blueprints that don't read this are unaffected.
+   *
+   * `back-office` is canonical; `service` is a @deprecated alias (see #797).
    */
-  readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'service';
+  readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
   /**
    * Optional eyebrow icon URL — manual override for decorative, non-
    * categorical images (campaign artwork, editorial illustrations).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.80.0",
+  "version": "0.81.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.80.0",
+      "version": "0.81.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Patch completing #797. The section-level `audience` union in `content-system/blueprints/astro/types.ts` still read `…| 'product' | 'service'` (no `back-office`), so consumers passing `audience='back-office'` to a `BlueprintSection` (brikdesigns service/plan detail heroes) hit a type error even though the CSS + ServiceTag already accept it. Types-only widening; bump 0.81.0 → 0.81.1. tsc clean; 10/10 pre-PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)