### PR TITLE
fix(test): pre-bundle storybook deps to kill cold-cache optimizer reload (#571)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,11 +48,10 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
-      # The `storybook` browser project is excluded for now: its story files
-      # fail nondeterministically with "Vitest failed to find the current
-      # suite" (a dep-optimizer/isolation race — see #571). Gating on a flaky
-      # project would red-flag every PR. The negated filter is fail-closed —
-      # any NEW project is gated by default; only `storybook` is opted out.
-      # Re-include it (drop the filter) once #571 makes the suite deterministic.
-      - name: Run Vitest suite (excludes flaky `storybook` project — see #571)
-        run: npm test -- --project='!storybook'
+      # Full suite, all projects. The `storybook` browser project was excluded
+      # while #571 (cold-cache dep-optimizer reload → "Vitest failed to find
+      # the current suite") was unfixed; vitest.config.ts now pre-bundles the
+      # story deps via optimizeDeps.include, so it runs deterministically and
+      # is back in the gate.
+      - name: Run Vitest suite
+        run: npm test

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,43 @@
 import { defineConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Deps the storybook browser tests pull in transitively through stories but
+// that the @storybook/addon-vitest plugin does NOT pre-bundle (it only
+// optimizes its own runtime). Listing them in optimizeDeps.include makes the
+// browser server's first optimize pass complete; otherwise Vite discovers them
+// lazily as stories import mid-run, fires "optimized dependencies changed.
+// reloading", and the page reload destroys the running suite → "Vitest failed
+// to find the current suite". Warm local caches already hold these, so the
+// race only bites cold CI runners — which is why #891's gate had to exclude
+// this project until this fix landed. See #571.
+// @radix-ui/* is derived from package.json so adding a new primitive to a
+// component auto-extends the list — the common BDS change that would otherwise
+// silently reintroduce the flake.
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(dirname, 'package.json'), 'utf8'),
+);
+const storybookOptimizeInclude = [
+  'react',
+  'react-dom',
+  'react-dom/client',
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
+  '@iconify/react',
+  'lottie-react',
+  'storybook/test',
+  'storybook/theming',
+  '@storybook/addon-docs',
+  '@storybook/addon-docs/blocks',
+  ...Object.keys(pkg.dependencies ?? {}).filter((d) =>
+    d.startsWith('@radix-ui/'),
+  ),
+];
 
 export default defineConfig({
   test: {
@@ -14,6 +47,11 @@ export default defineConfig({
         plugins: [
           storybookTest({ configDir: path.join(dirname, '.storybook') }),
         ],
+        // See storybookOptimizeInclude above — pre-bundles story deps so the
+        // cold-cache optimizer reload (#571) can't destroy the suite mid-run.
+        optimizeDeps: {
+          include: storybookOptimizeInclude,
+        },
         test: {
           name: 'storybook',
           browser: {


### PR DESCRIPTION
## What

Fixes the nondeterministic `storybook` browser-project failure (`Vitest failed to find the current suite`) and re-includes the project in the CI gate — closing the #891↔#571 link.

## Root cause

`@storybook/addon-vitest` only pre-bundles its own runtime in the browser server's optimizer. Each story's transitive deps (`react-dom`, `@radix-ui/*`, `@iconify/react`, `lottie-react`, `storybook/test`, …) are therefore discovered **lazily** as the browser imports stories mid-run. On a **cold** cache that fires Vite's `optimized dependencies changed. reloading`, and the page reload destroys the running suite.

Warm local caches already hold those deps — which is why it only reproduced on cold CI runners (and why the original "CI passes the same commit" premise in #571 was stale; #891's comment confirmed it reproduces in CI).

## Fix

List the story deps in the `storybook` project's `optimizeDeps.include` (in `vitest.config.ts`) so the browser server's first optimize pass is complete and nothing reloads mid-run. `@radix-ui/*` is derived from `package.json` so adding a new primitive to a component auto-extends the list — the common BDS change that would otherwise silently reintroduce the flake.

Then drop `--project='!storybook'` from `.github/workflows/test.yml` so the story-render tests rejoin the gate.

## Verification

Reproduced locally with a cold-cache harness (`rm -rf node_modules/.vite node_modules/.cache/storybook && vitest run`), which only triggers in a fresh worktree:

- **Empty `include` + cold** → reproduces `optimized dependencies changed. reloading` → `Vitest failed to find the current suite` (the #571 signature).
- **Populated `include` + cold** → **709 tests pass, 3× consecutive cold runs**, zero reloads.
- `npm run typecheck` → clean.

CI on this PR runs the full suite (storybook included) — re-run a few times to confirm determinism on the runner before merge.

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)