### PR TITLE
feat(nav): linkComponent escape hatch for NavItem family (#379)

### DIFF
--- a/components/ui/NavItem/NavItem.stories.tsx
+++ b/components/ui/NavItem/NavItem.stories.tsx
@@ -40,6 +40,10 @@ const meta: Meta<typeof NavItem> = {
       description: 'Optional className passthrough for layout slot integration.',
       control: false,
     },
+    linkComponent: {
+      description: 'Render the link with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. Ignored when `disabled` or `href` is omitted. See ADR-012.',
+      control: false,
+    },
   },
 };
 

--- a/components/ui/NavItem/NavItem.tsx
+++ b/components/ui/NavItem/NavItem.tsx
@@ -1,6 +1,20 @@
-import { type ReactNode, type MouseEvent } from 'react';
+import {
+  type ReactNode,
+  type MouseEvent,
+  type AnchorHTMLAttributes,
+  type ComponentType,
+} from 'react';
 import { bdsClass } from '../../utils';
 import './NavItem.css';
+
+/**
+ * Injectable link renderer for navigation components. Pass a router-aware
+ * component (Next.js `Link`, Remix `Link`) for client-side routing; defaults
+ * to a bare `<a>` when omitted. See ADR-012.
+ */
+export type BdsLinkComponent = ComponentType<
+  { href: string } & AnchorHTMLAttributes<HTMLAnchorElement>
+>;
 
 export interface NavItemProps {
   /** Visible label. Also used as `aria-label` when `iconOnly` is true. */
@@ -19,6 +33,12 @@ export interface NavItemProps {
   iconOnly?: boolean;
   /** Optional className passthrough for layout slot integration. */
   className?: string;
+  /**
+   * Render the link with a router-aware component (Next.js `Link`, Remix
+   * `Link`) for client-side routing instead of the default bare `<a>`.
+   * Ignored when `disabled` or when `href` is omitted. See ADR-012.
+   */
+  linkComponent?: BdsLinkComponent;
 }
 
 /**
@@ -38,6 +58,7 @@ export function NavItem({
   disabled = false,
   iconOnly = false,
   className,
+  linkComponent,
 }: NavItemProps) {
   const classes = bdsClass(
     'bds-nav-item',
@@ -47,24 +68,49 @@ export function NavItem({
     className,
   );
 
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (disabled) {
+      e.preventDefault();
+      return;
+    }
+    onClick?.(e);
+  };
+
+  const content = (
+    <>
+      {icon && <span className="bds-nav-item__icon">{icon}</span>}
+      {!iconOnly && <span className="bds-nav-item__label">{label}</span>}
+    </>
+  );
+
+  // A router `Link` requires `href` and must not navigate when disabled, so
+  // those cases always fall back to a bare `<a>`. See ADR-012.
+  if (href && !disabled && linkComponent) {
+    const LinkComponent = linkComponent;
+    return (
+      <LinkComponent
+        href={href}
+        onClick={handleClick}
+        className={classes}
+        aria-current={active ? 'page' : undefined}
+        aria-label={iconOnly ? label : undefined}
+      >
+        {content}
+      </LinkComponent>
+    );
+  }
+
   return (
     <a
       href={disabled ? undefined : href}
-      onClick={(e) => {
-        if (disabled) {
-          e.preventDefault();
-          return;
-        }
-        onClick?.(e);
-      }}
+      onClick={handleClick}
       className={classes}
       aria-current={active ? 'page' : undefined}
       aria-disabled={disabled || undefined}
       aria-label={iconOnly ? label : undefined}
       tabIndex={disabled ? -1 : undefined}
     >
-      {icon && <span className="bds-nav-item__icon">{icon}</span>}
-      {!iconOnly && <span className="bds-nav-item__label">{label}</span>}
+      {content}
     </a>
   );
 }

--- a/components/ui/NavItem/index.ts
+++ b/components/ui/NavItem/index.ts
@@ -1,2 +1,2 @@
-export { NavItem, type NavItemProps } from './NavItem';
+export { NavItem, type NavItemProps, type BdsLinkComponent } from './NavItem';
 export { default } from './NavItem';

--- a/components/ui/SidebarNavigation/SidebarNavigation.mdx
+++ b/components/ui/SidebarNavigation/SidebarNavigation.mdx
@@ -22,6 +22,12 @@ Toggle `collapsed`, `showProfile`, `showFooterActions`, or override `width` in t
 
 <Canvas of={Stories.Default} />
 
+### With Link Component
+
+Pass `linkComponent` (e.g. `next/link`) so nav items route client-side instead of triggering a full-page reload. See [framework guides → client-side routing](/docs/getting-started/framework-guides).
+
+<Canvas of={Stories.WithLinkComponent} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/SidebarNavigation/SidebarNavigation.stories.tsx
+++ b/components/ui/SidebarNavigation/SidebarNavigation.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Icon } from '@iconify/react';
 import { SidebarNavigation, type SidebarNavigationProps, type SidebarNavItem } from './SidebarNavigation';
+import { type BdsLinkComponent } from '../NavItem';
 import { Button } from '../Button';
 import * as Icons from '../../icons';
 
@@ -50,6 +51,16 @@ const profileBlock = (
       </div>
     </div>
   </div>
+);
+
+/**
+ * Stand-in for a router `Link` (Next.js `Link`, Remix `Link`). Renders an
+ * `<a>` tagged so the injected-component path is observable. See ADR-012.
+ */
+const MockLink: BdsLinkComponent = ({ href, children, ...props }) => (
+  <a href={href} data-link-component="mock" {...props}>
+    {children}
+  </a>
 );
 
 /* ─── Story wrapper with synthetic toggle controls ────────────── */
@@ -111,6 +122,10 @@ const meta = {
       description: 'Custom width (e.g. "240px"). Defaults to 260px expanded / 80px collapsed.',
       control: 'text',
     },
+    linkComponent: {
+      description: 'Render each nav item with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. See ADR-012.',
+      control: false,
+    },
     showProfile: {
       description: 'Story-only — toggles the `profile` slot.',
       control: 'boolean',
@@ -137,5 +152,15 @@ export const Default: Story = {
     collapsed: false,
     showProfile: true,
     showFooterActions: false,
+  },
+};
+
+/** @summary Nav items routed through an injected link component for client-side routing */
+export const WithLinkComponent: Story = {
+  args: {
+    logo: <BrikLogomark />,
+    navItems: defaultNavItems,
+    linkComponent: MockLink,
+    showProfile: true,
   },
 };

--- a/components/ui/SidebarNavigation/SidebarNavigation.tsx
+++ b/components/ui/SidebarNavigation/SidebarNavigation.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { NavItem } from '../NavItem';
+import { NavItem, type BdsLinkComponent } from '../NavItem';
 import { bdsClass } from '../../utils';
 import './SidebarNavigation.css';
 
@@ -44,6 +44,12 @@ export interface SidebarNavigationProps {
   position?: SidebarPosition;
   /** Custom width (default: 260px expanded, 80px collapsed). */
   width?: string;
+  /**
+   * Render each nav item with a router-aware component (Next.js `Link`, Remix
+   * `Link`) for client-side routing instead of the default bare `<a>`.
+   * Forwarded to every `NavItem`. See ADR-012.
+   */
+  linkComponent?: BdsLinkComponent;
 }
 
 /**
@@ -64,6 +70,7 @@ export function SidebarNavigation({
   collapsed = false,
   position = 'fixed',
   width,
+  linkComponent,
 }: SidebarNavigationProps) {
   const resolvedWidth = width ?? (collapsed ? '80px' : '260px');
   const resolvedProfile = profile ?? userSection;
@@ -89,6 +96,7 @@ export function SidebarNavigation({
             active={item.active}
             disabled={item.disabled}
             iconOnly={collapsed}
+            linkComponent={linkComponent}
           />
         ))}
       </nav>

--- a/components/ui/SubNavigation/SubNavigation.stories.tsx
+++ b/components/ui/SubNavigation/SubNavigation.stories.tsx
@@ -102,6 +102,10 @@ const meta = {
       description: 'Accessible label for the nav landmark.',
       control: 'text',
     },
+    linkComponent: {
+      description: 'Render each nav item with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. See ADR-012.',
+      control: false,
+    },
     showHeader: {
       description: 'Story-only — toggles the `header` slot.',
       control: 'boolean',

--- a/components/ui/SubNavigation/SubNavigation.tsx
+++ b/components/ui/SubNavigation/SubNavigation.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { NavItem } from '../NavItem';
+import { NavItem, type BdsLinkComponent } from '../NavItem';
 import './SubNavigation.css';
 
 export interface SubNavItem {
@@ -21,6 +21,12 @@ export interface SubNavigationProps {
   width?: string;
   /** Accessible label for the nav landmark. Required when multiple navs are on the page. */
   ariaLabel?: string;
+  /**
+   * Render each nav item with a router-aware component (Next.js `Link`, Remix
+   * `Link`) for client-side routing instead of the default bare `<a>`.
+   * Forwarded to every `NavItem`. See ADR-012.
+   */
+  linkComponent?: BdsLinkComponent;
 }
 
 /**
@@ -37,6 +43,7 @@ export function SubNavigation({
   footer,
   width = '194px',
   ariaLabel = 'Section navigation',
+  linkComponent,
 }: SubNavigationProps) {
   return (
     <aside className="bds-subnav" style={{ width }} aria-label={ariaLabel}>
@@ -51,6 +58,7 @@ export function SubNavigation({
             icon={item.icon}
             active={item.active}
             disabled={item.disabled}
+            linkComponent={linkComponent}
           />
         ))}
       </nav>

--- a/docs-site/content/docs/getting-started/framework-guides.mdx
+++ b/docs-site/content/docs/getting-started/framework-guides.mdx
@@ -142,6 +142,19 @@ Skip this block if you don't use Tailwind.
 
 The lightweight tier (token-driven CSS animations) is automatically available. Product apps rarely escalate beyond it. See [Motion → Tiers](/docs/motion/tiers).
 
+### 7. Client-side routing (nav components)
+
+BDS navigation components (`SidebarNavigation`, `SubNavigation`, `NavItem`) render a bare `<a>` by default, which triggers a **full-page reload** on every click in Next.js. Pass `next/link` as `linkComponent` so nav items route client-side and prefetch:
+
+```tsx
+import Link from 'next/link';
+import { SidebarNavigation } from '@brikdesigns/bds';
+
+<SidebarNavigation linkComponent={Link} navItems={navItems} logo={logo} />;
+```
+
+`next/link` satisfies the `BdsLinkComponent` contract (`{ href: string }` + standard anchor props) with no wrapper. Items that are `disabled` or have no `href` fall back to `<a>` automatically. See [ADR-012](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-012-link-component-escape-hatch.md). (react-router's `to`-based `NavLink` needs a one-line `href`→`to` adapter.)
+
 ### Common Next.js gotchas
 
 <Callout type="warn">

--- a/docs/adrs/ADR-012-link-component-escape-hatch.md
+++ b/docs/adrs/ADR-012-link-component-escape-hatch.md
@@ -1,0 +1,58 @@
+# ADR-012 — `linkComponent` escape hatch for navigation components
+
+**Status:** Accepted (2026-06-16)
+**Date:** 2026-06-16
+**Supersedes:** —
+**Superseded by:** —
+**Related:** [#525](https://github.com/brikdesigns/brik-bds/issues/525) (umbrella — link escape-hatch contract), [#379](https://github.com/brikdesigns/brik-bds/issues/379) (SidebarNavigation Next.js interop — first adopter), [#462](https://github.com/brikdesigns/brik-bds/issues/462) (Footer migration), [Framework Guides](../../docs-site/content/docs/getting-started/framework-guides.mdx)
+**Owner:** Nick Stanerson
+
+## Context
+
+BDS components that own their anchor rendering (`NavItem` and its containers `SidebarNavigation` / `SubNavigation`, plus `Footer`, `Breadcrumb`, `TabBar`, `NavBar`, `Menu`, `Pagination`) emit a bare `<a href>`. In a Next.js / Remix consumer this triggers a **full-page reload on every nav click** instead of client-side routing, and loses automatic prefetch. brik-client-portal is in production with this regression today (#379); brikdesigns.com hit it on the Footer migration (#462).
+
+The fix is not per-component styling — it is one **API contract** every link-emitting component adopts: an injectable component to render in place of the default `<a>`. Deciding it once keeps the surface area consistent and lets the remaining components migrate one PR at a time without re-litigating the shape each time.
+
+A consumer can only fix this when *it* composes the JSX (e.g. `SidebarNavigation`'s `logo` slot already works because the consumer passes the node). The nav items can't, because BDS owns their rendering — hence the escape hatch.
+
+## Decision
+
+Adopt a single optional prop, **`linkComponent`**, on every component that owns anchor rendering. The atom (`NavItem`) holds the contract; containers forward it.
+
+```ts
+import { type AnchorHTMLAttributes, type ComponentType } from 'react';
+
+/**
+ * Injectable link renderer for navigation components. Pass a router-aware
+ * component (Next.js `Link`, Remix `Link`) for client-side routing; defaults
+ * to a bare `<a>` when omitted.
+ */
+export type BdsLinkComponent = ComponentType<
+  { href: string } & AnchorHTMLAttributes<HTMLAnchorElement>
+>;
+```
+
+Rules:
+
+1. **Prop name is `linkComponent`** (not `as` / `LinkComponent` / a render-prop). It mirrors the established cross-library pattern (Mantine, Chakra) and reads as "what to render each link with." Note: the layout primitives' `as?: ElementType` (Grid/Stack/Cluster/Frame) is a *different* concept — polymorphic element swap on a single node — and is intentionally not reused here.
+2. **Default is a bare `<a>`.** Omitting the prop is the current behavior verbatim — **zero breaking change**, no consumer touches anything until it opts in.
+3. **The contract keys on `href`**, plus standard anchor passthrough (`className`, `onClick`, `aria-*`, `tabIndex`). Next.js `Link` and Remix `Link` both accept `href` and forward the rest to their inner `<a>`, so `<SidebarNavigation linkComponent={Link} />` type-checks with no wrapper. react-router's `to`-based `NavLink` is the one exception — consumers wrap it in a one-line `href`→`to` adapter. This is deliberate: all six Brik consumers are Next.js, so `href` is the right default and the type stays simple.
+4. **Disabled or href-less items always render `<a>`**, never `linkComponent`. A router `Link` requires `href` and must not navigate when disabled, so the dispatch falls back: `const El = (href && !disabled && linkComponent) ? linkComponent : 'a'`.
+5. **Containers forward, they don't re-declare semantics.** `SidebarNavigation` / `SubNavigation` take one `linkComponent` prop and pass it to every `NavItem`. The contract is defined once on the atom.
+
+`TextLink` is **out of scope** — it already extends `AnchorHTMLAttributes` and exposes its anchor, so a consumer composes routing around it directly; it does not own hidden anchor rendering.
+
+## Consequences
+
+- **Non-breaking, opt-in.** Existing call sites are unchanged; the prop is additive with an `<a>` default.
+- **Establishes the pattern for the umbrella.** #379 (NavItem + SidebarNavigation + SubNavigation) ships first. Footer, Breadcrumb, TabBar, NavBar, Menu, and Pagination each migrate in their own PR referencing this ADR — same prop name, same type, same dispatch rule.
+- **Consumer migration is a swap, not a rewrite.** brik-client-portal drops its `aside nav a { cursor }` workaround and passes `linkComponent={Link}`. renew-pms can retire the routing-control reasons it rolls its own `AppSidebar`.
+- **The `BdsLinkComponent` type is exported** from the package so consumers and future BDS components share one definition.
+
+## Alternatives considered
+
+| Option | Shape | Why rejected |
+|---|---|---|
+| **A — `linkComponent` prop** (chosen) | One component-valued prop per link-owning component | — |
+| B — `as?: ElementType` per item | Each `SidebarNavItem` carries `as: Link` | Verbose at every call site; repeats the component on every item; conflates with the layout-primitive `as` element-swap concept |
+| C — `renderNavItem` render-prop | Consumer renders each item | Moves rendering responsibility back to the consumer, defeating the point of a primitive; inconsistent across the surface area |


### PR DESCRIPTION
Closes #379. First adopter of the **#525** umbrella.

## What

Optional `linkComponent` prop on `NavItem`, forwarded by `SidebarNavigation` + `SubNavigation`, so Next.js/Remix consumers get client-side routing instead of a full-page reload on every nav click.

```tsx
import Link from 'next/link';
<SidebarNavigation linkComponent={Link} navItems={...} logo={...} />
```

## Contract (ADR-012)

- `BdsLinkComponent = ComponentType<{ href: string } & AnchorHTMLAttributes>` — `next/link` satisfies it unwrapped.
- **Default unset → bare `<a>`. Zero breaking change.**
- Disabled / href-less items always render `<a>` (router Links require href + must not navigate when disabled).
- Keys on `href`; react-router `to` needs a one-line adapter (documented, deliberate — all consumers are Next.js).

## Changes (10 files)

- `docs/adrs/ADR-012-link-component-escape-hatch.md` — contract + rejected alternatives
- `NavItem.tsx` (+ `index.ts`) — type, prop, branch dispatch
- `SidebarNavigation.tsx` / `SubNavigation.tsx` — prop forwarded to every `NavItem`
- 3 stories — `linkComponent` argTypes + `WithLinkComponent` demo
- `SidebarNavigation.mdx` + framework-guides Next.js routing section

## Scope

Pattern-establishing PR. **#525 stays open** for the remaining components (Footer #462, Breadcrumb, TabBar, NavBar, Menu, Pagination), one PR each. brik-client-portal consumer swap follows after publish.

## Gates

typecheck · token-lint · jsdoc · recipe-lint 0/86 · build:lib · vitest 710/710 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)