### PR TITLE
blueprint: 871 servicetag optout

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -64,9 +64,15 @@ const RATIO_ASPECT: Record<FrameRatio, string> = {
 
 interface Props extends BlueprintProps {
   imageRatio?: FrameRatio;
+  /**
+   * When false, suppresses the eyebrow icon slot (raw `iconUrl` image or the
+   * audience-driven ServiceTag) while keeping `audience` driving the hero's
+   * `data-audience` theming. Default true. (brik-bds#871)
+   */
+  showServiceTag?: boolean;
 }
 
-const { section, imageRatio = 'square' } = Astro.props;
+const { section, imageRatio = 'square', showServiceTag = true } = Astro.props;
 
 const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
 const titleId = `${section.sectionKey}-title`;
@@ -115,8 +121,11 @@ const cta = section.cta;
              the same `bds-service-tag*` classes so dist/styles.css renders
              it identically)
           3. neither → no eyebrow
+
+        `showServiceTag={false}` suppresses this whole slot while leaving
+        `data-audience` theming intact (brik-bds#871).
       */}
-      {iconUrl ? (
+      {showServiceTag && (iconUrl ? (
         <img
           src={iconUrl}
           alt={iconAlt ?? ''}
@@ -130,7 +139,7 @@ const cta = section.cta;
           role="img"
           aria-label={`${audience} category`}
         />
-      ) : null}
+      ) : null)}
 
       {eyebrow && <p class="bp-hero-img-card__subtitle">{eyebrow}</p>}
 

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -160,3 +160,21 @@ export const LandscapePhotography: Story = {
     },
   },
 };
+
+/**
+ * @summary Service-tag opt-out — `showServiceTag={false}` suppresses the
+ * eyebrow icon/ServiceTag slot while `audience` still drives the
+ * `data-audience` color theming (note the tint is unchanged from Playground).
+ * For support-plan heroes that want the audience tint without a service-line
+ * badge — brikdesigns.com #452.
+ */
+export const NoServiceTag: Story = {
+  args: {
+    ...baseProps,
+    showServiceTag: false,
+    section: {
+      ...interiorHeroSection,
+      sectionKey: 'hero-img-card-no-tag',
+    },
+  },
+};

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -25,9 +25,20 @@ import './HeroSplitImageCardOverlay.css';
 
 interface Props extends BlueprintProps {
   imageRatio?: FrameRatio;
+  /**
+   * When false, suppresses the eyebrow icon slot (raw `iconUrl` image or the
+   * audience-driven `<ServiceTag>`) while keeping `audience` driving the
+   * hero's `data-audience` theming. Default true — the tag still renders when
+   * the prop is absent. (brik-bds#871)
+   */
+  showServiceTag?: boolean;
 }
 
-export function HeroSplitImageCardOverlay({ section, imageRatio = 'square' }: Props) {
+export function HeroSplitImageCardOverlay({
+  section,
+  imageRatio = 'square',
+  showServiceTag = true,
+}: Props) {
   const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
   const titleId = `${section.sectionKey}-title`;
   const eyebrow = section.subheading;
@@ -61,23 +72,27 @@ export function HeroSplitImageCardOverlay({ section, imageRatio = 'square' }: Pr
            *      blueprint resolves the icon via BDS's service-token system,
            *      keeping theme awareness intact.
            *   3. If neither is set, no eyebrow renders.
+           *
+           * `showServiceTag={false}` suppresses this whole slot while leaving
+           * `data-audience` theming intact (brik-bds#871).
            */}
-          {iconUrl ? (
-            <img
-              src={iconUrl}
-              alt={iconAlt ?? ''}
-              className="bp-hero-img-card__icon"
-              loading="eager"
-              decoding="async"
-            />
-          ) : audience ? (
-            <ServiceTag
-              category={audience}
-              variant="icon"
-              size="lg"
-              className="bp-hero-img-card__icon"
-            />
-          ) : null}
+          {showServiceTag &&
+            (iconUrl ? (
+              <img
+                src={iconUrl}
+                alt={iconAlt ?? ''}
+                className="bp-hero-img-card__icon"
+                loading="eager"
+                decoding="async"
+              />
+            ) : audience ? (
+              <ServiceTag
+                category={audience}
+                variant="icon"
+                size="lg"
+                className="bp-hero-img-card__icon"
+              />
+            ) : null)}
 
           {eyebrow && <p className="bp-hero-img-card__subtitle">{eyebrow}</p>}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.93.2",
+  "version": "0.94.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.93.2",
+      "version": "0.94.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.93.2",
+  "version": "0.94.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- fix(tokens): darken orange/purple darkest so service buttons clear WCAG AA (#827) (#863)
- chore(release): 0.93.1 (#864)
- fix(tokens): pin dark-mode service on-light/dark tokens to -darkest (#865) (#866)
- chore(release): 0.93.2 (#865) (#867)
- feat(tokens): accessible color-pairing foundation — canonical dataset + CI gate + doc (#836, #839) (#868)
- feat(blueprint): add showServiceTag opt-out to HeroSplitImageCardOverlay

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)