### PR TITLE
docs(bds): tertiary/accent tiers consume raw --color-*, no new slot

### DIFF
--- a/content-system/vocabularies/color-primitive-tier.ts
+++ b/content-system/vocabularies/color-primitive-tier.ts
@@ -29,8 +29,10 @@
  *                  accents, `--text-link`.
  *   - secondary  — supporting brand color. Tag-only today; no automatic
  *                  mapping.
- *   - tertiary   — third-tier brand color. Tag-only today.
- *   - accent     — non-primary chromatic colors. Tag-only today.
+ *   - tertiary   — third-tier brand color. Tag-only by contract (ADR-012).
+ *   - accent     — non-primary chromatic color (Brik's tertiary brand
+ *                  colour; may be neutral OR chromatic by palette size).
+ *                  Tag-only by contract (ADR-012).
  *   - neutral    — gray ramp source. Drives gray-ramp neutral resolution.
  *   - brand-fill — AA-safe variant of primary used for filled brand
  *                  surfaces (`--background-brand-primary`) and brand-
@@ -46,6 +48,22 @@
  * from neutral primitives. To shift body neutrals brand-side, redefine
  * the brand's white/black primitive hex values; do not introduce
  * parallel tier vocabulary.
+ *
+ * Why no `--*-brand-tertiary` / `--*-brand-accent` slot (ADR-012, ratified
+ * 2026-06-23): `tertiary`/`accent` are tag-only by CONTRACT, not as a
+ * stopgap awaiting a slot. Adding one is the same speculative parallel-
+ * brand-tier shape #512/#553 rolled back, and a single slot cannot encode
+ * that the accent/tertiary tier is neutral OR chromatic by palette size.
+ * Resolution rule:
+ *   - CHROMATIC tertiary/accent → consumed as the raw `--color-{name}` /
+ *     `--color-{name}-{stop}` primitive (a canonical name already in
+ *     tokens.css). No brand slot; referenced ad hoc by generators/CSS.
+ *   - NEUTRAL tertiary/accent → resolves via the existing neutral path
+ *     (`neutral`-tier gray-ramp; in the mockup generator, the dark/light/
+ *     mid role assignment). Never gets a chromatic slot.
+ * `secondary` is unaffected — it keeps its canonical `--*-brand-secondary`
+ * slot. A future client genuinely needing a tertiary slot returns here for
+ * a definition step first.
  */
 export const COLOR_PRIMITIVE_TIERS = [
   'primary',

--- a/docs-site/content/docs/content-system/vocabularies/color-primitive-tier.mdx
+++ b/docs-site/content/docs/content-system/vocabularies/color-primitive-tier.mdx
@@ -15,14 +15,27 @@ This vocabulary is the **single source of truth** for tier values. It is exporte
 |---|---|---|
 | `primary` | Chromatic brand identity. Resolves into `--background-brand-primary`, `--surface-brand-primary`, `--text-brand-primary`, `--border-brand-primary`, `--text-link`. | Must be the brand identity color. Tag exactly one primitive. |
 | `secondary` | Supporting brand color. Drives `--background-brand-secondary`, `--surface-brand-secondary` when present. | Tag-only today; no automatic mapping beyond the brand-secondary slots. |
-| `tertiary` | Third-tier brand color. | Tag-only today. No automatic mapping. |
-| `accent` | Non-primary chromatic colors. | Tag-only today. No automatic mapping. |
+| `tertiary` | Third-tier brand color. | Tag-only **by contract** ([resolution rule below](#tertiary--accent-resolution)). No brand slot. |
+| `accent` | Non-primary chromatic color — Brik's tertiary brand colour; may be neutral *or* chromatic by palette size. | Tag-only **by contract** ([resolution rule below](#tertiary--accent-resolution)). No brand slot. |
 | `neutral` | Gray ramp source. Drives gray-ramp neutral resolution. | Tagged on the brand's gray primitive. **Never** the white or black primitive. |
 | `brand-fill` | AA-safe variant of `primary` used for filled brand surfaces and brand-colored text — `--background-brand-primary`, `--text-brand-primary`. | Specify when `primary` fails AA contrast against the paper/white surface. Pair with the underlying `primary` — `brand-fill` is the contrast-safe twin, not a replacement. |
 
 ### Why `brand-fill` exists
 
 When the brand identity color does not meet AA contrast on a white surface, the theme generator needs a darker variant for the slots that *must* be readable (filled brand backgrounds carrying text, brand-colored copy on a body surface). Vale Partners' olive `#698339` is 3.4:1 on white — fails AA. Their olive-deep `#3d4c23` is 9.0:1 — passes. Tagging the deep variant `brand-fill` lets the generator pick it for text/fill slots while `primary` continues to drive accents and decoration.
+
+### Tertiary / accent resolution
+
+`tertiary` and `accent` are **tag-only by contract, not as a stopgap awaiting a slot** (ratified 2026-06-23, brik-llm ADR-012 / portal [#1360](https://github.com/brikdesigns/brik-client-portal/issues/1360)). No `--*-brand-tertiary` or `--*-brand-accent` slot exists or will be added — that is the same speculative parallel-brand-tier shape rolled back in portal #512/#553, and a single slot cannot encode that the accent/tertiary tier is neutral *or* chromatic depending on palette size.
+
+How a brand's third-and-beyond colours resolve:
+
+| The tier value is… | Resolves via | Brand slot? |
+|---|---|---|
+| **chromatic** (a colour) | the raw `--color-{name}` / `--color-{name}-{stop}` primitive — a canonical name already emitted into [tokens.css](/docs/primitives/color). Referenced ad hoc by generators and CSS. | none |
+| **neutral** (a gray) | the existing neutral path — the `neutral`-tier gray ramp, and in the portal mockup generator the dark/light/mid role assignment. | none (a neutral accent never gets a chromatic slot) |
+
+Consuming raw `--color-{name}` is **not** inventing a parallel taxonomy — those are canonical primitive names. `secondary` is unaffected: it keeps its `--*-brand-secondary` slot, which both generators emit. A future client that genuinely needs a tertiary brand slot returns here for a definition step first.
 
 ## Anti-patterns
 
@@ -35,7 +48,7 @@ When the brand identity color does not meet AA contrast on a white surface, the 
 </Callout>
 
 <Callout type="error">
-  **Speculative tiers.** Adding a tier value because "the brand has 11 primitives and 3 already have tiers, so X needs one too." A tier exists only when its target token slot exists in canonical [tokens.css](/docs/primitives/color). If your brand has chromatic primitives that don't fit `primary` / `secondary` / `tertiary` / `accent` / `brand-fill`, leave them untagged — they emit as palette vars only.
+  **Speculative tiers.** Adding a tier value because "the brand has 11 primitives and 3 already have tiers, so X needs one too." A tier exists only when its target token slot exists in canonical [tokens.css](/docs/primitives/color). If your brand has chromatic primitives that don't fit `primary` / `secondary` / `tertiary` / `accent` / `brand-fill`, leave them untagged — they emit as palette vars only. Tagging `tertiary` / `accent` is allowed, but it adds **no slot** — those tiers resolve via raw `--color-{name}` ([rule above](#tertiary--accent-resolution)), so do not expect a `--*-brand-tertiary` to appear.
 </Callout>
 
 ## Decision tree


### PR DESCRIPTION
## Summary
- feat(blueprint): HeroSplitImageCardOverlay onPriceCtaClick for in-page CTA actions (#938)
- chore(release): v0.101.0 (#939)
- fix(select): use --text-secondary for placeholder + helper text (WCAG AA) (#942) (#943)
- chore(release): v0.101.1 (#944)
- fix(tokens): guard prune against cross-collection primitives (#936) (#948)
- refactor(tokens): migrate spaced font-weight consumers to canonical, prune dupes (#947) (#949)
- refactor(tokens): relocate 48 brand color ramps Foundations -> Brand-kit (#945) (#950)
- fix(a11y): solid Tag label holds WCAG AA in dark mode (#951) (#952)
- chore(release): v0.102.0 (#953)
- feat(blueprints): support action (onClick) CTAs, not just URLs (#954)
- chore(release): v0.103.0 (#958)
- docs(icons): add Color / theming section + ServiceTag mask note (#960)
- feat(tokens): add fluid display type tier (#959) (#961)
- docs(bds): tertiary/accent tiers consume raw --color-*, no new slot

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)