### PR TITLE
fix(blueprints): service hero pale surface + on-light text clears AAA (#838)

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -39,6 +39,7 @@
  *   --bp-hero-img-card-padding-y   (default: clamp block)
  *   --bp-hero-img-card-headline-color (default: var(--text-primary))
  *   --bp-hero-img-card-eyebrow-color  (default: var(--text-primary))
+ *   --bp-hero-img-card-lead-color     (default: var(--text-primary))
  *   --bp-hero-img-card-card-bg     (default: var(--surface-primary))
  *   --bp-hero-img-card-radius      (default: var(--border-radius-lg))
  *
@@ -204,12 +205,19 @@ const cta = section.cta;
    * Background uses the `surface` family (not `background`) because the hero
    * is a broad page-level container, not a small bounded component — per the
    * service-token decision tree (`-surface-` for sections/heroes/cards;
-   * `-background-` for badges/tags/pills/buttons). This keeps the hero band
-   * the same shade as section-level surfaces below it on the same page.
+   * `-background-` for badges/tags/pills/buttons).
    *
-   * `--background-inverse` stays on the `background` family: it's the
-   * mode-aware companion fill consumed by the inverse `<Button>` variant
-   * inside the hero, which IS a small bounded component.
+   * AAA pale pairing (brik-bds#838, locked in #836): the hero band uses the
+   * mode-INVARIANT pale `-light` tone (= each hue's `-lightest` step) paired
+   * with mode-invariant `-on-light` (= `-darkest`) foreground text. This clears
+   * AAA (≥7:1) for same-hue body text in BOTH light and dark themes — the band
+   * stays a pale tinted panel in dark mode instead of flipping deep. Every band
+   * foreground token therefore uses an `-on-light` variant so it does not flip
+   * light in dark mode and break contrast against the pale band:
+   *   - headline / eyebrow / lead → `--text-service-{hue}-on-light`
+   *   - breadcrumb (`--text-brand-primary`) → `--text-service-{hue}-on-light`
+   *   - inverse `<Button>` fill (`--background-inverse`) →
+   *     `--background-service-{hue}-on-light` (dark fill + white label, both modes)
    *
    * Note: the `data-audience='service'` attribute value still reads "service"
    * for component-API compat; the underlying tokens were renamed
@@ -217,38 +225,48 @@ const cta = section.cta;
    * office). API-level rename `data-audience` → `data-service-line` is a
    * separate cross-repo follow-up. */
   .bp-hero-img-card[data-audience='brand'] {
-    background: var(--surface-service-brand);
-    --bp-hero-img-card-headline-color: var(--text-service-brand);
-    --text-brand-primary: var(--text-service-brand);
-    --background-inverse: var(--background-service-brand-inverse);
+    background: var(--surface-service-brand-light);
+    --bp-hero-img-card-headline-color: var(--text-service-brand-on-light);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-brand-on-light);
+    --bp-hero-img-card-lead-color: var(--text-service-brand-on-light);
+    --text-brand-primary: var(--text-service-brand-on-light);
+    --background-inverse: var(--background-service-brand-on-light);
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='marketing'] {
-    background: var(--surface-service-marketing);
-    --bp-hero-img-card-headline-color: var(--text-service-marketing);
-    --text-brand-primary: var(--text-service-marketing);
-    --background-inverse: var(--background-service-marketing-inverse);
+    background: var(--surface-service-marketing-light);
+    --bp-hero-img-card-headline-color: var(--text-service-marketing-on-light);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-marketing-on-light);
+    --bp-hero-img-card-lead-color: var(--text-service-marketing-on-light);
+    --text-brand-primary: var(--text-service-marketing-on-light);
+    --background-inverse: var(--background-service-marketing-on-light);
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='information'] {
-    background: var(--surface-service-information);
-    --bp-hero-img-card-headline-color: var(--text-service-information);
-    --text-brand-primary: var(--text-service-information);
-    --background-inverse: var(--background-service-information-inverse);
+    background: var(--surface-service-information-light);
+    --bp-hero-img-card-headline-color: var(--text-service-information-on-light);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-information-on-light);
+    --bp-hero-img-card-lead-color: var(--text-service-information-on-light);
+    --text-brand-primary: var(--text-service-information-on-light);
+    --background-inverse: var(--background-service-information-on-light);
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='product'] {
-    background: var(--surface-service-product);
-    --bp-hero-img-card-headline-color: var(--text-service-product);
-    --text-brand-primary: var(--text-service-product);
-    --background-inverse: var(--background-service-product-inverse);
+    background: var(--surface-service-product-light);
+    --bp-hero-img-card-headline-color: var(--text-service-product-on-light);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-product-on-light);
+    --bp-hero-img-card-lead-color: var(--text-service-product-on-light);
+    --text-brand-primary: var(--text-service-product-on-light);
+    --background-inverse: var(--background-service-product-on-light);
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='service'] {
-    background: var(--surface-service-back-office);
-    --bp-hero-img-card-headline-color: var(--text-service-back-office);
-    --text-brand-primary: var(--text-service-back-office);
-    --background-inverse: var(--background-service-back-office-inverse);
+    background: var(--surface-service-back-office-light);
+    --bp-hero-img-card-headline-color: var(--text-service-back-office-on-light);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-back-office-on-light);
+    --bp-hero-img-card-lead-color: var(--text-service-back-office-on-light);
+    --text-brand-primary: var(--text-service-back-office-on-light);
+    --background-inverse: var(--background-service-back-office-on-light);
     --text-on-color-light: var(--color-grayscale-white);
   }
 
@@ -311,7 +329,7 @@ const cta = section.cta;
     font-family: var(--font-family-body);
     font-size: var(--body-xl);
     line-height: var(--line-height-relaxed, 1.5);
-    color: var(--text-primary);
+    color: var(--bp-hero-img-card-lead-color, var(--text-primary));
     max-width: 55ch;
   }
 

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -34,12 +34,19 @@
  * Background uses the `surface` family (not `background`) because the hero
  * is a broad page-level container, not a small bounded component — per the
  * service-token decision tree (`-surface-` for sections/heroes/cards;
- * `-background-` for badges/tags/pills/buttons). This keeps the hero band
- * the same shade as section-level surfaces below it on the same page.
+ * `-background-` for badges/tags/pills/buttons).
  *
- * `--background-inverse` stays on the `background` family: it's the
- * mode-aware companion fill consumed by the inverse `<Button>` variant
- * inside the hero, which IS a small bounded component.
+ * AAA pale pairing (brik-bds#838, locked in #836): the hero band uses the
+ * mode-INVARIANT pale `-light` tone (= each hue's `-lightest` step) paired
+ * with mode-invariant `-on-light` (= `-darkest`) foreground text. This clears
+ * AAA (≥7:1) for same-hue body text in BOTH light and dark themes — the band
+ * stays a pale tinted panel in dark mode instead of flipping deep. Every band
+ * foreground token therefore uses an `-on-light` variant so it does not flip
+ * light in dark mode and break contrast against the pale band:
+ *   - headline / eyebrow / lead → `--text-service-{hue}-on-light`
+ *   - breadcrumb (`--text-brand-primary`) → `--text-service-{hue}-on-light`
+ *   - inverse `<Button>` fill (`--background-inverse`) →
+ *     `--background-service-{hue}-on-light` (dark fill + white label, both modes)
  *
  * `data-audience='back-office'` is canonical; `data-audience='service'` is a
  * @deprecated alias kept for component-API compat during the cross-repo
@@ -48,51 +55,63 @@
  * `data-audience` → `data-service-line` is a separate cross-repo follow-up. */
 
 .bp-hero-img-card[data-audience='brand'] {
-  background: var(--surface-service-brand);
-  --bp-hero-img-card-headline-color: var(--text-service-brand);
-  --text-brand-primary: var(--text-service-brand);
-  --background-inverse: var(--background-service-brand-inverse);
+  background: var(--surface-service-brand-light);
+  --bp-hero-img-card-headline-color: var(--text-service-brand-on-light);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-brand-on-light);
+  --bp-hero-img-card-lead-color: var(--text-service-brand-on-light);
+  --text-brand-primary: var(--text-service-brand-on-light);
+  --background-inverse: var(--background-service-brand-on-light);
   --text-on-color-light: var(--color-grayscale-white);
 }
 
 .bp-hero-img-card[data-audience='marketing'] {
-  background: var(--surface-service-marketing);
-  --bp-hero-img-card-headline-color: var(--text-service-marketing);
-  --text-brand-primary: var(--text-service-marketing);
-  --background-inverse: var(--background-service-marketing-inverse);
+  background: var(--surface-service-marketing-light);
+  --bp-hero-img-card-headline-color: var(--text-service-marketing-on-light);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-marketing-on-light);
+  --bp-hero-img-card-lead-color: var(--text-service-marketing-on-light);
+  --text-brand-primary: var(--text-service-marketing-on-light);
+  --background-inverse: var(--background-service-marketing-on-light);
   --text-on-color-light: var(--color-grayscale-white);
 }
 
 .bp-hero-img-card[data-audience='information'] {
-  background: var(--surface-service-information);
-  --bp-hero-img-card-headline-color: var(--text-service-information);
-  --text-brand-primary: var(--text-service-information);
-  --background-inverse: var(--background-service-information-inverse);
+  background: var(--surface-service-information-light);
+  --bp-hero-img-card-headline-color: var(--text-service-information-on-light);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-information-on-light);
+  --bp-hero-img-card-lead-color: var(--text-service-information-on-light);
+  --text-brand-primary: var(--text-service-information-on-light);
+  --background-inverse: var(--background-service-information-on-light);
   --text-on-color-light: var(--color-grayscale-white);
 }
 
 .bp-hero-img-card[data-audience='product'] {
-  background: var(--surface-service-product);
-  --bp-hero-img-card-headline-color: var(--text-service-product);
-  --text-brand-primary: var(--text-service-product);
-  --background-inverse: var(--background-service-product-inverse);
+  background: var(--surface-service-product-light);
+  --bp-hero-img-card-headline-color: var(--text-service-product-on-light);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-product-on-light);
+  --bp-hero-img-card-lead-color: var(--text-service-product-on-light);
+  --text-brand-primary: var(--text-service-product-on-light);
+  --background-inverse: var(--background-service-product-on-light);
   --text-on-color-light: var(--color-grayscale-white);
 }
 
 .bp-hero-img-card[data-audience='back-office'] {
-  background: var(--surface-service-back-office);
-  --bp-hero-img-card-headline-color: var(--text-service-back-office);
-  --text-brand-primary: var(--text-service-back-office);
-  --background-inverse: var(--background-service-back-office-inverse);
+  background: var(--surface-service-back-office-light);
+  --bp-hero-img-card-headline-color: var(--text-service-back-office-on-light);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-back-office-on-light);
+  --bp-hero-img-card-lead-color: var(--text-service-back-office-on-light);
+  --text-brand-primary: var(--text-service-back-office-on-light);
+  --background-inverse: var(--background-service-back-office-on-light);
   --text-on-color-light: var(--color-grayscale-white);
 }
 
 /* @deprecated alias of [data-audience='back-office']. */
 .bp-hero-img-card[data-audience='service'] {
-  background: var(--surface-service-back-office);
-  --bp-hero-img-card-headline-color: var(--text-service-back-office);
-  --text-brand-primary: var(--text-service-back-office);
-  --background-inverse: var(--background-service-back-office-inverse);
+  background: var(--surface-service-back-office-light);
+  --bp-hero-img-card-headline-color: var(--text-service-back-office-on-light);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-back-office-on-light);
+  --bp-hero-img-card-lead-color: var(--text-service-back-office-on-light);
+  --text-brand-primary: var(--text-service-back-office-on-light);
+  --background-inverse: var(--background-service-back-office-on-light);
   --text-on-color-light: var(--color-grayscale-white);
 }
 
@@ -155,7 +174,7 @@
   font-family: var(--font-family-body);
   font-size: var(--body-xl);
   line-height: var(--font-line-height-relaxed, 1.5);
-  color: var(--text-primary);
+  color: var(--bp-hero-img-card-lead-color, var(--text-primary));
   max-width: 55ch;
 }
 

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { HeroSplitImageCardOverlay } from './HeroSplitImageCardOverlay';
@@ -159,4 +160,123 @@ export const LandscapePhotography: Story = {
       },
     },
   },
+};
+
+/* ─── Service-surface AAA contrast matrix (brik-bds#838) ──────────────
+ *
+ * Proves the locked #836 pairing: the mode-INVARIANT pale `-light` surface
+ * tone (= each hue's `-lightest` step) + the mode-invariant `-on-light`
+ * (= `-darkest`) text clears AAA (≥7:1) for same-hue body text on all five
+ * service lines. Both tokens are defined only in `:root` (NOT in the
+ * `:root[data-theme="dark"]` override block), so they resolve identically in
+ * light AND dark themes — toggle the theme toolbar (brik ↔ brik-dark) and the
+ * measured ratios below do not move. The ratio badge is computed live from the
+ * rendered colors via getComputedStyle, so it regresses loudly if a primitive
+ * shifts. Verified values: marketing 8.31 · brand 8.40 · information 9.29 ·
+ * product 11.43 · back-office 12.52 (:1). */
+
+/* Full canonical token names are spelled out per hue (not interpolated) so
+ * the static canonical-check / #839 lint gate can verify each name. */
+const SERVICE_HUES = [
+  { key: 'marketing', label: 'Marketing', surface: 'var(--surface-service-marketing-light)', text: 'var(--text-service-marketing-on-light)' },
+  { key: 'brand', label: 'Brand', surface: 'var(--surface-service-brand-light)', text: 'var(--text-service-brand-on-light)' },
+  { key: 'information', label: 'Information', surface: 'var(--surface-service-information-light)', text: 'var(--text-service-information-on-light)' },
+  { key: 'product', label: 'Product', surface: 'var(--surface-service-product-light)', text: 'var(--text-service-product-on-light)' },
+  { key: 'back-office', label: 'Back office', surface: 'var(--surface-service-back-office-light)', text: 'var(--text-service-back-office-on-light)' },
+] as const;
+
+function parseRgb(value: string): [number, number, number] {
+  const match = value.match(/\(([^)]+)\)/);
+  if (!match) return [0, 0, 0];
+  const parts = match[1].split(',').map((v) => parseFloat(v));
+  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+}
+
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const channel = (v: number) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(fg: string, bg: string): number {
+  const l1 = relativeLuminance(parseRgb(fg));
+  const l2 = relativeLuminance(parseRgb(bg));
+  const hi = Math.max(l1, l2);
+  const lo = Math.min(l1, l2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function ServiceSurfaceSwatch({ label, surface, text }: { label: string; surface: string; text: string }) {
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const textRef = useRef<HTMLParagraphElement>(null);
+  const [ratio, setRatio] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!surfaceRef.current || !textRef.current) return;
+    const bg = getComputedStyle(surfaceRef.current).backgroundColor;
+    const fg = getComputedStyle(textRef.current).color;
+    setRatio(contrastRatio(fg, bg));
+  });
+
+  const level = ratio == null ? '' : ratio >= 7 ? 'AAA' : ratio >= 4.5 ? 'AA' : 'FAIL';
+  const badgeText = ratio == null ? '…' : `${level} · ${ratio.toFixed(2)}:1`;
+
+  return (
+    <div
+      ref={surfaceRef}
+      style={{
+        background: surface,
+        color: text,
+        padding: 'var(--padding-lg)',
+        borderRadius: 'var(--border-radius-lg)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--gap-sm)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 'var(--gap-md)' }}>
+        <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-lg)', fontWeight: 'var(--font-weight-semibold)' }}>
+          {label}
+        </span>
+        <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-md)', fontWeight: 'var(--font-weight-bold)' }}>
+          {badgeText}
+        </span>
+      </div>
+      <h3 style={{ margin: 0, fontFamily: 'var(--font-family-heading)', fontSize: 'var(--heading-md)' }}>
+        Same-hue heading on the pale service surface
+      </h3>
+      <p ref={textRef} style={{ margin: 0, fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)', maxWidth: '55ch' }}>
+        Body copy in the service hue&rsquo;s <code>-darkest</code> step sits on the same hue&rsquo;s
+        <code> -lightest</code> surface. This pairing is mode-invariant, so the contrast ratio shown
+        above is identical whether the page is in the light or dark theme.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * @summary AAA contrast proof for the five service-line pale surfaces.
+ * Each panel renders same-hue body text on the canonical pale pairing and
+ * reports a live-computed WCAG ratio. Toggle the theme toolbar to confirm the
+ * ratios hold in dark mode (the tokens are mode-invariant by design).
+ */
+export const ServiceSurfaceContrastAAA: StoryObj = {
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        story:
+          'Verifies brik-bds#838: same-hue body text on each of the five service `-lightest` surfaces clears WCAG AAA (≥7:1) in both themes. Ratios are computed live from the rendered colors, so a primitive regression turns a badge red.',
+      },
+    },
+  },
+  render: () => (
+    <div style={{ display: 'grid', gap: 'var(--gap-md)', maxWidth: '720px' }}>
+      {SERVICE_HUES.map((hue) => (
+        <ServiceSurfaceSwatch key={hue.key} label={hue.label} surface={hue.surface} text={hue.text} />
+      ))}
+    </div>
+  ),
 };


### PR DESCRIPTION
Closes #838.

## What
Retargets the interior service hero (`HeroSplitImageCardOverlay`, both renderers) to the canonical **pale AAA pairing** locked in #836: the mode-invariant `-light` surface tone (= each hue's `-lightest` step) + mode-invariant `-on-light` (= `-darkest`) foreground text.

Previously the band paired `-darkest` text with the mid `-light` surface → **WCAG AA fail (2.43–2.98:1)**. Now: **AAA in both themes** — measured 8.31 / 8.40 / 9.29 / 11.43 / 12.52 :1.

## Scope correction (vs the issue as written)
While picking this up, several premises in #838 turned out stale — flagging for the record:
- **No token-source change / no Figma dep.** `--surface-service-{hue}-light` and `--text-service-{hue}-on-light` already exist and are canonical, so `dist/tokens.css` is unchanged. (The cited "ADR-011 / Figma dev-plugin" requirement doesn't apply — ADR-011 doesn't exist, and these service mappings live in the hand-maintained `tokens/gap-fills.css`.)
- **AC1 was already satisfied** — `--text-service-{hue}-on-light` has resolved to `-darkest` since #575. The failing axis was the *surface*, not the text.
- The issue's proposed `--text-on-surface-service-*` token is **non-canonical** (ADR-008 closed allowlist; only `--text-on-color-{dark,light}` exist). Avoided — the existing `-light` surface tone already expresses the pale step.

## Why every band foreground token moved to `-on-light`
The pale `-light` surface tone is **mode-invariant**. The band's text/breadcrumb/inverse-button previously used mode-aware tokens that flip *light* in dark mode — which would fail against the now-always-pale band. So headline/eyebrow/lead (`--text-service-{hue}-on-light`), breadcrumb (`--text-brand-primary`), and the inverse `<Button>` fill (`--background-inverse` → `--background-service-{hue}-on-light`) all move to mode-invariant variants. Net visual change in **light** mode = surface only; **dark** mode = band stays a pale tinted panel instead of flipping deep (the locked #836 intent). ServiceDot (fills with base `--surface-service-{hue}`) is untouched.

## Verification
- `canonical-check` 0 violations · `lint-tokens` 0 errors · `tsc --noEmit` clean · `build-storybook` succeeds
- New `ServiceSurfaceContrastAAA` story computes the live WCAG ratio per hue via `getComputedStyle` (AC4) — regresses loudly if a primitive shifts
- Chromatic (AC5): review the intentional color shift on this PR

## Follow-up (not in this PR)
Pre-existing: the **astro** renderer has no canonical `data-audience='back-office'` selector — only the deprecated `service` alias — so astro pages using the canonical `back-office` value get no service tint. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)