### PR TITLE
tokens: 936 foundations drift

### DIFF
--- a/scripts/sync-figma-mcp.js
+++ b/scripts/sync-figma-mcp.js
@@ -510,13 +510,24 @@ if (isPullShape) {
 // without deleting the sibling tokens the dump deliberately omits. The default
 // (prune on) assumes the dump is complete for every set it touches.
 if (isPullShape && !noPrune) {
+  // A leaf still present under ANY collection in this dump was not deleted —
+  // at most it moved collections. The foundations Library aggregates primitives
+  // whose Figma home is a different collection than the set they land in:
+  // blur-radius/box-shadow live in `elevation`, breakpoints in `breakpoint`,
+  // yet all three sit under `primitives/value` here. Pruning per-set seen-paths
+  // alone false-flags those cross-collection primitives as deleted, so guard
+  // with presence anywhere in the dump (brik-bds#936).
+  const seenAnywhere = new Set();
+  for (const names of changes.seenPaths.values()) {
+    for (const name of names) seenAnywhere.add(name);
+  }
   for (const [setKey, seen] of changes.seenPaths) {
     const set = tokensStudio[setKey];
     if (!set) continue; // unknown set — nothing to prune
     const existingLeaves = [];
     collectLeafPaths(set, '', existingLeaves);
     for (const leafPath of existingLeaves) {
-      if (seen.has(leafPath)) continue;
+      if (seen.has(leafPath) || seenAnywhere.has(leafPath)) continue;
       deleteLeaf(set, leafPath);
       bucket(setKey).removed.push({ path: leafPath });
       changes.totalRemoved += 1;


### PR DESCRIPTION
## What

Fixes the prune-scope bug behind #936. Unscoped `sync-figma-mcp --library=foundations` false-flagged **11 live primitives** for deletion because the prune pass assumed one Figma collection-mode maps to one token set — but `primitives/value` aggregates primitives whose Figma home is a different collection (`blur-radius`/`box-shadow` live in `elevation`, breakpoints in `breakpoint`).

**Fix:** a leaf present under *any* collection in the dump was not deleted (at most it moved collections), so prune is now guarded by presence-anywhere. Foundations dry-run removals drop **61 → 50** — the 11 cross-collection false-positives are no longer flagged.

## Verification

- `node scripts/sync-figma-mcp.js <foundations-pull> --library=foundations --dry-run` — blur-radius/box-shadow/breakpoint no longer in the Removed set.
- `npm run validate:full` — all 10 checks pass (script-only change, no token output touched).

## Scope / deferred

This ships **only the prune-scope gate**. The other drift #936 surfaced is real but needs sequencing the sync can't do safely, so each is tracked separately:

- **#946** — grayscale ramp shift is a real Figma change, but propagating it regresses **4 WCAG AA pairings** (secondary/muted text, button labels). Needs the color-a11y foundation pass (re-map semantic tokens).
- **#945** — 48 brand color ramps relocated to the brand-kit library; must land in `brik.json` before foundations can prune them.
- **#947** — spaced `font-weight` dupes still have ~77 CSS-var consumers; migrate consumers first.

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)
