### PR TITLE
fix(propagate): authenticate npm track headless + surface failures

### DIFF
--- a/scripts/propagate.sh
+++ b/scripts/propagate.sh
@@ -96,6 +96,28 @@ git_signed() {
   fi
 }
 
+# ─── npm registry auth (GitHub Packages) ──────────────────────────
+# The consumer .npmrc files authenticate to npm.pkg.github.com via
+# ${PACKAGES_READ_TOKEN}. Interactive shells get it from the profile; the
+# launchd context that runs this agent starts from a bare env (PATH + HOME
+# only), so npm install fails E401 Unauthorized and the npm track is silently
+# skipped. Self-source the same env file the shell uses (the established
+# entrypoint pattern — cf. the notion wrapper sourcing notion.env). No value is
+# ever echoed; npm reads it from the exported env.
+PACKAGES_ENV="$HOME/.secrets/brik-packages.env"
+if [ -z "${PACKAGES_READ_TOKEN:-}" ] && [ -f "$PACKAGES_ENV" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$PACKAGES_ENV"
+  set +a
+fi
+
+# Tracks whether any consumer failed in a way the daily digest should surface.
+# We finish every consumer + tag the release, then exit non-zero at the end so
+# launchd's exit-code check (morning-check launch_agents) flags it instead of
+# the failure being swallowed by a warn-and-return.
+DEGRADED=false
+
 # ─── Preflight ────────────────────────────────────────────────────
 info "Running preflight checks..."
 
@@ -385,7 +407,8 @@ propagate_npm() {
   # npm install the explicit new version
   info "Running npm install $BDS_PACKAGE_NAME@$BDS_VERSION..."
   if ! npm install --save "$BDS_PACKAGE_NAME@$BDS_VERSION" --silent 2>&1 | tail -5; then
-    err "npm install failed in $name — check registry auth"
+    err "npm install failed in $name — check registry auth (PACKAGES_READ_TOKEN)"
+    DEGRADED=true
     git checkout "$orig_branch" --quiet
     [ "$stashed" = true ] && git stash pop --quiet
     echo ""
@@ -468,4 +491,8 @@ elif [ "$ANY_UPDATED" = true ]; then
 fi
 
 echo ""
+if [ "$DEGRADED" = true ]; then
+  err "Completed with degraded consumers (see 'npm install failed' above) — exiting non-zero so the daily digest surfaces it."
+  exit 1
+fi
 echo -e "${GREEN}${BOLD}Done!${NC}"


### PR DESCRIPTION
## Why

#903 — `bds-propagate`'s npm track silently failed every run. Consumer `.npmrc` files authenticate to `npm.pkg.github.com` via `${PACKAGES_READ_TOKEN}`, which interactive shells load from `~/.secrets/brik-packages.env`. The launchd context that runs the agent starts from a bare env (PATH + HOME only), so the var is unset and `npm install @brikdesigns/bds@<v>` fails:

```
npm error code E401
npm error 401 Unauthorized - GET https://npm.pkg.github.com/@brikdesigns%2fbds - unauthenticated
```

`propagate_npm()` warned and returned, and the script **still exited 0** — so brik-client-portal + renew-pms never got their bds bump PRs, and the digest's exit-code check never surfaced it.

## What

- **Self-source `~/.secrets/brik-packages.env`** when `PACKAGES_READ_TOKEN` is unset — the established entrypoint pattern (same file the interactive shell uses; the registered `packages-read` credential). No value is echoed; npm reads it from the exported env.
- **`DEGRADED` flag** — finish every consumer + tag the release, then exit non-zero if any `npm install` failed, so launchd's exit-code check (`morning-check` → `launch_agents`) flags it instead of swallowing it.

## Verification

- Confirmed in the bare launchd-like env (`env -i`, PATH+HOME): **unsourced → E401**; **sourced → authenticates** (`npm view @brikdesigns/bds` → 0.91.1).
- `shellcheck -S warning` clean; `bash -n` clean.
- Agent-less `--dry-run` exits 0; npm consumers resolve versions with no E401.
- `packages-read` credential verified against provider (HTTP 200) via `brik-secrets verify`.
- Final `launchctl kickstart` exit-0 + bump-PR confirmation runs once this lands on `main`.

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)