### PR TITLE
feat(lint): cascade-contract-check — BDS-owned consumer redefinition gate (ADR-013 §2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
       "types": "./scripts/canonical-class-check.d.ts",
       "import": "./scripts/canonical-class-check.mjs",
       "default": "./scripts/canonical-class-check.mjs"
+    },
+    "./cascade-contract-check": {
+      "types": "./scripts/cascade-contract-check.d.ts",
+      "import": "./scripts/cascade-contract-check.mjs",
+      "default": "./scripts/cascade-contract-check.mjs"
     }
   },
   "files": [
@@ -62,12 +67,15 @@
     "scripts/canonical-check.mjs",
     "scripts/canonical-check.d.ts",
     "scripts/canonical-class-check.mjs",
-    "scripts/canonical-class-check.d.ts"
+    "scripts/canonical-class-check.d.ts",
+    "scripts/cascade-contract-check.mjs",
+    "scripts/cascade-contract-check.d.ts"
   ],
   "bin": {
     "bds-find": "scripts/bds-find.mjs",
     "canonical-check": "scripts/canonical-check.mjs",
-    "canonical-class-check": "scripts/canonical-class-check.mjs"
+    "canonical-class-check": "scripts/canonical-class-check.mjs",
+    "cascade-contract-check": "scripts/cascade-contract-check.mjs"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/scripts/__tests__/cascade-contract-check.test.mjs
+++ b/scripts/__tests__/cascade-contract-check.test.mjs
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import {
+  scanCascadeContract,
+  familyOfSizeToken,
+  familyOfFontFamilyToken,
+} from '../cascade-contract-check.mjs';
+
+const scan = (css, opts = {}) => scanCascadeContract({ css, ...opts }).violations;
+const rules = (css, opts) => scan(css, opts).map((v) => v.rule);
+
+describe('cascade-contract-check — family helpers', () => {
+  it('maps size tokens to families', () => {
+    expect(familyOfSizeToken('--heading-lg')).toBe('heading');
+    expect(familyOfSizeToken('--display-sm')).toBe('display');
+    expect(familyOfSizeToken('--label-md')).toBe('label');
+    expect(familyOfSizeToken('--surface-primary')).toBeNull();
+  });
+  it('maps font-family tokens to families', () => {
+    expect(familyOfFontFamilyToken('--font-family-display')).toBe('display');
+    expect(familyOfFontFamilyToken('--font-family-heading')).toBe('heading');
+    expect(familyOfFontFamilyToken('--font-family-nope')).toBeNull();
+  });
+});
+
+describe('Rule 1 — no-redefinition: scale families', () => {
+  it('flags a :root heading remap (the brikdesigns scaffold offender)', () => {
+    const css = `:root {\n  --heading-lg: var(--font-size-700);\n  --heading-huge: var(--font-size-1200);\n}`;
+    const v = scan(css);
+    expect(v).toHaveLength(2);
+    expect(v.every((x) => x.rule === 'no-redefinition')).toBe(true);
+    expect(v[0].token).toBe('--heading-lg');
+    expect(v[0].line).toBe(2);
+  });
+
+  it('flags scale redefinition EVEN inside Brand-Kit scope (scale is never brandable)', () => {
+    const css = `.theme-brand-brik {\n  --display-sm: 72px;\n}`;
+    expect(rules(css)).toEqual(['no-redefinition']);
+  });
+
+  it('flags --font-size-* redefinition too', () => {
+    const css = `:root { --font-size-700: 2rem; }`;
+    expect(rules(css)).toEqual(['no-redefinition']);
+  });
+
+  it('does not flag a var() *reference* to a scale token (only definitions)', () => {
+    const css = `.title { font-size: var(--heading-lg); }`;
+    expect(scan(css)).toHaveLength(0);
+  });
+});
+
+describe('Rule 1 — no-redefinition: brandable families', () => {
+  it('flags a brandable redefinition at bare :root', () => {
+    const css = `:root { --surface-secondary: #eee; }`;
+    expect(rules(css)).toEqual(['no-redefinition']);
+  });
+
+  it('ALLOWS a brandable redefinition inside .theme-{client} scope', () => {
+    const css = `.theme-brand-brik {\n  --surface-secondary: var(--color-tan-lightest);\n  --text-link: var(--color-poppy-dark);\n}`;
+    expect(scan(css)).toHaveLength(0);
+  });
+
+  it('ALLOWS a brandable redefinition when an ancestor selector is brand-scoped', () => {
+    const css = `:root[data-theme="dark"] .theme-brand-brik {\n  --surface-secondary: #222;\n}`;
+    expect(scan(css)).toHaveLength(0);
+  });
+
+  it('ALLOWS a brandable redefinition in a theme-{client}.css file (whole-file scope)', () => {
+    const css = `:root { --surface-secondary: #eee; }`;
+    expect(scan(css, { file: 'src/styles/theme-acme.css' })).toHaveLength(0);
+  });
+
+  it('ALLOWS [data-audience] scope binding', () => {
+    const css = `[data-audience="marketing"] { --background-brand-primary: #f30; }`;
+    expect(scan(css)).toHaveLength(0);
+  });
+});
+
+describe('Rule 2 — typography-family', () => {
+  it('flags display family paired with heading-scale size (the #536 bug)', () => {
+    const css = `.hero-title {\n  font-family: var(--font-family-display);\n  font-size: var(--heading-huge);\n}`;
+    const v = scan(css);
+    expect(v).toHaveLength(1);
+    expect(v[0].rule).toBe('typography-family');
+    expect(v[0].line).toBe(3);
+  });
+
+  it('passes when family and size share a family', () => {
+    const css = `.hero-title {\n  font-family: var(--font-family-display);\n  font-size: var(--display-sm);\n}`;
+    expect(scan(css)).toHaveLength(0);
+  });
+
+  it('does not cross rules — family in one rule, size in another', () => {
+    const css = `.a { font-family: var(--font-family-display); }\n.b { font-size: var(--heading-lg); }`;
+    expect(scan(css)).toHaveLength(0);
+  });
+
+  it('ignores rules with only one of the two declarations', () => {
+    const css = `.a { font-size: var(--heading-lg); }`;
+    expect(scan(css)).toHaveLength(0);
+  });
+});
+
+describe('exempt allowlist (transitional burn-down)', () => {
+  it('skips an exact token name', () => {
+    const css = `:root { --heading-lg: var(--font-size-700); }`;
+    expect(scan(css, { exemptTokens: ['--heading-lg'] })).toHaveLength(0);
+  });
+
+  it('skips by regex', () => {
+    const css = `:root {\n  --heading-lg: 1rem;\n  --heading-huge: 2rem;\n}`;
+    expect(scan(css, { exemptTokens: [/^--heading-/] })).toHaveLength(0);
+  });
+});
+
+describe('robustness', () => {
+  it('ignores tokens inside comments', () => {
+    const css = `:root {\n  /* --heading-lg: var(--font-size-700); */\n  --surface-secondary: #eee;\n}`;
+    // only the brandable :root redefinition should fire, not the commented scale one
+    expect(scan(css).map((v) => v.token)).toEqual(['--surface-secondary']);
+  });
+
+  it('handles compact single-line rules', () => {
+    const css = `:root { --heading-lg: 1rem; } .theme-x { --surface-primary: #fff; }`;
+    expect(rules(css)).toEqual(['no-redefinition']); // only the :root scale one
+  });
+
+  it('does not treat @layer / @media wrappers as brand scope', () => {
+    const css = `@media (min-width: 40rem) {\n  :root { --surface-primary: #fff; }\n}`;
+    expect(rules(css)).toEqual(['no-redefinition']);
+  });
+});

--- a/scripts/cascade-contract-check.d.ts
+++ b/scripts/cascade-contract-check.d.ts
@@ -1,0 +1,59 @@
+/**
+ * Type definitions for @brikdesigns/bds/cascade-contract-check.
+ *
+ * Source: scripts/cascade-contract-check.mjs (hand-authored ESM with named
+ * exports + CLI entry). Hand-written to keep the .mjs portable and out of the
+ * BDS lib build. ADR-013 §2.
+ */
+
+export type ExemptPattern = string | RegExp;
+
+export type CascadeRule = 'no-redefinition' | 'typography-family';
+
+export interface CascadeViolation {
+  /** Which rule fired. */
+  rule: CascadeRule;
+  severity: 'error';
+  /** The offending token name (the redefined token, or the font-family token). */
+  token: string;
+  /** File the violation was found in (`<input>` for raw-string scans). */
+  file: string;
+  /** 1-based line number. */
+  line: number;
+  message: string;
+}
+
+export interface ScanOptions {
+  /** CSS string to inspect. */
+  css: string;
+  /** File path — used for messages and whole-file brand-scope (`theme-*.css`). */
+  file?: string;
+  /** Token names or RegExps to skip (transitional burn-down allowlist). */
+  exemptTokens?: ExemptPattern[];
+}
+
+export interface ScanResult {
+  violations: CascadeViolation[];
+  file: string;
+}
+
+/** Scan one CSS string for cascade-contract violations. Does not throw. */
+export function scanCascadeContract(opts: ScanOptions): ScanResult;
+
+/** Throw on the first violation (vitest-friendly). */
+export function assertCascadeContract(css: string, opts?: Omit<ScanOptions, 'css'>): void;
+
+/** Family of a font-size token (`--heading-lg` → `'heading'`), or null. */
+export function familyOfSizeToken(token: string): string | null;
+
+/** Family of a `--font-family-*` token (`--font-family-display` → `'display'`), or null. */
+export function familyOfFontFamilyToken(token: string): string | null;
+
+/** Scale families a consumer may never redefine. */
+export const SCALE_FAMILIES: string[];
+
+/** Semantic families a consumer may override only within Brand-Kit scope. */
+export const BRANDABLE_FAMILIES: string[];
+
+/** `--font-family-{family}` → family map. */
+export const FONT_FAMILY_TO_FAMILY: Record<string, string>;

--- a/scripts/cascade-contract-check.mjs
+++ b/scripts/cascade-contract-check.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+/**
+ * cascade-contract-check — enforce the BDS token adoption contract in consumers.
+ *
+ * ADR-013 §2. The companion to canonical-check:
+ *   - canonical-check         → forbids INVENTED token names (`--surface-paper`).
+ *   - cascade-contract-check  → forbids REDEFINING canonical tokens, and
+ *                               catches typography family↔size mismatches.
+ *
+ * Two rules:
+ *
+ * 1. no-redefinition — a consumer consumes BDS tokens; it does not redefine
+ *    them (the cascade adoption contract, see cascade.mdx).
+ *    - SCALE families (`--heading-*`, `--display-*`, `--font-size-*`):
+ *      redefining is a violation ANYWHERE in consumer CSS. A Brand Kit varies
+ *      font-*family*, never the shared type scale — the brikdesigns `:root`
+ *      heading remap is the canonical offender (load-bearing + invisible for
+ *      ~3 months).
+ *    - BRANDABLE families (`--surface-*`, `--text-*`, `--border-*`, `--page-*`,
+ *      `--background-*`): redefining is allowed ONLY inside Brand-Kit scope —
+ *      a `theme-{client}.css` file, or a selector scoped to `.theme-{client}`
+ *      / `[data-audience|service|department]`. At a bare `:root` (or any
+ *      non-brand selector) it is a violation. This is the one allowed
+ *      exception the contract names: brand-color (and brand neutral) override.
+ *
+ * 2. typography-family — within a single CSS rule, a `font-family:
+ *    var(--font-family-X)` declaration and a font-size token `var(--Y-…)` must
+ *    share a family (X === Y). Catches e.g. a display family paired with a
+ *    heading-scale size (the home-hero token-pairing bug, brikdesigns #536).
+ *
+ * Why this lives in @brikdesigns/bds (not a per-repo copy): one owner, no
+ * fork. `bds@x.y` ships the gate that matches `bds@x.y`'s token registry;
+ * consumers import it into their own `lint-tokens` run. Per-repo copies are
+ * exactly the drift this rule exists to stop. See cascade.mdx (the adoption
+ * contract) and ADR-013.
+ *
+ * ── CLI ────────────────────────────────────────────────────────────────────
+ *   cascade-contract-check <file.css...>      Scan CSS files; non-zero on violations
+ *   cascade-contract-check --exempt <list>    Comma-separated token names / regexes
+ *                                             to skip (transitional burn-down allowlist)
+ *   cascade-contract-check --format md|json   Output format (default: md for TTY)
+ *   cascade-contract-check --help
+ *
+ * ── Library ──────────────────────────────────────────────────────────────-─
+ *   import {
+ *     scanCascadeContract,   // (css, opts) -> { violations, ... }
+ *     assertCascadeContract, // throws on first violation (vitest-friendly)
+ *     familyOfSizeToken,
+ *     familyOfFontFamilyToken,
+ *   } from '@brikdesigns/bds/cascade-contract-check';
+ *
+ * ── Exit codes ─────────────────────────────────────────────────────────────
+ *   0  Clean
+ *   1  Violations found
+ *   2  Bad invocation (no files, unreadable file, etc.)
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Replace `/* … *​/` block-comment content with spaces while preserving every
+ * character position and newline, so line numbers map 1:1 to the source. (Note:
+ * canonical-check's `stripCssComments` *removes* blank/comment lines — fine for
+ * its Set-returning token extraction, but it would corrupt our line numbers.)
+ * CSS has no `//` line comments, so block comments are the only case.
+ */
+function maskComments(css) {
+  let out = '';
+  const n = css.length;
+  let i = 0;
+  while (i < n) {
+    if (css[i] === '/' && css[i + 1] === '*') {
+      out += '  ';
+      i += 2;
+      while (i < n && !(css[i] === '*' && css[i + 1] === '/')) {
+        out += css[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      if (i < n) { out += '  '; i += 2; }
+    } else {
+      out += css[i];
+      i++;
+    }
+  }
+  return out;
+}
+
+// ── Token family model ──────────────────────────────────────────────────────
+
+/**
+ * Scale families: the shared type scale. A consumer may NEVER redefine these —
+ * a Brand Kit changes `--font-family-*`, not the scale steps.
+ */
+export const SCALE_FAMILIES = ['heading', 'display', 'font-size'];
+
+/**
+ * Brandable families: semantic color/surface tokens a Brand Kit legitimately
+ * overrides — but only within brand scope (a `theme-{client}.css` file or a
+ * `.theme-{client}` / `[data-*]` selector). Redefining them at a bare `:root`
+ * is off-contract.
+ */
+export const BRANDABLE_FAMILIES = ['surface', 'text', 'border', 'page', 'background'];
+
+/** `--font-family-{family}` → family. Mirrors dist/tokens.css. */
+export const FONT_FAMILY_TO_FAMILY = {
+  '--font-family-heading': 'heading',
+  '--font-family-display': 'display',
+  '--font-family-body': 'body',
+  '--font-family-label': 'label',
+  '--font-family-subtitle': 'subtitle',
+};
+
+/** font-size token prefix → family. `--font-size-*` is the raw math scale (no family). */
+const SIZE_PREFIX_TO_FAMILY = [
+  ['--heading-', 'heading'],
+  ['--display-', 'display'],
+  ['--body-', 'body'],
+  ['--label-', 'label'],
+  ['--subtitle-', 'subtitle'],
+];
+
+/** Selectors that establish Brand-Kit scope (the redefinition exception). */
+const BRAND_SCOPE_SELECTOR_RE = /\.theme-[a-z0-9-]+|\[data-(?:audience|service|department)\b/i;
+
+/** Filenames that ARE a Brand Kit output (whole-file brand scope). */
+const BRAND_SCOPE_FILE_RE = /(?:^|[\\/])theme-[a-z0-9-]+\.css$/i;
+
+/** Family of a font-size token, or null if it is not a size token. */
+export function familyOfSizeToken(token) {
+  for (const [prefix, family] of SIZE_PREFIX_TO_FAMILY) {
+    if (token.startsWith(prefix)) return family;
+  }
+  return null;
+}
+
+/** Family of a `--font-family-*` token, or null. */
+export function familyOfFontFamilyToken(token) {
+  return FONT_FAMILY_TO_FAMILY[token] ?? null;
+}
+
+/** Redefinition class of a declared token name: 'scale' | 'brandable' | null. */
+function redefinitionClass(name) {
+  if (SCALE_FAMILIES.some((f) => name.startsWith(`--${f}-`))) return 'scale';
+  if (BRANDABLE_FAMILIES.some((f) => name.startsWith(`--${f}-`))) return 'brandable';
+  return null;
+}
+
+function isExempt(token, exemptPatterns) {
+  for (const pat of exemptPatterns) {
+    if (typeof pat === 'string' && token === pat) return true;
+    if (pat instanceof RegExp && pat.test(token)) return true;
+  }
+  return false;
+}
+
+// ── Core scan ─────────────────────────────────────────────────────────────
+
+/**
+ * Scan one CSS string for cascade-contract violations.
+ *
+ * A char-level scanner tracks the selector stack and line numbers so it works
+ * on both expanded (`one decl per line`) and compact (`.foo { --x: y; }`)
+ * formatting, and resolves a declaration's brand-scope from any enclosing
+ * selector — not just the innermost one (e.g. `:root[data-theme] .theme-x {…}`).
+ *
+ * Does NOT throw — callers decide how to surface (CLI exits non-zero, vitest
+ * uses `assertCascadeContract`).
+ */
+export function scanCascadeContract({ css, file = '<input>', exemptTokens = [] }) {
+  const fileBrandScoped = BRAND_SCOPE_FILE_RE.test(file);
+  const stripped = maskComments(css);
+
+  const violations = [];
+  // Selector stack: each frame { selectors: string, brand: boolean }.
+  const stack = [];
+  // Per-rule accumulator for the typography-family check, parallel to `stack`.
+  const ruleFonts = [];
+
+  let buf = '';
+  let line = 1;
+  let bufStartLine = 1;
+
+  const brandScopedNow = () => fileBrandScoped || stack.some((f) => f.brand);
+
+  const flushDeclaration = () => {
+    const decl = buf.trim();
+    buf = '';
+    if (!decl) return;
+    const colon = decl.indexOf(':');
+    if (colon === -1) return;
+    const prop = decl.slice(0, colon).trim();
+    const value = decl.slice(colon + 1).trim();
+
+    // ── Rule 1: redefinition ──
+    if (prop.startsWith('--')) {
+      const klass = redefinitionClass(prop);
+      if (klass && !isExempt(prop, exemptTokens)) {
+        if (klass === 'scale') {
+          violations.push({
+            rule: 'no-redefinition',
+            severity: 'error',
+            token: prop,
+            file,
+            line: bufStartLine,
+            message:
+              `Consumer redefines BDS scale token \`${prop}\`. The type scale is ` +
+              `shared — vary \`--font-family-*\` or emit a typography Mode, never ` +
+              `redefine the scale. (cascade adoption contract / ADR-013)`,
+          });
+        } else if (klass === 'brandable' && !brandScopedNow()) {
+          violations.push({
+            rule: 'no-redefinition',
+            severity: 'error',
+            token: prop,
+            file,
+            line: bufStartLine,
+            message:
+              `Consumer redefines BDS semantic token \`${prop}\` outside Brand-Kit ` +
+              `scope. Brand override belongs in a \`theme-{client}.css\` / ` +
+              `\`.theme-{client}\` block, not a bare \`:root\`. (ADR-013)`,
+          });
+        }
+      }
+    }
+
+    // ── Rule 2: collect font-family / font-size for the current rule ──
+    const frame = ruleFonts[ruleFonts.length - 1];
+    if (frame) {
+      const varMatch = value.match(/var\(\s*(--[a-z0-9-]+)/i);
+      const token = varMatch?.[1];
+      if (prop === 'font-family' && token) {
+        const fam = familyOfFontFamilyToken(token);
+        if (fam) frame.familyFamily = { fam, token, line: bufStartLine };
+      } else if (prop === 'font-size' && token) {
+        const fam = familyOfSizeToken(token);
+        if (fam) frame.sizeFamily = { fam, token, line: bufStartLine };
+      }
+    }
+  };
+
+  const finishRule = () => {
+    const frame = ruleFonts.pop();
+    if (!frame) return;
+    const { familyFamily, sizeFamily } = frame;
+    if (familyFamily && sizeFamily && familyFamily.fam !== sizeFamily.fam) {
+      violations.push({
+        rule: 'typography-family',
+        severity: 'error',
+        token: familyFamily.token,
+        file,
+        line: sizeFamily.line,
+        message:
+          `Typography family mismatch: \`font-family: var(${familyFamily.token})\` ` +
+          `(${familyFamily.fam}) paired with \`font-size: var(${sizeFamily.token})\` ` +
+          `(${sizeFamily.fam}). font-family and font-size must share a family. (ADR-013)`,
+      });
+    }
+  };
+
+  for (let i = 0; i < stripped.length; i++) {
+    const ch = stripped[i];
+    if (ch === '\n') {
+      line++;
+      continue;
+    }
+    if (ch === '{') {
+      const selectors = buf.trim();
+      buf = '';
+      // At-rules (@media, @layer, @supports) are not real selectors — they
+      // don't establish brand scope, but they DO open a brace level.
+      const isAtRule = selectors.startsWith('@');
+      stack.push({ selectors, brand: !isAtRule && BRAND_SCOPE_SELECTOR_RE.test(selectors) });
+      // Only declaration-bearing rules carry a typography frame; @layer/@media
+      // wrappers get one too (harmless — they hold no font decls directly).
+      ruleFonts.push({ familyFamily: null, sizeFamily: null });
+      bufStartLine = line;
+    } else if (ch === '}') {
+      flushDeclaration();
+      finishRule();
+      stack.pop();
+      bufStartLine = line;
+    } else if (ch === ';') {
+      flushDeclaration();
+      bufStartLine = line;
+    } else {
+      if (buf === '') bufStartLine = line;
+      buf += ch;
+    }
+  }
+
+  return { violations, file };
+}
+
+/**
+ * Throw on the first violation. Convenience for vitest / generator tests.
+ */
+export function assertCascadeContract(css, opts = {}) {
+  const { violations } = scanCascadeContract({ css, ...opts });
+  if (violations.length > 0) {
+    const v = violations[0];
+    throw new Error(
+      `cascade-contract-check: ${violations.length} violation(s). First:\n  ` +
+      `${v.file}:${v.line} [${v.rule}] ${v.message}`,
+    );
+  }
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const files = [];
+  let format = process.stdout.isTTY ? 'md' : 'json';
+  const exempt = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') return { help: true };
+    else if (a === '--format') format = argv[++i];
+    else if (a === '--exempt') {
+      for (const t of (argv[++i] ?? '').split(',').map((s) => s.trim()).filter(Boolean)) {
+        exempt.push(t.startsWith('/') && t.endsWith('/') ? new RegExp(t.slice(1, -1)) : t);
+      }
+    } else if (a.startsWith('-')) {
+      process.stderr.write(`Unknown flag: ${a}\n`);
+      return { bad: true };
+    } else files.push(a);
+  }
+  return { files, format, exempt };
+}
+
+const HELP = `cascade-contract-check — enforce the BDS token adoption contract (ADR-013 §2)
+
+Usage:
+  cascade-contract-check <file.css...>
+  cascade-contract-check --exempt --heading-lg,--heading-huge   transitional burn-down
+  cascade-contract-check --format json
+
+Checks consumer CSS for:
+  • no-redefinition  — redefining a BDS scale (--heading/display/font-size) token
+                       anywhere, or a semantic color token outside Brand-Kit scope
+  • typography-family — font-family family must match font-size family in a rule
+`;
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+  if (opts.bad) process.exit(2);
+  if (!opts.files.length) {
+    process.stderr.write('cascade-contract-check: no CSS files given.\n');
+    process.exit(2);
+  }
+
+  const all = [];
+  for (const file of opts.files) {
+    if (!existsSync(file)) {
+      process.stderr.write(`cascade-contract-check: file not found: ${file}\n`);
+      process.exit(2);
+    }
+    const { violations } = scanCascadeContract({
+      css: readFileSync(file, 'utf8'),
+      file,
+      exemptTokens: opts.exempt,
+    });
+    all.push(...violations);
+  }
+
+  if (opts.format === 'json') {
+    process.stdout.write(JSON.stringify({ violations: all }, null, 2) + '\n');
+  } else if (all.length === 0) {
+    process.stdout.write('cascade-contract-check: OK — no redefinitions, no family mismatches.\n');
+  } else {
+    process.stdout.write(`cascade-contract-check: ${all.length} violation(s):\n`);
+    for (const v of all) {
+      process.stdout.write(`  ${v.file}:${v.line} [${v.rule}] ${v.token}\n    ${v.message}\n`);
+    }
+  }
+  process.exit(all.length > 0 ? 1 : 0);
+}
+
+// Run as CLI only when invoked directly (not when imported as a library).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}


### PR DESCRIPTION
## What
Implements **ADR-013 §2** — the BDS-owned, consumer-imported lint gate that enforces the cascade adoption contract (companion to `canonical-check`, which catches *invented* names; this catches *redefinitions* + family mismatches).

New published module `scripts/cascade-contract-check.mjs` (CLI + library), wired into `exports` / `files` / `bin` exactly like `canonical-check`.

**Two rules:**
- **`no-redefinition`** — a consumer may not redefine **scale** tokens (`--heading-*`, `--display-*`, `--font-size-*`) *anywhere* (a Brand Kit varies `--font-family-*`, never the scale); **semantic color** tokens (`--surface/--text/--border/--page/--background-*`) only inside **Brand-Kit scope** — a `theme-{client}.css` file or a `.theme-{client}` / `[data-audience|service|department]` selector. At a bare `:root` it's a violation. This is the rule the brikdesigns `:root` heading remap violated (load-bearing + invisible ~3 months).
- **`typography-family`** — within one rule, `font-family: var(--font-family-X)` and `font-size: var(--Y-…)` must share a family (the #536 display-vs-heading-scale pairing bug).

## Why this shape
Owned in one place so the gate can't fork into drifting per-repo copies — the ADR-008 move (stop drift at the source) applied to token *values*. Consumers `import '@brikdesigns/bds/cascade-contract-check'` into their existing `lint-tokens` run with a transitional `--exempt` allowlist for pre-existing drift, then burn down. Folds in brikdesigns#540 (the family↔size check).

## Validation
- **20 unit tests** (`scripts/__tests__/cascade-contract-check.test.mjs`) — both rules, the brand-scope exception (file-level + ancestor selector + `[data-audience]`), comment robustness, compact single-line rules, `@media`/`@layer` not treated as brand scope, exempt allowlist.
- **Against real `brikdesigns/globals.css`**: flags the `:root` heading remap (L184–191) + `--background-tertiary` (L179) + `--text-*` overrides in non-brand `.service-surface`/`.lp-form-card` blocks (18 total); correctly **exempts** every `.theme-brand-brik` override (L56–160); zero typography-family violations (post-#536). That 18-item first-run drift is what PR-B transitionally allowlists.
- `typecheck` + `gitleaks` + anti-slop green.

Implementation note: uses an in-place comment **mask** (preserves line numbers) rather than `canonical-check`'s `stripCssComments` (which drops blank/comment lines — fine for its Set-returning extraction, wrong for line-accurate linting).

## Not in this PR
- **Version bump + publish** — separate `chore(release)` PR (repo convention: releases are their own commits, e.g. #918→0.97.4).
- **brikdesigns adoption** — PR-B (bump dep, wire into `lint-tokens.mjs`, transitional allowlist the 18 drift items; the heading remap entries clear once #920 emits `data-mode-typography`).

Refs ADR-013, brikdesigns#534, brikdesigns#540.