### PR TITLE
chore(release): v0.103.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Release **v0.103.0** — minor bump shipping the one commit landed since v0.102.0:

- **brik-bds#941 / PR #954** — blueprint CTAs accept an action (`onClick`), not just a URL.

## Why now
Unblocks **brikdesigns#595**: the service-detail hero price-card CTA can finally carry `{ label, onClick }` to open the Get Started modal (the pricing-grid CTAs already do). brikdesigns is pinned at `^0.93.1` and will bump to `^0.103.0` after this publishes.

## Release mechanics (per docs/RELEASE.md)
This PR only bumps `package.json` → `0.103.0`. After merge, the tag `v0.103.0` is pushed against main's tip; the `Release` workflow validates `version == tag`, runs the token/jsdoc/blueprint/typecheck gates, and `npm publish`es to GitHub Packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)