### PR TITLE
fix(propagate): add --force to worktree remove in success/no-change paths

### DIFF
--- a/scripts/propagate.sh
+++ b/scripts/propagate.sh
@@ -286,7 +286,7 @@ propagate_submodule() {
   if git diff --cached --quiet; then
     warn "$name submodule already at $LOCAL_HEAD — no change"
     cd "$BDS_DIR"
-    git -C "$path" worktree remove "$worktree_path"
+    git -C "$path" worktree remove --force "$worktree_path"
     git -C "$path" branch -D "$pr_branch" 2>/dev/null || true
     echo ""
     return
@@ -323,7 +323,7 @@ EOF
 
   # Remove worktree + local branch — PR is on the remote; local ref no longer needed
   cd "$BDS_DIR"
-  git -C "$path" worktree remove "$worktree_path"
+  git -C "$path" worktree remove --force "$worktree_path"
   git -C "$path" branch -D "$pr_branch" 2>/dev/null || true
   echo ""
 }
@@ -417,7 +417,7 @@ propagate_npm() {
   if git diff --quiet package.json package-lock.json; then
     warn "No changes after npm install — consumer may already satisfy the range"
     cd "$BDS_DIR"
-    git -C "$path" worktree remove "$worktree_path"
+    git -C "$path" worktree remove --force "$worktree_path"
     git -C "$path" branch -D "$pr_branch" 2>/dev/null || true
     echo ""
     return
@@ -455,7 +455,7 @@ EOF
 
   # Remove worktree + local branch — PR is on the remote; local ref no longer needed
   cd "$BDS_DIR"
-  git -C "$path" worktree remove "$worktree_path"
+  git -C "$path" worktree remove --force "$worktree_path"
   git -C "$path" branch -D "$pr_branch" 2>/dev/null || true
   echo ""
 }


### PR DESCRIPTION
## Summary
`git worktree remove` refuses to remove a worktree that contains submodules unless `--force` is passed. The pre-run cleanup paths in `propagate_submodule()` already used `--force`, but the success and no-change cleanup paths did not, causing `propagate.sh` to exit 128 after successfully pushing the brik-llm submodule PR.

Caught in the acceptance test run for #675 (first real live run of the worktree refactor).

## Test plan
- [ ] Merge, pull in brik-bds, re-run `./scripts/propagate.sh --auto` for brikdesigns consumer
- [ ] Confirm worktree is created, npm bump PR opens, worktree is cleaned up without error

Closes n/a — followup fix to #846.