### PR TITLE
components: 823 hero inverse dark

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -252,6 +252,7 @@ const cta = section.cta;
     --background-inverse: var(--surface-service-product-dark);
     --text-on-color-light: var(--color-grayscale-white);
   }
+  .bp-hero-img-card[data-audience='back-office'],
   .bp-hero-img-card[data-audience='service'] {
     background: var(--surface-service-back-office);
     --bp-hero-img-card-headline-color: var(--text-service-back-office-on-light);
@@ -260,6 +261,23 @@ const cta = section.cta;
     --text-brand-primary: var(--text-service-back-office-on-light);
     --background-inverse: var(--surface-service-back-office-dark);
     --text-on-color-light: var(--color-grayscale-white);
+  }
+
+  /* ── Dark-mode: --text-inverse must track the softened service-dark surface.
+   * surface-service-{hue}-dark softens one tier in dark mode (darkest → darker,
+   * per ADR-011). Lighter darker-step surfaces (brand yellow, marketing green)
+   * can't sustain white text (2.87–4.36:1); darker ones can. Override
+   * --text-inverse per luminance group so all five lines pass AA in dark mode.
+   * Uses mode-invariant --text-on-color-light (black) / --text-on-color-dark (white). */
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='brand'],
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='marketing'] {
+    --text-inverse: var(--text-on-color-light); /* black on yellow/green-darker: 4.82–7.33:1 */
+  }
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='information'],
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='product'],
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='back-office'],
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='service'] {
+    --text-inverse: var(--text-on-color-dark);  /* white on blue/purple/orange-darker: 5.48–9.48:1 */
   }
 
   .bp-hero-img-card__container {

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -108,6 +108,23 @@
   --text-on-color-light: var(--color-grayscale-white);
 }
 
+/* ── Dark-mode: --text-inverse must track the softened service-dark surface.
+ * surface-service-{hue}-dark softens one tier in dark mode (darkest → darker,
+ * per ADR-011). Lighter darker-step surfaces (brand yellow, marketing green)
+ * can't sustain white text (2.87–4.36:1); darker ones can. Override
+ * --text-inverse per luminance group so all five lines pass AA in dark mode.
+ * Uses mode-invariant --text-on-color-light (black) / --text-on-color-dark (white). */
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='brand'],
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='marketing'] {
+  --text-inverse: var(--text-on-color-light); /* black on yellow/green-darker: 4.82–7.33:1 */
+}
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='information'],
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='product'],
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='back-office'],
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='service'] {
+  --text-inverse: var(--text-on-color-dark);  /* white on blue/purple/orange-darker: 5.48–9.48:1 */
+}
+
 .bp-hero-img-card__container {
   max-width: 1280px;
   margin-inline: auto;


### PR DESCRIPTION
Closes #823.

## What

Fixes the dark-mode inverse-button contrast failure in `HeroSplitImageCardOverlay` for all five service lines.

**Root cause:** `surface-service-{hue}-dark` softens one tier in dark mode (`darkest → darker`, per ADR-011). White text fails on the lighter brand/marketing `darker`-step surfaces (2.87–4.36:1 with white). When `--text-inverse` flips to black in dark mode (canonical theme behavior), it fixes brand/marketing but breaks information/product/back-office (2.21–3.83:1 with black) — because those surfaces are too dark for black text.

**Fix:** Per-audience `--text-inverse` overrides scoped to `[data-theme="dark"]`:
- brand + marketing (lighter `darker` surfaces): `--text-on-color-light` (black) → 4.82–7.33:1
- information + product + back-office (darker `darker` surfaces): `--text-on-color-dark` (white) → 5.48–9.48:1

Both tokens are mode-invariant (black/white respectively in all themes), so they're stable override anchors.

**Also fixed:** Astro renderer was missing the canonical `[data-audience='back-office']` selector — only the deprecated `service` alias existed, leaving back-office pages without a service tint on Astro-rendered heroes.

## Contrast table (dark mode, all five lines)

| Line | Dark surface (darker step) | Text | Ratio | Status |
|---|---|---|---|---|
| brand | `#8e7729` (yellow-darker) | black | 4.82:1 | AA ✓ |
| marketing | `#71a74a` (green-darker) | black | 7.33:1 | AAA ✓ |
| information | `#4d6e7b` (blue-darker) | white | 5.48:1 | AA ✓ |
| product | `#574a71` (purple-darker) | white | 8.01:1 | AAA ✓ |
| back-office | `#812608` (orange-darker) | white | 9.48:1 | AAA ✓ |

Light mode is unchanged — all five already cleared AA with white text on the `darkest`-step surfaces.

## Verification

- `canonical-check` 0 violations
- `tsc --noEmit` clean
- Pre-commit hooks: gitleaks clean · blueprint naming clean · typecheck clean

## Scope note

This does not fix the ServiceTag product/back-office AA failures in light mode (4.26:1 / 4.32:1). Those require Brand Kit primitive value adjustments — documented in #850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)