### PR TITLE
fix(a11y): solid Tag label holds WCAG AA in dark mode (#951)

### DIFF
--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -33,6 +33,12 @@
 
 .bds-tag--solid {
   background-color: var(--background-secondary);
+  /* On-color label. The base `--text-primary` pairs with the page, not this
+     fill: it holds in light (dark text on the light --background-secondary tint)
+     but fails WCAG AA in dark mode (3.43:1, light text on the mid-gray tint).
+     `--text-on-color-light` holds AA in both themes (18.76:1 / 5.46:1) — the
+     same pairing SegmentedControl uses for its `--background-secondary` track. */
+  color: var(--text-on-color-light);
 }
 
 .bds-tag--subtle {

--- a/tokens/contrast-pairings.json
+++ b/tokens/contrast-pairings.json
@@ -9,6 +9,7 @@
     { "group": "neutral", "label": "Secondary text on page", "fg": "--text-secondary", "bg": "--page-primary", "thresholdType": "AA" },
     { "group": "neutral", "label": "Muted text on page", "fg": "--text-muted", "bg": "--page-primary", "thresholdType": "AA-large" },
     { "group": "neutral", "label": "SegmentedControl inactive label on track", "fg": "--text-on-color-light", "bg": "--background-secondary", "thresholdType": "AA" },
+    { "group": "neutral", "label": "Solid Tag / MultiSelect chip label on fill", "fg": "--text-on-color-light", "bg": "--background-secondary", "thresholdType": "AA" },
 
     { "group": "brand", "label": "Brand text on page", "fg": "--text-brand-primary", "bg": "--page-primary", "thresholdType": "AA" },
     { "group": "brand", "label": "On-color label on brand fill", "fg": "--text-on-color-dark", "bg": "--background-brand-primary", "thresholdType": "AA" },


### PR DESCRIPTION
## Summary
- refactor(TextInput): move inline styles to CSS, drop from inline-var baseline (#892) (#899)
- chore(deps-dev): bump @vitest/browser from 4.1.6 to 4.1.8 (#900)
- chore(deps-dev): bump vite and @vitejs/plugin-react (#901)
- fix(button): keep text color steady on secondary & outline press (BDS-19, #902) (#903)
- chore(release): v0.97.2 (#904)
- fix(build): externalize lottie to keep ESM entry require()-free + add gate (#906)
- docs(adr): amend ADR-011 — dark-step service variants are mode-invariant (#865) (#909)
- docs(typography): document heading title-case standard (#910) (#911)
- feat(nav): linkComponent escape hatch for NavItem family (#379) (#912)
- fix(segmented-control): legible inactive label in dark mode (#917)
- chore(release): v0.97.4 (#918)
- docs(adr): add ADR-013 — token last mile (enforce contract + complete emission) (#921)
- docs(cascade): promote cascade.mdx to the canonical adoption contract (#922)
- feat(lint): cascade-contract-check — BDS-owned consumer redefinition gate (#923)
- chore(release): v0.98.0 (#924)
- feat(tokens): wire data-mode-typography emission (#920) (#925)
- feat(tokens): add expressive heading-scale variant + differentiate density trio (#928) (#933)
- chore(release): v0.99.0 (#934)
- feat(blueprints): export WIRED_BLUEPRINT_KEYS implemented-set (#621) (#935)
- chore(release): v0.100.0 (#937)
- feat(blueprint): HeroSplitImageCardOverlay onPriceCtaClick for in-page CTA actions (#938)
- chore(release): v0.101.0 (#939)
- fix(select): use --text-secondary for placeholder + helper text (WCAG AA) (#942) (#943)
- chore(release): v0.101.1 (#944)
- fix(tokens): guard prune against cross-collection primitives (#936) (#948)
- refactor(tokens): migrate spaced font-weight consumers to canonical, prune dupes (#947) (#949)
- refactor(tokens): relocate 48 brand color ramps Foundations -> Brand-kit (#945) (#950)
- fix(a11y): solid Tag label holds WCAG AA in dark mode (#951)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)