### PR TITLE
components: segmented contrast

### DIFF
--- a/components/ui/SegmentedControl/SegmentedControl.tsx
+++ b/components/ui/SegmentedControl/SegmentedControl.tsx
@@ -76,7 +76,12 @@ const segmentBase: CSSProperties = {
   background: 'none',
   border: 'none',
   borderRadius: 'var(--border-radius-sm)',
-  color: 'var(--text-secondary)',
+  // Inactive label sits on the --background-secondary track, which is a light-ish
+  // neutral surface in BOTH themes (grayscale-lightest light / grayscale-light dark).
+  // --text-secondary flips to grayscale-light in dark mode and collapses onto the
+  // track (same stop → ~1:1, invisible). --text-on-color-light is fixed dark in both
+  // themes → AA on the track either way. See contrast-pairings.json.
+  color: 'var(--text-on-color-light)',
   minWidth: 0,
   transition: 'background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease',
 };

--- a/tokens/contrast-pairings.json
+++ b/tokens/contrast-pairings.json
@@ -8,6 +8,7 @@
     { "group": "neutral", "label": "Body text on background", "fg": "--text-primary", "bg": "--background-primary", "thresholdType": "AAA" },
     { "group": "neutral", "label": "Secondary text on page", "fg": "--text-secondary", "bg": "--page-primary", "thresholdType": "AA" },
     { "group": "neutral", "label": "Muted text on page", "fg": "--text-muted", "bg": "--page-primary", "thresholdType": "AA-large" },
+    { "group": "neutral", "label": "SegmentedControl inactive label on track", "fg": "--text-on-color-light", "bg": "--background-secondary", "thresholdType": "AA" },
 
     { "group": "brand", "label": "Brand text on page", "fg": "--text-brand-primary", "bg": "--page-primary", "thresholdType": "AA" },
     { "group": "brand", "label": "On-color label on brand fill", "fg": "--text-on-color-dark", "bg": "--background-brand-primary", "thresholdType": "AA" },


### PR DESCRIPTION
## Summary
- fix(segmented-control): legible inactive label in dark mode

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)