### PR TITLE
card: 834 display borderless

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -227,6 +227,16 @@
  *   tag/badge   — own their own typography (component-internal)
  */
 
+/* Borderless override for display preset — same semantics as the default-shape
+ * .bds-card--borderless, but higher specificity is needed because
+ * .bds-card--preset-display declares its own background + border after
+ * .bds-card--borderless in source order. */
+.bds-card--preset-display.bds-card--borderless {
+  background-color: transparent;
+  border: none;
+  box-shadow: var(--box-shadow-none);
+}
+
 .bds-card--preset-display {
   background-color: var(--surface-primary);
   border: var(--border-width-md) solid var(--border-secondary);

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -247,6 +247,52 @@ export const Display: Story = {
 };
 
 /**
+ * `preset="display"` + `variant="borderless"` — transparent fill, no border,
+ * no shadow. Use when the card grid sits on a service-tinted colored surface
+ * where the default white fill + border ring reads as visual noise. The card
+ * inherits the parent surface; shown here on a service-product (purple) tint.
+ *
+ * @summary preset="display" variant="borderless" — on a colored surface
+ */
+export const DisplayBorderless: Story = {
+  args: {
+    preset: 'display',
+    variant: 'borderless',
+    title: 'Brand strategy',
+    description:
+      'A two-line card description that sets the type rhythm without trying to tell the whole story.',
+    tag: <Badge>Marketing</Badge>,
+    action: (
+      <Button variant="on-color" size="sm">
+        Learn more
+      </Button>
+    ),
+  },
+  argTypes: {
+    padding: { table: { disable: true } },
+    interactive: { table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 200px)',
+          gap: 'var(--gap-md)',
+          padding: 'var(--padding-xl)',
+          backgroundColor: 'var(--surface-service-product)',
+          borderRadius: 'var(--border-radius-md)',
+        }}
+      >
+        <Story />
+        <Story />
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
  * `preset="display-row"` — horizontal sibling of `preset="display"`. Image
  * on the left, content (tag, title, description, optional `extras`, action)
  * on the right. Use for single-card sections where a vertical layout wastes

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -99,6 +99,12 @@ interface CardDisplayPresetProps extends CardBaseProps {
    * `bds-card-grid` blueprint.
    */
   preset: 'display';
+  /**
+   * `borderless` — transparent fill, no border, no shadow. Use when the
+   * card grid sits on a colored surface (service-tier tint) where the
+   * default white fill + border ring reads as visual noise.
+   */
+  variant?: 'borderless';
   /** Card heading. Renders as `<h3>` with `--font-family-heading` + `--heading-md`. */
   title: string;
   /**
@@ -401,6 +407,7 @@ function renderDisplayPreset({
   badge,
   action,
   href,
+  variant,
   className,
   style,
   preset: _preset,
@@ -409,6 +416,7 @@ function renderDisplayPreset({
   const classes = bdsClass(
     'bds-card',
     'bds-card--preset-display',
+    variant && `bds-card--${variant}`,
     href && 'bds-card--link',
     className,
   );


### PR DESCRIPTION
## Summary
- fix(blueprints): dark-mode inverse-button contrast on service hero (#823) (#851)
- feat(card): add variant="borderless" to display preset (#834)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)