### PR TITLE
Inspector exits inspect mode on Report-feedback (v0.97.1)

### DIFF
--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -1073,14 +1073,15 @@
       scanAndCopyReport();
     });
     // Emit element context for any feedback surface listening for
-    // `brik:inspect:report` (e.g. the product app's DevFeedbackWidget). Brief
-    // inline confirmation so the action reads as "fired" even when no host is
-    // wired (standalone mockup pages have no listener).
+    // `brik:inspect:report` (e.g. the product app's DevFeedbackWidget), then
+    // hand off: exit inspect mode so the inspector stops intercepting page
+    // clicks (its capture-phase onClick preventDefaults every non-chrome click)
+    // and the user can interact with the feedback form that just opened. If no
+    // host is wired (standalone mockup pages), the event is simply unobserved.
     const reportBtn = panelEl.querySelector('[data-action="report-feedback"]');
     reportBtn.addEventListener('click', () => {
       emitReport(el);
-      reportBtn.textContent = 'Reported ✓';
-      setTimeout(() => { reportBtn.textContent = 'Feedback'; }, 1200);
+      if (active) toggleActive();
     });
     panelEl.style.display = 'block';
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.97.0",
+      "version": "0.97.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## What

Follow-up to #881 (ADR-007 inspector convergence). The inspector's capture-phase `onClick` calls `preventDefault()` on every non-chrome click while inspect mode is active. The BDS `DevFeedbackWidget` panel renders as `role="dialog"` with **no** `bi-`/`bfb-` ignored class, so once a host opened the form from `brik:inspect:report`, the inspector would hijack clicks into it — the user couldn't focus the textarea or type.

Clicking **Feedback** now emits the event and then deactivates inspect mode, handing off cleanly to the feedback surface. Standalone mockup pages with no listener are unaffected (the event is simply unobserved).

**Patch** (0.97.0 → 0.97.1): behavior fix, no API change. Found while wiring brik-client-portal#1131; 0.97.0 has no other consumers yet.

Tag `v0.97.1` is pushed after merge — the Release workflow validates `package.json` matches the tag and publishes.

Refs brik-bds#880, brikdesigns/brik-llm#979

🤖 Generated with [Claude Code](https://claude.com/claude-code)