### PR TITLE
feat(card): display preset accepts variant="elevated" (#870)

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -237,6 +237,16 @@
   box-shadow: var(--box-shadow-none);
 }
 
+/* Elevated override for display preset — same specificity rationale as the
+ * borderless override above: .bds-card--preset-display redeclares border after
+ * .bds-card--elevated in source order, so the ring needs explicit removal here.
+ * surface-primary fill + box-shadow-md, no border. */
+.bds-card--preset-display.bds-card--elevated {
+  background-color: var(--surface-primary);
+  border: none;
+  box-shadow: var(--box-shadow-md);
+}
+
 .bds-card--preset-display {
   background-color: var(--surface-primary);
   border: var(--border-width-md) solid var(--border-secondary);

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -293,6 +293,53 @@ export const DisplayBorderless: Story = {
 };
 
 /**
+ * `preset="display"` + `variant="elevated"` — surface-primary fill +
+ * `box-shadow-md`, no border. The restored-fill counterpart to `borderless`:
+ * use when a card grid on a service-tinted surface still needs a contained
+ * "card" read but the default border ring is unwanted. Shown here on a
+ * service-product (purple) tint.
+ *
+ * @summary preset="display" variant="elevated" — on a colored surface
+ */
+export const DisplayElevated: Story = {
+  args: {
+    preset: 'display',
+    variant: 'elevated',
+    title: 'Brand strategy',
+    description:
+      'A two-line card description that sets the type rhythm without trying to tell the whole story.',
+    tag: <Badge>Marketing</Badge>,
+    action: (
+      <Button variant="on-color" size="sm">
+        Learn more
+      </Button>
+    ),
+  },
+  argTypes: {
+    padding: { table: { disable: true } },
+    interactive: { table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 200px)',
+          gap: 'var(--gap-md)',
+          padding: 'var(--padding-xl)',
+          backgroundColor: 'var(--surface-service-product)',
+          borderRadius: 'var(--border-radius-md)',
+        }}
+      >
+        <Story />
+        <Story />
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
  * `preset="display-row"` — horizontal sibling of `preset="display"`. Image
  * on the left, content (tag, title, description, optional `extras`, action)
  * on the right. Use for single-card sections where a vertical layout wastes

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -103,8 +103,13 @@ interface CardDisplayPresetProps extends CardBaseProps {
    * `borderless` — transparent fill, no border, no shadow. Use when the
    * card grid sits on a colored surface (service-tier tint) where the
    * default white fill + border ring reads as visual noise.
+   *
+   * `elevated` — surface-primary fill + `box-shadow-md`, no border. Use when
+   * a card grid on a colored surface still needs a contained "card" read but
+   * the border ring is unwanted (the restored-fill counterpart to
+   * `borderless`).
    */
-  variant?: 'borderless';
+  variant?: 'borderless' | 'elevated';
   /** Card heading. Renders as `<h3>` with `--font-family-heading` + `--heading-md`. */
   title: string;
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(card): display preset accepts variant="elevated" (#870)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)