### PR TITLE
layout: dataview family

### DIFF
--- a/components/ui/DataView/DataView.css
+++ b/components/ui/DataView/DataView.css
@@ -1,0 +1,9 @@
+@layer bds-components {
+/* ─── DataView skeletons ─────────────────────────────────────────
+   The named views (TableView / ListView / ProfileView) are logic-only
+   shells; the only DOM they own is the default loading skeleton. */
+
+.bds-data-view__skeleton {
+  width: 100%;
+}
+}

--- a/components/ui/DataView/DataView.mdx
+++ b/components/ui/DataView/DataView.mdx
@@ -1,0 +1,75 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './DataView.stories';
+
+<Meta of={Stories} />
+
+# DataView family
+
+<ComponentLinks slug="data-view" />
+
+Thin shells that own the three states every data display needs — **loading, empty, error** — so consumers stop rebuilding them per page. The display primitive (`Table`, `CardList`, a `DataSection` stack) is passed as `children`; the view swaps in a skeleton, an `EmptyState`, or an error `Banner` as needed.
+
+Five named views were specced (brik-bds#404); this batch ships the three the portal consumes:
+
+- **`TableView`** — around a `Table`
+- **`ListView`** — around a `CardList` / `InteractiveListItem` stack
+- **`ProfileView`** — around a read-mode `DataSection` + `FieldGrid` + `Field` stack
+
+`BoardView` / `CalendarView` are deferred until the renew-pms migration needs them (board/calendar surfaces don't exist in the portal).
+
+Named components — not a polymorphic `<DataDisplay variant>` — so each is discoverable and you import only what you render.
+
+```tsx
+<Page.Content>
+  <FilterBar … />
+  <TableView
+    loading={isLoading}
+    error={error?.message}
+    empty={rows.length === 0}
+    emptyState={{ title: 'No services yet', description: 'Add one to get started.' }}
+  >
+    <Table>…</Table>
+  </TableView>
+</Page.Content>
+```
+
+## State precedence
+
+A view renders exactly one state, in this order: **error → loading → empty → content**. `error` fails loud (an error `Banner`, `role="alert"`) — it is never silently swallowed. Override the default skeleton with the `skeleton` prop; pass `emptyState` as structured copy (`{ title, description?, buttonProps? }`) or any `ReactNode`.
+
+## Playground
+
+<Canvas of={Stories.Playground} />
+
+## Variants
+
+### TableView — loading
+
+<Canvas of={Stories.Loading} />
+
+### TableView — empty
+
+<Canvas of={Stories.Empty} />
+
+### TableView — error
+
+<Canvas of={Stories.Error} />
+
+### ListView
+
+<Canvas of={Stories.List} />
+
+<Canvas of={Stories.ListLoading} />
+
+### ProfileView
+
+<Canvas of={Stories.Profile} />
+
+<Canvas of={Stories.ProfileLoading} />
+
+## Props
+
+The same surface on every view (`TableView` shown):
+
+<ArgTypes of={Stories} />

--- a/components/ui/DataView/DataView.stories.tsx
+++ b/components/ui/DataView/DataView.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TableView } from './TableView';
+import { ListView } from './ListView';
+import { ProfileView } from './ProfileView';
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '../Table';
+import { Card } from '../Card';
+import { CardList } from '../CardList';
+import { DataSection } from '../DataSection';
+import { Field } from '../Field';
+import { FieldGrid } from '../FieldGrid';
+
+const meta: Meta<typeof TableView> = {
+  title: 'Displays/data-view',
+  component: TableView,
+  tags: ['surface-product'],
+  parameters: { layout: 'padded' },
+  argTypes: {
+    loading: { control: 'boolean' },
+    empty: { control: 'boolean' },
+    error: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TableView>;
+
+/* ─── Story helpers (ship nothing) ───────────────────────────── */
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ maxWidth: '880px', padding: 'var(--padding-lg)', background: 'var(--surface-primary)' }}>
+    {children}
+  </div>
+);
+
+const DemoTable = () => (
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead>Name</TableHead>
+        <TableHead>Service line</TableHead>
+        <TableHead>Status</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {['Website Design', 'Brand Identity', 'SEO Setup'].map((name) => (
+        <TableRow key={name}>
+          <TableCell>{name}</TableCell>
+          <TableCell>Marketing Design</TableCell>
+          <TableCell>Active</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+const DemoList = () => (
+  <CardList>
+    <Card preset="display" title="Website Design" description="Marketing Design" />
+    <Card preset="display" title="Brand Identity" description="Brand Design" />
+    <Card preset="display" title="SEO Setup" description="Back Office" />
+  </CardList>
+);
+
+const DemoProfile = () => (
+  <DataSection title="Identity">
+    <FieldGrid columns={2}>
+      <Field label="Company">Acme Corp</Field>
+      <Field label="Plan">Enterprise</Field>
+      <Field label="Status">Active</Field>
+      <Field label="MRR">$12,400</Field>
+    </FieldGrid>
+  </DataSection>
+);
+
+const tableEmpty = { title: 'No services yet', description: 'Add a service to get started.' };
+
+/* ─── 1. Playground ──────────────────────────────────────────── */
+
+/** @summary TableView — toggle loading / empty / error to see state precedence */
+export const Playground: Story = {
+  args: { loading: false, empty: false, error: '' },
+  render: (args) => (
+    <Frame>
+      <TableView {...args} emptyState={tableEmpty}>
+        <DemoTable />
+      </TableView>
+    </Frame>
+  ),
+};
+
+/* ─── 2. TableView states ────────────────────────────────────── */
+
+/** @summary TableView loading — default skeleton stands in for the table */
+export const Loading: Story = {
+  render: () => (
+    <Frame>
+      <TableView loading emptyState={tableEmpty}>
+        <DemoTable />
+      </TableView>
+    </Frame>
+  ),
+};
+
+/** @summary TableView empty — structured EmptyState copy */
+export const Empty: Story = {
+  render: () => (
+    <Frame>
+      <TableView empty emptyState={{ ...tableEmpty, buttonProps: { children: 'Add Service' } }}>
+        <DemoTable />
+      </TableView>
+    </Frame>
+  ),
+};
+
+/** @summary TableView error — fails loud with an error Banner */
+export const Error: Story = {
+  render: () => (
+    <Frame>
+      <TableView error="The request timed out. Try again." emptyState={tableEmpty}>
+        <DemoTable />
+      </TableView>
+    </Frame>
+  ),
+};
+
+/* ─── 3. ListView ────────────────────────────────────────────── */
+
+/** @summary ListView — content and its default list skeleton */
+export const List: Story = {
+  render: () => (
+    <Frame>
+      <ListView emptyState={{ title: 'No items' }}>
+        <DemoList />
+      </ListView>
+    </Frame>
+  ),
+};
+
+/** @summary ListView loading skeleton */
+export const ListLoading: Story = {
+  render: () => (
+    <Frame>
+      <ListView loading emptyState={{ title: 'No items' }}>
+        <DemoList />
+      </ListView>
+    </Frame>
+  ),
+};
+
+/* ─── 4. ProfileView ─────────────────────────────────────────── */
+
+/** @summary ProfileView — read-mode DataSection content */
+export const Profile: Story = {
+  render: () => (
+    <Frame>
+      <ProfileView emptyState={{ title: 'No profile data' }}>
+        <DemoProfile />
+      </ProfileView>
+    </Frame>
+  ),
+};
+
+/** @summary ProfileView loading skeleton */
+export const ProfileLoading: Story = {
+  render: () => (
+    <Frame>
+      <ProfileView loading emptyState={{ title: 'No profile data' }}>
+        <DemoProfile />
+      </ProfileView>
+    </Frame>
+  ),
+};

--- a/components/ui/DataView/DataView.tsx
+++ b/components/ui/DataView/DataView.tsx
@@ -1,0 +1,131 @@
+import { type ReactNode } from 'react';
+import { Banner } from '../Banner';
+import { EmptyState } from '../EmptyState';
+import { Skeleton } from '../Skeleton';
+import { Stack } from '../Stack';
+import './DataView.css';
+
+/** Structured empty-state copy. Pass a `ReactNode` instead for full control. */
+export interface DataViewEmptyConfig {
+  title: string;
+  description?: string;
+  buttonProps?: {
+    children: ReactNode;
+    onClick?: () => void;
+    iconBefore?: ReactNode;
+    iconAfter?: ReactNode;
+  };
+}
+
+export type DataViewEmpty = DataViewEmptyConfig | ReactNode;
+
+/**
+ * Shared prop surface for every `*View`. A view renders exactly one of four
+ * states, in precedence order: **error → loading → empty → content**.
+ */
+export interface DataViewProps {
+  /** Render the loading skeleton instead of `children`. */
+  loading?: boolean;
+  /**
+   * When set (non-empty string), render an error `Banner` (`tone="error"`)
+   * instead of `children`. Fail loud — never silently swallow.
+   */
+  error?: string | null;
+  /** Title for the error banner. Default `"Couldn't load"`. */
+  errorTitle?: string;
+  /** When `true` (and not loading/error), render the empty state. */
+  empty?: boolean;
+  /** Empty-state copy. An object renders `<EmptyState>`; a `ReactNode` renders as-is. */
+  emptyState?: DataViewEmpty;
+  /** Override the default loading skeleton for this view. */
+  skeleton?: ReactNode;
+  /** The data display — `Table`, `CardList`, a `DataSection` stack, etc. */
+  children: ReactNode;
+}
+
+function isEmptyConfig(value: DataViewEmpty): value is DataViewEmptyConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'title' in value &&
+    typeof (value as DataViewEmptyConfig).title === 'string'
+  );
+}
+
+/**
+ * Internal state resolver shared by every `*View`. Re-exported only within
+ * the DataView module (not from the package index) — consumers use the named
+ * wrappers `TableView` / `ListView` / `ProfileView`.
+ */
+export function DataViewShell({
+  loading,
+  error,
+  errorTitle = "Couldn't load",
+  empty,
+  emptyState,
+  skeleton,
+  defaultSkeleton,
+  children,
+}: DataViewProps & { defaultSkeleton: ReactNode }) {
+  if (error) {
+    return <Banner tone="error" title={errorTitle} description={error} />;
+  }
+  if (loading) {
+    return <>{skeleton ?? defaultSkeleton}</>;
+  }
+  if (empty) {
+    if (emptyState === undefined) return null;
+    return isEmptyConfig(emptyState) ? (
+      <EmptyState
+        title={emptyState.title}
+        description={emptyState.description}
+        buttonProps={emptyState.buttonProps}
+      />
+    ) : (
+      <>{emptyState}</>
+    );
+  }
+  return <>{children}</>;
+}
+
+/* ─── Default skeletons ──────────────────────────────────────────
+   Generic placeholders sized to the display shape. Consumers override
+   via the `skeleton` prop when they want a higher-fidelity match. */
+
+export function TableSkeleton() {
+  return (
+    <Stack gap="sm" className="bds-data-view__skeleton" aria-hidden="true">
+      <Skeleton variant="rectangular" height={40} />
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Skeleton key={i} variant="rectangular" height={52} />
+      ))}
+    </Stack>
+  );
+}
+
+export function ListSkeleton() {
+  return (
+    <Stack gap="sm" className="bds-data-view__skeleton" aria-hidden="true">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton key={i} variant="rectangular" height={64} />
+      ))}
+    </Stack>
+  );
+}
+
+export function ProfileSkeleton() {
+  return (
+    <Stack gap="xl" className="bds-data-view__skeleton" aria-hidden="true">
+      {Array.from({ length: 2 }).map((_, section) => (
+        <Stack key={section} gap="sm">
+          <Skeleton variant="text" width="30%" height={20} />
+          <Skeleton variant="rectangular" height={88} />
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+/* The named views live in their own files (`TableView.tsx`, `ListView.tsx`,
+   `ProfileView.tsx`) — distinct components, not one polymorphic `variant` —
+   each a thin shell over `DataViewShell` with its display-shaped skeleton. */

--- a/components/ui/DataView/ListView.tsx
+++ b/components/ui/DataView/ListView.tsx
@@ -1,0 +1,13 @@
+import { DataViewShell, ListSkeleton, type DataViewProps } from './DataView';
+
+/**
+ * ListView — loading / empty / error shell around a `CardList` /
+ * `InteractiveListItem` stack. The list is passed as `children`.
+ *
+ * @summary Loading/empty/error shell around a list.
+ */
+export function ListView(props: DataViewProps) {
+  return <DataViewShell defaultSkeleton={<ListSkeleton />} {...props} />;
+}
+
+export default ListView;

--- a/components/ui/DataView/ProfileView.tsx
+++ b/components/ui/DataView/ProfileView.tsx
@@ -1,0 +1,14 @@
+import { DataViewShell, ProfileSkeleton, type DataViewProps } from './DataView';
+
+/**
+ * ProfileView — loading / empty / error shell around a read-mode
+ * `DataSection` + `FieldGrid` + `Field` stack. Children-only (V1): compose the
+ * sections as `children`; this wrapper owns only the three states.
+ *
+ * @summary Loading/empty/error shell around a read-mode profile.
+ */
+export function ProfileView(props: DataViewProps) {
+  return <DataViewShell defaultSkeleton={<ProfileSkeleton />} {...props} />;
+}
+
+export default ProfileView;

--- a/components/ui/DataView/TableView.tsx
+++ b/components/ui/DataView/TableView.tsx
@@ -1,0 +1,25 @@
+import { DataViewShell, TableSkeleton, type DataViewProps } from './DataView';
+
+/**
+ * TableView — loading / empty / error shell around a `Table`. A thin wrapper
+ * that owns only those three states; the `Table` is passed as `children`.
+ *
+ * @example
+ * ```tsx
+ * <TableView
+ *   loading={isLoading}
+ *   error={error?.message}
+ *   empty={rows.length === 0}
+ *   emptyState={{ title: 'No services yet', description: 'Add one to get started.' }}
+ * >
+ *   <Table>…</Table>
+ * </TableView>
+ * ```
+ *
+ * @summary Loading/empty/error shell around a Table.
+ */
+export function TableView(props: DataViewProps) {
+  return <DataViewShell defaultSkeleton={<TableSkeleton />} {...props} />;
+}
+
+export default TableView;

--- a/components/ui/DataView/index.ts
+++ b/components/ui/DataView/index.ts
@@ -1,0 +1,8 @@
+export { TableView } from './TableView';
+export { ListView } from './ListView';
+export { ProfileView } from './ProfileView';
+export {
+  type DataViewProps,
+  type DataViewEmpty,
+  type DataViewEmptyConfig,
+} from './DataView';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -34,6 +34,7 @@ export * from './CollapsibleCard';
 export * from './CompletionToggle';
 export * from './Counter';
 export * from './DataSection';
+export * from './DataView';
 export * from './DatePicker';
 export * from './DevFeedbackWidget';
 export * from './Dialog';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.84.0",
+      "version": "0.85.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",

--- a/scripts/lint-jsdoc.js
+++ b/scripts/lint-jsdoc.js
@@ -85,6 +85,7 @@ const EXEMPT_COMPONENTS = new Set([
 // for a single `<Name>.tsx`.
 const MULTI_EXPORT = {
   SheetTypography: ['SheetSectionTitle', 'SheetFieldLabel', 'SheetFieldValue', 'SheetHelperText'],
+  DataView: ['TableView', 'ListView', 'ProfileView'],
 };
 
 // Build the (file, exportName) scan tasks.


### PR DESCRIPTION
## Summary
- feat(DataView): loading/empty/error views — TableView, ListView, ProfileView

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)