### PR TITLE
feat(blueprint): HeroSplitImageCardOverlay onPriceCtaClick (#843)

### DIFF
--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { HeroSplitImageCardOverlay } from './HeroSplitImageCardOverlay';
 import type { BlueprintProps } from '../astro/types';
@@ -195,5 +196,40 @@ export const PriceCardCtaMd: Story = {
         cta: { ...interiorHeroSection.priceCard!.cta!, size: 'md' },
       },
     },
+  },
+};
+
+/**
+ * @summary Action CTA — pass `onPriceCtaClick` to intercept the price-card CTA
+ * and run an in-page handler (e.g. open a modal) instead of navigating. The
+ * `priceCard.cta.url` stays as the rendered `href`, so the link still works as
+ * a no-JS / SEO fallback (progressive enhancement). Click the CTA and watch the
+ * Actions panel: the handler fires and navigation is suppressed. Astro-rendered
+ * blueprints never receive this prop and keep the plain anchor. (brik-bds#843)
+ */
+export const PriceCtaAsAction: Story = {
+  args: {
+    ...baseProps,
+    onPriceCtaClick: fn(),
+    section: {
+      ...interiorHeroSection,
+      sectionKey: 'hero-img-card-cta-action',
+      priceCard: {
+        ...interiorHeroSection.priceCard!,
+        cta: { label: 'Get started', url: '/get-started' },
+      },
+    },
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const cta = canvas.getByRole('link', { name: 'Get started' });
+    await expect(cta).toBeVisible();
+    // `url` is preserved as the rendered href — the no-JS / SEO fallback.
+    await expect(cta).toHaveAttribute('href', '/get-started');
+    // Clicking hands off to the consumer handler and suppresses navigation
+    // (preventDefault): the spy fires once and the CTA stays mounted.
+    await userEvent.click(cta);
+    await expect(args.onPriceCtaClick).toHaveBeenCalledTimes(1);
+    await expect(cta).toBeInTheDocument();
   },
 };

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -15,6 +15,7 @@
  *
  * @summary Interior-page split hero with image card + optional price overlay.
  */
+import type { MouseEvent } from 'react';
 import { Breadcrumb } from '../../../components/ui/Breadcrumb/Breadcrumb';
 import { Button } from '../../../components/ui/Button';
 import { Frame } from '../../../components/ui/Frame/Frame';
@@ -32,12 +33,22 @@ interface Props extends BlueprintProps {
    * the prop is absent. (brik-bds#871)
    */
   showServiceTag?: boolean;
+  /**
+   * Optional handler for the price-card CTA. When provided, the CTA's click is
+   * intercepted (`preventDefault` + handler invoked) so consumers can trigger
+   * an in-page action — e.g. open a modal — instead of navigating. The
+   * `priceCard.cta.url` stays as the rendered `href`, so it remains a working
+   * no-JS / SEO fallback (progressive enhancement). Astro-rendered blueprints
+   * never receive this prop and keep their plain-anchor behavior. (brik-bds#843)
+   */
+  onPriceCtaClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export function HeroSplitImageCardOverlay({
   section,
   imageRatio = 'square',
   showServiceTag = true,
+  onPriceCtaClick,
 }: Props) {
   const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
   const titleId = `${section.sectionKey}-title`;
@@ -135,6 +146,18 @@ export function HeroSplitImageCardOverlay({
                     href={priceCard.cta.url}
                     variant="primary"
                     size={priceCard.cta.size ?? 'sm'}
+                    onClick={
+                      onPriceCtaClick
+                        ? (event) => {
+                            // Progressive enhancement: with JS, suppress the
+                            // anchor navigation and hand off to the consumer's
+                            // handler (e.g. open a modal). Without JS, the
+                            // `href` still navigates. (brik-bds#843)
+                            event.preventDefault();
+                            onPriceCtaClick(event);
+                          }
+                        : undefined
+                    }
                   >
                     {priceCard.cta.label}
                   </Button>


### PR DESCRIPTION
## Summary
- refactor(TextInput): move inline styles to CSS, drop from inline-var baseline (#892) (#899)
- chore(deps-dev): bump @vitest/browser from 4.1.6 to 4.1.8 (#900)
- chore(deps-dev): bump vite and @vitejs/plugin-react (#901)
- fix(button): keep text color steady on secondary & outline press (BDS-19, #902) (#903)
- chore(release): v0.97.2 (#904)
- fix(build): externalize lottie to keep ESM entry require()-free + add gate (#906)
- docs(adr): amend ADR-011 — dark-step service variants are mode-invariant (#865) (#909)
- docs(typography): document heading title-case standard (#910) (#911)
- feat(nav): linkComponent escape hatch for NavItem family (#379) (#912)
- fix(segmented-control): legible inactive label in dark mode (#917)
- chore(release): v0.97.4 (#918)
- docs(adr): add ADR-013 — token last mile (enforce contract + complete emission) (#921)
- docs(cascade): promote cascade.mdx to the canonical adoption contract (#922)
- feat(lint): cascade-contract-check — BDS-owned consumer redefinition gate (#923)
- chore(release): v0.98.0 (#924)
- feat(tokens): wire data-mode-typography emission (#920) (#925)
- feat(tokens): add expressive heading-scale variant + differentiate density trio (#928) (#933)
- chore(release): v0.99.0 (#934)
- feat(blueprints): export WIRED_BLUEPRINT_KEYS implemented-set (#621) (#935)
- chore(release): v0.100.0 (#937)
- feat(blueprint): HeroSplitImageCardOverlay onPriceCtaClick for in-page CTA actions

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)