### PR TITLE
feat(Card): add borderless variant for cards on colored surfaces

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -30,6 +30,15 @@
   box-shadow: var(--box-shadow-md);
 }
 
+/* Borderless — transparent, no border, no shadow. For cards on a colored
+ * surface (service-tier / brand-image background) where the outlined ring
+ * reads as visual noise; the card inherits the parent surface. */
+.bds-card--borderless {
+  background-color: transparent;
+  border: none;
+  box-shadow: var(--box-shadow-none);
+}
+
 /* ─── Padding ────────────────────────────────────────────────── */
 
 .bds-card--padding-none { padding: var(--padding-none); }

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -20,6 +20,14 @@ Flexible content container. A single primitive serves four shapes via the `prese
 
 The `preset` prop selects the shape. Default (no `preset`) gives a flexible `children` slot composable with `CardTitle`, `CardDescription`, and `CardFooter`. Each preset locks the layout in exchange for a typed API.
 
+The default shape also takes a `variant`: `outlined` (default, secondary border), `brand` (primary-color border), `elevated` (drop shadow, no border), and `borderless`.
+
+### Borderless variant
+
+`variant="borderless"` — transparent fill, no border, no shadow. Use for cards placed on a colored surface (service-tier or brand-image background) where the `outlined` border ring reads as visual noise. The card inherits the parent surface rather than forcing its own.
+
+<Canvas of={Stories.Borderless} />
+
 ### Control preset
 
 `preset="control"` — settings/control row. Leading badge + (title + description) on the left, action on the right. Use `actionAlign="top"` for long descriptions where the action should anchor to the upper-right corner.

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -12,9 +12,9 @@ const meta: Meta<typeof Card> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['outlined', 'brand', 'elevated'],
+      options: ['outlined', 'brand', 'elevated', 'borderless'],
       description:
-        'Visual variant (Default shape only). `outlined` = secondary border; `brand` = primary-color border; `elevated` = drop shadow.',
+        'Visual variant (Default shape only). `outlined` = secondary border; `brand` = primary-color border; `elevated` = drop shadow; `borderless` = transparent, no border, no shadow (for cards on a colored surface).',
     },
     padding: {
       control: 'select',
@@ -67,6 +67,48 @@ export const Default: Story = {
   decorators: [
     (Story) => (
       <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * `variant="borderless"` — transparent fill, no border, no shadow. For cards
+ * placed on a colored surface (service-tier / brand-image background) where
+ * the `outlined` ring reads as visual noise. The card inherits the parent
+ * surface; shown here on a brand-primary background.
+ *
+ * @summary variant="borderless" — for cards on a colored surface
+ */
+export const Borderless: Story = {
+  args: {
+    variant: 'borderless',
+    padding: 'md',
+    children: (
+      <>
+        <CardTitle>Card title</CardTitle>
+        <CardDescription>
+          Sits directly on the colored surface — no border ring, no shadow.
+        </CardDescription>
+        <CardFooter>
+          <Button variant="on-color" size="sm">
+            Action
+          </Button>
+        </CardFooter>
+      </>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: 320,
+          padding: 'var(--padding-xl)',
+          backgroundColor: 'var(--background-brand-primary)',
+          borderRadius: 'var(--border-radius-md)',
+        }}
+      >
         <Story />
       </div>
     ),

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -2,7 +2,7 @@ import { type HTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
 import './Card.css';
 
-export type CardVariant = 'outlined' | 'brand' | 'elevated';
+export type CardVariant = 'outlined' | 'brand' | 'elevated' | 'borderless';
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
 export type CardPreset = 'control' | 'summary' | 'display' | 'display-row';
 export type CardControlActionAlign = 'center' | 'top';
@@ -30,7 +30,7 @@ interface CardBaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
 interface CardDefaultProps extends CardBaseProps {
   /** No preset — default flexible Card with `children` content slot. */
   preset?: undefined;
-  /** Visual variant — outlined / brand / elevated (default `outlined`). */
+  /** Visual variant — outlined / brand / elevated / borderless (default `outlined`). Use `borderless` for cards sitting on a colored surface, where the border ring reads as visual noise. */
   variant?: CardVariant;
   /** Padding scale (default `md`). */
   padding?: CardPadding;
@@ -215,7 +215,9 @@ function formatSummaryValue(value: string | number, type: CardSummaryType): stri
  *
  * - **Default** (no `preset`) — flexible content slot. Compose with
  *   `<CardTitle>`, `<CardDescription>`, `<CardFooter>` subcomponents.
- *   Visual variants: `outlined` (default) / `brand` / `elevated`.
+ *   Visual variants: `outlined` (default) / `brand` / `elevated` / `borderless`.
+ *   Use `borderless` (transparent, no border, no shadow) for cards placed on
+ *   a colored surface where the border ring would read as visual noise.
  * - **`preset="control"`** — settings/control card with locked-down
  *   badge + title + description + action layout. Replaces the legacy
  *   `CardControl` component.

--- a/manifest/component-axes.json
+++ b/manifest/component-axes.json
@@ -100,7 +100,8 @@
     "variant": [
       "outlined",
       "brand",
-      "elevated"
+      "elevated",
+      "borderless"
     ]
   },
   "CardTestimonial": {


### PR DESCRIPTION
## What

Adds `variant="borderless"` to `Card`: transparent background, no border, no shadow.

## Why

`Card` shipped `outlined` / `brand` / `elevated`. All three force a `--surface-primary` (white) fill, and only `elevated` drops the border — but it adds a shadow. So a card placed on a **colored surface** (service-tier or brand-image background) always renders an outlined ring that reads as visual noise, with no way to opt out.

`borderless` lets the card inherit the parent's colored surface cleanly. This is the BDS prerequisite for **brikdesigns#360** (borderless Card on colored surfaces) — that consumer issue adopts this variant once it ships in a release.

## Changes

- `CardVariant` union + prop/JSDoc (`Card.tsx`)
- `.bds-card--borderless` — `transparent` / `none` / `box-shadow-none` (`Card.css`)
- `Borderless` story on a `--background-brand-primary` surface + argTypes option (`Card.stories.tsx`)
- Variants doc + `### Borderless variant` subsection (`Card.mdx`)
- Regenerated `manifest/component-axes.json` (`Card.variant`)

## Verification

- typecheck · token lint (0 errors) · full `validate` (incl. Storybook build) · MDX recipe lint (86/86) · pre-push axes/grid/theme/blueprint/BCS checks — all green
- **Visual:** verify the `Containers/card → Borderless` story on the Netlify Storybook deploy-preview (local Chromatic needs op auth unavailable in the authoring shell); post-merge Chromatic (`chromatic.yml` on push to `main`) captures the snapshot.

## Consumer note

Additive, non-breaking — existing `Card` usage is unaffected (default stays `outlined`). brikdesigns#360 picks this up on the next BDS bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)