### PR TITLE
refactor(TextInput): move inline styles to CSS (#892 batch 2)

### DIFF
--- a/components/ui/TextInput/TextInput.css
+++ b/components/ui/TextInput/TextInput.css
@@ -1,13 +1,31 @@
 @layer bds-components {
 /**
- * BDS TextInput Interactive States
+ * BDS TextInput
+ *
+ * `.bds-text-input-field` is a cross-component contract — SearchInput and
+ * NumberInput compose <TextInput> and target this class in their own CSS
+ * (search cancel-button, number spin-buttons). Do not rename it.
  *
  * Token reference:
- * - --border-input (default border)
- * - --border-primary (hover border — darker)
- * - --border-brand-primary (focus border — theme color)
- * - --text-muted (placeholder color)
+ * - --background-input (field fill)          - --border-input (default border)
+ * - --border-primary (hover border)          - --border-brand-primary (focus)
+ * - --border-negative (error border)         - --text-primary / --text-muted
+ * - --text-negative (error/helper-error text)
  */
+
+/* ─── Wrapper ────────────────────────────────────────────────── */
+
+.bds-text-input {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  color: var(--text-primary);
+  width: auto;
+}
+
+.bds-text-input--full-width {
+  width: 100%;
+}
 
 /* ─── Label ──────────────────────────────────────────────────── */
 
@@ -26,12 +44,44 @@
   color: var(--text-negative);
 }
 
+/* ─── Field region (positions icons relative to the input) ───── */
+
+.bds-text-input__field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 /* ─── Input field ────────────────────────────────────────────── */
 
 .bds-text-input-field {
   /* ─── Component-scoped override surface ── */
   --text-input-focus-ring-width: 1px; /* bds-lint-ignore — component-scoped CSS variable, not a design token */
+  width: 100%;
+  padding: 0 var(--padding-xs);
+  font-family: var(--font-family-body);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-primary);
+  background-color: var(--background-input);
+  border: var(--border-width-md) solid var(--border-input);
+  border-radius: var(--border-radius-md);
+  outline: none;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
 }
+
+/* Size — heights match the Button scale (8px steps on the 4px grid) */
+.bds-text-input--sm .bds-text-input-field { font-size: var(--body-sm); height: 32px; }
+.bds-text-input--md .bds-text-input-field { font-size: var(--body-md); height: 40px; }
+.bds-text-input--lg .bds-text-input-field { font-size: var(--body-lg); height: 48px; }
+
+/* Icon clearance — pad the side that carries an icon */
+.bds-text-input-field--has-icon-before { padding-left: calc(var(--padding-xs) * 4); }
+.bds-text-input-field--has-icon-after  { padding-right: calc(var(--padding-xs) * 4); }
+
+/* Borderless — for dark/inverse surfaces where the fill carries contrast */
+.bds-text-input-field--no-border { border: none; }
 
 .bds-text-input-field::placeholder {
   color: var(--text-muted);
@@ -55,6 +105,42 @@
 .bds-text-input-field:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Error border — wins over hover/focus, mirroring the previous inline-style
+   precedence (inline borderColor beat the stylesheet :hover/:focus rules). */
+.bds-text-input-field--error,
+.bds-text-input-field--error:hover:not(:disabled),
+.bds-text-input-field--error:focus,
+.bds-text-input-field--error:focus-visible {
+  border-color: var(--border-negative);
+}
+
+/* ─── Icons ──────────────────────────────────────────────────── */
+
+.bds-text-input__icon {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.bds-text-input__icon--before { left: var(--padding-xs); }
+.bds-text-input__icon--after  { right: var(--padding-xs); }
+
+/* ─── Helper / error text ────────────────────────────────────── */
+
+.bds-text-input__helper,
+.bds-text-input__error {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+}
+
+.bds-text-input__error {
+  color: var(--text-negative);
 }
 
 }

--- a/components/ui/TextInput/TextInput.tsx
+++ b/components/ui/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useId, type InputHTMLAttributes, type ReactNode, type CSSProperties } from 'react';
+import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
 import './TextInput.css';
 
@@ -28,108 +28,6 @@ export interface TextInputProps extends Omit<InputHTMLAttributes<HTMLInputElemen
   /** Hide the input border. Use on dark/inverse surfaces where the fill provides sufficient contrast. */
   hideBorder?: boolean;
 }
-
-/**
- * Wrapper styles — vertical stack with gap between label and field
- *
- * Token reference:
- * - --gap-md = 8px
- */
-const wrapperStyles: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'var(--gap-md)',
-  color: 'var(--text-primary)',
-};
-
-/**
- * Field wrapper styles — positions icons relative to input
- */
-const fieldWrapperStyles: CSSProperties = {
-  position: 'relative',
-  display: 'flex',
-  alignItems: 'center',
-};
-
-/**
- * Input field base styles using BDS semantic tokens
- *
- * Token reference:
- * - --background-input (field background — white per Figma)
- * - --border-input (field border — grayscale/light per Figma)
- * - --border-width-md = 1px (border thickness)
- * - --border-radius-md = 4px (field corners)
- * - --padding-xs = 10px (horizontal field padding)
- * - --font-family-body (field text font)
- * - --font-weight-regular = 400
- * - --font-line-height-normal = 150%
- */
-const inputBaseStyles: CSSProperties = {
-  width: '100%',
-  padding: '0 var(--padding-xs)',
-  fontFamily: 'var(--font-family-body)',
-  fontWeight: 'var(--font-weight-regular)' as unknown as number,
-  lineHeight: 'var(--font-line-height-normal)',
-  color: 'var(--text-primary)',
-  backgroundColor: 'var(--background-input)',
-  border: 'var(--border-width-md) solid var(--border-input)',
-  borderRadius: 'var(--border-radius-md)',
-  outline: 'none',
-  transition: 'border-color 0.2s',
-  boxSizing: 'border-box',
-};
-
-/**
- * Icon positioning styles
- *
- * Token reference:
- * - --padding-xs = 10px (icon inset from edge)
- */
-const iconStyles: CSSProperties = {
-  position: 'absolute',
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: 'var(--text-muted)',
-};
-
-/**
- * Helper/error text base styles
- *
- * Token reference:
- * - --font-family-body (helper font)
- * - --body-sm (small text size)
- * - --text-muted (helper text color)
- */
-const helperBaseStyles: CSSProperties = {
-  fontFamily: 'var(--font-family-body)',
-  fontSize: 'var(--body-sm)',
-  lineHeight: 'var(--font-line-height-normal)',
-  color: 'var(--text-muted)',
-};
-
-/**
- * Size-specific styles (per Figma bds-text-input)
- *
- * Heights match Button scale (8px steps, 4px grid):
- *   sm=32  md=40  lg=48
- *
- * Typography:
- * - sm: label 14px, body 14px
- * - md: label 16px, body 16px
- * - lg: label 18px, body 18px
- */
-const sizeStyles: Record<TextInputSize, { input: CSSProperties }> = {
-  sm: {
-    input: { fontSize: 'var(--body-sm)', height: '32px' },
-  },
-  md: {
-    input: { fontSize: 'var(--body-md)', height: '40px' },
-  },
-  lg: {
-    input: { fontSize: 'var(--body-lg)', height: '48px' },
-  },
-};
 
 /**
  * TextInput - BDS themed text input component
@@ -167,7 +65,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     const generatedId = useId();
     const inputId = id || `input-${generatedId}`;
     const hasError = Boolean(error);
-    const sizeStyle = sizeStyles[size];
 
     // Suppress 1Password / LastPass prompts on non-credential text fields.
     // A field is treated as credential-adjacent when its `type` signals
@@ -177,23 +74,15 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     const isCredentialField =
       type === 'email' || type === 'password' || autoComplete !== undefined;
 
-    const inputStyles: CSSProperties = {
-      ...inputBaseStyles,
-      ...sizeStyle.input,
-      ...(iconBefore ? { paddingLeft: 'calc(var(--padding-xs) * 4)' } : {}),
-      ...(iconAfter ? { paddingRight: 'calc(var(--padding-xs) * 4)' } : {}),
-      ...(hideBorder ? { border: 'none' } : {}),
-      ...(hasError ? { borderColor: 'var(--border-negative)' } : {}),
-    };
-
     return (
       <div
-        className={bdsClass('bds-text-input', className)}
-        style={{
-          ...wrapperStyles,
-          width: fullWidth ? '100%' : 'auto',
-          ...style,
-        }}
+        className={bdsClass(
+          'bds-text-input',
+          `bds-text-input--${size}`,
+          fullWidth && 'bds-text-input--full-width',
+          className,
+        )}
+        style={style}
       >
         {label && (
           <label
@@ -208,9 +97,9 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           </label>
         )}
 
-        <div style={fieldWrapperStyles}>
+        <div className="bds-text-input__field">
           {iconBefore && (
-            <span style={{ ...iconStyles, left: 'var(--padding-xs)' }}>
+            <span className="bds-text-input__icon bds-text-input__icon--before">
               {iconBefore}
             </span>
           )}
@@ -220,8 +109,13 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             data-lpignore={isCredentialField ? undefined : 'true'}
             ref={ref}
             id={inputId}
-            className="bds-text-input-field"
-            style={inputStyles}
+            className={bdsClass(
+              'bds-text-input-field',
+              Boolean(iconBefore) && 'bds-text-input-field--has-icon-before',
+              Boolean(iconAfter) && 'bds-text-input-field--has-icon-after',
+              hideBorder && 'bds-text-input-field--no-border',
+              hasError && 'bds-text-input-field--error',
+            )}
             aria-invalid={hasError}
             aria-describedby={
               error ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined
@@ -230,24 +124,20 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           />
 
           {iconAfter && (
-            <span style={{ ...iconStyles, right: 'var(--padding-xs)' }}>
+            <span className="bds-text-input__icon bds-text-input__icon--after">
               {iconAfter}
             </span>
           )}
         </div>
 
         {error && (
-          <span
-            id={`${inputId}-error`}
-            style={{ ...helperBaseStyles, color: 'var(--text-negative)' }}
-            role="alert"
-          >
+          <span id={`${inputId}-error`} className="bds-text-input__error" role="alert">
             {error}
           </span>
         )}
 
         {helperText && !error && (
-          <span id={`${inputId}-helper`} style={helperBaseStyles}>
+          <span id={`${inputId}-helper`} className="bds-text-input__helper">
             {helperText}
           </span>
         )}

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -66,7 +66,6 @@ function repoRel(file) {
 // introduced this rule (#892, first cleanup batch).
 const INLINE_VAR_BASELINE = new Set([
   'components/ui/TabBar/TabBar.tsx',
-  'components/ui/TextInput/TextInput.tsx',
   'components/ui/TextArea/TextArea.tsx',
   'components/ui/SegmentedControl/SegmentedControl.tsx',
   'components/ui/Slider/Slider.tsx',


### PR DESCRIPTION
Second #892 cleanup batch (follows #898, now merged — Rule 6 + baseline + AddressInput are on main).

## What this does

Moves every `CSSProperties` style object in `TextInput.tsx` into `TextInput.css`, and removes `TextInput` from `INLINE_VAR_BASELINE` so the component now **errors** on any future inline `var()`. Baseline is down to 9 components.

- Wrapper / field / icons / helper / error → `bds-text-input{,__field,__icon,__helper,__error}` classes; size + full-width via block modifiers. Label slots were already in CSS — matched that convention.
- **Input keeps the `.bds-text-input-field` class name.** It is a cross-component contract: `SearchInput` and `NumberInput` compose `<TextInput>` and target this class in their own CSS (search cancel-button, number spin-buttons). Renaming to `__input` would break them, so I left it and added state modifiers `--{has-icon-before,has-icon-after,no-border,error}`.
- **Error border** uses a compound selector (`--error:hover/:focus`) so it wins over `:hover`/`:focus`, mirroring the old inline-style precedence — no visual change on error+hover/focus.
- Fixed a latent type hole the migration surfaced: `iconBefore`/`iconAfter` are `ReactNode` (can be `0`), so coerced with `Boolean()` before class composition.

## Verification

- `npm run typecheck` — clean
- repo-wide `lint-tokens --errors-only` — green
- Storybook play/render tests pass in chromium for **TextInput, SearchInput, and NumberInput** (the two composers confirm the contract held)

Chromatic runs on push to `main` post-merge (not locally runnable here — `.env.1p` absent).

## Note for reviewer (applies to all #892 batches)

Component-internal state modifiers (`--has-icon-before`, `--error`, etc.) aren't enumerated in `docs/SLOT-ALLOWLIST.md`. That lint is blueprint-scoped (not `components/ui`), and these are modifiers on existing allowlisted slots, not new slots — nothing fails. If you'd prefer them enumerated, say so once and I'll apply it across the remaining batches (TabBar, TextArea, SegmentedControl, Slider, Stepper, ProgressStepper, Switch, BoardColumn, PageHeader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)