### PR TITLE
components: 858 radio story assertion

### DIFF
--- a/components/ui/Radio/Radio.stories.tsx
+++ b/components/ui/Radio/Radio.stories.tsx
@@ -64,7 +64,11 @@ export const Single: Story = {
     const canvas = within(canvasElement);
     const radio = canvas.getByLabelText('Option A') as HTMLInputElement;
 
-    await expect(radio).toBeVisible();
+    // The native input is visually hidden by design (custom radio —
+    // position:absolute; opacity:0; width/height:0), so assert it renders
+    // and is accessible rather than visible; the visible label proves render.
+    await expect(radio).toBeInTheDocument();
+    await expect(canvas.getByText('Option A')).toBeVisible();
     await expect(radio).not.toBeChecked();
     // Radios don't toggle off on second click — exclusivity comes from
     // other radios sharing the same `name`. The play test verifies


### PR DESCRIPTION
## Summary
- chore(animations): prune dead Storybook-only skeleton/spinner CSS (#786) (#857)
- fix(radio): assert hidden input is in-document, not visible, in Single story (#858)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)