### PR TITLE
chore(release): v0.97.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.95.0",
+  "version": "0.97.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.95.0",
+      "version": "0.97.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Version bump for the inspector element-context release (brik-bds#880, ADR-007).

**Minor** (0.96.0 → 0.97.0): `DevFeedbackWidget` gains optional `page` / `section` / `component` props — backward-compatible, no breaking changes. The inspector now emits `brik:inspect:report`; consumers pre-fill the widget from it.

Tag `v0.97.0` is pushed after this merges — the `Release` workflow validates `package.json` matches the tag and publishes `@brikdesigns/bds@0.97.0` to GitHub Packages.

Refs brikdesigns/brik-llm#979

🤖 Generated with [Claude Code](https://claude.com/claude-code)