### PR TITLE
button: press text color

### DIFF
--- a/components/ui/Button/Button.css
+++ b/components/ui/Button/Button.css
@@ -177,8 +177,10 @@
 }
 
 .bds-button--secondary:active:not(:disabled) {
-  background-color: var(--background-secondary-pressed);
-  color: var(--text-on-color-dark);
+  /* Hold the hover fill on press — text color stays put (no white flip).
+   * Press feedback is the translateY nudge; a distinct darker grayscale step
+   * fails AA against --text-primary, so we don't introduce one. */
+  background-color: var(--background-secondary-hover);
   transform: translateY(var(--button-active-translate-y)); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
 }
 
@@ -188,9 +190,9 @@
 }
 
 .bds-button--outline:active:not(:disabled) {
-  background-color: var(--background-brand-primary-pressed);
-  color: var(--text-on-color-dark);
-  border-color: var(--background-brand-primary-pressed);
+  /* Hold the hover fill on press — keep the brand text + brand border from the
+   * base variant rather than flipping to a solid brand fill with white text. */
+  background-color: var(--background-primary-hover);
   transform: translateY(var(--button-active-translate-y)); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
 }
 

--- a/tokens/contrast-pairings.json
+++ b/tokens/contrast-pairings.json
@@ -11,6 +11,8 @@
 
     { "group": "brand", "label": "Brand text on page", "fg": "--text-brand-primary", "bg": "--page-primary", "thresholdType": "AA" },
     { "group": "brand", "label": "On-color label on brand fill", "fg": "--text-on-color-dark", "bg": "--background-brand-primary", "thresholdType": "AA" },
+    { "group": "brand", "label": "Secondary Button label on hover/press fill", "fg": "--text-primary", "bg": "--background-secondary-hover", "thresholdType": "AA" },
+    { "group": "brand", "label": "Outline Button label on hover/press fill", "fg": "--text-brand-primary", "bg": "--background-primary-hover", "thresholdType": "AA" },
 
     { "group": "service", "label": "Service brand — text on pale surface", "fg": "--text-service-brand-on-light", "bg": "--surface-service-brand-light", "thresholdType": "AAA", "darkException": { "issue": 823, "reason": "ADR-011 dark-mode softening lightens service context text one tier while the surface stays fixed-light, eroding contrast" } },
     { "group": "service", "label": "Service brand — text on mid-tone surface", "fg": "--text-service-brand-on-light", "bg": "--surface-service-brand", "thresholdType": "AA", "darkException": { "issue": 823, "reason": "mid-tone base service surface is decorative; dark-mode softening erodes contrast" } },

--- a/tokens/theme-brand-brik.css
+++ b/tokens/theme-brand-brik.css
@@ -51,7 +51,8 @@
   --background-primary: var(--color-grayscale-white);
   --background-secondary: var(--color-grayscale-lightest);
   --background-secondary-hover: var(--color-grayscale-lighter);
-  /* Mirrors dark-mode value; Button :active hardcodes white text → needs ≥AA. */
+  /* Dark fill used by the inverse Button :hover (paired with white --text-inverse).
+   * No longer consumed by secondary :active — that holds the hover fill (#902). */
   --background-secondary-pressed: var(--color-grayscale-darker);
   --background-inverse: var(--color-grayscale-darkest);
   --background-input: var(--color-grayscale-white);


### PR DESCRIPTION
## Summary
- ci: run Vitest suite on PRs and pushes to main (#891) (#896)
- fix(test): pre-bundle storybook deps to kill cold-cache optimizer reload (#897)
- feat(tooling): gate raw inline var() in component TSX + migrate AddressInput (#892) (#898)
- refactor(TextInput): move inline styles to CSS, drop from inline-var baseline (#892) (#899)
- chore(deps-dev): bump @vitest/browser from 4.1.6 to 4.1.8 (#900)
- chore(deps-dev): bump vite and @vitejs/plugin-react (#901)
- fix(button): keep text color steady on secondary & outline press (BDS-19, #902)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)