### PR TITLE
feat(tokens): add fluid display type tier (#959)

### DIFF
--- a/scripts/__tests__/fluid-type.test.mjs
+++ b/scripts/__tests__/fluid-type.test.mjs
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * Fluid display type tier (brik-bds#959 / brik-client-portal#1350).
+ *
+ * Pins that the hand-authored `--display-fluid-*` clamp() tier is defined for
+ * every display step, stays on-system (max anchors to a static --display-*
+ * token, min to a --font-size-* primitive), is distinct from the static scale,
+ * and is wired into the dist/tokens.css concat so consumers actually receive it.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const TOKENS_DIR = join(here, '..', '..', 'tokens');
+const fluidCss = readFileSync(join(TOKENS_DIR, 'fluid-type.css'), 'utf8');
+// Declarations only — the doc-comment intentionally cites resolved px (72.8px …).
+const fluidDecls = fluidCss.replace(/\/\*[\s\S]*?\*\//g, '');
+const buildScript = readFileSync(join(here, '..', 'build-dist-tokens.js'), 'utf8');
+
+const STEPS = ['sm', 'md', 'lg', 'xl'];
+
+describe('fluid-type.css — fluid display tier', () => {
+  it('defines a fluid token for every display step', () => {
+    for (const step of STEPS) {
+      expect(fluidCss).toMatch(new RegExp(`--display-fluid-${step}\\s*:`));
+    }
+  });
+
+  it('every fluid display token interpolates via clamp(min, vw, max)', () => {
+    for (const step of STEPS) {
+      const m = fluidCss.match(new RegExp(`--display-fluid-${step}\\s*:\\s*([^;]+);`));
+      expect(m, `--display-fluid-${step} missing`).toBeTruthy();
+      const value = m[1];
+      expect(value).toContain('clamp(');
+      expect(value).toMatch(/\dvw/); // viewport-relative preferred term
+    }
+  });
+
+  it('anchors max to the static --display-* token and min to a --font-size-* primitive (stays on-system)', () => {
+    // sm → display-sm, md → display-md, etc.; min references a raw font-size primitive.
+    for (const step of STEPS) {
+      const value = fluidCss.match(new RegExp(`--display-fluid-${step}\\s*:\\s*([^;]+);`))[1];
+      expect(value).toContain(`var(--display-${step})`); // max anchor
+      expect(value).toMatch(/var\(--font-size-\d+\)/); // min anchor — no raw px
+    }
+  });
+
+  it('is distinct from the static display scale (additive, not a redefinition)', () => {
+    // It must NOT redefine the static --display-sm/md/lg/xl tokens themselves.
+    for (const step of STEPS) {
+      expect(fluidCss).not.toMatch(new RegExp(`(?<!fluid-)--display-${step}\\s*:`));
+    }
+  });
+
+  it('introduces no raw px (fluidity rides on tokens + vw only)', () => {
+    expect(fluidDecls).not.toMatch(/\d+px/);
+  });
+
+  it('is wired into the dist/tokens.css concat', () => {
+    expect(buildScript).toContain("'fluid-type.css'");
+    expect(buildScript).toMatch(/fluidType/);
+  });
+});

--- a/scripts/build-dist-tokens.js
+++ b/scripts/build-dist-tokens.js
@@ -4,7 +4,7 @@
  * Called by: npm run build:lib (as the final step)
  *
  * Produces:
- *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + theme-brand-brik.css + modes-*.css + gap-fills.css + ratios.css + animations.css concatenated
+ *   dist/tokens.css  — figma-tokens.css + figma-tokens-dark.css + theme-brand-brik.css + modes-*.css + gap-fills.css + ratios.css + fluid-type.css + animations.css concatenated
  *   dist/bridge.css  — clean name ↔ Webflow internal name aliases
  */
 const fs = require('fs');
@@ -71,12 +71,16 @@ for (const file of MODE_FILES) {
 // Aspect-ratio tokens — `--aspect-*` primitives + semantic aliases (BDS #486).
 const ratios = fs.readFileSync(path.join(TOKENS_DIR, 'ratios.css'), 'utf8');
 
+// Fluid display type tier — `--display-fluid-*` clamp() tokens. Hand-authored
+// because clamp() can't be a Figma Variable (brik-bds#959 / brik-client-portal#1350).
+const fluidType = fs.readFileSync(path.join(TOKENS_DIR, 'fluid-type.css'), 'utf8');
+
 // Shared keyframe library — required for any component using bds-spin, bds-pulse, bds-pop, etc.
 const animations = fs.readFileSync(path.join(TOKENS_DIR, 'animations.css'), 'utf8');
 
 fs.writeFileSync(
   path.join(DIST_DIR, 'tokens.css'),
-  header + figmaTokens + darkTokens + themeBrandBrik + modeOverrides + '\n\n' + gapFills + '\n\n' + ratios + '\n\n' + animations,
+  header + figmaTokens + darkTokens + themeBrandBrik + modeOverrides + '\n\n' + gapFills + '\n\n' + ratios + '\n\n' + fluidType + '\n\n' + animations,
 );
 console.log('  ✓ dist/tokens.css');
 

--- a/tokens/CASCADE.md
+++ b/tokens/CASCADE.md
@@ -29,7 +29,9 @@ renew-pms, brikdesigns) via `@brikdesigns/bds/tokens.css`. Built by
 5. `modes-spacing.css` — spacing density mode overrides (`[data-mode-spacing="compact|comfortable|spacious"]`) — auto-generated from `design-tokens/tokens-studio.json` via `npm run build:modes`
 6. `modes-typography.css` — typography heading-scale-variant overrides (`[data-mode-typography="compact|comfortable|spacious|expressive"]`) — auto-generated from `design-tokens/tokens-studio.json` via `npm run build:modes`
 7. `gap-fills.css` — manual tokens not yet in Figma
-8. `animations.css` — shared keyframe library (`bds-spin`, `bds-pulse`, `bds-pop`, etc.) — required by any component CSS that references these names
+8. `ratios.css` — `--aspect-*` tokens (dimensionless `<ratio>`, can't be a Figma Variable; BDS #486)
+9. `fluid-type.css` — `--display-fluid-*` clamp() tier (viewport-fluid marketing display type; can't be a Figma Variable; brik-bds#959)
+10. `animations.css` — shared keyframe library (`bds-spin`, `bds-pulse`, `bds-pop`, etc.) — required by any component CSS that references these names
 
 **Not bundled:** `bridge.css` (opt-in via separate export), `font-audit.css`
 (Storybook-only), `motion-classes.css` (opt-in utility classes — consumers import

--- a/tokens/fluid-type.css
+++ b/tokens/fluid-type.css
@@ -1,0 +1,52 @@
+/**
+ * BDS Fluid Display Type Tier — Manually Maintained
+ *
+ * Loaded by: bundled into dist/tokens.css (after ratios, before animations).
+ * Every consumer picks these up automatically via `@import '@brikdesigns/bds/tokens.css'`.
+ * See tokens/CASCADE.md for the full load-order + decision tree.
+ *
+ * Why these are here, not in figma-tokens.css:
+ *   `clamp()` is a CSS function, not a Figma Variable — Figma variables resolve
+ *   to a single static number, so a viewport-interpolating display size can
+ *   never round-trip through Tokens Studio / Style Dictionary. This tier is
+ *   the hand-authored counterpart to the static `--display-*` scale, in the
+ *   same spirit as `ratios.css` (dimensionless `<ratio>` values Figma can't
+ *   express). brik-bds#959 / umbrella brik-client-portal#1350.
+ *
+ * What it is:
+ *   A fluid MARKETING display tier — each step interpolates min → max across
+ *   the viewport via `clamp(min, <vw>, max)`. The max anchors to the existing
+ *   static `--display-*` token (so the top end stays on the Figma scale); the
+ *   min is a raw `--font-size-*` primitive a few steps down (so display type
+ *   shrinks gracefully on small viewports instead of overflowing). The `<vw>`
+ *   preferred term is the only literal — fluidity is inherently a length-vs-
+ *   viewport relationship, not a token.
+ *
+ * Distinct from the static product-UI scale:
+ *   The static `--display-*` / `--heading-*` / `--body-*` scale is unchanged —
+ *   app surfaces depend on its fixed sizing. These `--display-fluid-*` tokens
+ *   are an ADDITIVE, opt-in tier for viewport-responsive marketing display
+ *   type (heroes, editorial headers). Consume them where the static scale was
+ *   previously hand-clamped inline, e.g.
+ *     font-size: var(--display-fluid-lg);
+ *   instead of the ad-hoc `clamp(var(--heading-xl), 4vw, var(--display-sm))`
+ *   pattern blueprints compose today.
+ *
+ * Resolved range (max = static --display-* via --font-size-*):
+ *   sm  40.5px → 72.8px   (font-size-900  → display-sm/1400)
+ *   md  45.5px → 81.9px   (font-size-1000 → display-md/1500)
+ *   lg  51px   → 92.2px   (font-size-1100 → display-lg/1600)
+ *   xl  57.5px → 116.9px  (font-size-1200 → display-xl/1800)
+ *
+ * Type-scale MODE (data-mode-typography) and a width mode remain follow-ups —
+ * the type-scale mode already exists for `--heading-*` (modes-typography.css,
+ * ADR-013 amendment / #928, which keeps `--display-*` mode-invariant); making
+ * display participate and adding a width mode are deferred (see #959 thread).
+ */
+
+:root {
+  --display-fluid-sm: clamp(var(--font-size-900), 6vw, var(--display-sm));
+  --display-fluid-md: clamp(var(--font-size-1000), 6.5vw, var(--display-md));
+  --display-fluid-lg: clamp(var(--font-size-1100), 7vw, var(--display-lg));
+  --display-fluid-xl: clamp(var(--font-size-1200), 8vw, var(--display-xl));
+}


### PR DESCRIPTION
## What

Adds a `clamp()`-based **fluid display type tier** — the genuinely-new, Figma-can't-express primitive from #959 (umbrella brik-client-portal#1350).

`tokens/fluid-type.css` defines `--display-fluid-{sm,md,lg,xl}`, each `clamp(min, <vw>, max)` where **max anchors to the static `--display-*` token** and **min to a `--font-size-*` primitive** — so the tier stays entirely on the existing scale; the `<vw>` preferred term is the only literal. Hand-authored alongside `ratios.css` because `clamp()` can't round-trip through Tokens Studio / Style Dictionary (Figma variables resolve to a single static number).

| token | range |
|---|---|
| `--display-fluid-sm` | 40.5px → 72.8px |
| `--display-fluid-md` | 45.5px → 81.9px |
| `--display-fluid-lg` | 51px → 92.2px |
| `--display-fluid-xl` | 57.5px → 116.9px |

## Why scoped to the fluid tier (not the full #959 spec)

Investigating #959 surfaced that two of its four ACs are not greenfield:

- **Type-scale mode already exists** — `modes-typography.css` ships `[data-mode-typography="compact|comfortable|spacious|expressive"]` over `--heading-*`, and **ADR-013 amendment / #928** explicitly keeps `--display-*` **mode-invariant** ("this axis owns `--heading-*` alone"). Making display participate in the mode would amend an accepted ADR.
- **Width mode is a new token family** — `--container-*` doesn't exist in BDS and there's no `modes-width.css`.

Per the umbrella owner's call, this PR ships only the **fluid tier** (additive, no ADR conflict, no new mode axis). The type-scale-mode-for-display and width-mode work are deferred follow-ups tracked on the #959 thread.

## Changes

- `tokens/fluid-type.css` — the tier (new).
- `scripts/build-dist-tokens.js` — wired into the `dist/tokens.css` concat (after `ratios.css`), so every consumer receives it and it joins the canonical allowlist.
- `tokens/CASCADE.md` — load-order list updated (also restores the previously-omitted `ratios.css` entry).
- `scripts/__tests__/fluid-type.test.mjs` — 6 tests.

## Verification

- 6 unit tests green (tier defined for every step, clamp-based, on-system min/max anchors, distinct from the static scale, no raw px, wired into the concat).
- `lint-tokens` 0 errors; `contrast-gate` ✓; `pr-checklist.sh` automated checks ✓; `scripts` test project green (109 passing).
- `dist/tokens.css` regenerates with the tier (gitignored — CI rebuilds via `build:dist-tokens`).

## Consumer note

Additive only — no existing token changes, so no consumer sync is required to land. Consumers can adopt `var(--display-fluid-*)` in place of ad-hoc inline `clamp(...)` when convenient.