### PR TITLE
fix(ServiceTag): render service glyphs as CSS-colorable mask-image (#574)

### DIFF
--- a/components/ui/ServiceTag/ServiceTag.css
+++ b/components/ui/ServiceTag/ServiceTag.css
@@ -52,10 +52,20 @@
 
 /* ─── Icon ───────────────────────────────────────────────────── */
 
+/* Per-service glyph rendered via mask so the fill is CSS-recolorable (#574).
+   The glyph SVG is the mask; `currentColor` paints it the tag's service text
+   token, so the icon always matches the label and retones per theme. The glyph
+   URL + box size are set inline (runtime values) on the element. */
 .bds-service-tag__icon {
-  object-fit: contain;
   display: block;
   flex-shrink: 0;
+  background-color: currentColor;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: contain;
 }
 
 /* ─── Icon-only variant (square badge) ───────────────────────── */

--- a/components/ui/ServiceTag/ServiceTag.mdx
+++ b/components/ui/ServiceTag/ServiceTag.mdx
@@ -75,3 +75,7 @@ The `serviceName` prop resolves to an SVG icon via two mechanisms:
 - **Normalization** — service names are lowercased and hyphenated, then prefixed by category (e.g., "Brand Guidelines" resolves to `brand-guidelines.svg`)
 
 Icons are stored in `components/ui/ServiceTag/icons/[category]/` and served from `.storybook/public/icons/` in Storybook.
+
+### Coloring
+
+The glyph renders as a CSS `mask-image` painted with `currentColor`, so it inherits the tag's service text token (`--text-service-{name}`) and retones correctly in both `brik-light` and `brik-dark` — the icon always matches the label. To recolor an icon in a custom context, set `color` on the parent and the glyph follows. ([#574](https://github.com/brikdesigns/brik-bds/issues/574))

--- a/components/ui/ServiceTag/ServiceTag.tsx
+++ b/components/ui/ServiceTag/ServiceTag.tsx
@@ -97,14 +97,7 @@ export function ServiceTag({
         {...props}
       >
         {showIcon && (
-          <img
-            src={iconSrc}
-            alt=""
-            width={iconSize}
-            height={iconSize}
-            className="bds-service-tag__icon"
-            onError={() => setImageError(true)}
-          />
+          <ServiceTagIcon src={iconSrc} size={iconSize} onError={() => setImageError(true)} />
         )}
       </span>
     );
@@ -126,17 +119,39 @@ export function ServiceTag({
       {...props}
     >
       {showIcon && (
-        <img
+        <ServiceTagIcon
           src={getServiceIconPath(category, serviceName!)}
-          alt=""
-          width={iconSize}
-          height={iconSize}
-          className="bds-service-tag__icon"
+          size={iconSize}
           onError={() => setImageError(true)}
         />
       )}
       {displayLabel}
     </span>
+  );
+}
+
+/**
+ * ServiceTagIcon — the per-service glyph, rendered as a CSS `mask-image` so the
+ * fill is recolorable (the masked element takes `currentColor` from the tag's
+ * service text token). The custom service SVGs are "System 2" — loaded by URL
+ * from the consuming app's `/public/icons`, not Phosphor — so they keep the
+ * url() asset model; only the recolor mechanism changes (#574).
+ *
+ * A `<mask-image>` can't surface a load error, so a visually-hidden `<img>`
+ * probe preserves the prior graceful "hide on missing asset" fallback.
+ */
+function ServiceTagIcon({ src, size, onError }: { src: string; size: number; onError: () => void }) {
+  return (
+    <>
+      <span
+        aria-hidden
+        className="bds-service-tag__icon"
+        // Runtime values: dynamic glyph URL + Figma-driven px box. Static mask
+        // sizing/positioning + the currentColor fill live in ServiceTag.css.
+        style={{ width: size, height: size, maskImage: `url("${src}")`, WebkitMaskImage: `url("${src}")` }}
+      />
+      <img src={src} alt="" hidden onError={onError} />
+    </>
   );
 }
 


### PR DESCRIPTION
## Problem
ServiceTag's per-service glyphs were loaded as `<img src="/icons/{cat}/{name}.svg">` with fills baked into the SVG — CSS couldn't recolor them. In dark mode they read faded against the service surface (surfaced in the 2026-05-12 #563 Storybook review).

## Approach — CSS `mask-image` + `currentColor` (option b)
The glyph SVG becomes a `mask-image`; the element is painted with `background-color: currentColor`, so the icon inherits the tag's service **text** token (`--text-service-{name}`) and always matches the label, retoning with the theme.

**Why mask, not inline SVG (option a):** the custom service glyphs are "System 2" — consumer-owned, loaded by URL from each app's `/public/icons` (BDS only keeps Storybook copies). Inlining would force BDS to bundle/fetch 45+ consumer assets. Mask keeps the exact `url()` model and adds zero bundle; the glyphs are single-color, so a mask is sufficient.

A masked element can't surface a load error, so a visually-hidden `<img>` probe preserves the prior graceful "hide on missing asset" fallback.

## Acceptance
- [x] Rendering refactored to CSS-colorable (mask-image), `<img>` → masked span
- [x] Icon fill via `--text-service-{name}` family (`currentColor` inherits the tag's service text token)
- [x] Verified fill is CSS-settable + correct contrast in **brik-light** and **brik-dark**
- [x] Storybook `text` / `icon-text` / `icon` variants render correctly in both themes (all categories + sizes)
- [x] Coloring rule documented (`ServiceTag.mdx › Icon resolution › Coloring`)
- [x] icons.mdx `Related` → ServiceTag — **already correct** (resolved with #572)

## Verification
- typecheck ✓ · lint-tokens 0 errors ✓ · canonical-class-check **0 violations** (reuses `bds-service-tag__icon`, no new slot) ✓ · ServiceTag tests **5/5** ✓ · build:lib ✓ · MDX recipe 86/0 ✓
- Visual: both themes, all variants — glyph matches label color, no more dark-mode fade

## Notes
- Unblocks **brikdesigns#358** (service-tag icon rendering + md sizing).
- **Before merge:** sync consumers (portal, renew-pms, brikdesigns) via `bds-sync.sh` per repo convention.
- No `--text-service-*` token changes — relies on the reconciled tokens shipped in v0.89.0 (#563).

🤖 Generated with [Claude Code](https://claude.com/claude-code)