### PR TITLE
chore(release): 0.91.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.90.1",
+  "version": "0.91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.90.1",
+      "version": "0.91.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.90.1",
+  "version": "0.91.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Minor release bump `0.90.1 → 0.91.0`.

## Included since v0.90.1
- **#832** — `feat(Card)`: `variant="borderless"` (transparent, no border, no shadow) for cards on colored surfaces. Unblocks **brikdesigns#360**.
- **#831** — `docs(tokens)`: documented the 9 intentional cross-family aliases (#777). Comment/doc only.

## Semver
**minor** — new prop on an existing component, no breaking changes. Existing `Card` usage is unaffected (default stays `outlined`).

## Release steps after merge
1. Tag `v0.91.0` from the merged main tip → triggers the `Release` workflow (validates version↔tag, lints, `npm publish` to GitHub Packages).
2. Bump consumers (`brikdesigns` first, for #360).

🤖 Generated with [Claude Code](https://claude.com/claude-code)