### PR TITLE
chore(release): v0.102.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.101.1",
+  "version": "0.102.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- refactor(TextInput): move inline styles to CSS, drop from inline-var baseline (#892) (#899)
- chore(deps-dev): bump @vitest/browser from 4.1.6 to 4.1.8 (#900)
- chore(deps-dev): bump vite and @vitejs/plugin-react (#901)
- fix(button): keep text color steady on secondary & outline press (BDS-19, #902) (#903)
- chore(release): v0.97.2 (#904)
- fix(build): externalize lottie to keep ESM entry require()-free + add gate (#906)
- docs(adr): amend ADR-011 — dark-step service variants are mode-invariant (#865) (#909)
- docs(typography): document heading title-case standard (#910) (#911)
- feat(nav): linkComponent escape hatch for NavItem family (#379) (#912)
- fix(segmented-control): legible inactive label in dark mode (#917)
- chore(release): v0.97.4 (#918)
- docs(adr): add ADR-013 — token last mile (enforce contract + complete emission) (#921)
- docs(cascade): promote cascade.mdx to the canonical adoption contract (#922)
- feat(lint): cascade-contract-check — BDS-owned consumer redefinition gate (#923)
- chore(release): v0.98.0 (#924)
- feat(tokens): wire data-mode-typography emission (#920) (#925)
- feat(tokens): add expressive heading-scale variant + differentiate density trio (#928) (#933)
- chore(release): v0.99.0 (#934)
- feat(blueprints): export WIRED_BLUEPRINT_KEYS implemented-set (#621) (#935)
- chore(release): v0.100.0 (#937)
- feat(blueprint): HeroSplitImageCardOverlay onPriceCtaClick for in-page CTA actions (#938)
- chore(release): v0.101.0 (#939)
- fix(select): use --text-secondary for placeholder + helper text (WCAG AA) (#942) (#943)
- chore(release): v0.101.1 (#944)
- fix(tokens): guard prune against cross-collection primitives (#936) (#948)
- refactor(tokens): migrate spaced font-weight consumers to canonical, prune dupes (#947) (#949)
- refactor(tokens): relocate 48 brand color ramps Foundations -> Brand-kit (#945) (#950)
- fix(a11y): solid Tag label holds WCAG AA in dark mode (#951) (#952)
- chore(release): v0.102.0

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)