### PR TITLE
forms: select placeholder contrast

### DIFF
--- a/components/ui/Select/Select.css
+++ b/components/ui/Select/Select.css
@@ -110,10 +110,12 @@
   pointer-events: none;
 }
 
-/* Placeholder color */
+/* Placeholder color. Use --text-secondary (~9:1 on white, WCAG AA) — not
+   --text-muted (#bdbdbd, 1.87:1), which fails AA as rendered select text.
+   Same root cause / fix as #765 (breadcrumb + pricing-card). brik-bds#942. */
 .bds-select:invalid,
 .bds-select--placeholder {
-  color: var(--text-muted);
+  color: var(--text-secondary);
 }
 
 /* Error state */
@@ -164,7 +166,8 @@
   font-family: var(--font-family-body);
   font-size: var(--body-sm);
   line-height: var(--font-line-height-normal);
-  color: var(--text-muted);
+  /* AA-compliant: --text-muted (#bdbdbd) fails as below-input helper text. #942 */
+  color: var(--text-secondary);
 }
 
 .bds-select-helper--error {


### PR DESCRIPTION
## Summary
- feat(blueprint): HeroSplitImageCardOverlay onPriceCtaClick for in-page CTA actions (#938)
- chore(release): v0.101.0 (#939)
- fix(select): use --text-secondary for placeholder + helper text (WCAG AA) (#942)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)