### PR TITLE
feat(blueprints): priceCard.cta size hook on HeroSplitImageCardOverlay (#869)

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -177,7 +177,7 @@ const cta = section.cta;
               <p class="bp-hero-img-card__price-value">{priceCard.price}</p>
             )}
             {priceCard.cta && (
-              <a href={priceCard.cta.url} class="bds-button bds-button--primary bds-button--sm">
+              <a href={priceCard.cta.url} class={`bds-button bds-button--primary bds-button--${priceCard.cta.size ?? 'sm'}`}>
                 <span class="bds-button__content">{priceCard.cta.label}</span>
               </a>
             )}

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -164,7 +164,18 @@ export interface BlueprintSection {
     readonly imageAlt?: string;
     readonly priceLabel?: string;
     readonly price?: string;
-    readonly cta?: { readonly label: string; readonly url: string };
+    readonly cta?: {
+      readonly label: string;
+      readonly url: string;
+      /**
+       * Optional CTA button size. Mirrors the `Button` `size` union
+       * (inlined so this contract stays framework-agnostic — see the
+       * `illustration` note below). Omitted → the blueprint's `sm`
+       * default is preserved (no visual change for existing
+       * consumers). brikdesigns.com #453 passes `md`. (#869)
+       */
+      readonly size?: 'tiny' | 'sm' | 'md' | 'lg' | 'xl';
+    };
   };
   /**
    * Optional structured illustration data for blueprints that compose a

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -178,3 +178,22 @@ export const NoServiceTag: Story = {
     },
   },
 };
+
+/**
+ * @summary Medium price-card CTA — opt in via `priceCard.cta.size="md"`.
+ * The default is `sm` (see Playground); support-plan heroes that want a
+ * weightier price-card action pass `md`. brikdesigns.com #453.
+ */
+export const PriceCardCtaMd: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...interiorHeroSection,
+      sectionKey: 'hero-img-card-cta-md',
+      priceCard: {
+        ...interiorHeroSection.priceCard!,
+        cta: { ...interiorHeroSection.priceCard!.cta!, size: 'md' },
+      },
+    },
+  },
+};

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -131,7 +131,11 @@ export function HeroSplitImageCardOverlay({
                   <p className="bp-hero-img-card__price-value">{priceCard.price}</p>
                 )}
                 {priceCard.cta && (
-                  <Button href={priceCard.cta.url} variant="primary" size="sm">
+                  <Button
+                    href={priceCard.cta.url}
+                    variant="primary"
+                    size={priceCard.cta.size ?? 'sm'}
+                  >
                     {priceCard.cta.label}
                   </Button>
                 )}


### PR DESCRIPTION
Closes #869.

## What
`HeroSplitImageCardOverlay`'s price-card CTA was hardcoded `size="sm"` in both the React and Astro twins, with `priceCard.cta` typed as `{ label, url }` only — consumers couldn't change the CTA size without overriding BDS internals (which the consumer operating rules forbid). Surfaced by brikdesigns.com #453 (R4 UI cleanup, umbrella #449): the support-plan hero CTA should be `md`.

Adds an optional `priceCard.cta.size` (the `Button` size union, inlined into `types.ts` to keep the blueprint contract framework-agnostic — same convention as the `illustration` field). Wired through both twins; story added.

## Acceptance criteria
- [x] `priceCard.cta` accepts optional `size`; omitted preserves current `sm` rendering (no visual change for existing consumers)
- [x] **Default decision: keep `sm`, expose the hook.** Moving the blueprint default to `md` would be a silent visual change for every existing consumer, which the AC's "no visual change" line forbids. brikdesigns.com #453 opts in explicitly with `size="md"`.
- [x] Storybook story (`PriceCardCtaMd`) demonstrates a `md` price-card CTA
- [ ] Release published — `v0.95.0` to be tagged on merge (minor: additive prop)

## Verification
- `typecheck`, `validate` (incl. storybook build), `pr-checklist.sh` (lint-tokens + contrast-gate), blueprint naming lint — all green
- Browser-verified the built Storybook locally: `Playground` (no `size`) renders the CTA at `sm` (default preserved); `PriceCardCtaMd` renders it at `md`
- ⚠️ Local Chromatic could not run on this machine (`.env.1p` / 1P project token not provisioned on the secondary MacBook). Chromatic CI runs on push to `main`, so the visual baseline is captured on merge. Risk is low: existing stories are unchanged, only one additive story.
- ⚠️ `verify:blueprints-astro` fails locally with a rollup `native.js MODULE_NOT_FOUND` in its `/tmp` scratch install — reproduced identically on clean `main`, so it's the known npm optional-dep bug on this machine, not this change. CI's npm install resolves it.

## Out of scope
- `priceCard.cta` url-only → `onClick`/action gap (#843) — same API surface, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)