### PR TITLE
pageheader: divider gap

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -9,7 +9,7 @@
   --page-header-section-gap: var(--gap-xl);     /* between root sections (inner/metadata/stats/tabs) */
   --page-header-content-gap: var(--gap-sm);     /* between title-row and subtitle */
   --page-header-actions-gap: var(--gap-sm);     /* between content column and actions column */
-  --page-header-padding-bottom: 0;              /* breathing room before the bottom divider */
+  --page-header-padding-bottom: var(--padding-md); /* breathing room before the bottom divider */
 
   display: flex;
   flex-direction: column;
@@ -24,9 +24,12 @@
   border-bottom: var(--border-width-sm) solid var(--border-secondary);
 }
 
-/* Suppress root divider when tabs are present — TabBar provides its baseline. */
+/* Suppress root divider + bottom padding when tabs are present — TabBar provides
+   its own baseline and rhythm, so the breathing-room padding (which exists to
+   space the subtitle off the divider) would otherwise just push the tabs down. */
 .bds-page-header:has(.bds-page-header__tabs) {
   border-bottom: none;
+  padding-bottom: 0; /* bds-lint-ignore — zeroing the component-scoped override */
 }
 
 /* ─── Title row ──────────────────────────────────────────────── */

--- a/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/components/ui/PageHeader/PageHeader.stories.tsx
@@ -353,25 +353,25 @@ export const TunableSpacing: Story = {
       <Stack gap="var(--gap-huge)">
         {/* Defaults */}
         <div>
-          <SectionLabel>Defaults — gap-sm content gap, 0 divider padding</SectionLabel>
+          <SectionLabel>Defaults — gap-sm content gap, padding-md divider breathing room</SectionLabel>
           <PageHeader
             title="Default Header"
-            subtitle="Title↔subtitle gap = 6px (gap-sm). Subtitle sits flush above the divider."
+            subtitle="Title↔subtitle gap = gap-sm. Default padding-md breathing room before the divider."
             actions={<Button variant="primary" size="sm">Action</Button>}
           />
         </div>
 
         {/* Tuned for clinical density (renew-pms) */}
         <div>
-          <SectionLabel>Tuned — wider content gap + divider breathing room</SectionLabel>
+          <SectionLabel>Tuned — wider content gap + extra divider breathing room</SectionLabel>
           <PageHeader
             title="Tuned Header"
-            subtitle="Title↔subtitle gap bumped to 12px; 16px breathing room before the divider."
+            subtitle="Content gap widened to padding-sm; divider breathing room bumped past the default to padding-lg."
             actions={<Button variant="primary" size="sm">Action</Button>}
             style={{
               // bds-lint-ignore — component-scoped CSS variables, not design tokens
               ['--page-header-content-gap' as string]: 'var(--padding-sm)',
-              ['--page-header-padding-bottom' as string]: 'var(--padding-md)',
+              ['--page-header-padding-bottom' as string]: 'var(--padding-lg)',
             }}
           />
         </div>

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -87,8 +87,9 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
  *   the title-row and the subtitle.
  * - `--page-header-actions-gap` (default `var(--gap-sm)` = 6px) — between
  *   the content column (title + subtitle) and the actions column.
- * - `--page-header-padding-bottom` (default `0`) — breathing room before the
- *   bottom divider, useful when the divider sits flush against the title.
+ * - `--page-header-padding-bottom` (default `var(--padding-md)`) — breathing
+ *   room between the subtitle and the bottom divider. Auto-zeroed when the
+ *   `tabs` slot is filled (TabBar owns its own baseline + rhythm).
  *
  * @summary Page-level header — title, breadcrumbs, actions, tabs
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.82.0",
+      "version": "0.83.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- fix(PageHeader): add breathing room before the bottom divider

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)