### PR TITLE
feat(service-tag): line-default icon fallback for icon variant

### DIFF
--- a/components/ui/ServiceTag/ServiceTag.tsx
+++ b/components/ui/ServiceTag/ServiceTag.tsx
@@ -3,6 +3,7 @@ import { bdsClass } from '../../utils';
 import {
   categoryConfig,
   getServiceIconPath,
+  getServiceLineIconPath,
   type ServiceLine,
   type ServiceBadgeSize,
 } from './service-config';
@@ -19,7 +20,11 @@ export interface ServiceTagProps extends Omit<HTMLAttributes<HTMLSpanElement>, '
   size?: ServiceBadgeSize;
   /** Display label — defaults to the category name (e.g. "Back Office"). Pass a service name to label a specific service. */
   label?: string;
-  /** Service name for icon resolution — required for icon-text and icon variants to show an icon */
+  /**
+   * Service name for icon resolution. Required for `icon-text` to show a glyph.
+   * For `icon`, optional — when omitted the tag falls back to the service-line
+   * default glyph instead of rendering an empty box.
+   */
   serviceName?: string;
 }
 
@@ -70,7 +75,13 @@ export function ServiceTag({
   if (variant === 'icon') {
     const boxSize = boxSizeMap[size];
     const iconSize = Math.round(boxSize * iconScaleMap[size]);
-    const showIcon = !!serviceName && !imageError;
+    // Icon-only tags have no label, so an empty colored box reads as broken.
+    // Fall back to the service-line default glyph when no specific service is
+    // named, so a category tag still shows its line icon.
+    const iconSrc = serviceName
+      ? getServiceIconPath(category, serviceName)
+      : getServiceLineIconPath(category);
+    const showIcon = !imageError;
 
     return (
       <span
@@ -87,7 +98,7 @@ export function ServiceTag({
       >
         {showIcon && (
           <img
-            src={getServiceIconPath(category, serviceName!)}
+            src={iconSrc}
             alt=""
             width={iconSize}
             height={iconSize}

--- a/components/ui/ServiceTag/service-config.ts
+++ b/components/ui/ServiceTag/service-config.ts
@@ -104,3 +104,24 @@ export function getServiceIconPath(category: ServiceLine, serviceName: string): 
   }
   return `/icons/${dir}/${category}-${normalized.replace(`${category}-`, '')}.svg`;
 }
+
+/**
+ * Service-line default icon basename — the line-level glyph used when an icon
+ * variant has no specific `serviceName` (e.g. a category tag with no service).
+ * Without this, `<ServiceTag variant="icon">` rendered an empty colored box.
+ * Files resolve to the consuming app's `/public/icons/{dir}/{name}.svg`.
+ */
+const serviceLineDefaultIcon: Record<ServiceLine, string> = {
+  brand: 'brand-design',
+  marketing: 'marketing-design',
+  information: 'information-design',
+  product: 'product-design',
+  'back-office': 'back-office-design',
+  // @deprecated alias of 'back-office' — same default icon.
+  service: 'back-office-design',
+};
+
+/** Line-level default icon path — fallback for icon variants lacking a serviceName. */
+export function getServiceLineIconPath(category: ServiceLine): string {
+  return `/icons/${iconDir(category)}/${serviceLineDefaultIcon[category]}.svg`;
+}


### PR DESCRIPTION
## What

`<ServiceTag variant="icon">` rendered an **empty colored box** whenever no `serviceName` was passed — e.g. category-level tags and the service-detail hero's audience-only tag (`HeroSplitImageCardOverlay`). Icon-only tags carry no label, so the empty box reads as a broken/missing icon.

This adds a `serviceLineDefaultIcon` map + `getServiceLineIconPath()` helper and uses it as the fallback `src` when `serviceName` is absent, so a category tag always shows its service-line glyph.

- `icon-text` is **unchanged** (it already shows a label, so no glyph fallback is needed).
- Defaults map to the canonical line icons: `brand-design`, `marketing-design`, `information-design`, `product-design`, `back-office-design` (resolved through the existing `iconDir()`, so `back-office` → `icons/service/`).
- Icons resolve from the consuming app's `/public/icons/`; if a consumer lacks a file, the existing `onError` path still degrades to an empty box (no regression).

## Why

Consumer report (brikdesigns): empty icon tags across the service-detail hero, customer-story meta, and service-line cards. Root cause was the `!!serviceName` guard in the `icon` branch. Ties into the wider ServiceTag variant-logic cleanup.

## Verification

- `typecheck`, `lint-jsdoc`, `build:lib`, full `validate` suite (10/10) — all pass.
- Storybook **Patterns → "Color palette reference"** (the canonical `variant="icon"` + no-`serviceName` case): previously empty boxes, now renders the line-default glyph for all six categories. Verified visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)