### PR TITLE
docs(tokens): document the 9 intentional cross-family aliases (#777)

### DIFF
--- a/components/ui/ActivityTimeline/ActivityTimeline.css
+++ b/components/ui/ActivityTimeline/ActivityTimeline.css
@@ -66,7 +66,7 @@
   width: 2px; /* bds-lint-ignore — hairline connector */
   flex: 1;
   min-height: 20px; /* bds-lint-ignore — minimum connector height */
-  background-color: var(--border-muted); /* bds-lint-ignore token-family — hairline connector rendered as 1px background; see #777 */
+  background-color: var(--border-muted); /* bds-lint-ignore token-family — intentional alias: hairline connector (border semantics, fill mechanics); see docs/TOKEN-PR-CHECKLIST.md */
 }
 
 /* ─── Content ────────────────────────────────────────────────── */

--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -30,12 +30,12 @@
 }
 
 .bds-board::-webkit-scrollbar-thumb {
-  background-color: var(--border-muted); /* bds-lint-ignore token-family — scrollbar thumb shares border hue; see #777 */
+  background-color: var(--border-muted); /* bds-lint-ignore token-family — intentional alias: scrollbar thumb (thin UI, border hue by intent); see docs/TOKEN-PR-CHECKLIST.md */
   border-radius: var(--border-radius-pill);
 }
 
 .bds-board:hover::-webkit-scrollbar-thumb {
-  background-color: var(--border-secondary); /* bds-lint-ignore token-family — scrollbar thumb shares border hue; see #777 */
+  background-color: var(--border-secondary); /* bds-lint-ignore token-family — intentional alias: scrollbar thumb hover (thin UI, border hue by intent); see docs/TOKEN-PR-CHECKLIST.md */
 }
 
 /* ─── Board column ────────────────────────────────────── */

--- a/components/ui/ProgressStepper/ProgressStepper.css
+++ b/components/ui/ProgressStepper/ProgressStepper.css
@@ -154,7 +154,7 @@
 }
 
 .bds-progress-stepper__connector--incomplete {
-  background-color: var(--border-secondary); /* bds-lint-ignore token-family — connector line styled as 2px background; see #777 */
+  background-color: var(--border-secondary); /* bds-lint-ignore token-family — intentional alias: 2px connector line (border semantics, fill mechanics); see docs/TOKEN-PR-CHECKLIST.md */
 }
 
 /* ─── Dots variant ───────────────────────────────────────────── */
@@ -178,7 +178,7 @@
 }
 
 .bds-progress-stepper__dot--inactive {
-  background-color: var(--border-secondary); /* bds-lint-ignore token-family — inactive dot shares border-secondary hue; see #777 */
+  background-color: var(--border-secondary); /* bds-lint-ignore token-family — intentional alias: inactive dot (thin UI, border hue by intent); see docs/TOKEN-PR-CHECKLIST.md */
   opacity: 1;
 }
 

--- a/components/ui/Slider/Slider.css
+++ b/components/ui/Slider/Slider.css
@@ -40,7 +40,7 @@
 .bds-slider-input::-moz-range-track {
   height: var(--bds-slider-track-height, 6px);
   border-radius: 999px;
-  background: var(--border-secondary); /* bds-lint-ignore token-family — slider track styled with border-family hue; see #777 */
+  background: var(--border-secondary); /* bds-lint-ignore token-family — intentional alias: track rail (thin neutral line, border hue by intent); see docs/TOKEN-PR-CHECKLIST.md */
   border: none;
 }
 
@@ -90,12 +90,12 @@
 }
 
 .bds-slider-input:disabled::-webkit-slider-thumb {
-  background: var(--border-secondary); /* bds-lint-ignore token-family — disabled thumb shares border hue; see #777 */
+  background: var(--border-secondary); /* bds-lint-ignore token-family — intentional alias: disabled thumb flattened to border neutral; see docs/TOKEN-PR-CHECKLIST.md */
   border-color: var(--border-secondary);
 }
 
 .bds-slider-input:disabled::-moz-range-thumb {
-  background: var(--border-secondary); /* bds-lint-ignore token-family — disabled thumb shares border hue; see #777 */
+  background: var(--border-secondary); /* bds-lint-ignore token-family — intentional alias: disabled thumb flattened to border neutral; see docs/TOKEN-PR-CHECKLIST.md */
   border-color: var(--border-secondary);
 }
 }

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -205,7 +205,7 @@
 .bds-task-console .bds-task-console__icon--in-progress {
   width: var(--icon-lg);
   height: var(--icon-lg);
-  border-color: var(--surface-muted); /* bds-lint-ignore token-family — spinner track uses surface-muted hue; see #777 */
+  border-color: var(--surface-muted); /* bds-lint-ignore token-family — intentional alias: spinner track needs surface-tracking lightness (no border token stays subtle in both light brand-theme + dark mode); see docs/TOKEN-PR-CHECKLIST.md */
   border-top-color: var(--border-brand-primary);
 }
 

--- a/docs/TOKEN-PR-CHECKLIST.md
+++ b/docs/TOKEN-PR-CHECKLIST.md
@@ -67,6 +67,27 @@ color: var(--background-warning);
 border-color: var(--text-negative);
 ```
 
+### Registry of intentional cross-family aliases
+
+The aliases below are reviewed, design-approved exceptions — each is a `bds-lint-ignore token-family` site whose cross-family use is the correct call, not a deferred swap. Adding to this list requires the same justification bar as the escape hatch above. Tracked under [#777](https://github.com/brikdesigns/brik-bds/issues/777).
+
+**`--border-*` rendered as `background` — thin lines / hairline UI (border semantics, fill mechanics).**
+A 1–2px line or a thin neutral UI element has no content box to hang a `border` on, so it is painted as a `background` fill. The hue is the border-family neutral by intent — these *are* borders, mechanically expressed as fills.
+
+| Site | Token | Element |
+|---|---|---|
+| `ActivityTimeline.css` | `--border-muted` | hairline connector (2px) |
+| `Board.css` | `--border-muted`, `--border-secondary` | scrollbar thumb |
+| `ProgressStepper.css` | `--border-secondary` | connector line (2px) + inactive dot |
+| `Slider.css` | `--border-secondary` | track rail + disabled thumb |
+
+**`--surface-muted` rendered as `border-color` — `TaskConsole` in-progress spinner track.**
+The spinner ring's 3/4 track must stay *subtle on whatever surface it sits on* across themes. No border-family token does this: `--border-primary` resolves to `grayscale-darkest` (#1b1b1b) under `.theme-brand-brik` and reads dark on white; `--border-muted` is mid-grey (#828282) in `:root`. `--surface-muted` is the only token that tracks surface lightness per theme (#f2f2f2 light / #1b1b1b dark), keeping the track subtle in both modes while the leading quadrant carries `--border-brand-primary`. This is a surface-tracking fill in a border slot by design, not a hue mismatch.
+
+| Site | Token | Element |
+|---|---|---|
+| `TaskConsole.css` | `--surface-muted` | spinner track (`border-color`, 3/4 ring) |
+
 ---
 
 ## Author checklist


### PR DESCRIPTION
## What

Dispositions the 9 remaining `bds-lint-ignore token-family` sites (the ones #578 left for a design call) as **design-approved intentional cross-family aliases** — not deferred swaps.

Two patterns:

- **`--border-*` rendered as `background`** — thin lines / hairline UI: ActivityTimeline connector, Board scrollbar thumb, ProgressStepper connector + inactive dot, Slider track + disabled thumb. Border semantics, fill mechanics.
- **`--surface-muted` as `border-color`** — TaskConsole in-progress spinner track. On inspection this is *not* a clean swap: no border-family token stays subtle in both the light brand theme (`--border-primary` → `#1b1b1b`) and dark mode, so `--surface-muted` (surface-tracking) is the deliberate correct choice.

## Changes

- New **Registry of intentional cross-family aliases** section in `docs/TOKEN-PR-CHECKLIST.md`, grouped by pattern with rationale.
- All 9 inline annotations upgraded from `; see #777` → `intentional alias: <reason>; see docs/TOKEN-PR-CHECKLIST.md`.

## Acceptance (both met)

- [x] Each of the 9 violations has a design-approved disposition (intentional alias) documented in `docs/TOKEN-PR-CHECKLIST.md`.
- [x] No `bds-lint-ignore` for token-family remains without an inline justification comment.

## Verification

- `lint-tokens.js` → **0 errors**
- `pr-checklist.sh` → all automated checks pass
- Commit hooks (token lint, JSDoc, typecheck, anti-slop) → pass

Comment + doc only — **no token values, CSS behavior, or rendered output change** (Storybook check skipped as non-visual diff).

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)