### PR TITLE
chore(release): v0.101.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.101.0",
+  "version": "0.101.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",
@@ -17,7 +17,8 @@
       "bin": {
         "bds-find": "scripts/bds-find.mjs",
         "canonical-check": "scripts/canonical-check.mjs",
-        "canonical-class-check": "scripts/canonical-class-check.mjs"
+        "canonical-class-check": "scripts/canonical-class-check.mjs",
+        "cascade-contract-check": "scripts/cascade-contract-check.mjs"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",
@@ -2058,9 +2059,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2078,9 +2076,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2098,9 +2093,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2118,9 +2110,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2138,9 +2127,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2158,9 +2144,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4633,9 +4616,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4657,9 +4637,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4681,9 +4658,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4705,9 +4679,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.101.0",
+  "version": "0.101.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Patch release cutting **v0.101.1**.

## Includes
- **#943** (brik-bds#942): Select placeholder + helper text use `--text-secondary` (WCAG AA) instead of `--text-muted` (#bdbdbd, 1.87:1). Unblocks the brikdesigns `/get-started` axe gate (brikdesigns#580).

## Release steps
- [x] Bump `package.json` + lockfile → 0.101.1
- [ ] Merge this PR
- [ ] Push tag `v0.101.1` → release.yml publishes to GitHub Packages
- [ ] Adopt in brikdesigns (#580)

Version-only diff (package.json + package-lock.json).