### PR TITLE
feat(blueprints): support action (onClick) CTAs, not just URLs

### DIFF
--- a/content-system/blueprints/astro/CtaDarkCentered.astro
+++ b/content-system/blueprints/astro/CtaDarkCentered.astro
@@ -42,7 +42,7 @@ const titleId = `${section.sectionKey}-title`;
     {section.body && (
       <p class="bp-cta-dark-centered__description">{section.body}</p>
     )}
-    {section.cta && (
+    {section.cta && 'url' in section.cta && (
       <a href={section.cta.url} class="bds-button bds-button--primary bds-button--lg"><span class="bds-button__content">{section.cta.label}</span></a>
     )}
   </div>

--- a/content-system/blueprints/astro/CtaSplitContact.astro
+++ b/content-system/blueprints/astro/CtaSplitContact.astro
@@ -50,7 +50,7 @@ const email = clientFacts.email;
       {section.body && (
         <p class="bp-cta-split-contact__description">{section.body}</p>
       )}
-      {section.cta && (
+      {section.cta && 'url' in section.cta && (
         <a href={section.cta.url} class="bds-button bds-button--primary bds-button--md"><span class="bds-button__content">{section.cta.label}</span></a>
       )}
     </div>

--- a/content-system/blueprints/astro/HeroInteriorMinimal.astro
+++ b/content-system/blueprints/astro/HeroInteriorMinimal.astro
@@ -45,7 +45,7 @@ const cta = section.cta;
     {eyebrow && <p class="bp-hero-interior-minimal__subtitle">{eyebrow}</p>}
     <h1 id={titleId} class="bp-hero-interior-minimal__title">{headline}</h1>
     {lead && <p class="bp-hero-interior-minimal__lead">{lead}</p>}
-    {cta && (
+    {cta && 'url' in cta && (
       <a href={cta.url} class="bds-button bds-button--primary bds-button--md"><span class="bds-button__content">{cta.label}</span></a>
     )}
   </div>

--- a/content-system/blueprints/astro/HeroSplit6040.astro
+++ b/content-system/blueprints/astro/HeroSplit6040.astro
@@ -79,7 +79,7 @@ const imageAlt = '';
       {eyebrow && <p class="bp-hero-split-60-40__subtitle">{eyebrow}</p>}
       <h1 id={titleId} class="bp-hero-split-60-40__title">{headline}</h1>
       {lead && <p class="bp-hero-split-60-40__lead">{lead}</p>}
-      {cta && (
+      {cta && 'url' in cta && (
         <a href={cta.url} class="bds-button bds-button--primary bds-button--md">
           <span class="bds-button__content">{cta.label}</span>
         </a>

--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -147,7 +147,7 @@ const cta = section.cta;
 
       {lead && <p class="bp-hero-img-card__lead">{lead}</p>}
 
-      {cta && (
+      {cta && 'url' in cta && (
         <a href={cta.url} class="bds-button bds-button--inverse bds-button--md">
           <span class="bds-button__content">{cta.label}</span>
         </a>
@@ -176,7 +176,7 @@ const cta = section.cta;
             {priceCard.price && (
               <p class="bp-hero-img-card__price-value">{priceCard.price}</p>
             )}
-            {priceCard.cta && (
+            {priceCard.cta && 'url' in priceCard.cta && (
               <a href={priceCard.cta.url} class={`bds-button bds-button--primary bds-button--${priceCard.cta.size ?? 'sm'}`}>
                 <span class="bds-button__content">{priceCard.cta.label}</span>
               </a>

--- a/content-system/blueprints/astro/SupportPlanCalloutSplit.astro
+++ b/content-system/blueprints/astro/SupportPlanCalloutSplit.astro
@@ -163,7 +163,7 @@ const hasIllustration = illustration && tiles.length > 0;
           {plan.description && (
             <p class="bp-support-plan-callout__plan-description">{plan.description}</p>
           )}
-          {cta && (
+          {cta && 'url' in cta && (
             <a
               class="bds-button bds-button--primary bds-button--md bp-support-plan-callout__cta"
               href={cta.url}

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -86,6 +86,42 @@ export const WIRED_BLUEPRINT_KEYS = [
 export type WiredBlueprintKey = (typeof WIRED_BLUEPRINT_KEYS)[number];
 
 /**
+ * Optional CTA button size. Mirrors the `Button` `size` union (inlined so
+ * this contract stays framework-agnostic). Omitted → the blueprint's own
+ * default is preserved (no visual change for existing consumers).
+ * brikdesigns.com #453 passes `md`. (#869)
+ */
+export type CtaSize = 'tiny' | 'sm' | 'md' | 'lg' | 'xl';
+
+/**
+ * A blueprint CTA. Two shapes, both back-compatible with the original
+ * `{ label, url }` link form (#941):
+ *
+ *   - **Link** (`url`): renders an `<a>`. The only form static Astro
+ *     blueprints can use — author from serializable content.
+ *   - **Action** (`onClick`): renders a `<button>` that fires client
+ *     behavior (open a modal/drawer, analytics, scroll-to-anchor). React
+ *     blueprints only — a function can't live in serializable Astro data.
+ *     Surfaced by brikdesigns#577/#579: the service hero CTA must open the
+ *     lead-capture modal, not navigate.
+ *
+ * The two are mutually exclusive (`url XOR onClick`); use `isActionCta()`
+ * to discriminate. A future `actionId` indirection (a serializable handle
+ * the consumer maps to a handler) is deliberately deferred — no consumer
+ * needs it yet, and static Astro action support is out of scope here.
+ */
+export type BlueprintCta =
+  | { readonly label: string; readonly url: string; readonly size?: CtaSize }
+  | { readonly label: string; readonly onClick: () => void; readonly size?: CtaSize };
+
+/** True when the CTA carries a client action (`onClick`) rather than a link. */
+export function isActionCta(
+  cta: BlueprintCta,
+): cta is Extract<BlueprintCta, { onClick: () => void }> {
+  return typeof (cta as { onClick?: unknown }).onClick === 'function';
+}
+
+/**
  * Resolved section content — what the portal's content generator emits
  * and the dispatcher consumes. Shape matches the typed section output
  * produced by `generate-content-page-worker` in the portal.
@@ -132,10 +168,7 @@ export interface BlueprintSection {
     /** Alt text for `imageUrl`. Defaults to empty (decorative) when omitted. */
     readonly imageAlt?: string;
   }[];
-  readonly cta: {
-    readonly label: string;
-    readonly url: string;
-  } | null;
+  readonly cta: BlueprintCta | null;
   /**
    * Optional ordered breadcrumb trail. Used by interior-page hero
    * blueprints (e.g. `hero_split_image_card_overlay`) where the hero
@@ -201,18 +234,7 @@ export interface BlueprintSection {
     readonly imageAlt?: string;
     readonly priceLabel?: string;
     readonly price?: string;
-    readonly cta?: {
-      readonly label: string;
-      readonly url: string;
-      /**
-       * Optional CTA button size. Mirrors the `Button` `size` union
-       * (inlined so this contract stays framework-agnostic — see the
-       * `illustration` note below). Omitted → the blueprint's `sm`
-       * default is preserved (no visual change for existing
-       * consumers). brikdesigns.com #453 passes `md`. (#869)
-       */
-      readonly size?: 'tiny' | 'sm' | 'md' | 'lg' | 'xl';
-    };
+    readonly cta?: BlueprintCta;
   };
   /**
    * Optional structured illustration data for blueprints that compose a

--- a/content-system/blueprints/react/CtaDarkCentered.stories.tsx
+++ b/content-system/blueprints/react/CtaDarkCentered.stories.tsx
@@ -65,3 +65,21 @@ export const NoBody: Story = {
     theme: baseTheme,
   },
 };
+
+/**
+ * @summary Action CTA (#941) — an `onClick` CTA (no `url`) renders a
+ * `<button>` instead of an `<a>`, so the blueprint can trigger in-page
+ * behavior (open a modal, fire analytics). Inspect the rendered element:
+ * it is a real button with button semantics, not a link.
+ */
+export const ActionCta: Story = {
+  args: {
+    section: {
+      ...section,
+      sectionKey: 'cta-dark-centered-action',
+      cta: { label: 'Open contact form', onClick: () => {} },
+    },
+    clientFacts: baseClientFacts,
+    theme: baseTheme,
+  },
+};

--- a/content-system/blueprints/react/CtaDarkCentered.tsx
+++ b/content-system/blueprints/react/CtaDarkCentered.tsx
@@ -9,12 +9,14 @@
  */
 import { Button } from '../../../components/ui/Button';
 import type { BlueprintProps } from '../astro/types';
+import { isActionCta } from '../astro/types';
 import './CtaDarkCentered.css';
 
 interface Props extends BlueprintProps {}
 
 export function CtaDarkCentered({ section }: Props) {
   const titleId = `${section.sectionKey}-title`;
+  const cta = section.cta;
 
   return (
     <section
@@ -29,9 +31,13 @@ export function CtaDarkCentered({ section }: Props) {
         {section.body && (
           <p className="bp-cta-dark-centered__description">{section.body}</p>
         )}
-        {section.cta && (
-          <Button href={section.cta.url} variant="primary" size="lg">
-            {section.cta.label}
+        {cta && (
+          <Button
+            {...(isActionCta(cta) ? { onClick: cta.onClick } : { href: cta.url })}
+            variant="primary"
+            size="lg"
+          >
+            {cta.label}
           </Button>
         )}
       </div>

--- a/content-system/blueprints/react/HeroInteriorMinimal.tsx
+++ b/content-system/blueprints/react/HeroInteriorMinimal.tsx
@@ -18,6 +18,7 @@
  */
 import { Button } from '../../../components/ui/Button';
 import type { BlueprintProps } from '../astro/types';
+import { isActionCta } from '../astro/types';
 import './HeroInteriorMinimal.css';
 
 interface Props extends BlueprintProps {}
@@ -44,7 +45,11 @@ export function HeroInteriorMinimal({ section }: Props) {
         </h1>
         {lead && <p className="bp-hero-interior-minimal__lead">{lead}</p>}
         {cta && (
-          <Button href={cta.url} variant="primary" size="md">
+          <Button
+            {...(isActionCta(cta) ? { onClick: cta.onClick } : { href: cta.url })}
+            variant="primary"
+            size="md"
+          >
             {cta.label}
           </Button>
         )}

--- a/content-system/blueprints/react/HeroSplit6040.tsx
+++ b/content-system/blueprints/react/HeroSplit6040.tsx
@@ -11,6 +11,7 @@
  */
 import { Button } from '../../../components/ui/Button';
 import type { BlueprintProps } from '../astro/types';
+import { isActionCta } from '../astro/types';
 import './HeroSplit6040.css';
 
 interface Props extends BlueprintProps {}
@@ -39,7 +40,11 @@ export function HeroSplit6040({ section, clientFacts }: Props) {
           </h1>
           {lead && <p className="bp-hero-split-60-40__lead">{lead}</p>}
           {cta && (
-            <Button href={cta.url} variant="primary" size="md">
+            <Button
+              {...(isActionCta(cta) ? { onClick: cta.onClick } : { href: cta.url })}
+              variant="primary"
+              size="md"
+            >
               {cta.label}
             </Button>
           )}

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -233,3 +233,34 @@ export const PriceCtaAsAction: Story = {
     await expect(cta).toBeInTheDocument();
   },
 };
+
+/**
+ * @summary Native action CTA (#941) — when `priceCard.cta` carries an
+ * `onClick` (instead of a `url`), the blueprint renders a real `<button>`
+ * with button semantics — no href, no anchor. This is the first-class way
+ * to wire a CTA to client behavior (open a modal, etc.), distinct from the
+ * `onPriceCtaClick` link-intercept above (#843), which keeps a URL fallback.
+ * Use this when there is no meaningful no-JS destination.
+ */
+export const PriceCtaActionButton: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...interiorHeroSection,
+      sectionKey: 'hero-img-card-cta-action-button',
+      priceCard: {
+        ...interiorHeroSection.priceCard!,
+        cta: { label: 'Open the form', onClick: fn() },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // An action CTA is a <button>, not a <link> — verify the semantics.
+    const cta = canvas.getByRole('button', { name: 'Open the form' });
+    await expect(cta).toBeVisible();
+    await expect(canvas.queryByRole('link', { name: 'Open the form' })).toBeNull();
+    // Clicking fires the config's own handler.
+    await userEvent.click(cta);
+  },
+};

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -22,6 +22,7 @@ import { Frame } from '../../../components/ui/Frame/Frame';
 import type { FrameRatio } from '../../../components/ui/Frame/Frame';
 import { ServiceTag } from '../../../components/ui/ServiceTag/ServiceTag';
 import type { BlueprintProps } from '../astro/types';
+import { isActionCta } from '../astro/types';
 import './HeroSplitImageCardOverlay.css';
 
 interface Props extends BlueprintProps {
@@ -114,7 +115,11 @@ export function HeroSplitImageCardOverlay({
           {lead && <p className="bp-hero-img-card__lead">{lead}</p>}
 
           {cta && (
-            <Button href={cta.url} variant="inverse" size="md">
+            <Button
+              {...(isActionCta(cta) ? { onClick: cta.onClick } : { href: cta.url })}
+              variant="inverse"
+              size="md"
+            >
               {cta.label}
             </Button>
           )}
@@ -141,27 +146,38 @@ export function HeroSplitImageCardOverlay({
                 {priceCard.price && (
                   <p className="bp-hero-img-card__price-value">{priceCard.price}</p>
                 )}
-                {priceCard.cta && (
-                  <Button
-                    href={priceCard.cta.url}
-                    variant="primary"
-                    size={priceCard.cta.size ?? 'sm'}
-                    onClick={
-                      onPriceCtaClick
-                        ? (event) => {
-                            // Progressive enhancement: with JS, suppress the
-                            // anchor navigation and hand off to the consumer's
-                            // handler (e.g. open a modal). Without JS, the
-                            // `href` still navigates. (brik-bds#843)
-                            event.preventDefault();
-                            onPriceCtaClick(event);
-                          }
-                        : undefined
-                    }
-                  >
-                    {priceCard.cta.label}
-                  </Button>
-                )}
+                {priceCard.cta &&
+                  (isActionCta(priceCard.cta) ? (
+                    // Action CTA (#941): the config carries its own handler, so
+                    // render a real <button> — no href, no fallback navigation.
+                    <Button
+                      onClick={priceCard.cta.onClick}
+                      variant="primary"
+                      size={priceCard.cta.size ?? 'sm'}
+                    >
+                      {priceCard.cta.label}
+                    </Button>
+                  ) : (
+                    <Button
+                      href={priceCard.cta.url}
+                      variant="primary"
+                      size={priceCard.cta.size ?? 'sm'}
+                      onClick={
+                        onPriceCtaClick
+                          ? (event) => {
+                              // Progressive enhancement: with JS, suppress the
+                              // anchor navigation and hand off to the consumer's
+                              // handler (e.g. open a modal). Without JS, the
+                              // `href` still navigates. (brik-bds#843)
+                              event.preventDefault();
+                              onPriceCtaClick(event);
+                            }
+                          : undefined
+                      }
+                    >
+                      {priceCard.cta.label}
+                    </Button>
+                  ))}
               </div>
             )}
           </aside>

--- a/content-system/blueprints/react/SupportPlanCalloutSplit.tsx
+++ b/content-system/blueprints/react/SupportPlanCalloutSplit.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../../components';
 
 import type { BlueprintProps } from '../astro/types';
+import { isActionCta } from '../astro/types';
 import './SupportPlanCalloutSplit.css';
 
 interface Props extends BlueprintProps {}
@@ -113,7 +114,7 @@ export function SupportPlanCalloutSplit({ section }: Props) {
                 )}
                 {cta && (
                   <Button
-                    href={cta.url}
+                    {...(isActionCta(cta) ? { onClick: cta.onClick } : { href: cta.url })}
                     variant="primary"
                     size="md"
                     className="bp-support-plan-callout__cta"


### PR DESCRIPTION
## Summary
- feat(blueprint): HeroSplitImageCardOverlay onPriceCtaClick for in-page CTA actions (#938)
- chore(release): v0.101.0 (#939)
- fix(select): use --text-secondary for placeholder + helper text (WCAG AA) (#942) (#943)
- chore(release): v0.101.1 (#944)
- fix(tokens): guard prune against cross-collection primitives (#936) (#948)
- refactor(tokens): migrate spaced font-weight consumers to canonical, prune dupes (#947) (#949)
- refactor(tokens): relocate 48 brand color ramps Foundations -> Brand-kit (#945) (#950)
- fix(a11y): solid Tag label holds WCAG AA in dark mode (#951) (#952)
- chore(release): v0.102.0 (#953)
- feat(blueprints): support action (onClick) CTAs, not just URLs

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)