### PR TITLE
chore(release): 0.92.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.91.1",
+  "version": "0.92.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.91.1",
+      "version": "0.92.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.91.1",
+  "version": "0.92.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Bump version to 0.92.0 — new minor for `variant="borderless"` on `preset="display"` (brik-bds#834 / PR #852).

## Checklist
- [x] Version in `package.json` matches tag `v0.92.0`
- [x] Change is a new prop on an existing component (minor bump correct)