### PR TITLE
chore(release): 0.82.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.81.1",
+  "version": "0.82.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.81.1",
+      "version": "0.82.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.81.1",
+  "version": "0.82.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Version bump to **0.82.0** to publish the ServiceTag line-default icon fallback (#805).

Minor bump — additive, non-breaking (new `getServiceLineIconPath` export + fallback behavior on `variant="icon"` when no `serviceName`).

After merge: tag `v0.82.0` from `main` to trigger the Release workflow → `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)