### PR TITLE
inspect: section detector

### DIFF
--- a/components/ui/BrikDevBar/widgets/inspect-widget.detect.browser.test.ts
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.detect.browser.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Section-detector regression tests for the BDS inspect widget (brik-bds#886).
+ *
+ * The widget is a browser-only IIFE that exposes `window.BrikInspect.detectContext`
+ * (ADR-007: the single element-context detector). We execute the IIFE source in a
+ * real chromium DOM and assert the section-resolution rules that #886 fixed:
+ *
+ *   - A click whose nearest landmark is `<main>` (no labeled region) reports NO
+ *     section — the page H1 / skip-link id is never surfaced as a section.
+ *   - Explicit author labels (aria-label / data-section / `section--{type}`) and
+ *     real (non-H1) section headings ARE reported.
+ *
+ * Runs under the `widgets` browser vitest project (see vitest.config.ts).
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+// Raw source so we can execute the IIFE in the page's global scope; it attaches
+// detectContext to `window` on load.
+import widgetSource from './inspect-widget.js?raw';
+
+interface ReportContext {
+  page?: string;
+  section?: string;
+  component?: string;
+  element_tag?: string;
+}
+
+let detectContext: (el: Element) => ReportContext;
+
+beforeAll(() => {
+  // The widget self-disables (`if (!SHOULD_ENABLE) return`) unless data-auto-enable
+  // or ?inspect=1 is present; flip the URL flag so the IIFE proceeds far enough to
+  // expose detectContext.
+  history.replaceState(null, '', `${location.pathname}?inspect=1`);
+  // Execute the IIFE synchronously in the page scope; it attaches detectContext
+  // to `window`. eval (not a dynamic <script>) so any load-time throw surfaces here.
+  try {
+    // eslint-disable-next-line no-eval
+    (0, eval)(widgetSource);
+  } catch (err) {
+    throw new Error(`widget IIFE threw on load: ${(err as Error).stack ?? String(err)}`);
+  }
+  const api = (window as unknown as {
+    BrikInspect?: { detectContext?: (el: Element) => ReportContext };
+  }).BrikInspect;
+  if (!api?.detectContext) throw new Error('widget did not expose BrikInspect.detectContext');
+  detectContext = api.detectContext;
+});
+
+function render(html: string): Element {
+  document.body.innerHTML = html;
+  const target = document.getElementById('target');
+  if (!target) throw new Error('fixture is missing #target');
+  return target;
+}
+
+describe('inspect widget — section detection (#886)', () => {
+  it('reports no section for a <main>-only click (page H1 never surfaced)', () => {
+    const target = render(`
+      <main id="main-content">
+        <h1>Good Evening, Brik</h1>
+        <p id="target">Portal activity and quick stats.</p>
+      </main>
+    `);
+    expect(detectContext(target).section).toBeUndefined();
+  });
+
+  it('does not surface the page H1 even when a bare <section> wraps it', () => {
+    const target = render(`
+      <main>
+        <section>
+          <h1 id="target">Good Evening, Brik</h1>
+        </section>
+      </main>
+    `);
+    expect(detectContext(target).section).toBeUndefined();
+  });
+
+  it('reports an aria-label on a section region', () => {
+    const target = render(`
+      <main>
+        <section aria-label="Recent Engagements"><p id="target">row</p></section>
+      </main>
+    `);
+    expect(detectContext(target).section).toBe('Recent Engagements');
+  });
+
+  it('reports a data-section attribute', () => {
+    const target = render(`
+      <main><div data-section="stats"><p id="target">x</p></div></main>
+    `);
+    expect(detectContext(target).section).toBe('stats');
+  });
+
+  it('reports the mockup section--{type} convention', () => {
+    const target = render(`
+      <section class="section section--hero"><p id="target">x</p></section>
+    `);
+    expect(detectContext(target).section).toBe('hero');
+  });
+
+  it('reports a real section heading that is not the page H1', () => {
+    const target = render(`
+      <main>
+        <h1>Page Title</h1>
+        <section><h2>Pricing</h2><p id="target">x</p></section>
+      </main>
+    `);
+    expect(detectContext(target).section).toBe('Pricing');
+  });
+});

--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -693,18 +693,44 @@
     return undefined;
   }
 
+  // The page's primary heading — the first <h1> (preferring one inside <main>).
+  // Used to stop the section detector from reporting the page title as a
+  // "section" (brik-bds#886).
+  function isPageHeading(heading) {
+    const pageH1 = document.querySelector('main h1') || document.querySelector('h1');
+    return !!pageH1 && heading === pageH1;
+  }
+
   function sectionLabel(section) {
     // Mockup convention first: "section section--hero" → "hero".
     const typeMatch = section.className.match(/section--([a-z0-9-]+)/i);
     if (typeMatch) return typeMatch[1];
 
-    // Product-app fallbacks, most-explicit first.
+    // Explicit, author-provided labels, most-explicit first. These deliberately
+    // name a region, so they're trusted even on <main>.
     const ariaLabel = section.getAttribute('aria-label');
     const dataSection = section.getAttribute('data-section');
     const labelledBy = section.getAttribute('aria-labelledby');
     const labelledByText = labelledBy ? document.getElementById(labelledBy)?.textContent : undefined;
-    const heading = section.querySelector('h1, h2, h3, h4')?.textContent;
-    return firstText(ariaLabel, dataSection, labelledByText, heading, section.id || undefined);
+    const explicit = firstText(ariaLabel, dataSection, labelledByText);
+    if (explicit) return explicit;
+
+    // <main> is the page-level landmark, not a section. Product-app pages
+    // typically have a single <main> whose first heading is the page H1 and
+    // whose id is a skip-link target ("main-content"); deriving a section name
+    // from either is misleading (brik-bds#886). Without an explicit label
+    // above, <main> names no section — let the caller omit it.
+    if (section.tagName === 'MAIN') return undefined;
+
+    // Non-landmark regions: nearest heading, then id. Never the page H1 — a
+    // <section> whose only heading is the document title is effectively
+    // page-level and would mislead a triager.
+    const heading = section.querySelector('h1, h2, h3, h4');
+    if (heading && !isPageHeading(heading)) {
+      const text = heading.textContent?.trim();
+      if (text) return text;
+    }
+    return firstText(section.id || undefined);
   }
 
   // Structured section metadata for the Astro mockup environment. Mockups

--- a/types/raw.d.ts
+++ b/types/raw.d.ts
@@ -1,0 +1,7 @@
+// Vite `?raw` imports return the file's text. Declared here (inside the
+// tsconfig `types/**` include) so `tsc --noEmit` accepts widget IIFE source
+// loaded into browser tests.
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,8 +38,25 @@ export default defineConfig({
           name: 'components',
           environment: 'node',
           include: ['components/**/*.test.ts'],
+          // Browser-only widget tests run under the `widgets` project below.
+          exclude: ['**/*.browser.test.ts'],
           deps: {
             inline: ['react', 'react-dom', '@testing-library/react'],
+          },
+        },
+      },
+      {
+        // Vanilla DevBar widgets (inspect/feedback) are browser-only IIFEs that
+        // attach to `window`; exercise them in a real DOM, not node/jsdom.
+        extends: true,
+        test: {
+          name: 'widgets',
+          include: ['components/ui/BrikDevBar/widgets/**/*.browser.test.ts'],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: 'chromium' }],
           },
         },
       },


### PR DESCRIPTION
## Why

On product-app pages a click usually resolves to `<main>` (often the only landmark), and `sectionLabel()` fell through to `<main>`'s first heading — the **page H1** — or its skip-link id (`main-content`). Feedback rows then showed the page greeting as the "section". Surfaced by the brik-llm#979 staging close-gate (2026-06-14): a table-cell click on `/admin` reported `section = "Good Evening, Brik"`.

## What (lever 1 of 2 — the BDS detector)

`sectionLabel()` in `inspect-widget.js` now:
- trusts explicit author labels (`aria-label` / `data-section` / `aria-labelledby` / `section--{type}`) on any element, including `<main>`;
- returns **no** section for `<main>` absent such a label;
- guards the heading/id fallback via `isPageHeading()` so the document H1 is never surfaced as a section.

## Gate

New chromium browser vitest project **`widgets`** executes the IIFE in a real DOM and asserts the rules — `<main>`-only → no section; `aria-label` / `data-section` / `section--{type}` / real (non-H1) headings → reported. **No new dependencies** (reuses the installed `@vitest/browser-playwright`). Node `components` project excludes `*.browser.test.ts` so they don't double-run.

- ✅ `npm run typecheck`
- ✅ `vitest --project widgets` (6/6)
- ✅ node projects (230/230)

## Scope / follow-up

Advances brik-bds#886 **AC #1 + AC #2**. Does **not** close it — **AC #3** (wrap a high-traffic portal page's regions in `<section aria-label>` / `[data-section]` + end-to-end staging verification) is brik-client-portal work, and the updated widget must be propagated to consumers via `npm run sync:devbar-widgets`.

Relates to brik-bds#886 · brik-llm#979 · ADR-007
