### PR TITLE
fix(devbar): inspector flags --font-line-height-* tokens as unknown

### DIFF
--- a/.storybook/public/brik-inspect.js
+++ b/.storybook/public/brik-inspect.js
@@ -67,7 +67,7 @@
     '--padding-', '--space-', '--spacing-', '--gap-', '--margin-',
     '--font-family-', '--typography-', '--font-size-', '--font-weight-',
     '--body-', '--heading-', '--display-', '--label-',
-    '--line-height-', '--letter-spacing-',
+    '--font-line-height-', '--letter-spacing-',
     '--border-radius-', '--radius-',
     '--shadow-', '--elevation-',
     '--transition-', '--motion-', '--duration-', '--easing-',

--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -67,7 +67,7 @@
     '--padding-', '--space-', '--spacing-', '--gap-', '--margin-',
     '--font-family-', '--typography-', '--font-size-', '--font-weight-',
     '--body-', '--heading-', '--display-', '--label-',
-    '--line-height-', '--letter-spacing-',
+    '--font-line-height-', '--letter-spacing-',
     '--border-radius-', '--radius-',
     '--shadow-', '--elevation-',
     '--transition-', '--motion-', '--duration-', '--easing-',


### PR DESCRIPTION
## Problem

The BDS inspect widget's **Unknown tokens** panel flags every `var(--font-line-height-*)` reference as unknown on all consumer surfaces (brikdesigns staging dev-tools, portal, renew-pms, Storybook). Reported on brikdesigns.

## Root cause

`isValidToken()` validates by prefix against `VALID_TOKEN_PREFIXES`. The list carried a dead `'--line-height-'` prefix — **no BDS token uses that bare form**. The canonical line-height family is `--font-line-height-*` (`dist/tokens.css:207-213`: `tight/snug/normal/relaxed/loose/none/moderate`). Since `--font-line-height-tight` does not start with `--line-height-`, the whole family fell through to "unknown."

Verified across the GitHub tree: zero genuine bare `--line-height-*` token usages exist; every line-height reference uses `--font-line-height-*`.

## Fix

Replace the dead `'--line-height-'` prefix with the canonical `'--font-line-height-'` in both the source widget and the bundled `.storybook/public/brik-inspect.js` copy.

## Downstream (post-merge)

Consumer `/public/brik-inspect.js` copies (brikdesigns, portal, renew-pms) and the brik-llm cache are synced via `scripts/sync-devbar-widgets.sh`. The **brikdesigns** copy is handled in its own PR (reported surface); portal + renew-pms + brik-llm need a `sync-devbar-widgets.sh` run after this merges — tracked in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)