### PR TITLE
fix(build): externalize lottie to keep ESM entry require()-free + add ESM bundle gate

### DIFF
--- a/.github/workflows/esm-bundle-check.yml
+++ b/.github/workflows/esm-bundle-check.yml
@@ -1,0 +1,56 @@
+name: ESM Bundle Check
+
+# Asserts the published ESM entry (dist/index.esm.js) is import-clean — no
+# dynamic `require()` / `__require`. @brikdesigns/bds is consumed as ESM by
+# SSR/prerender builds (Next.js turbopack, Astro/Vite); a CJS/UMD dependency
+# inlined into the ESM entry carries a `require()` those builds reject with
+# "dynamic usage of require is not supported", breaking every downstream
+# consumer.
+#
+# Why this is a CI gate (not just prepublishOnly):
+#   - BDS never builds itself as an SSR app, so its own test/typecheck gates
+#     stay green even when the published bundle is broken for consumers.
+#   - v0.97.2 shipped this exact regression after a vite 6→8 Dependabot bump
+#     inlined lottie-web into the ESM entry (peerDependency missing from
+#     rollup `external`). Caught only when consumer bumps failed to build.
+# This workflow makes a bundler/externals regression fail PRE-MERGE, not at
+# release time. `prepublishOnly` is the publish-blocking backstop.
+#
+# Issue: brikdesigns/brik-bds#905
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: esm-bundle-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  esm-bundle-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Only the Vite lib build is needed to produce dist/index.esm.js — skip
+      # the rest of build:lib (types, content-system, tokens, inspector) which
+      # add time without affecting the ESM require() surface.
+      - name: Build library bundle (Vite ESM/CJS)
+        run: npx vite build --config vite.config.lib.ts
+
+      - name: ESM bundle require() gate
+        run: npm run check:esm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.97.2",
+  "version": "0.97.3",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",
@@ -127,6 +127,7 @@
     "health": "node scripts/health.js",
     "health:json": "node scripts/health.js --json",
     "typecheck": "tsc --noEmit",
+    "check:esm": "node scripts/check-esm-bundle.mjs",
     "validate:blueprints": "node scripts/validate-blueprints.mjs",
     "contrast-gate": "node scripts/validate-themes.js",
     "validate": "node scripts/lint-tokens.js --errors-only && npm run contrast-gate && npm run lint-jsdoc && npm run validate:blueprints && npm run typecheck && npm run build-storybook",
@@ -164,7 +165,7 @@
     "propagate:dry": "bash scripts/propagate.sh --dry-run",
     "sync:devbar-widgets": "bash scripts/sync-devbar-widgets.sh",
     "prepare": "husky || true",
-    "prepublishOnly": "rm -rf dist && npm run build:lib",
+    "prepublishOnly": "rm -rf dist && npm run build:lib && npm run check:esm",
     "verify:blueprints-astro": "node scripts/verify-blueprints-astro-exports.mjs"
   },
   "keywords": [

--- a/scripts/check-esm-bundle.mjs
+++ b/scripts/check-esm-bundle.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * check-esm-bundle.js — assert the published ESM entry is import-clean.
+ *
+ * Why this gate exists:
+ *   `@brikdesigns/bds` is consumed as ESM by SSR/prerender builds (Next.js
+ *   turbopack, Astro/Vite). If a CJS/UMD dependency (e.g. lottie-web) gets
+ *   inlined into `dist/index.esm.js`, the bundle carries a dynamic `require()`
+ *   that those builds reject with "dynamic usage of require is not supported"
+ *   — breaking every downstream consumer, even though BDS's own CI is green
+ *   (BDS never builds itself as an SSR app).
+ *
+ *   v0.97.2 shipped exactly this regression after a vite 6→8 bump inlined
+ *   lottie-web into the ESM entry (peerDependency missing from rollup
+ *   `external`). This check makes that class of break publish-blocking.
+ *
+ * What it does: scans the built ESM entry for `require(` / `__require` and
+ * fails if any are present. Run after `build:lib`, before publish.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const esmEntry = resolve(__dirname, '..', 'dist', 'index.esm.js');
+
+if (!existsSync(esmEntry)) {
+  console.error(`\n❌ ESM bundle check: ${esmEntry} not found.`);
+  console.error('   Run `npm run build:lib` before this check.\n');
+  process.exit(1);
+}
+
+const src = readFileSync(esmEntry, 'utf8');
+const lines = src.split('\n');
+
+// Match a require call: `require(`, `__require(`, `require_<x>(` — but NOT the
+// substring inside identifiers like `requireConfig` that are followed by a
+// letter. The offending patterns all call require as a function.
+const RE = /(?:^|[^A-Za-z0-9_$])(__require|require)\s*\(/;
+
+const hits = [];
+lines.forEach((line, i) => {
+  if (RE.test(line)) hits.push({ n: i + 1, text: line.trim().slice(0, 120) });
+});
+
+if (hits.length > 0) {
+  console.error('\n❌ ESM bundle check FAILED — dist/index.esm.js contains require():');
+  console.error('   ESM-prerender consumers (turbopack / Astro) reject dynamic require.');
+  console.error('   A CJS/UMD dependency is being inlined into the ESM entry.');
+  console.error('   Fix: add the offending dependency to `external` in vite.config.lib.ts.\n');
+  hits.slice(0, 10).forEach((h) => console.error(`   L${h.n}: ${h.text}`));
+  if (hits.length > 10) console.error(`   …and ${hits.length - 10} more.`);
+  console.error('');
+  process.exit(1);
+}
+
+console.log('✅ ESM bundle check: dist/index.esm.js is require()-free.');

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -12,12 +12,18 @@ export default defineConfig({
       fileName: (format) => format === 'es' ? 'index.esm.js' : 'index.cjs.js',
     },
     rollupOptions: {
-      // Externalize peer dependencies — do NOT bundle React or Iconify
+      // Externalize peer dependencies — do NOT bundle React, Iconify, or Lottie.
+      // lottie-react/lottie-web is a UMD/CJS module; bundling it inlines a
+      // dynamic `require()` into the ESM entry, which breaks ESM-prerender
+      // consumers (turbopack / Astro). It is a declared peerDependency, so it
+      // must be external. See the ESM-no-require gate in scripts/check-esm-bundle.mjs.
       external: [
         'react',
         'react/jsx-runtime',
         'react-dom',
         '@iconify/react',
+        'lottie-react',
+        'lottie-web',
       ],
       output: {
         // Next.js App Router requires 'use client' directive for modules that


### PR DESCRIPTION
## Summary
- fix(build): externalize lottie to keep ESM entry require()-free + add gate

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)