### PR TITLE
ci: run Vitest suite on PRs and pushes to main (#891)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Two vitest projects (`storybook`, `widgets`) run in browser mode via
+      # The `widgets` vitest project runs in browser mode via
       # @vitest/browser-playwright → Chromium. Local runs reuse a cached
       # browser; CI has none, so install it (with OS deps) before the suite.
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Run Vitest suite
-        run: npm test
+      # The `storybook` browser project is excluded for now: its story files
+      # fail nondeterministically with "Vitest failed to find the current
+      # suite" (a dep-optimizer/isolation race — see #571). Gating on a flaky
+      # project would red-flag every PR. The negated filter is fail-closed —
+      # any NEW project is gated by default; only `storybook` is opted out.
+      # Re-include it (drop the filter) once #571 makes the suite deterministic.
+      - name: Run Vitest suite (excludes flaky `storybook` project — see #571)
+        run: npm test -- --project='!storybook'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test Suite
+
+# Runs the Vitest suite on every PR and on every push to main.
+#
+# Why this is a CI gate (not just a local hook):
+#   - Pre-commit runs token + JSDoc + recipe + typecheck — NOT tests.
+#   - Pre-push runs `validate:full` (scripts/validate-all.js), which runs
+#     JSDoc Lint + Grid Audit + TypeScript — the test suite is absent.
+#   - `pr-task.sh` re-runs tests POST-merge, so a regression is only caught
+#     after it has already landed on main.
+#   - Cloud-agent commits and fork PRs bypass local hooks entirely.
+# This workflow is the pre-merge guarantee that component regressions can't
+# land green. Suite is ~17s + setup; cheap enough to run on every PR.
+#
+# Issue: brikdesigns/brik-bds#891
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Vitest suite
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Two vitest projects (`storybook`, `widgets`) run in browser mode via
+      # @vitest/browser-playwright → Chromium. Local runs reuse a cached
+      # browser; CI has none, so install it (with OS deps) before the suite.
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Run Vitest suite
         run: npm test


### PR DESCRIPTION
## What

Adds `.github/workflows/test.yml` — runs the Vitest suite on every PR to `main` and on pushes to `main`.

## Why

The test suite never ran automatically before this:

- **pre-commit** → token lint + JSDoc + ADR-007 recipe + typecheck (no tests)
- **pre-push** → `validate:full` (`scripts/validate-all.js`) = JSDoc Lint + Grid Audit + TypeScript (no tests)
- **pr-task.sh** → re-runs `npm test` *post-merge*, so a regression is only caught after it lands

Component regressions could land on a green PR. This is the pre-merge gate that closes the hole. Fork PRs and cloud-agent commits (which bypass local hooks) are covered too.

## Scope — `storybook` browser project excluded (see #571)

Wiring the gate surfaced that #571 ("Vitest failed to find the current suite") **reproduces in CI**, not just locally: the `storybook` browser project fails nondeterministically (3 story files here, 11 in #571's local repro — a dep-optimizer/isolation race, not real failures; 682 tests pass). Gating on a flaky project would red-flag every PR.

So the gate runs `npm test -- --project='!storybook'` — the deterministic projects (**components, content-system, scripts, widgets**) are gated now. The negated filter is **fail-closed**: any new project is gated by default; only `storybook` is opted out. Re-including story-render tests is tracked on #571 — drop the filter once it lands.

## Shape

Mirrors `canonical-check.yml` (Node 22, `npm ci`, concurrency-cancel) + a `playwright install --with-deps chromium` step (the `widgets` project runs in browser mode).

## Verification

`test` check green in CI (1m10s); deterministic projects pass. Per-project run verified locally.

Refs #891 (partial — full close is gated on #571 re-inclusion). Closes #891 for the deterministic-suite gate; storybook re-inclusion tracked on #571.