### PR TITLE
fix: content system esm packaging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.91.0",
+  "version": "0.91.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.91.0",
+      "version": "0.91.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",
@@ -36,6 +36,7 @@
         "axe-core": "^4.10.0",
         "chromatic": "^15.3.0",
         "dotenv": "^16.6.1",
+        "esbuild": "^0.25.12",
         "husky": "^9.1.7",
         "lottie-react": "^2.4.1",
         "playwright": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.91.0",
+  "version": "0.91.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",
@@ -14,7 +14,7 @@
     },
     "./content-system": {
       "types": "./dist/content-system/index.d.ts",
-      "import": "./dist/content-system/index.js"
+      "import": "./dist/content-system/index.mjs"
     },
     "./blueprints-astro": {
       "types": "./content-system/blueprints/astro/index.ts",
@@ -89,6 +89,7 @@
     "axe-core": "^4.10.0",
     "chromatic": "^15.3.0",
     "dotenv": "^16.6.1",
+    "esbuild": "^0.25.12",
     "husky": "^9.1.7",
     "lottie-react": "^2.4.1",
     "playwright": "^1.59.1",
@@ -135,7 +136,7 @@
     "build:modes": "node scripts/generate-modes-css.mjs",
     "build:all-tokens": "npm run build:sd-figma && npm run build:sd-dark && npm run build:modes",
     "build:lib": "vite build --config vite.config.lib.ts && npm run build:types && npm run build:content-system && npm run build:dist-tokens && npm run build:inspector-manifest",
-    "build:content-system": "tsc --project tsconfig.content-system.json",
+    "build:content-system": "tsc --project tsconfig.content-system.json && esbuild content-system/index.ts --bundle --format=esm --platform=neutral --outfile=dist/content-system/index.mjs",
     "build:inspector-manifest": "node scripts/build-inspector-manifest.mjs",
     "bds:find": "node scripts/bds-find.mjs",
     "bcs-vocab-check": "node scripts/bcs-vocab-check.mjs",


### PR DESCRIPTION
## Summary
- fix(breadcrumb): regular weight on current page for recessive hierarchy (#837)
- fix(propagate): headless signing via git-sign-headless + brikdesigns npm reclassification (#841)
- fix(content-system): ship self-contained ESM for the import condition

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)