### PR TITLE
feat(tokens): expressive heading-scale variant + differentiate density trio (#928)

### DIFF
--- a/design-tokens/foundations.json
+++ b/design-tokens/foundations.json
@@ -4325,7 +4325,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.700}"
+        "$value": "{font-size.500}"
       },
       "xl": {
         "$extensions": {
@@ -4334,7 +4334,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.800}"
+        "$value": "{font-size.600}"
       },
       "xxl": {
         "$extensions": {
@@ -4343,7 +4343,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.900}"
+        "$value": "{font-size.700}"
       },
       "md": {
         "$extensions": {
@@ -4352,7 +4352,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.600}"
+        "$value": "{font-size.400}"
       },
       "tiny": {
         "$extensions": {
@@ -4361,7 +4361,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.400}"
+        "$value": "{font-size.200}"
       },
       "sm": {
         "$extensions": {
@@ -4370,7 +4370,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.500}"
+        "$value": "{font-size.300}"
       },
       "huge": {
         "$extensions": {
@@ -4379,7 +4379,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.1000}"
+        "$value": "{font-size.800}"
       }
     },
     "icon": {
@@ -4965,7 +4965,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.700}"
+        "$value": "{font-size.800}"
       },
       "xl": {
         "$extensions": {
@@ -4974,7 +4974,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.800}"
+        "$value": "{font-size.900}"
       },
       "xxl": {
         "$extensions": {
@@ -4983,7 +4983,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.900}"
+        "$value": "{font-size.1000}"
       },
       "md": {
         "$extensions": {
@@ -4992,7 +4992,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.600}"
+        "$value": "{font-size.700}"
       },
       "tiny": {
         "$extensions": {
@@ -5001,7 +5001,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.400}"
+        "$value": "{font-size.500}"
       },
       "sm": {
         "$extensions": {
@@ -5010,7 +5010,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.500}"
+        "$value": "{font-size.600}"
       },
       "huge": {
         "$extensions": {
@@ -5019,7 +5019,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.1000}"
+        "$value": "{font-size.1100}"
       }
     },
     "icon": {
@@ -5198,8 +5198,329 @@
       "typography/default",
       "typography/compact",
       "typography/comfortable",
-      "typography/spacious"
+      "typography/spacious",
+      "typography/expressive"
     ]
   },
-  "$themes": []
+  "$themes": [],
+  "typography/expressive": {
+    "body": {
+      "xs": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.50}"
+      },
+      "tiny": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.25}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.75}"
+      },
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.200}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.300}"
+      },
+      "huge": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.500}"
+      }
+    },
+    "display": {
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1400}"
+      },
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1600}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1500}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1800}"
+      }
+    },
+    "heading": {
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.700}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.900}"
+      },
+      "xxl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1000}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.500}"
+      },
+      "tiny": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.300}"
+      },
+      "huge": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1200}"
+      }
+    },
+    "icon": {
+      "tiny": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.50}"
+      },
+      "xs": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.75}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.200}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.300}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.400}"
+      },
+      "huge": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.500}"
+      }
+    },
+    "label": {
+      "tiny": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.25}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.200}"
+      },
+      "xs": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.50}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.75}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.300}"
+      }
+    },
+    "subtitle": {
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.50}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.25}"
+      }
+    }
+  }
 }

--- a/design-tokens/tokens-studio.json
+++ b/design-tokens/tokens-studio.json
@@ -4325,7 +4325,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.700}"
+        "$value": "{font-size.500}"
       },
       "xl": {
         "$extensions": {
@@ -4334,7 +4334,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.800}"
+        "$value": "{font-size.600}"
       },
       "xxl": {
         "$extensions": {
@@ -4343,7 +4343,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.900}"
+        "$value": "{font-size.700}"
       },
       "md": {
         "$extensions": {
@@ -4352,7 +4352,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.600}"
+        "$value": "{font-size.400}"
       },
       "tiny": {
         "$extensions": {
@@ -4361,7 +4361,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.400}"
+        "$value": "{font-size.200}"
       },
       "sm": {
         "$extensions": {
@@ -4370,7 +4370,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.500}"
+        "$value": "{font-size.300}"
       },
       "huge": {
         "$extensions": {
@@ -4379,7 +4379,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.1000}"
+        "$value": "{font-size.800}"
       }
     },
     "icon": {
@@ -4965,7 +4965,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.700}"
+        "$value": "{font-size.800}"
       },
       "xl": {
         "$extensions": {
@@ -4974,7 +4974,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.800}"
+        "$value": "{font-size.900}"
       },
       "xxl": {
         "$extensions": {
@@ -4983,7 +4983,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.900}"
+        "$value": "{font-size.1000}"
       },
       "md": {
         "$extensions": {
@@ -4992,7 +4992,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.600}"
+        "$value": "{font-size.700}"
       },
       "tiny": {
         "$extensions": {
@@ -5001,7 +5001,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.400}"
+        "$value": "{font-size.500}"
       },
       "sm": {
         "$extensions": {
@@ -5010,7 +5010,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.500}"
+        "$value": "{font-size.600}"
       },
       "huge": {
         "$extensions": {
@@ -5019,7 +5019,7 @@
           ]
         },
         "$type": "number",
-        "$value": "{font-size.1000}"
+        "$value": "{font-size.1100}"
       }
     },
     "icon": {
@@ -5170,6 +5170,326 @@
         },
         "$type": "number",
         "$value": "{font-size.500}"
+      }
+    }
+  },
+  "typography/expressive": {
+    "body": {
+      "xs": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.50}"
+      },
+      "tiny": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.25}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.75}"
+      },
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.200}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.300}"
+      },
+      "huge": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.500}"
+      }
+    },
+    "display": {
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1400}"
+      },
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1600}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1500}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1800}"
+      }
+    },
+    "heading": {
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.700}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.900}"
+      },
+      "xxl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1000}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.500}"
+      },
+      "tiny": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.300}"
+      },
+      "huge": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.1200}"
+      }
+    },
+    "icon": {
+      "tiny": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.50}"
+      },
+      "xs": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.75}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.200}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.300}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.400}"
+      },
+      "huge": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.500}"
+      }
+    },
+    "label": {
+      "tiny": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.25}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.200}"
+      },
+      "xs": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.50}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.75}"
+      },
+      "xl": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.300}"
+      }
+    },
+    "subtitle": {
+      "lg": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.100}"
+      },
+      "md": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.50}"
+      },
+      "sm": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ]
+        },
+        "$type": "number",
+        "$value": "{font-size.25}"
       }
     }
   },
@@ -7641,6 +7961,7 @@
       "typography/compact",
       "typography/comfortable",
       "typography/spacious",
+      "typography/expressive",
       "color/light",
       "color/dark"
     ]

--- a/docs-site/content/docs/getting-started/cascade.mdx
+++ b/docs-site/content/docs/getting-started/cascade.mdx
@@ -114,12 +114,14 @@ A Mode varies a token's *value* on a system-wide axis any consumer can toggle. M
 | `borderwidth` | `data-mode-borderwidth` | `default` | `thin`, `bold` | ✅ |
 | `spacing` | `data-mode-spacing` | `default` | `compact`, `comfortable`, `spacious` | ✅ |
 | `border-radius` | `data-mode-radius` | `soft` | `sharp`, `round`, `pill` | ⏳ [#340](https://github.com/brikdesigns/brik-bds/issues/340) |
-| `typography` | `data-mode-typography` | `default` | `compact`, `comfortable`, `spacious` | ⏳ #340 |
+| `typography` | `data-mode-typography` | `default` | `compact`, `comfortable`, `spacious`, `expressive` | ✅ `modes-typography.css` (heading-* only) |
 | `elevation` | `data-mode-elevation` | `subtle` | `flat`, `lifted`, `dramatic` | ⏳ #340 |
 | `breakpoint` | `data-mode-breakpoint` | `default` | `compact`, `comfortable` | ⏳ #340 |
 | `icon` | `data-mode-icon` | `solid` | `outline` | ⏳ #340 |
 
 Each wired mode emits a `tokens/modes-{collection}.css` file scoped via `[data-mode-{collection}="value"]`. Modes are **not** a substitute for Theming Dimensions (which compose subsystems per brand) or for Brand Kit overrides (which change *values*, not modes).
+
+The `typography` axis is **heading-scale-variant selection**, not strictly density: `compact`/`comfortable`/`spacious` are uniform density steps, while `expressive` is a steeper modular curve (smaller small end, larger large end) for editorial / marketing surfaces. The variants are mutually exclusive — this axis owns `--heading-*` alone, so a second axis varying the same tokens is not added (it would collide on cascade order rather than compose). See [ADR-013](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-013-token-last-mile-enforce-contract-complete-emission.md) amendment 2026-06-21.
 
 ## Color foundations vocabulary
 

--- a/docs-site/content/docs/primitives/typography.mdx
+++ b/docs-site/content/docs/primitives/typography.mdx
@@ -80,6 +80,27 @@ The heading scale starts at 18px (`--heading-tiny`). 16px territory is body and 
   ]}
 />
 
+#### Heading scale variants (`data-mode-typography`)
+
+The heading scale is the one mode axis on `--heading-*` (see [Cascade → Modes](/docs/getting-started/cascade#modes--orthogonal-axes)). Default needs no attribute; set `data-mode-typography` on `:root` (or any subtree) to select a variant. `compact`/`comfortable`/`spacious` are uniform density steps; `expressive` is a steeper modular curve (smaller small end, larger large end) for editorial / marketing surfaces. Values are `--font-size-*` references (px shown):
+
+| token | `default` | `compact` | `comfortable` | `spacious` | `expressive` |
+|---|---|---|---|---|---|
+| `--heading-tiny` | 20 | 18 | 22.5 | 25.3 | 16 |
+| `--heading-sm` | 22.5 | 20 | 25.3 | 28.5 | 20 |
+| `--heading-md` | 25.3 | 22.5 | 28.5 | 32 | 25.3 |
+| `--heading-lg` | 28.5 | 25.3 | 32 | 36 | 32 |
+| `--heading-xl` | 32 | 28.5 | 36 | 40.5 | 40.5 |
+| `--heading-xxl` | 36 | 32 | 40.5 | 45.5 | 45.5 |
+| `--heading-huge` | 40.5 | 36 | 45.5 | 51 | 57.5 |
+
+```html
+<html data-mode-typography="expressive"> <!-- whole document -->
+<section data-mode-typography="compact">…</section> <!-- one subtree -->
+```
+
+`display-*` is mode-invariant — variants move `--heading-*` only.
+
 ### Body sizes
 
 <SemanticTypographyTable

--- a/docs/adrs/ADR-013-token-last-mile-enforce-contract-complete-emission.md
+++ b/docs/adrs/ADR-013-token-last-mile-enforce-contract-complete-emission.md
@@ -46,3 +46,20 @@ Treat the token "last mile" as one initiative with three mechanisms. We do **not
 - **Documentation-only (write/expand the contract, no gate).** Rejected: the contract already exists in cascade.mdx and was still violated for 3 months. Docs without enforcement is the status quo that produced this ADR.
 - **Per-consumer local scales (let each repo define its own).** Rejected: this *is* the parallel-taxonomy failure mode that rolled back portal #512/#553 and produced the brikdesigns remap. One root scale + modes + Brand Kit theming is the decision; local scales are the thing the gate exists to stop.
 - **Redesign the scale/mode model.** Rejected: the model is correct and ~80% built. The work is completeness and enforcement, not redesign.
+
+## Amendment — 2026-06-21 (the typography axis is scale-variant selection, not density)
+
+**Trigger:** [#928](https://github.com/brikdesigns/brik-bds/issues/928) measured the brikdesigns marketing heading scale against the emitted typography modes and falsified an assumption baked into §Decision-3 and the Consequences ("brikdesigns … adopts a mode (`comfortable`/`spacious`)").
+
+**The falsified premise.** §Decision assumed the marketing scale equals an existing *density* step. It does not. Density (compact/comfortable/spacious) shifts the whole heading ramp **uniformly** one direction. The marketing scale keeps a **steeper modular ratio** — smaller at the small end (`tiny` 20→16px), larger at the large end (`huge` 40.5→57.5px), crossing default at `md` (25.3px). Uniform-shift and steeper-ratio are different operations; no density step reproduces the marketing curve. (Compounding this, the three density slices in `tokens-studio.json` were byte-identical — all `default`+1 rung — so none was even a real density step; #928 also fixes that.)
+
+**The structural constraint.** `--heading-*` can be owned by exactly **one** mode axis. Two mode collections both writing `--heading-*` do not *compose* — they collide on cascade order, which is the opposite of the orthogonality modes promise (modes compose precisely because each targets distinct tokens). So a separate "expressiveness" axis alongside "density" is not viable: there is one axis on the heading scale.
+
+**The decision.** The `typography` mode axis is **heading-scale-variant selection** — "pick one named heading scale" — not strictly density. Its values are mutually-exclusive variants that may differ by density **or** by modular contrast:
+
+- `compact` / `comfortable` / `spacious` — uniform density steps (`compact ≤ default < comfortable < spacious`).
+- `expressive` — a steeper modular curve for editorial / marketing surfaces (the scale brikdesigns adopts to delete its `:root` remap). Named for its typographic *character*, not its consumer, per build-standards/naming-principles ("intent, not shape").
+
+This keeps "scale via modes" (the gate still forbids consumer scale *redefinition*; Brand Kit still varies color/font-family *values*, not the size scale) and leaves the cascade contract unchanged. brikdesigns' proof-of-loop (§Decision-3) stands — it adopts `data-mode-typography="expressive"` and deletes the remap — only the variant name changes from the assumed `comfortable`/`spacious` to `expressive`.
+
+**Out of this amendment:** the `display-*` scale stays mode-invariant; the brikdesigns home-hero `--display-sm` treatment is unaffected (locked under brikdesigns #534).

--- a/scripts/generate-modes-css.mjs
+++ b/scripts/generate-modes-css.mjs
@@ -64,17 +64,19 @@ const COLLECTIONS = {
   typography: {
     groups: ['display', 'heading'],
     defaultMode: 'default',
-    nonDefaultModes: ['compact', 'comfortable', 'spacious'],
+    nonDefaultModes: ['compact', 'comfortable', 'spacious', 'expressive'],
     unitSuffix: '',
     tokenName: (group, name) => `--${group}-${name}`,
     resolve: resolveFontSizeRef,
     description:
-      'Typography density mode — modulates the display-* and heading-* type ' +
-      'scales. Emitted as var(--font-size-NNN) references (matching how ' +
-      'figma-tokens.css emits the default scale), so each mode reuses the ' +
-      'shared font-size primitives. Set `[data-mode-typography]` on :root to ' +
-      'opt a surface into a larger scale; display-* is mode-invariant in ' +
-      'Figma today so only heading-* emits overrides (see BDS #920).',
+      'Typography heading-scale variant — selects one named heading scale. ' +
+      'compact/comfortable/spacious are uniform density steps; expressive is a ' +
+      'steeper modular curve (smaller small end, larger large end) for editorial / ' +
+      'marketing surfaces. The variants are mutually exclusive — this axis owns ' +
+      '--heading-* alone (see ADR-013 amendment 2026-06-21, BDS #928). Emitted as ' +
+      'var(--font-size-NNN) references (matching how figma-tokens.css emits the ' +
+      'default scale), so each variant reuses the shared font-size primitives. ' +
+      'display-* is mode-invariant in Figma today so only heading-* emits overrides.',
   },
 };
 

--- a/tokens/CASCADE.md
+++ b/tokens/CASCADE.md
@@ -27,7 +27,7 @@ renew-pms, brikdesigns) via `@brikdesigns/bds/tokens.css`. Built by
 3. `theme-brand-brik.css` — Brik brand overrides (scoped to `.theme-brand-brik` class)
 4. `modes-borderwidth.css` — borderWidth mode overrides (`[data-mode-borderwidth="thin|bold"]`)
 5. `modes-spacing.css` — spacing density mode overrides (`[data-mode-spacing="compact|comfortable|spacious"]`) — auto-generated from `design-tokens/tokens-studio.json` via `npm run build:modes`
-6. `modes-typography.css` — typography density mode overrides (`[data-mode-typography="compact|comfortable|spacious"]`) — auto-generated from `design-tokens/tokens-studio.json` via `npm run build:modes`
+6. `modes-typography.css` — typography heading-scale-variant overrides (`[data-mode-typography="compact|comfortable|spacious|expressive"]`) — auto-generated from `design-tokens/tokens-studio.json` via `npm run build:modes`
 7. `gap-fills.css` — manual tokens not yet in Figma
 8. `animations.css` — shared keyframe library (`bds-spin`, `bds-pulse`, `bds-pop`, etc.) — required by any component CSS that references these names
 
@@ -56,7 +56,7 @@ No consumer should toggle a `.dark` class — the attribute is the only switch.
 | `borderwidth` | `data-mode-borderwidth` | `default` | `thin`, `bold` | ✅ `modes-borderwidth.css` |
 | `spacing` | `data-mode-spacing` | `default` | `compact`, `comfortable`, `spacious` | ✅ `modes-spacing.css` |
 | `border-radius` | `data-mode-radius` | `soft` | `sharp`, `round`, `pill` | ⏳ pending #340 |
-| `typography` | `data-mode-typography` | `default` | `compact`, `comfortable`, `spacious` | ✅ `modes-typography.css` (heading-* only; display-* mode-invariant) |
+| `typography` | `data-mode-typography` | `default` | `compact`, `comfortable`, `spacious`, `expressive` | ✅ `modes-typography.css` (heading-* only; display-* mode-invariant) |
 | `elevation` | `data-mode-elevation` | `subtle` | `flat`, `lifted`, `dramatic` | ⏳ pending #340 |
 | `breakpoint` | `data-mode-breakpoint` | `default` | `compact`, `comfortable` | ⏳ pending #340 |
 | `icon` | `data-mode-icon` | `solid` | `outline` | ⏳ pending #340 |

--- a/tokens/modes-typography.css
+++ b/tokens/modes-typography.css
@@ -5,9 +5,9 @@
  * design-tokens/tokens-studio.json. Do not hand-edit — re-run
  * the generator after any Figma mode update.
  *
- * Typography density mode — modulates the display-* and heading-* type scales. Emitted as var(--font-size-NNN) references (matching how figma-tokens.css emits the default scale), so each mode reuses the shared font-size primitives. Set `[data-mode-typography]` on :root to opt a surface into a larger scale; display-* is mode-invariant in Figma today so only heading-* emits overrides (see BDS #920).
+ * Typography heading-scale variant — selects one named heading scale. compact/comfortable/spacious are uniform density steps; expressive is a steeper modular curve (smaller small end, larger large end) for editorial / marketing surfaces. The variants are mutually exclusive — this axis owns --heading-* alone (see ADR-013 amendment 2026-06-21, BDS #928). Emitted as var(--font-size-NNN) references (matching how figma-tokens.css emits the default scale), so each variant reuses the shared font-size primitives. display-* is mode-invariant in Figma today so only heading-* emits overrides.
  *
- * Selector contract: `[data-mode-typography="compact|comfortable|spacious"]`
+ * Selector contract: `[data-mode-typography="compact|comfortable|spacious|expressive"]`
  * on :root (html). Default mode requires no attribute (uses figma-tokens.css base).
  *
  * Companion to figma-tokens-dark.css and modes-borderwidth.css per the cascade
@@ -17,13 +17,13 @@
 /* ─── Compact ────────────────────────────────────────── */
 [data-mode-typography="compact"] {
   /* heading */
-  --heading-huge: var(--font-size-1000);
-  --heading-lg: var(--font-size-700);
-  --heading-md: var(--font-size-600);
-  --heading-sm: var(--font-size-500);
-  --heading-tiny: var(--font-size-400);
-  --heading-xl: var(--font-size-800);
-  --heading-xxl: var(--font-size-900);
+  --heading-huge: var(--font-size-800);
+  --heading-lg: var(--font-size-500);
+  --heading-md: var(--font-size-400);
+  --heading-sm: var(--font-size-300);
+  --heading-tiny: var(--font-size-200);
+  --heading-xl: var(--font-size-600);
+  --heading-xxl: var(--font-size-700);
 }
 
 /* ─── Comfortable ────────────────────────────────────────── */
@@ -41,11 +41,22 @@
 /* ─── Spacious ────────────────────────────────────────── */
 [data-mode-typography="spacious"] {
   /* heading */
-  --heading-huge: var(--font-size-1000);
+  --heading-huge: var(--font-size-1100);
+  --heading-lg: var(--font-size-800);
+  --heading-md: var(--font-size-700);
+  --heading-sm: var(--font-size-600);
+  --heading-tiny: var(--font-size-500);
+  --heading-xl: var(--font-size-900);
+  --heading-xxl: var(--font-size-1000);
+}
+
+/* ─── Expressive ────────────────────────────────────────── */
+[data-mode-typography="expressive"] {
+  /* heading */
+  --heading-huge: var(--font-size-1200);
   --heading-lg: var(--font-size-700);
-  --heading-md: var(--font-size-600);
-  --heading-sm: var(--font-size-500);
-  --heading-tiny: var(--font-size-400);
-  --heading-xl: var(--font-size-800);
-  --heading-xxl: var(--font-size-900);
+  --heading-sm: var(--font-size-300);
+  --heading-tiny: var(--font-size-100);
+  --heading-xl: var(--font-size-900);
+  --heading-xxl: var(--font-size-1000);
 }


### PR DESCRIPTION
## Summary
- feat(tokens): add expressive heading-scale variant + differentiate density trio (#928)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)