### PR TITLE
chore(release): v0.98.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.97.4",
+  "version": "0.98.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.97.4",
+      "version": "0.98.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.97.4",
+  "version": "0.98.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- chore(release): v0.98.0 — minor bump

## What's in this release
- **#923** `feat(lint): cascade-contract-check` — new `@brikdesigns/bds/cascade-contract-check` subpath export (ADR-013 §2). Additive only → minor bump.

## Consumer sync plan
- [ ] brikdesigns: adopt in PR-B — bump dep + wire `cascade-contract-check` into `lint-tokens.mjs` with a transitional `--exempt` allowlist (the 18 first-run drift items; heading-remap entries clear once #920 emits `data-mode-typography`).
- [ ] Portal / renew-pms: no action required (export is opt-in; adopt when they wire the gate).

## Publish
On merge, push tag `v0.98.0` on the merge commit → `release.yml` publishes to GitHub Packages.

Refs ADR-013, brikdesigns#534.