### PR TITLE
scaffold: pindrop shared detector

### DIFF
--- a/components/ui/BrikDevBar/widgets/feedback-widget.js
+++ b/components/ui/BrikDevBar/widgets/feedback-widget.js
@@ -432,55 +432,27 @@
     removeForm();
   }
 
-  // ── Section detection ──────────────────────────────────────────────────
-  function detectSectionContext(target) {
+  // ── Section detection (delegates to the shared inspector detector) ────────
+  // ADR-007 makes the inspector the single element-context detector. On mockup
+  // deploys the inspect widget is injected alongside this one and exposes
+  // window.BrikInspect.detectContext(el); we map its result to the
+  // section_context shape stored in Supabase design_feedback.section_context.
+  // No parallel detection here (brik-client-portal#1132). If the inspector is
+  // somehow absent, degrade to empty context rather than throw.
+  function sectionContextFromDetector(target) {
+    const detect =
+      (typeof window !== 'undefined' && window.BrikInspect && window.BrikInspect.detectContext) || null;
+    if (!detect) return {};
+
+    const c = detect(target) || {};
     const ctx = {};
-
-    // Find nearest <section> ancestor with section classes
-    const section = target.closest('section[class*="section--"], [class*="section--"]');
-    if (section) {
-      // Extract section type from class: "section section--hero" → "hero"
-      const typeMatch = section.className.match(/section--([a-z-]+)/);
-      if (typeMatch) ctx.section_type = typeMatch[1];
-
-      // aria-label is the human-readable name
-      if (section.getAttribute('aria-label')) ctx.section_label = section.getAttribute('aria-label');
-
-      // id for anchoring
-      if (section.id) ctx.section_id = section.id;
-
-      // Look for <!-- Source: home.md Section-XX --> comment above the section
-      let prev = section.previousSibling;
-      while (prev) {
-        if (prev.nodeType === 8) { // Comment node
-          const commentMatch = prev.textContent.trim().match(/Source:\s*(.+)/);
-          if (commentMatch) {
-            ctx.content_source = commentMatch[1].trim();
-            break;
-          }
-        }
-        // Stop if we hit another element
-        if (prev.nodeType === 1) break;
-        prev = prev.previousSibling;
-      }
-
-      // Section number from DOM order
-      const allSections = document.querySelectorAll('section[class*="section--"]');
-      const idx = Array.from(allSections).indexOf(section);
-      if (idx >= 0) ctx.section_number = idx + 1;
-    }
-
-    // Detect layout class on nearest layout container
-    const layout = target.closest('[class*="layout--"]');
-    if (layout) {
-      const layoutMatch = layout.className.match(/layout--([a-z0-9-]+)/);
-      if (layoutMatch) ctx.layout = layoutMatch[1];
-    }
-
-    // Detect the clicked element type
-    const el = target.closest('a, button, h1, h2, h3, h4, img, video, input, textarea, p, li, span');
-    if (el) ctx.element_tag = el.tagName.toLowerCase();
-
+    if (c.section_type) ctx.section_type = c.section_type;
+    if (c.section_label) ctx.section_label = c.section_label;
+    if (c.section_id) ctx.section_id = c.section_id;
+    if (c.content_source) ctx.content_source = c.content_source;
+    if (c.section_number) ctx.section_number = c.section_number;
+    if (c.layout) ctx.layout = c.layout;
+    if (c.element_tag) ctx.element_tag = c.element_tag;
     return ctx;
   }
 
@@ -501,7 +473,7 @@
     const y = e.pageY;
 
     // Detect section context before creating the pin overlay
-    currentSectionContext = detectSectionContext(e.target);
+    currentSectionContext = sectionContextFromDetector(e.target);
 
     pendingPin = document.createElement('div');
     pendingPin.className = 'bfb-pin bfb-pin--pending';

--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -707,6 +707,52 @@
     return firstText(ariaLabel, dataSection, labelledByText, heading, section.id || undefined);
   }
 
+  // Structured section metadata for the Astro mockup environment. Mockups
+  // annotate sections with `section--{type}` / `layout--{name}` classes and a
+  // preceding `<!-- Source: home.md Section-XX -->` comment; the pin-drop
+  // feedback widget records these in Supabase design_feedback.section_context.
+  // Surfacing them here (all undefined in product apps, which have none of these
+  // conventions) lets the pin-drop widget consume this one detector instead of a
+  // parallel detectSectionContext() copy — brik-client-portal#1132 / ADR-007.
+  function detectSectionMeta(el) {
+    const meta = {};
+
+    const section = el.closest('section[class*="section--"], [class*="section--"]');
+    if (section) {
+      const typeMatch = section.className.match(/section--([a-z0-9-]+)/i);
+      if (typeMatch) meta.section_type = typeMatch[1];
+
+      const ariaLabel = section.getAttribute('aria-label');
+      if (ariaLabel) meta.section_label = ariaLabel;
+
+      if (section.id) meta.section_id = section.id;
+
+      // Walk back over text nodes to the nearest preceding comment / element.
+      let prev = section.previousSibling;
+      while (prev) {
+        if (prev.nodeType === 8) {
+          const m = prev.textContent.trim().match(/Source:\s*(.+)/);
+          if (m) { meta.content_source = m[1].trim(); break; }
+        }
+        if (prev.nodeType === 1) break;
+        prev = prev.previousSibling;
+      }
+
+      // 1-based position among all `section--` blocks in document order.
+      const all = document.querySelectorAll('section[class*="section--"]');
+      const idx = Array.from(all).indexOf(section);
+      if (idx >= 0) meta.section_number = idx + 1;
+    }
+
+    const layout = el.closest('[class*="layout--"]');
+    if (layout) {
+      const m = layout.className.match(/layout--([a-z0-9-]+)/i);
+      if (m) meta.layout = m[1];
+    }
+
+    return meta;
+  }
+
   function detectReportContext(el) {
     const ctx = {};
 
@@ -730,6 +776,9 @@
     );
     if (meaningful) ctx.element_tag = meaningful.tagName.toLowerCase();
 
+    // Mockup-environment structured fields (superset; undefined elsewhere).
+    Object.assign(ctx, detectSectionMeta(el));
+
     return ctx;
   }
 
@@ -740,6 +789,15 @@
     const detail = detectReportContext(el);
     window.dispatchEvent(new CustomEvent('brik:inspect:report', { detail }));
     return detail;
+  }
+
+  // Expose the shared detector for surfaces that resolve element context without
+  // entering inspect mode or listening for brik:inspect:report — the mockup
+  // pin-drop feedback widget calls this synchronously on click. ADR-007 makes
+  // this the single detector; consumers must not reimplement it (#1132).
+  if (typeof window !== 'undefined') {
+    window.BrikInspect = window.BrikInspect || {};
+    window.BrikInspect.detectContext = detectReportContext;
   }
 
   // ── Stylesheet rule index ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- feat(inspector): own element-context capture; retire DevFeedbackWidget picker (#881)
- chore(release): v0.97.0 (#882)
- fix(inspector): exit inspect mode when Report-feedback is clicked (#883)
- chore(deps-dev): bump esbuild from 0.25.12 to 0.28.1 (#884)
- fix(inspector): derive page context from URL slug, not document.title (#885)
- feat(inspector): expose shared detectContext; converge pin-drop widget

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)