### PR TITLE
feedback: page detect slug

### DIFF
--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -670,9 +670,18 @@
   // as optional context, never required.
 
   function detectPage() {
+    // The URL pathname is the canonical page identity and is preferred — product
+    // apps (portal, renew-pms) share one templated <title> across every route, so
+    // document.title is non-discriminating there (every page reported the same
+    // name; brik-llm#979). The slug ("admin", "settings/services") is what a
+    // triager needs. document.title is kept only as a fallback for the root path,
+    // where the slug is empty.
+    if (typeof location !== 'undefined' && location.pathname) {
+      const slug = location.pathname.replace(/^\/+|\/+$/g, '');
+      if (slug) return slug;
+    }
     const title = document.title?.trim();
     if (title) return title;
-    if (typeof location !== 'undefined' && location.pathname) return location.pathname;
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- feat(inspector): own element-context capture; retire DevFeedbackWidget picker (#881)
- chore(release): v0.97.0 (#882)
- fix(inspector): exit inspect mode when Report-feedback is clicked (#883)
- chore(deps-dev): bump esbuild from 0.25.12 to 0.28.1 (#884)
- fix(inspector): derive page context from URL slug, not document.title

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)