### PR TITLE
refactor(PageHeader): remove deprecated stats slot (v0.87.0)

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -6,7 +6,7 @@
      Consumers can tune these via cascade (theme file, globals.css, or
      a per-instance style prop) to dial in the right rhythm without
      forking the component. Defaults preserve the lean 0.57.0 shape. */
-  --page-header-section-gap: var(--gap-xl);     /* between root sections (inner/metadata/stats/tabs) */
+  --page-header-section-gap: var(--gap-xl);     /* between root sections (inner/metadata/tabs) */
   --page-header-content-gap: var(--gap-sm);     /* between title-row and subtitle */
   --page-header-actions-gap: var(--gap-sm);     /* between content column and actions column */
   --page-header-padding-bottom: var(--padding-md); /* breathing room before the bottom divider */
@@ -144,12 +144,6 @@
   font-weight: var(--font-weight-regular);
   line-height: var(--font-line-height-normal);
   color: var(--text-primary);
-}
-
-/* ─── Stats ──────────────────────────────────────────────────── */
-
-.bds-page-header__stats {
-  width: 100%;
 }
 
 /* ─── Tabs ─────────────────────────────────────────────────────

--- a/components/ui/PageHeader/PageHeader.mdx
+++ b/components/ui/PageHeader/PageHeader.mdx
@@ -22,8 +22,7 @@ All slot combinations: title only, subtitle, breadcrumbs, actions, tabs, metadat
 - **`breadcrumbs`** — `Breadcrumb` navigation trail above title
 - **`actions`** — `Button` action buttons aligned right
 - **`metadata`** — built-in key-value grid with border-top
-- **`stats`** — summary content (e.g. `CardSummary` grid) rendered between metadata and tabs
-- **`tabs`** — `TabBar` tab navigation below stats
+- **`tabs`** — `TabBar` tab navigation below the title block
 
 <Canvas of={Stories.Variants} />
 

--- a/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/components/ui/PageHeader/PageHeader.stories.tsx
@@ -5,7 +5,6 @@ import { Breadcrumb } from '../Breadcrumb';
 import { TabBar, type TabItem } from '../TabBar';
 import { Button } from '../Button';
 import { ServiceTag } from '../ServiceTag';
-import { CardSummary } from '../Card';
 
 /* ─── Layout Helpers (story-only) ─────────────────────────────── */
 
@@ -156,32 +155,6 @@ export const Variants: Story = {
               { label: 'Billing', value: 'One-time' },
               { label: 'Stripe Product', value: 'brand-design' },
             ]}
-          />
-        </div>
-
-        <div>
-          <SectionLabel>With stats (summary cards above tabs)</SectionLabel>
-          <PageHeader
-            title="Acme Corp"
-            breadcrumbs={<Breadcrumb items={[
-              { label: 'Admin', href: '#' },
-              { label: 'Companies', href: '#' },
-              { label: 'Acme Corp' },
-            ]} />}
-            metadata={[
-              { label: 'Status', value: 'Active' },
-              { label: 'Type', value: 'Client' },
-              { label: 'Start Date', value: 'Jan 1, 2024' },
-            ]}
-            stats={
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--gap-lg)' }}>
-                <CardSummary label="Services" value={4} />
-                <CardSummary label="Projects" value={2} />
-                <CardSummary label="Open Invoices" value={1} />
-                <CardSummary label="Contacts" value={5} />
-              </div>
-            }
-            tabs={<TabBar variant="tab" items={filterTabs} />}
           />
         </div>
 

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -44,16 +44,6 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
   tabs?: ReactNode;
   /** Key/value pairs rendered below the title row (e.g. Owner, Status, Updated). */
   metadata?: MetadataItem[];
-  /**
-   * Summary content (e.g. stat cards) rendered between metadata and tabs.
-   *
-   * @deprecated Summary stats belong in the page **body**, not the header
-   * (2026-06-03 decision, brik-bds#404). Render them in `<PageContent>` as a
-   * `Grid` of `Card preset="summary"` above the `FilterBar` / display.
-   * Slated for removal after the standard deprecation window once the portal
-   * consumers migrate (brik-client-portal#927).
-   */
-  stats?: ReactNode;
   /** Title scale. Default: 'lg' */
   size?: 'sm' | 'md' | 'lg';
   /**
@@ -80,7 +70,7 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * PageHeader — composable page-level header with breadcrumbs, badge, actions, metadata, stats, and tabs.
+ * PageHeader — composable page-level header with breadcrumbs, badge, actions, metadata, and tabs.
  *
  * ## Tunable spacing
  *
@@ -90,7 +80,7 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
  * the lean 0.57.0 shape:
  *
  * - `--page-header-section-gap` (default `var(--gap-xl)` = 24px) — between
- *   root sections (inner / metadata / stats / tabs).
+ *   root sections (inner / metadata / tabs).
  * - `--page-header-content-gap` (default `var(--gap-sm)` = 6px) — between
  *   the title-row and the subtitle.
  * - `--page-header-actions-gap` (default `var(--gap-sm)` = 6px) — between
@@ -109,7 +99,6 @@ export function PageHeader({
   actions,
   tabs,
   metadata,
-  stats,
   size = 'lg',
   mode,
   onEdit,
@@ -192,8 +181,6 @@ export function PageHeader({
           </div>
         </div>
       )}
-
-      {stats && <div className="bds-page-header__stats">{stats}</div>}
 
       {tabs && <div className="bds-page-header__tabs">{tabs}</div>}
     </div>

--- a/docs-site/content/docs/components/index.mdx
+++ b/docs-site/content/docs/components/index.mdx
@@ -190,7 +190,7 @@ Identity primitives, icon reference, page-level chrome, list and console utiliti
   <Card title="Avatar" href="/docs/components/avatar" description="User profile image with initials fallback. Four sizes, four presence states." />
   <Card title="Icons" href="/docs/components/icons" description="Iconify + Phosphor icon reference. Inline SVGs, no CDN, six weights per icon." />
   <Card title="Footer" href="/docs/components/footer" description="Site-wide footer with logo, columns, social links, copyright. Default + brand variants." />
-  <Card title="Page header" href="/docs/components/page-header" description="Composable page-level header. Title + breadcrumbs + actions + tabs + metadata + stats." />
+  <Card title="Page header" href="/docs/components/page-header" description="Composable page-level header. Title + breadcrumbs + actions + tabs + metadata." />
   <Card title="Bullet list" href="/docs/components/bullet-list" description="Structured short-item list. disc / decimal / none markers, two density modes." />
   <Card title="Task console" href="/docs/components/task-console" description="Floating progress console for long-running batch operations. Per-item state, auto-dismiss." />
 </Cards>

--- a/docs-site/content/docs/components/page-header.mdx
+++ b/docs-site/content/docs/components/page-header.mdx
@@ -1,6 +1,6 @@
 ---
 title: Page header
-description: Composable page-level header. Title + subtitle + breadcrumbs + actions + tabs + metadata + stats.
+description: Composable page-level header. Title + subtitle + breadcrumbs + actions + tabs + metadata.
 ---
 
 PageHeader is the standard page-top header — composes [Breadcrumb](/docs/components/breadcrumb), [Button](/docs/components/button), [TabBar](/docs/components/tab-bar), and a metadata grid into one component. Inherits background from parent context (no surface of its own), so it works on pages with any background.
@@ -9,7 +9,7 @@ PageHeader is the standard page-top header — composes [Breadcrumb](/docs/compo
 
 - Detail page headers (company / project / record pages)
 - Section headers that need breadcrumbs + page title + primary action
-- Dashboards with metadata + stat tiles + tab navigation
+- Dashboards with metadata + tab navigation
 - Any page where the top region groups identity + navigation + primary CTA
 
 For Sheet headers (inside a `<Sheet>`), the [Sheet](/docs/components/sheet) component composes its own — don't reach for PageHeader inside a Sheet body.
@@ -29,8 +29,7 @@ PageHeader has six optional regions plus a required title. From top to bottom:
 3. **`subtitle`** — supporting paragraph under the title
 4. **`actions`** — right-aligned action buttons (typically a [Button](/docs/components/button) or [ButtonGroup](/docs/components/button-group))
 5. **`metadata`** — built-in key/value grid (Owner, Status, Updated)
-6. **`stats`** — summary content (e.g. stat-tile [Card preset="summary"](/docs/components/card#summary-preset) grid)
-7. **`tabs`** — [TabBar](/docs/components/tab-bar) for in-page section nav
+6. **`tabs`** — [TabBar](/docs/components/tab-bar) for in-page section nav
 
 ## Variants
 
@@ -89,23 +88,6 @@ PageHeader has six optional regions plus a required title. From top to bottom:
     { label: 'Status', value: <Badge status="positive">Active</Badge> },
     { label: 'Updated', value: '2 days ago' },
   ]}
-/>
-```
-
-### With stats
-
-`stats` renders summary content between metadata and tabs — typically a row of stat tiles.
-
-```tsx
-<PageHeader
-  title="Q1 Performance"
-  stats={
-    <CardList orientation="horizontal" gap="md">
-      <Card preset="summary" label="Revenue" value={48250.75} type="price" />
-      <Card preset="summary" label="New clients" value={12} />
-      <Card preset="summary" label="Projects" value={34} />
-    </CardList>
-  }
 />
 ```
 
@@ -201,7 +183,6 @@ The canonical layout — breadcrumb + service badge + title + actions + metadata
 | `actions` | `ReactNode` | — |
 | `tabs` | `ReactNode` | — |
 | `metadata` | `MetadataItem[]` | — |
-| `stats` | `ReactNode` | — |
 | `showDivider` | `boolean` | `true` |
 | `flush` | `boolean` | `false` |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'lg'` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.86.0",
+  "version": "0.87.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary

Removes the `PageHeader.stats` slot, deprecated 2026-06-03 (#404). Summary stats belong in the page **body** — a `Card preset="summary"` grid inside `<PageContent>`, above the display — not the header.

The portal was the only consumer, and its migration is complete: brik-client-portal **#944** moved all dashboard pages onto Page primitives and **#945** added a lint guard. This PR retires the now-unused slot.

## Zero-consumer audit

Swept all three BDS consumers + BDS itself for any `PageHeader` `stats` prop usage:

| Repo | `stats` prop consumers |
|---|---|
| brik-client-portal | none (the `{stats}` in `admin/contacts`/`admin/services` are local vars rendered in `<PageContent>` — the correct body pattern) |
| renew-pms | none (no PageHeader references) |
| brikdesigns | none (no PageHeader references) |
| brik-bds | only the slot's own impl, CSS, and demo story — all removed here |

## Changes

- `PageHeader.tsx` — remove the `stats` prop (+ deprecation JSDoc), the destructure, the render branch, and two component-JSDoc mentions.
- `PageHeader.css` — remove the `.bds-page-header__stats` rule + its section comment.
- `PageHeader.stories.tsx` — remove the "With stats" story and the now-orphaned `CardSummary` import.
- `PageHeader.mdx`, docs-site `page-header.mdx` + components `index.mdx` — drop `stats` from prop lists, the "With stats" example, the props table, and descriptions.
- `package.json` — `0.86.0 → 0.87.0` (minor; deprecated-prop removal, pre-1.0 convention).

## Verification

typecheck · token lint · JSDoc lint · ADR-007 recipe lint — all clean. `npm run build-storybook` builds all 86 component story sets green (confirms the removed story + import broke nothing).

Story-check skipped (`SKIP_STORY_CHECK=1`, justified): the only visual deletion is the deprecated demo story itself; every **retained** PageHeader variant renders via untouched code paths, and the full Storybook build is green.

## Post-merge (release)

1. Merge to `main`.
2. `git tag v0.87.0 && git push origin v0.87.0` → `release.yml` publishes `@brikdesigns/bds@0.87.0` to GitHub Packages.
3. Bump the portal's `@brikdesigns/bds` pointer to `0.87.0` (+ renew-pms/brikdesigns at their convenience — no behavior change for them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)