### PR TITLE
Add icons Color / theming docs + ServiceTag mask note

### DIFF
--- a/docs-site/content/docs/components/icons.mdx
+++ b/docs-site/content/docs/components/icons.mdx
@@ -109,6 +109,43 @@ Phosphor provides six weights per icon. BDS primarily uses the regular and fill 
 <Icon icon="ph:star-bold" />     {/* heavier outline */}
 ```
 
+## Color / theming
+
+Iconify icons render with `fill="currentColor"`, so they inherit color from the CSS `color` of any ancestor — no per-icon fill prop needed. To recolor an icon, set `color` on it or a parent, ideally to a BDS text token rather than a raw hex:
+
+```tsx
+{/* inherits the surrounding text color */}
+<span style={{ color: 'var(--text-muted)' }}>
+  <Icon icon="ph:info" /> Quiet hint
+</span>
+
+{/* status icon */}
+<Icon icon="ph:check-circle-fill" style={{ color: 'var(--text-positive)' }} />
+```
+
+Text tokens commonly used for icon fill:
+
+| Token | Use |
+|---|---|
+| `--text-primary` | Default icon next to body text |
+| `--text-secondary` / `--text-muted` | Quiet / secondary icons |
+| `--text-link` | Icons inside links |
+| `--text-positive` / `--text-negative` / `--text-info` | Status icons |
+| `--text-inverse` | Icons on dark / inverted surfaces |
+
+BDS text tokens are mode-aware, so an icon colored with one retones automatically in `brik-dark` — prefer them over hardcoded colors.
+
+### Service-line glyphs (ServiceTag)
+
+[ServiceTag](https://storybook.brikdesigns.com/?path=/docs/components-service-tag--overview)'s per-service glyphs are **not** Phosphor icons — they're custom SVG assets under `components/ui/ServiceTag/icons/`. They render via CSS `mask-image` with `background-color: currentColor` (not `<img src>`), so the fill is CSS-recolorable and inherits the tag's service text token:
+
+```css
+.bds-service-tag--marketing { color: var(--text-service-marketing-on-light); }
+.bds-service-tag__icon      { background-color: currentColor; /* masked glyph */ }
+```
+
+Each service line carries a mode-aware `--text-service-{line}-on-light` / `-on-dark` pair (`brand`, `marketing`, `information`, `product`, `back-office`), so the glyph retones per theme. Reach for `ServiceTag` rather than a raw `<img>` whenever you need a service-line glyph — Phosphor does not cover every icon need.
+
 ## Adding icons to BDS
 
 1. Find the icon name at [phosphoricons.com](https://phosphoricons.com/) — copy the kebab-case name.


### PR DESCRIPTION
## What

Closes the remaining doc debt on #574. The rendering refactor and token adoption already shipped in **0.90.x** (`d12f6c7e`, mask-image + `background-color: currentColor`); the only open AC boxes were doc updates to `icons.mdx`.

## Changes (`docs-site/content/docs/components/icons.mdx`)

- **New "Color / theming" section** — explains `fill="currentColor"` inheritance, lists the BDS text tokens typically used for icon fill (`--text-primary`, `--text-muted`, `--text-link`, `--text-positive/negative/info`, `--text-inverse`), and notes they're mode-aware so icons retone in `brik-dark`.
- **"Service-line glyphs (ServiceTag)" subsection** — acknowledges "System 2": ServiceTag's per-service glyphs are custom SVGs (not Phosphor), rendered via CSS `mask-image` + `currentColor` (no longer `<img src>`), inheriting the tag's `--text-service-{line}-on-light/-dark` token.

All token names verified against the brik-bds CSS source — none invented.

The `Related`-section ServiceTag link was already corrected in a prior pass (the `ServiceBadge` reference is gone), so no change needed there.

## Notes

- Docs-only; no component/token changes.
- The dark-mode contrast concern referenced in #574's Storybook box (#823) is already closed and was consumer-verified (~80 glyphs across brikdesigns, both themes, 0 failures — brikdesigns#358).

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)