### PR TITLE
feat(tooling): gate raw inline var() in component TSX + migrate AddressInput (#892)

### DIFF
--- a/components/ui/AddressInput/AddressInput.css
+++ b/components/ui/AddressInput/AddressInput.css
@@ -1,39 +1,185 @@
 @layer bds-components {
 /**
- * BDS AddressInput Interactive States
+ * BDS AddressInput
+ *
+ * Location input with a leading map-pin icon and an autocomplete dropdown.
+ * Border, radius, and background tokens match TextInput / SearchInput.
  *
  * Token reference:
- * - --border-input (default border)
- * - --border-primary (hover border — darker)
- * - --border-brand-primary (focus border — theme color)
- * - --text-muted (placeholder color)
+ * - --background-input (field fill)         - --border-input (default border)
+ * - --border-primary (hover/dropdown border) - --border-brand-primary (focus)
+ * - --surface-primary (dropdown panel)       - --text-primary / --text-muted
  */
 
-.bds-address-input-field::placeholder {
+/* Wrapper — vertical stack: label above field */
+.bds-address-input {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  width: auto;
+}
+
+.bds-address-input--full-width {
+  width: 100%;
+}
+
+/* Label */
+.bds-address-input__label {
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--font-line-height-tight);
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+.bds-address-input--sm .bds-address-input__label {
+  font-size: var(--label-sm);
+}
+
+.bds-address-input--md .bds-address-input__label {
+  font-size: var(--label-md);
+}
+
+/* Field region — positions icon + dropdown relative to the input */
+.bds-address-input__field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+/* Icon — shared base for the leading map-pin and the suggestion-row icon */
+.bds-address-input__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--text-muted);
 }
 
-.bds-address-input-field:hover:not(:disabled) {
+/* Leading map-pin icon, inset inside the field */
+.bds-address-input__field > .bds-address-input__icon {
+  position: absolute;
+  left: var(--padding-sm);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Input — base appearance (size-specific metrics below) */
+.bds-address-input__input {
+  width: 100%;
+  font-family: var(--font-family-body);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-primary);
+  background-color: var(--background-input);
+  border: var(--border-width-md) solid var(--border-input);
+  border-radius: var(--border-radius-md);
+  outline: none;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+/* Size — heights match the Button scale (8px steps on the 4px grid).
+   Left padding clears the leading icon (icon inset + 24px glyph slot). */
+.bds-address-input--md .bds-address-input__input {
+  font-size: var(--body-md);
+  height: 40px;
+  padding-right: var(--padding-sm);
+  padding-left: calc(var(--padding-sm) + 24px);
+}
+
+.bds-address-input--sm .bds-address-input__input {
+  font-size: var(--body-sm);
+  height: 32px;
+  padding-right: var(--padding-xs);
+  padding-left: calc(var(--padding-xs) + 24px);
+}
+
+/* Interactive states */
+.bds-address-input__input::placeholder {
+  color: var(--text-muted);
+}
+
+.bds-address-input__input:hover:not(:disabled) {
   border-color: var(--border-primary);
 }
 
-.bds-address-input-field:focus {
+.bds-address-input__input:focus {
   border-color: var(--border-brand-primary);
   box-shadow: 0 0 0 1px var(--border-brand-primary);
 }
 
-.bds-address-input-field:focus-visible {
+.bds-address-input__input:focus-visible {
   border-color: var(--border-brand-primary);
   box-shadow: 0 0 0 1px var(--border-brand-primary);
   outline: none;
 }
 
-.bds-address-input-field:disabled {
+.bds-address-input__input:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.bds-address-input-suggestion:hover {
+/* Suggestions dropdown panel */
+.bds-address-input__dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  margin-top: var(--gap-sm);
+  background-color: var(--surface-primary);
+  border-radius: var(--border-radius-lg);
+  border: var(--border-width-lg) solid var(--border-primary);
+  padding: var(--padding-sm);
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.12); /* bds-lint-ignore — shadow tokens resolve to zero */
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  max-height: 240px;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+/* Suggestion item */
+.bds-address-input__option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--gap-md);
+  padding: var(--padding-xs);
+  background: none;
+  border: none;
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-family-body);
+  font-size: var(--body-md);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-primary);
+  box-sizing: border-box;
+  min-width: 0;
+}
+
+.bds-address-input__option:hover {
   background-color: var(--surface-secondary);
+}
+
+/* Suggestion-row leading icon */
+.bds-address-input__option > .bds-address-input__icon {
+  width: 20px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+/* Suggestion text wrapper — stacks label over description */
+.bds-address-input__content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.bds-address-input__description {
+  font-size: var(--body-sm);
+  color: var(--text-muted);
 }
 }

--- a/components/ui/AddressInput/AddressInput.tsx
+++ b/components/ui/AddressInput/AddressInput.tsx
@@ -3,7 +3,6 @@ import {
   useId,
   type InputHTMLAttributes,
   type ReactNode,
-  type CSSProperties,
   useState,
   useRef,
   useEffect,
@@ -49,211 +48,6 @@ export interface AddressInputProps
   /** Callback when a suggestion is selected */
   onSuggestionSelect?: (suggestion: AddressSuggestion) => void;
 }
-
-/**
- * Wrapper styles — vertical stack with gap between label and field
- *
- * Token reference:
- * - --gap-md = 8px
- */
-const wrapperStyles: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'var(--gap-md)',
-};
-
-/**
- * Label styles
- *
- * Token reference:
- * - --font-family-label
- * - --font-weight-semi-bold = 600
- * - --font-line-height-tight
- * - --text-primary
- */
-const labelStyles: CSSProperties = {
-  fontFamily: 'var(--font-family-label)',
-  fontWeight: 'var(--font-weight-semi-bold)' as unknown as number,
-  lineHeight: 'var(--font-line-height-tight)',
-  color: 'var(--text-primary)',
-  textTransform: 'capitalize' as const,
-};
-
-/**
- * Label size variants
- */
-const labelSizeStyles: Record<AddressInputSize, CSSProperties> = {
-  sm: { fontSize: 'var(--label-sm)' },
-  md: { fontSize: 'var(--label-md)' },
-};
-
-/**
- * Field wrapper — positions icon and dropdown relative to input
- */
-const fieldWrapperStyles: CSSProperties = {
-  position: 'relative',
-  display: 'flex',
-  alignItems: 'center',
-};
-
-/**
- * Address icon positioning
- *
- * Token reference:
- * - --text-muted (icon color)
- * - --padding-xs = 10px (inset)
- */
-const iconStyles: CSSProperties = {
-  position: 'absolute',
-  left: 'var(--padding-sm)',
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: 'var(--text-muted)',
-  pointerEvents: 'none',
-  zIndex: 1,
-};
-
-/**
- * Input base styles — matches TextInput and SearchInput
- *
- * Token reference:
- * - --background-input (white)
- * - --border-input (border)
- * - --border-width-md = 1px (border thickness)
- * - --border-radius-md = 4px (corners)
- * - --font-family-body
- * - --body-md = 16px
- * - --font-weight-regular = 400
- * - --font-line-height-normal
- */
-const inputBaseStyles: CSSProperties = {
-  width: '100%',
-  fontFamily: 'var(--font-family-body)',
-  fontWeight: 'var(--font-weight-regular)' as unknown as number,
-  lineHeight: 'var(--font-line-height-normal)',
-  color: 'var(--text-primary)',
-  backgroundColor: 'var(--background-input)',
-  border: 'var(--border-width-md) solid var(--border-input)',
-  borderRadius: 'var(--border-radius-md)',
-  outline: 'none',
-  transition: 'border-color 0.2s',
-  boxSizing: 'border-box',
-};
-
-/**
- * Size-specific styles
- *
- * Heights match Button scale (8px steps, 4px grid):
- *   sm=32  md=40
- */
-const inputSizeStyles: Record<AddressInputSize, CSSProperties> = {
-  md: {
-    fontSize: 'var(--body-md)',
-    height: '40px',
-    paddingRight: 'var(--padding-sm)',
-    paddingLeft: 'calc(var(--padding-sm) + 24px)',
-  },
-  sm: {
-    fontSize: 'var(--body-sm)',
-    height: '32px',
-    paddingRight: 'var(--padding-xs)',
-    paddingLeft: 'calc(var(--padding-xs) + 24px)',
-  },
-};
-
-/**
- * Suggestions dropdown panel
- *
- * Token reference:
- * - --surface-primary (white)
- * - --border-radius-lg = 8px
- * - --padding-sm = 12px (padding)
- * - --gap-sm = 6px (item gap)
- */
-const dropdownStyles: CSSProperties = {
-  position: 'absolute',
-  top: '100%',
-  left: 0,
-  right: 0,
-  zIndex: 100,
-  marginTop: 'var(--gap-sm)',
-  backgroundColor: 'var(--surface-primary)',
-  borderRadius: 'var(--border-radius-lg)',
-  border: 'var(--border-width-lg) solid var(--border-primary)',
-  padding: 'var(--padding-sm)',
-  boxShadow: '0px 4px 16px rgba(0, 0, 0, 0.12)', // bds-lint-ignore — shadow tokens resolve to zero
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'var(--gap-sm)',
-  maxHeight: 240,
-  overflowY: 'auto',
-  boxSizing: 'border-box',
-};
-
-/**
- * Suggestion item button styles
- *
- * Token reference:
- * - --font-family-body
- * - --body-md = 16px
- * - --font-line-height-normal
- * - --text-primary
- * - --gap-md = 8px (icon gap)
- * - --border-radius-sm = 2px
- */
-const suggestionItemStyles: CSSProperties = {
-  display: 'flex',
-  alignItems: 'flex-start',
-  gap: 'var(--gap-md)',
-  padding: 'var(--padding-xs)',
-  background: 'none',
-  border: 'none',
-  borderRadius: 'var(--border-radius-sm)',
-  cursor: 'pointer',
-  width: '100%',
-  textAlign: 'left',
-  fontFamily: 'var(--font-family-body)',
-  fontSize: 'var(--body-md)',
-  lineHeight: 'var(--font-line-height-normal)',
-  color: 'var(--text-primary)',
-  boxSizing: 'border-box',
-  minWidth: 0,
-};
-
-/**
- * Suggestion icon wrapper
- */
-const suggestionIconStyles: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: 20, // bds-lint-ignore — icon wrapper alignment
-  height: 24, // bds-lint-ignore
-  color: 'var(--text-muted)',
-  flexShrink: 0,
-};
-
-/**
- * Suggestion text wrapper — allows label + description stacking
- */
-const suggestionTextStyles: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  minWidth: 0,
-};
-
-/**
- * Description text under suggestion label
- *
- * Token reference:
- * - --body-sm = 14px
- * - --text-muted
- */
-const suggestionDescriptionStyles: CSSProperties = {
-  fontSize: 'var(--body-sm)',
-  color: 'var(--text-muted)',
-};
 
 /**
  * AddressInput - Location input with autocomplete suggestions
@@ -335,31 +129,24 @@ export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
       setIsFocused(false);
     };
 
-    const inputStyles: CSSProperties = {
-      ...inputBaseStyles,
-      ...inputSizeStyles[size],
-    };
-
     return (
       <div
         ref={wrapperRef}
-        className={bdsClass('bds-address-input', className)}
-        style={{
-          ...wrapperStyles,
-          width: fullWidth ? '100%' : 'auto',
-          ...style,
-        }}
+        className={bdsClass(
+          'bds-address-input',
+          `bds-address-input--${size}`,
+          fullWidth && 'bds-address-input--full-width',
+          className,
+        )}
+        style={style}
       >
         {label && (
-          <label
-            htmlFor={inputId}
-            style={{ ...labelStyles, ...labelSizeStyles[size] }}
-          >
+          <label htmlFor={inputId} className="bds-address-input__label">
             {label}
           </label>
         )}
-        <div style={fieldWrapperStyles}>
-          <span style={iconStyles}>
+        <div className="bds-address-input__field">
+          <span className="bds-address-input__icon">
             <Icon icon={MapPin} />
           </span>
           <input
@@ -368,13 +155,12 @@ export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
             ref={ref}
             id={inputId}
             type="text"
-            className="bds-address-input-field"
-            style={inputStyles}
+            className="bds-address-input__input"
             onFocus={handleFocus}
             {...props}
           />
           {showDropdown && (
-            <div role="listbox" style={dropdownStyles}>
+            <div role="listbox" className="bds-address-input__dropdown">
               {suggestions.map((suggestion) => (
                 <button
                   key={suggestion.id}
@@ -383,16 +169,15 @@ export const AddressInput = forwardRef<HTMLInputElement, AddressInputProps>(
                   aria-selected={false}
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => handleSelect(suggestion)}
-                  className="bds-address-input-suggestion"
-                  style={suggestionItemStyles}
+                  className="bds-address-input__option"
                 >
-                  <span style={suggestionIconStyles}>
+                  <span className="bds-address-input__icon">
                     {suggestion.icon || <Icon icon={MapPin} />}
                   </span>
-                  <span style={suggestionTextStyles}>
+                  <span className="bds-address-input__content">
                     <span>{suggestion.label}</span>
                     {suggestion.description && (
-                      <span style={suggestionDescriptionStyles}>
+                      <span className="bds-address-input__description">
                         {suggestion.description}
                       </span>
                     )}

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -4,7 +4,7 @@
  * BDS Token Validation Linter
  *
  * Validates CSS variable usage in BDS components against Style Dictionary token outputs.
- * Catches five types of violations:
+ * Catches six types of violations:
  *   1. Primitive token usage (use semantic tokens instead)
  *   2. Hardcoded CSS values (use tokens)
  *   3. Unknown tokens (typos or non-existent variables)
@@ -12,6 +12,12 @@
  *   5. Token-family pairing mismatch — a token used in a property whose family
  *      it doesn't belong to (e.g. background-color: var(--text-*)). See
  *      docs/TOKEN-PR-CHECKLIST.md for the property↔family table.
+ *   6. Raw inline var(--…) in component TSX — styles belong in the component's
+ *      .css file (BEM under bds-), never a CSSProperties object. See the
+ *      component-build standard §"Styles live in CSS". Files in
+ *      INLINE_VAR_BASELINE are grandfathered to warnings (ratchet); clean
+ *      files error. Escape hatch: `bds-lint-ignore` for runtime-calculated
+ *      values that genuinely cannot live in CSS.
  *
  * Usage:
  *   node scripts/lint-tokens.js              # full report (errors + warnings)
@@ -33,7 +39,43 @@ const path = require('path');
 const SD_CSS_PATH = path.join(
   __dirname, '..', 'build', 'figma', 'css', 'variables.css'
 );
+const REPO_ROOT = path.join(__dirname, '..');
 const COMPONENTS_DIR = path.join(__dirname, '..', 'components', 'ui');
+
+// Repo-relative POSIX path, stable regardless of cwd or how the file was passed
+// (absolute from findFiles, or resolved from a relative --files arg).
+function repoRel(file) {
+  return path.relative(REPO_ROOT, file).split(path.sep).join('/');
+}
+
+// ---------------------------------------------------------------------------
+// Rule 6 baseline (inline-var ratchet) — brik-bds#892
+// ---------------------------------------------------------------------------
+// Component TSX files with KNOWN pre-existing inline var(--…) style objects.
+// These are grandfathered to `warning` so the repo-wide CI run (release.yml +
+// pr-checklist.sh both call `--errors-only`) stays green while the 157-violation
+// backlog is migrated to CSS over a series of per-component PRs.
+//
+// RATCHET: any component TSX NOT on this list errors on the first inline var().
+// New components therefore can never introduce inline-var debt. As each file is
+// migrated to .css (CSSProperties → bds- BEM classes), delete its entry here.
+// When the set is empty, delete it and the conditional in checkInlineVarTsx —
+// the rule then errors repo-wide for every component.
+//
+// AddressInput is intentionally absent: it was migrated in the same PR that
+// introduced this rule (#892, first cleanup batch).
+const INLINE_VAR_BASELINE = new Set([
+  'components/ui/TabBar/TabBar.tsx',
+  'components/ui/TextInput/TextInput.tsx',
+  'components/ui/TextArea/TextArea.tsx',
+  'components/ui/SegmentedControl/SegmentedControl.tsx',
+  'components/ui/Slider/Slider.tsx',
+  'components/ui/Stepper/Stepper.tsx',
+  'components/ui/PageHeader/PageHeader.tsx',
+  'components/ui/Switch/Switch.tsx',
+  'components/ui/ProgressStepper/ProgressStepper.tsx',
+  'components/ui/Board/BoardColumn.tsx',
+]);
 
 // Primitive token prefixes that should be replaced with semantic equivalents
 // Covers both Webflow (double-dash) and SD (single-dash) naming
@@ -744,6 +786,51 @@ function checkTokenFamilyPairing(line, lineNum, file, isComponent) {
   return violations;
 }
 
+/**
+ * Rule 6: Raw inline var(--…) in component TSX
+ *
+ * The component-build standard (§"Styles live in CSS") forbids CSSProperties
+ * objects in component .tsx — appearance belongs in the component's .css file
+ * as bds- BEM classes. A raw `var(--…)` string in a .tsx is the fingerprint of
+ * an inline style object, so this rule flags every such reference.
+ *
+ * Severity is ratcheted via INLINE_VAR_BASELINE: files with known pre-existing
+ * debt warn (so repo-wide --errors-only CI stays green during migration); every
+ * other component file errors, so no NEW inline-var debt can land.
+ *
+ * Only runs for component .tsx (callers exclude .stories.tsx / .test.tsx, where
+ * inline style is allowed for layout helpers). Skips comment lines and any line
+ * carrying `bds-lint-ignore` — the escape hatch for runtime-calculated values
+ * (percentages, positions) that genuinely cannot live in static CSS.
+ */
+function checkInlineVarTsx(line, lineNum, file) {
+  const violations = [];
+
+  const trimmed = line.trim();
+  if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*') || trimmed.startsWith('`')) {
+    return violations;
+  }
+  if (line.includes('bds-lint-ignore')) return violations;
+
+  const severity = INLINE_VAR_BASELINE.has(repoRel(file)) ? 'warning' : 'error';
+
+  const regex = /var\((--[\w-]+)/g;
+  let match;
+  while ((match = regex.exec(line)) !== null) {
+    violations.push({
+      rule: 'inline-var',
+      severity,
+      file,
+      line: lineNum,
+      column: match.index + 1,
+      message: `Raw inline "var(${match[1]})" in component TSX — styles belong in the .css file`,
+      suggestion: `Move this declaration into the component's .css as a bds- BEM class (see component-build standard §"Styles live in CSS"). Runtime-calculated value? Append a bds-lint-ignore comment.`,
+    });
+  }
+
+  return violations;
+}
+
 // ---------------------------------------------------------------------------
 // Reporter
 // ---------------------------------------------------------------------------
@@ -832,6 +919,7 @@ function main() {
     const content = fs.readFileSync(file, 'utf8');
     const lines = content.split('\n');
     const isStory = /\.stories\.tsx$/.test(file);
+    const isTest = /\.test\.tsx$/.test(file);
     const isComponent = !isStory;
 
     for (let i = 0; i < lines.length; i++) {
@@ -842,6 +930,12 @@ function main() {
       allViolations.push(...checkHardcodedValues(line, lineNum, file, isComponent));
       allViolations.push(...checkUnknownTokens(line, lineNum, file, tokens, isComponent));
       allViolations.push(...checkTokenFamilyPairing(line, lineNum, file, isComponent));
+
+      // Rule 6: raw inline var() — component .tsx only (stories/tests may use
+      // inline style for layout helpers).
+      if (isComponent && !isTest) {
+        allViolations.push(...checkInlineVarTsx(line, lineNum, file));
+      }
 
       // Rule 4: grid compliance (opt-in via --check-grid)
       if (checkGrid) {


### PR DESCRIPTION
Closes the first slice of #892.

## What this does

**1. New lint rule — `lint-tokens.js` Rule 6 (raw inline `var()` in component TSX).**
A raw `var(--…)` string in a component `.tsx` is the fingerprint of an inline `CSSProperties` object, which violates the component-build standard §"Styles live in CSS". The rule flags every such reference and points to the `.css` migration.

**2. Baseline ratchet — `INLINE_VAR_BASELINE`.**
The 10 known-dirty component files are grandfathered to **warnings** so the repo-wide `--errors-only` run (used by `release.yml` and `pr-checklist.sh`) stays green during migration. Every other component **errors** on the first inline `var()`, so no NEW inline-var debt can land. Each future cleanup PR deletes its file from the baseline; when the set is empty, the grandfather logic is removed and the rule errors repo-wide. This mirrors the in-repo blueprint-naming precedent (staged-only → clean up in PRs → enforce).

**3. First cleanup batch — AddressInput (40 violations → 0).**
All `CSSProperties` style objects moved into `AddressInput.css` as `bds-address-input__{label,field,input,icon,dropdown,option,content,description}` slots (all SLOT-ALLOWLIST-compliant). Size handled via the `bds-address-input--{sm,md}` block modifier instead of per-element style maps. AddressInput is intentionally **absent** from the baseline — it errors going forward.

## Premise correction (why the fix differs from the issue text)

Issue #892 proposed the rule "suggest the `@/lib/tokens` / `@/lib/styles` equivalent." Those helpers are **consumer-side only** — they don't exist in brik-bds (confirmed: `tokens/index.ts:10`, `docs-site/.../react-reference/utilities.mdx:11`). The BDS-canonical fix is to **move inline styles into the component's `.css`** per the component-build standard §"Styles live in CSS" + its migration checklist. The rule and cleanup follow that.

> Follow-up: the component-build standard itself still carries the consumer-oriented `@/lib/tokens` guidance (lines 143–154, 380–384). Worth reconciling in a separate docs PR — out of scope here.

## Verification

- `npm run typecheck` — clean
- repo-wide `node scripts/lint-tokens.js --errors-only` — **green** (0 errors; baselined files emit warnings only)
- `pr-checklist.sh` — lint-tokens ✓, contrast-gate ✓
- AddressInput Storybook play-function passes in chromium (input + dropdown-open + value-set unchanged)

**Chromatic:** not run locally — `.env.1p` (1Password env file) is absent on this machine, so `npm run chromatic` can't supply the token. The Chromatic workflow runs on push to `main` (not PRs), so the visual diff will surface automatically post-merge. This is a faithful inline→CSS refactor (identical token values), behavior-verified by the play test.

## Remaining (follow-up PRs, tracked by the baseline)

TabBar (33), TextInput (25), TextArea (20), SegmentedControl (20), Slider (10), Stepper (9), ProgressStepper (2), Switch (1), Board/BoardColumn (1) — ~121 warnings to migrate, one component per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)