### PR TITLE
feat(DevFeedbackWidget): pick-element section/component capture (#979)

### DIFF
--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
@@ -58,6 +58,7 @@ const FEEDBACK_TYPES = [
 // ── DevBar integration types ────────────────────────────────────────────
 // Types live in BrikDevBar — imported here to avoid duplicate declarations.
 import type { DevBarSlotDef } from '../BrikDevBar';
+import { detectContext, type CapturedContext } from './detectContext';
 
 /**
  * Rendering variant.
@@ -110,8 +111,13 @@ export function DevFeedbackWidget({
   // we keep it false (no DevBar lookup runs). Auto seeds false and lets
   // runtime detection update it.
   const [devBarPresent, setDevBarPresent] = useState(variant === 'slot');
+  // Pick-element mode: when active, the next page click captures section/element
+  // context for the submission (brik-llm#979).
+  const [picking, setPicking] = useState(false);
+  const [captured, setCaptured] = useState<CapturedContext | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const fabRef = useRef<HTMLDivElement>(null);
+  const highlightRef = useRef<HTMLDivElement>(null);
 
   // Poppins (once per page; other Brik widgets inject it too but this is idempotent).
   useEffect(() => {
@@ -139,6 +145,7 @@ export function DevFeedbackWidget({
   useEffect(() => {
     if (!open) return;
     const onMouseDown = (e: MouseEvent) => {
+      if (picking) return; // pick-element mode owns page clicks
       const target = e.target as Node | null;
       if (!target) return;
       if (panelRef.current?.contains(target)) return;
@@ -153,6 +160,7 @@ export function DevFeedbackWidget({
       setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
+      if (picking) return; // Esc cancels picking, not the panel (handled below)
       if (e.key === 'Escape') setOpen(false);
     };
     document.addEventListener('mousedown', onMouseDown);
@@ -161,7 +169,75 @@ export function DevFeedbackWidget({
       document.removeEventListener('mousedown', onMouseDown);
       document.removeEventListener('keydown', onKey);
     };
+  }, [open, picking]);
+
+  // Reset capture + picking whenever the panel closes so nothing carries over.
+  useEffect(() => {
+    if (!open) {
+      setPicking(false);
+      setCaptured(null);
+    }
   }, [open]);
+
+  // Pick-element mode: highlight the hovered element and capture context on
+  // click. Page clicks are intercepted in the capture phase; widget chrome is
+  // ignored so the user can still interact with the panel. Esc cancels.
+  useEffect(() => {
+    if (!picking || typeof document === 'undefined') return;
+
+    const style = document.createElement('style');
+    style.textContent = '.bfb-picking, .bfb-picking * { cursor: crosshair !important; }';
+    document.head.appendChild(style);
+    document.documentElement.classList.add('bfb-picking');
+
+    const isWidgetChrome = (el: Element | null): boolean =>
+      !el ||
+      !!panelRef.current?.contains(el) ||
+      !!fabRef.current?.contains(el) ||
+      !!highlightRef.current?.contains(el) ||
+      !!el.closest?.('.bdb-bar');
+
+    const onMove = (e: MouseEvent) => {
+      const box = highlightRef.current;
+      if (!box) return;
+      const el = document.elementFromPoint(e.clientX, e.clientY);
+      if (isWidgetChrome(el)) {
+        box.style.display = 'none';
+        return;
+      }
+      const r = (el as Element).getBoundingClientRect();
+      box.style.display = 'block';
+      box.style.top = `${r.top}px`;
+      box.style.left = `${r.left}px`;
+      box.style.width = `${r.width}px`;
+      box.style.height = `${r.height}px`;
+    };
+    const onClick = (e: MouseEvent) => {
+      const el = document.elementFromPoint(e.clientX, e.clientY);
+      if (isWidgetChrome(el)) return; // let widget interactions through
+      e.preventDefault();
+      e.stopPropagation();
+      if (el) setCaptured(detectContext(el));
+      setPicking(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setPicking(false);
+      }
+    };
+
+    document.addEventListener('mousemove', onMove, true);
+    document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKey, true);
+    return () => {
+      document.documentElement.classList.remove('bfb-picking');
+      style.remove();
+      document.removeEventListener('mousemove', onMove, true);
+      document.removeEventListener('click', onClick, true);
+      document.removeEventListener('keydown', onKey, true);
+    };
+  }, [picking]);
 
   // Detect DevBar so we can hide the standalone FAB. Only runs in 'auto'
   // mode — explicit variants short-circuit the polling.
@@ -249,6 +325,13 @@ export function DevFeedbackWidget({
           feedback_type: type,
           description: description.trim(),
           context: contextValue,
+          // Human page name is always known; section/component only when the
+          // user picked a target element (brik-llm#979).
+          page:
+            captured?.page ??
+            (typeof document !== 'undefined' ? document.title || undefined : undefined),
+          section: captured?.section,
+          component: captured?.component,
           ...extraPayload,
         }),
       });
@@ -259,6 +342,7 @@ export function DevFeedbackWidget({
           setSubmitted(false);
           setDescription('');
           setType('bug');
+          setCaptured(null);
         }, 1500);
         return;
       }
@@ -410,6 +494,44 @@ export function DevFeedbackWidget({
     padding: '20px 0',
   };
 
+  const pickBtnStyle: CSSProperties = {
+    padding: '7px 12px',
+    borderRadius: '999px',
+    border: `1px dashed ${picking ? BDS.poppy : BDS.grayLight}`,
+    backgroundColor: picking ? BDS.tanLightest : 'transparent',
+    color: picking ? BDS.poppy : BDS.grayDarker,
+    cursor: 'pointer',
+    fontFamily: BDS.fontFamily,
+    fontSize: '12px', // bds-lint-ignore — dev overlay renders fixed
+    fontWeight: 600, // bds-lint-ignore — dev overlay renders fixed
+    letterSpacing: '0.02em',
+    textAlign: 'center',
+  };
+
+  const capturedStyle: CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px', // bds-lint-ignore — dev overlay renders fixed
+    fontSize: '11px', // bds-lint-ignore — dev overlay renders fixed
+    color: BDS.grayDarker,
+    fontFamily: BDS.fontFamily,
+    backgroundColor: BDS.tanLightest,
+    borderRadius: '8px', // bds-lint-ignore — dev overlay renders fixed
+    padding: '8px 10px',
+  };
+
+  // Hover outline drawn over the page while picking. Direct-positioned via ref.
+  const highlightStyle: CSSProperties = {
+    position: 'fixed',
+    zIndex: 9997,
+    display: 'none',
+    pointerEvents: 'none',
+    border: `2px solid ${BDS.poppy}`,
+    backgroundColor: 'rgba(227,83,53,0.08)',
+    borderRadius: '2px', // bds-lint-ignore — dev overlay renders fixed
+    transition: 'all 0.04s linear',
+  };
+
   return (
     <>
       {!devBarPresent && (
@@ -473,6 +595,40 @@ export function DevFeedbackWidget({
                   autoFocus
                 />
 
+                <button
+                  type="button"
+                  style={pickBtnStyle}
+                  aria-pressed={picking}
+                  onClick={() => setPicking((v) => !v)}
+                >
+                  {picking
+                    ? 'Click an element… (Esc to cancel)'
+                    : captured
+                    ? '📍 Re-pick element'
+                    : '📍 Pick element'}
+                </button>
+
+                {captured &&
+                  (captured.section || captured.component || captured.element_tag) && (
+                    <div style={capturedStyle}>
+                      {captured.section && (
+                        <div>
+                          Section: <strong>{captured.section}</strong>
+                        </div>
+                      )}
+                      {captured.component && (
+                        <div>
+                          Component: <strong>{captured.component}</strong>
+                        </div>
+                      )}
+                      {!captured.component && captured.element_tag && (
+                        <div>
+                          Element: <strong>&lt;{captured.element_tag}&gt;</strong>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
                 <div style={contextStyle}>
                   {contextLabel}: {contextValue}
                 </div>
@@ -489,6 +645,9 @@ export function DevFeedbackWidget({
           </div>,
           document.body,
         )}
+      {picking &&
+        typeof document !== 'undefined' &&
+        createPortal(<div ref={highlightRef} style={highlightStyle} />, document.body)}
     </>
   );
 }

--- a/components/ui/DevFeedbackWidget/detectContext.ts
+++ b/components/ui/DevFeedbackWidget/detectContext.ts
@@ -1,0 +1,111 @@
+/**
+ * detectContext — derive page / section / component context for a clicked element.
+ *
+ * Framework-agnostic (operates on a DOM Element) so both the React
+ * DevFeedbackWidget and the vanilla pin-drop widget can share one detector
+ * rather than maintaining parallel logic (brik-llm#979).
+ *
+ * Two environments are supported with one pass:
+ *   - Astro client mockups use the BDS `section--{type}` / `layout--{name}`
+ *     class convention — the original `detectSectionContext()` behavior.
+ *   - Product apps (portal, renew-pms) do NOT use those classes, so section is
+ *     resolved from semantic landmarks (`<section>`, `<main>`, `[role=region]`,
+ *     `[data-section]`) + an aria-label / nearest-heading / id fallback, and the
+ *     targeted BDS component is read from its `bds-{name}` block class
+ *     (e.g. `bds-button`).
+ *
+ * Every field is best-effort and may be absent — callers treat the result as
+ * optional context, never required.
+ */
+
+export interface CapturedContext {
+  /** Human-readable page name (document title, falling back to pathname). */
+  page?: string;
+  /** Section label/type the element sits in (e.g. "hero", "Billing settings"). */
+  section?: string;
+  /** BDS component block class without the prefix (e.g. "bds-button"). */
+  component?: string;
+  /** Tag name of the nearest meaningful element (e.g. "button", "h2"). */
+  element_tag?: string;
+}
+
+/** Resolve the human-readable page name for the current document. */
+function detectPage(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const title = document.title?.trim();
+  if (title) return title;
+  if (typeof location !== 'undefined' && location.pathname) return location.pathname;
+  return undefined;
+}
+
+/** First non-empty, trimmed string from the candidates. */
+function firstText(...candidates: Array<string | null | undefined>): string | undefined {
+  for (const c of candidates) {
+    const t = c?.trim();
+    if (t) return t;
+  }
+  return undefined;
+}
+
+/** Derive a section label from a resolved section element. */
+function sectionLabel(section: Element): string | undefined {
+  // Mockup convention first: "section section--hero" → "hero".
+  const typeMatch = section.className.match(/section--([a-z0-9-]+)/i);
+  if (typeMatch) return typeMatch[1];
+
+  // Product-app fallbacks, most-explicit first.
+  const ariaLabel = section.getAttribute('aria-label');
+  const dataSection = section.getAttribute('data-section');
+  const labelledBy = section.getAttribute('aria-labelledby');
+  const labelledByText =
+    labelledBy && typeof document !== 'undefined'
+      ? document.getElementById(labelledBy)?.textContent
+      : undefined;
+  const heading = section.querySelector('h1, h2, h3, h4')?.textContent;
+
+  return firstText(ariaLabel, dataSection, labelledByText, heading, section.id || undefined);
+}
+
+/** Extract the BDS component block class (`bds-button`) nearest to the target. */
+function detectComponent(target: Element): string | undefined {
+  const el = target.closest('[class*="bds-"]');
+  if (!el) return undefined;
+  // Match the block class only, not modifiers: `bds-button` from
+  // `bds-button bds-button--primary`; ignore `bds-button__icon` elements by
+  // preferring the shortest `bds-<word>` token present.
+  const blocks = Array.from(el.classList)
+    .map((c) => c.match(/^(bds-[a-z0-9]+)(?:--|__|$)/i)?.[1])
+    .filter((c): c is string => Boolean(c));
+  if (blocks.length === 0) return undefined;
+  // Shortest token is the block (modifiers/elements are longer); stable + simple.
+  return blocks.sort((a, b) => a.length - b.length)[0];
+}
+
+/**
+ * Inspect a clicked target and return whatever page/section/component context
+ * can be resolved. Safe to call with any Element; missing context is omitted.
+ */
+export function detectContext(target: Element): CapturedContext {
+  const ctx: CapturedContext = {};
+
+  const page = detectPage();
+  if (page) ctx.page = page;
+
+  const section =
+    target.closest('[class*="section--"]') ??
+    target.closest('section, article, main, [role="region"], [data-section]');
+  if (section) {
+    const label = sectionLabel(section);
+    if (label) ctx.section = label;
+  }
+
+  const component = detectComponent(target);
+  if (component) ctx.component = component;
+
+  const meaningful = target.closest(
+    'a, button, h1, h2, h3, h4, img, video, input, textarea, select, p, li, span',
+  );
+  if (meaningful) ctx.element_tag = meaningful.tagName.toLowerCase();
+
+  return ctx;
+}


### PR DESCRIPTION
## Why

The form feedback widget only sent the page path — agents triaging the Notion Backlog couldn't see which section/component a comment targeted. brik-llm#979 wires the pinpoint capability (which already existed on the pin-drop widget for the Supabase design-review path) into the form widget + Notion path.

## What

- **`detectContext.ts`** (new) — framework-agnostic detector. Generalized for product apps: nearest semantic landmark (`section`/`main`/`[role=region]`/`[data-section]`) + `aria-label`/heading/id for the section label, and the nearest `bds-{component}` block class (e.g. `bds-button`) for the component. Preserves the mockup `section--*` convention. Shareable with the vanilla pin-drop widget later.
- **`DevFeedbackWidget.tsx`** — optional **Pick element** mode: crosshair + hover highlight, click to capture (Esc cancels), captured context shown in the form. Sends `page`/`section`/`component` in the `/api/feedback` payload (page name always; section/component only when picked). Click-outside is suppressed while picking.

## Consumes

Pairs with `@brikdesigns/feedback-contract@0.2.0` (brikdesigns/brik-llm#981) which writes the new fields to the Backlog. Independent of that publish — the widget degrades gracefully (route ignores absent fields).

## Verification

- `tsc --noEmit` clean; BDS token linter + JSDoc lint + anti-slop clean (pre-commit).
- Manual pick-element interaction verification pending a Storybook/preview run.

Refs #979 (sub-issue of brik-llm#352)

🤖 Generated with [Claude Code](https://claude.com/claude-code)