### PR TITLE
chore(release): 0.90.1 — ServiceTag CSS-colorable glyphs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.86.0",
+  "version": "0.90.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.86.0",
+      "version": "0.90.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.90.0",
+  "version": "0.90.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Patch release bump for the ServiceTag mask-image fix (#574, merged in #829) so consumers can pull it.

- `0.90.0 → 0.90.1` (patch — internal rendering fix, no API change)
- Sole change on `main` since v0.90.0 is #829.

After merge: tag `v0.90.1` on `main` to trigger the Release workflow (publish to GitHub Packages), then bump consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)