### PR TITLE
fix: page rsc siblings

### DIFF
--- a/components/ui/DataView/DataView.mdx
+++ b/components/ui/DataView/DataView.mdx
@@ -21,7 +21,7 @@ Five named views were specced (brik-bds#404); this batch ships the three the por
 Named components — not a polymorphic `<DataDisplay variant>` — so each is discoverable and you import only what you render.
 
 ```tsx
-<Page.Content>
+<PageContent>
   <FilterBar … />
   <TableView
     loading={isLoading}
@@ -31,7 +31,7 @@ Named components — not a polymorphic `<DataDisplay variant>` — so each is di
   >
     <Table>…</Table>
   </TableView>
-</Page.Content>
+</PageContent>
 ```
 
 ## State precedence

--- a/components/ui/Page/Page.css
+++ b/components/ui/Page/Page.css
@@ -12,7 +12,7 @@
   min-width: 0;
   /* Shared horizontal inset. Header + body sit inside this padded column so
      the header's bottom divider aligns with body content (the renew #224
-     model). Exposed as a custom property so Page.Content can break out of it. */
+     model). Exposed as a custom property so PageContent can break out of it. */
   padding-inline: var(--bds-page-padding-inline, 0); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
 }
 
@@ -31,7 +31,7 @@
 .bds-page--gap-xl   { gap: var(--gap-xl); }
 .bds-page--gap-huge { gap: var(--gap-huge); }
 
-/* ─── Page.Content ──────────────────────────────────────────────── */
+/* ─── PageContent ──────────────────────────────────────────────── */
 
 .bds-page__content {
   display: flex;

--- a/components/ui/Page/Page.mdx
+++ b/components/ui/Page/Page.mdx
@@ -8,19 +8,19 @@ import * as Stories from './Page.stories';
 
 <ComponentLinks slug="page" />
 
-The compound page shell — the connective tissue every product page shares. A `<Page.Header>` hands off to a `<Page.Content>` across a known vertical `gap`, inside one shared horizontal `padding` column. Replaces the per-app `main` + bare-`div` + inline-style stacks that drift across consumers.
+The compound page shell — the connective tissue every product page shares. A `<PageHeader>` hands off to a `<PageContent>` across a known vertical `gap`, inside one shared horizontal `padding` column. Replaces the per-app `main` + bare-`div` + inline-style stacks that drift across consumers.
 
 ```tsx
 <Page padding="md" gap="xl">
-  <Page.Header title="Services" subtitle="…" actions={<Button>Add</Button>} />
-  <Page.Content>
+  <PageHeader title="Services" subtitle="…" actions={<Button>Add</Button>} />
+  <PageContent>
     <Grid columns="auto-fit" minColumnWidth="180px" gap="md">
       <Card preset="summary" label="Total" value={49} />
       <Card preset="summary" label="Public" value={33} />
     </Grid>
     <FilterBar total={49} filtered={49} label="services" />
     <Table>…</Table>
-  </Page.Content>
+  </PageContent>
 </Page>
 ```
 
@@ -31,8 +31,8 @@ The compound page shell — the connective tissue every product page shares. A `
 ### Anatomy
 
 - **`Page`** owns the shared horizontal inset (`padding`) and the header→body `gap`. It always sets `flex: 1; min-height: 0` on itself.
-- **`Page.Header`** is the existing [`PageHeader`](/docs/components/page-header) (title · subtitle · actions · tabs), re-exported so call-sites migrate by import, not JSX shape.
-- **`Page.Content`** owns the body region: per-region inset override, the vertical rhythm between stacked sections, and (optionally) its own scroll.
+- **`PageHeader`** is the existing [`PageHeader`](/docs/components/page-header) (title · subtitle · actions · tabs), re-exported so call-sites migrate by import, not JSX shape.
+- **`PageContent`** owns the body region: per-region inset override, the vertical rhythm between stacked sections, and (optionally) its own scroll.
 
 ### Precondition — flex-column parent
 
@@ -42,31 +42,31 @@ The compound page shell — the connective tissue every product page shares. A `
 
 ### Stats in the body
 
-Summary stat cards are a **body** concern, not a header slot — they summarize the display below them. Render them in `<Page.Content>` as a `Grid` of `Card preset="summary"` above the `FilterBar` (brik-bds#404, 2026-06-03). The `PageHeader.stats` slot is deprecated.
+Summary stat cards are a **body** concern, not a header slot — they summarize the display below them. Render them in `<PageContent>` as a `Grid` of `Card preset="summary"` above the `FilterBar` (brik-bds#404, 2026-06-03). The `PageHeader.stats` slot is deprecated.
 
 <Canvas of={Stories.StatsInBody} />
 
 ### Tabs handoff
 
-When `<Page.Header tabs>` is set, the header's bottom divider is suppressed and the TabBar baseline becomes the handoff to the body.
+When `<PageHeader tabs>` is set, the header's bottom divider is suppressed and the TabBar baseline becomes the handoff to the body.
 
 <Canvas of={Stories.WithTabs} />
 
 ### Full-bleed body
 
-`<Page.Content padding="none">` breaks out of the page column for edge-to-edge boards and tables, while the header stays in the padded column.
+`<PageContent padding="none">` breaks out of the page column for edge-to-edge boards and tables, while the header stays in the padded column.
 
 <Canvas of={Stories.FullBleedBody} />
 
 ### Fill-height scroll
 
-`<Page.Content scroll>` owns the vertical scroll on fill-height pages, so the header stays put while the body scrolls internally.
+`<PageContent scroll>` owns the vertical scroll on fill-height pages, so the header stays put while the body scrolls internally.
 
 <Canvas of={Stories.FillHeightScroll} />
 
 ### Headerless
 
-`<Page.Header>` is optional — a body-only page is valid, and `gap` becomes a no-op.
+`<PageHeader>` is optional — a body-only page is valid, and `gap` becomes a no-op.
 
 <Canvas of={Stories.Headerless} />
 

--- a/components/ui/Page/Page.stories.tsx
+++ b/components/ui/Page/Page.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Page } from './Page';
+import { PageHeader } from '../PageHeader';
+import { PageContent } from './PageContent';
 import { Grid } from '../Grid';
 import { Card } from '../Card';
 import { FilterBar } from '../FilterBar';
@@ -91,16 +93,16 @@ export const Playground: Story = {
   render: (args) => (
     <Shell>
       <Page {...args}>
-        <Page.Header
+        <PageHeader
           title="Services"
           subtitle="The middle-tier service catalog — what we offer under each service line."
           actions={<Button variant="primary" size="sm">Add Service</Button>}
         />
-        <Page.Content>
+        <PageContent>
           <StatRow />
           <ServicesFilterBar />
           <ServicesTable />
-        </Page.Content>
+        </PageContent>
       </Page>
     </Shell>
   ),
@@ -109,7 +111,7 @@ export const Playground: Story = {
 /* ─── 2. Stats in body ───────────────────────────────────────── */
 
 /**
- * The canonical index-page shape: summary stats live in `<Page.Content>` as a
+ * The canonical index-page shape: summary stats live in `<PageContent>` as a
  * `Grid` of `Card preset="summary"` above the `FilterBar` and display — not
  * in the header (brik-bds#404, 2026-06-03 decision).
  *
@@ -119,12 +121,12 @@ export const StatsInBody: Story = {
   render: () => (
     <Shell>
       <Page padding="md" gap="xl">
-        <Page.Header title="Services" subtitle="Edits sync to brikdesigns.com on save." />
-        <Page.Content>
+        <PageHeader title="Services" subtitle="Edits sync to brikdesigns.com on save." />
+        <PageContent>
           <StatRow />
           <ServicesFilterBar />
           <ServicesTable />
-        </Page.Content>
+        </PageContent>
       </Page>
     </Shell>
   ),
@@ -133,7 +135,7 @@ export const StatsInBody: Story = {
 /* ─── 3. Tabs handoff ────────────────────────────────────────── */
 
 /**
- * When `<Page.Header tabs>` is filled, the header's bottom divider is
+ * When `<PageHeader tabs>` is filled, the header's bottom divider is
  * suppressed and the TabBar baseline becomes the handoff to the body.
  *
  * @summary Header with tabs — the TabBar baseline replaces the divider
@@ -142,7 +144,7 @@ export const WithTabs: Story = {
   render: () => (
     <Shell>
       <Page padding="md" gap="xl">
-        <Page.Header
+        <PageHeader
           title="Billing"
           subtitle="Invoices and payment activity across all clients."
           tabs={
@@ -155,10 +157,10 @@ export const WithTabs: Story = {
             />
           }
         />
-        <Page.Content>
+        <PageContent>
           <StatRow />
           <ServicesTable />
-        </Page.Content>
+        </PageContent>
       </Page>
     </Shell>
   ),
@@ -167,7 +169,7 @@ export const WithTabs: Story = {
 /* ─── 4. Full-bleed body ─────────────────────────────────────── */
 
 /**
- * `<Page.Content padding="none">` breaks out of the page column to render a
+ * `<PageContent padding="none">` breaks out of the page column to render a
  * data display edge-to-edge — for full-width boards and tables.
  *
  * @summary Full-bleed body — table runs edge-to-edge
@@ -176,10 +178,10 @@ export const FullBleedBody: Story = {
   render: () => (
     <Shell>
       <Page padding="lg" gap="xl">
-        <Page.Header title="All Tasks" subtitle="Header stays in the padded column; the table goes full-bleed below." />
-        <Page.Content padding="none">
+        <PageHeader title="All Tasks" subtitle="Header stays in the padded column; the table goes full-bleed below." />
+        <PageContent padding="none">
           <ServicesTable rows={6} />
-        </Page.Content>
+        </PageContent>
       </Page>
     </Shell>
   ),
@@ -188,7 +190,7 @@ export const FullBleedBody: Story = {
 /* ─── 5. Fill-height scroll ──────────────────────────────────── */
 
 /**
- * `<Page.Content scroll>` owns the vertical scroll on fill-height pages so the
+ * `<PageContent scroll>` owns the vertical scroll on fill-height pages so the
  * header stays put while the body scrolls internally. Requires the flex-column
  * parent (the Shell here, the app shell in production).
  *
@@ -198,10 +200,10 @@ export const FillHeightScroll: Story = {
   render: () => (
     <Shell height={420}>
       <Page padding="md" gap="xl">
-        <Page.Header title="All Tasks" subtitle="The body scrolls; this header does not." />
-        <Page.Content scroll>
+        <PageHeader title="All Tasks" subtitle="The body scrolls; this header does not." />
+        <PageContent scroll>
           <ServicesTable rows={20} />
-        </Page.Content>
+        </PageContent>
       </Page>
     </Shell>
   ),
@@ -210,8 +212,8 @@ export const FillHeightScroll: Story = {
 /* ─── 6. Headerless ──────────────────────────────────────────── */
 
 /**
- * `<Page.Header>` is optional. A header-less page (e.g. an embedded or
- * outer-shell page) is just `<Page><Page.Content>…</Page.Content></Page>`; the
+ * `<PageHeader>` is optional. A header-less page (e.g. an embedded or
+ * outer-shell page) is just `<Page><PageContent>…</PageContent></Page>`; the
  * `gap` prop becomes a no-op with nothing to gap against.
  *
  * @summary Header is optional — body-only page
@@ -220,10 +222,10 @@ export const Headerless: Story = {
   render: () => (
     <Shell>
       <Page padding="md">
-        <Page.Content>
+        <PageContent>
           <StatRow />
           <ServicesTable />
-        </Page.Content>
+        </PageContent>
       </Page>
     </Shell>
   ),

--- a/components/ui/Page/Page.tsx
+++ b/components/ui/Page/Page.tsx
@@ -1,7 +1,5 @@
 import { type HTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
-import { PageHeader } from '../PageHeader';
-import { PageContent } from './PageContent';
 import './Page.css';
 
 export type PagePadding = 'none' | 'sm' | 'md' | 'lg';
@@ -10,22 +8,57 @@ export type PageGap = 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'huge';
 export interface PageProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Horizontal inset shared by the header + body column — the single source
-   * of truth for page padding. `<Page.Content>` inherits it by default and can
+   * of truth for page padding. `<PageContent>` inherits it by default and can
    * override per-region (e.g. `padding="none"` for a full-bleed board).
    * Default `'md'`.
    */
   padding?: PagePadding;
   /**
-   * Vertical gap between `<Page.Header>` and `<Page.Content>`. Maps 1:1 to BDS
+   * Vertical gap between `<PageHeader>` and `<PageContent>`. Maps 1:1 to BDS
    * `--gap-*` tokens. No-op when there is no header. Default `'xl'` (24px) —
    * the header→body rhythm Brik product surfaces converged on.
    */
   gap?: PageGap;
-  /** `<Page.Header>` and/or `<Page.Content>`. Both are optional. */
+  /** `<PageHeader>` and/or `<PageContent>`. Both are optional. */
   children: ReactNode;
 }
 
-function PageRoot({ padding = 'md', gap = 'xl', className, children, ...props }: PageProps) {
+/**
+ * Page — the page shell container. The connective tissue every product page
+ * shares: a `<PageHeader>` handing off to a `<PageContent>` across a known
+ * vertical gap, inside one shared horizontal column.
+ *
+ * **Composition uses sibling named exports** — `<Page>`, `<PageHeader>`,
+ * `<PageContent>` — not a compound `Page.Header` namespace. A compound static
+ * (`Page.Header`) does not survive Next/Turbopack RSC bundling (the statics are
+ * tree-shaken to `undefined` in the consumer), so the parts are plain named
+ * exports.
+ *
+ * **Precondition:** `<Page>` always sets `flex: 1; min-height: 0` on itself so
+ * fill-height bodies work. That only takes effect inside a flex-column parent
+ * (the app shell). In a non-flex parent `flex: 1` no-ops and the page sizes to
+ * content — degraded, not broken.
+ *
+ * @example
+ * ```tsx
+ * import { Page, PageHeader, PageContent } from '@brikdesigns/bds';
+ *
+ * // Parent must be a flex column (the app shell provides this).
+ * <Page padding="md" gap="xl">
+ *   <PageHeader title="Services" subtitle="…" actions={<Button>Add</Button>} />
+ *   <PageContent>
+ *     <Grid columns="auto-fit" minColumnWidth="180px" gap="md">
+ *       <Card preset="summary" label="Total" value={49} />
+ *     </Grid>
+ *     <FilterBar total={49} filtered={49} label="services" />
+ *     <Table>…</Table>
+ *   </PageContent>
+ * </Page>
+ * ```
+ *
+ * @summary Page shell container — shared inset + header→body rhythm.
+ */
+export function Page({ padding = 'md', gap = 'xl', className, children, ...props }: PageProps) {
   return (
     <div
       className={bdsClass(
@@ -40,44 +73,5 @@ function PageRoot({ padding = 'md', gap = 'xl', className, children, ...props }:
     </div>
   );
 }
-PageRoot.displayName = 'Page';
-
-/**
- * Page — compound page shell. The connective tissue every product page shares:
- * a `<Page.Header>` handing off to a `<Page.Content>` across a known vertical gap,
- * inside one shared horizontal column.
- *
- * Compound members:
- * - `Page.Header` — the existing {@link PageHeader} (title · subtitle · actions
- *   · tabs), re-exported so call-sites migrate by import, not JSX shape.
- * - `Page.Content` — the body region ({@link PageContent}); holds the stat row,
- *   `FilterBar`, and data display.
- *
- * **Precondition:** `<Page>` always sets `flex: 1; min-height: 0` on itself so
- * fill-height bodies work. That only takes effect inside a flex-column parent
- * (the app shell). In a non-flex parent `flex: 1` no-ops and the page sizes to
- * content — degraded, not broken.
- *
- * @example
- * ```tsx
- * // Parent must be a flex column (the app shell provides this).
- * <Page padding="md" gap="xl">
- *   <Page.Header title="Services" subtitle="…" actions={<Button>Add</Button>} />
- *   <Page.Content>
- *     <Grid columns="auto-fit" minColumnWidth="180px" gap="md">
- *       <Card preset="summary" label="Total" value={49} />
- *     </Grid>
- *     <FilterBar total={49} filtered={49} label="services" />
- *     <Table>…</Table>
- *   </Page.Content>
- * </Page>
- * ```
- *
- * @summary Compound page shell — header + body with shared inset + rhythm.
- */
-export const Page = Object.assign(PageRoot, {
-  Header: PageHeader,
-  Content: PageContent,
-});
 
 export default Page;

--- a/components/ui/Page/PageContent.tsx
+++ b/components/ui/Page/PageContent.tsx
@@ -28,28 +28,28 @@ export interface PageContentProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * Page.Content — the body region of a {@link Page}. Owns the horizontal inset,
+ * PageContent — the body region of a {@link Page}. Owns the horizontal inset,
  * the vertical rhythm between stacked sections, and (optionally) its own
- * scroll. Always rendered as `<Page.Content>`, a static member of `<Page>`.
+ * scroll. A sibling of `<PageHeader>` inside `<Page>`.
  *
- * Summary stats live here (not in `<Page.Header>`) as a `Grid` of
+ * Summary stats live here (not in `<PageHeader>`) as a `Grid` of
  * `Card preset="summary"`, above the `FilterBar` and display:
  *
  * @example
  * ```tsx
- * <Page.Content>
+ * <PageContent>
  *   <Grid columns="auto-fit" minColumnWidth="180px" gap="md">
  *     <Card preset="summary" label="Total" value={49} />
  *     <Card preset="summary" label="Public" value={33} />
  *   </Grid>
  *   <FilterBar total={49} filtered={49} label="services" />
  *   <Table>…</Table>
- * </Page.Content>
+ * </PageContent>
  *
  * // Full-bleed board page that owns its own scroll:
- * <Page.Content padding="none" scroll>
+ * <PageContent padding="none" scroll>
  *   <Board>…</Board>
- * </Page.Content>
+ * </PageContent>
  * ```
  *
  * @summary Page body region — inset, section rhythm, optional scroll.

--- a/components/ui/Page/index.ts
+++ b/components/ui/Page/index.ts
@@ -1,3 +1,8 @@
 export { Page, type PageProps, type PagePadding, type PageGap } from './Page';
-export { type PageContentProps, type PageContentPadding, type PageContentGap } from './PageContent';
+export {
+  PageContent,
+  type PageContentProps,
+  type PageContentPadding,
+  type PageContentGap,
+} from './PageContent';
 export { default } from './Page';

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -48,7 +48,7 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
    * Summary content (e.g. stat cards) rendered between metadata and tabs.
    *
    * @deprecated Summary stats belong in the page **body**, not the header
-   * (2026-06-03 decision, brik-bds#404). Render them in `<Page.Content>` as a
+   * (2026-06-03 decision, brik-bds#404). Render them in `<PageContent>` as a
    * `Grid` of `Card preset="summary"` above the `FilterBar` / display.
    * Slated for removal after the standard deprecation window once the portal
    * consumers migrate (brik-client-portal#927).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.85.0",
+      "version": "0.86.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",

--- a/scripts/lint-jsdoc.js
+++ b/scripts/lint-jsdoc.js
@@ -86,6 +86,7 @@ const EXEMPT_COMPONENTS = new Set([
 const MULTI_EXPORT = {
   SheetTypography: ['SheetSectionTitle', 'SheetFieldLabel', 'SheetFieldValue', 'SheetHelperText'],
   DataView: ['TableView', 'ListView', 'ProfileView'],
+  Page: ['Page', 'PageContent'],
 };
 
 // Build the (file, exportName) scan tasks.


### PR DESCRIPTION
## Summary
- fix(Page): sibling named exports — compound Page.Header/.Content broke in RSC

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)