### PR TITLE
feat(components): add ProductSummaryCard (#963)

### DIFF
--- a/components/ui/ProductSummaryCard/ProductSummaryCard.css
+++ b/components/ui/ProductSummaryCard/ProductSummaryCard.css
@@ -1,0 +1,46 @@
+@layer bds-components {
+/* ─── ProductSummaryCard ─────────────────────────────────────── */
+
+.bds-product-summary-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--gap-md);
+  padding: var(--padding-md);
+  background-color: var(--surface-secondary);
+  border-radius: var(--border-radius-md);
+  box-sizing: border-box;
+}
+
+/* Leading ServiceTag — fixed-size glyph, never compressed by the text block. */
+.bds-product-summary-card__icon {
+  flex-shrink: 0;
+}
+
+/* ─── Text block ─────────────────────────────────────────────── */
+
+.bds-product-summary-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  min-width: 0;
+}
+
+.bds-product-summary-card__label {
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  color: var(--text-secondary);
+}
+
+.bds-product-summary-card__value {
+  font-family: var(--font-family-heading);
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--heading-tiny);
+  color: var(--text-primary);
+}
+
+.bds-product-summary-card__description {
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  color: var(--text-secondary);
+}
+}

--- a/components/ui/ProductSummaryCard/ProductSummaryCard.stories.tsx
+++ b/components/ui/ProductSummaryCard/ProductSummaryCard.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ProductSummaryCard } from './ProductSummaryCard';
+
+const meta: Meta<typeof ProductSummaryCard> = {
+  title: 'Containers/product-summary-card',
+  component: ProductSummaryCard,
+  tags: ['surface-shared'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    serviceLine: {
+      control: 'select',
+      options: ['brand', 'marketing', 'information', 'product', 'back-office', 'service'],
+    },
+    serviceName: { control: 'text' },
+    label: { control: 'text' },
+    value: { control: 'text' },
+    price: { control: 'text' },
+    frequency: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProductSummaryCard>;
+
+/**
+ * Offering selection — echoes the offering/tier a visitor clicked through on.
+ * Omit `price`/`frequency` via Controls to see the graceful collapse.
+ *
+ * @summary Offering summary — service tag + "Interested in" + price • frequency
+ */
+export const Default: Story = {
+  args: {
+    serviceLine: 'brand',
+    label: 'Interested in',
+    value: 'Standard Logo Design',
+    price: '$650',
+    frequency: 'one time',
+  },
+  decorators: [(Story) => <div style={{ width: 420 }}><Story /></div>],
+};
+
+/**
+ * Plan selection — same card with the parent service-line tag and recurring
+ * frequency, as rendered in the Service Plan "Get Started" modal.
+ *
+ * @summary Plan summary — service-line tag + "Selected plan" + recurring price
+ */
+export const Plan: Story = {
+  args: {
+    serviceLine: 'marketing',
+    label: 'Selected plan',
+    value: 'Growth Marketing Plan',
+    price: '$1,200',
+    frequency: 'monthly',
+  },
+  decorators: [(Story) => <div style={{ width: 420 }}><Story /></div>],
+};

--- a/components/ui/ProductSummaryCard/ProductSummaryCard.tsx
+++ b/components/ui/ProductSummaryCard/ProductSummaryCard.tsx
@@ -1,0 +1,65 @@
+import { type HTMLAttributes } from 'react';
+import { bdsClass } from '../../utils';
+import { ServiceTag } from '../ServiceTag/ServiceTag';
+import { type ServiceLine } from '../ServiceTag/service-config';
+import './ProductSummaryCard.css';
+
+export interface ProductSummaryCardProps extends HTMLAttributes<HTMLDivElement> {
+  /** Parent service line — drives the leading `ServiceTag` colour + glyph. */
+  serviceLine: ServiceLine;
+  /** Specific service/offering name used to resolve the `ServiceTag` glyph. */
+  serviceName?: string;
+  /** Caption above the value, e.g. "Interested in" or "Selected plan". */
+  label: string;
+  /** The offering / plan name, e.g. "Standard Logo Design". */
+  value: string;
+  /** Price, e.g. "$650". Rendered below the value as secondary text. */
+  price?: string;
+  /** Billing frequency, e.g. "one time" or "monthly". Joined to price with a `•`. */
+  frequency?: string;
+}
+
+/**
+ * ProductSummaryCard — compact summary of a selected product/service: a leading
+ * `ServiceTag` beside a stacked label → value → price • frequency block.
+ *
+ * Used in lead-capture flows to echo the offering or plan a visitor clicked
+ * through on. The label/value pair carries the selection; price + frequency are
+ * secondary supporting detail.
+ *
+ * @summary Selected product/service summary — ServiceTag + label/value + price
+ */
+export function ProductSummaryCard({
+  serviceLine,
+  serviceName,
+  label,
+  value,
+  price,
+  frequency,
+  className,
+  style,
+  ...props
+}: ProductSummaryCardProps) {
+  // Join only the parts that exist so a missing price or frequency never leaves
+  // a dangling separator.
+  const detail = [price, frequency].filter(Boolean).join(' • ');
+
+  return (
+    <div className={bdsClass('bds-product-summary-card', className)} style={style} {...props}>
+      <ServiceTag
+        category={serviceLine}
+        variant="icon"
+        size="lg"
+        serviceName={serviceName}
+        className="bds-product-summary-card__icon"
+      />
+      <div className="bds-product-summary-card__content">
+        <span className="bds-product-summary-card__label">{label}</span>
+        <span className="bds-product-summary-card__value">{value}</span>
+        {detail && <span className="bds-product-summary-card__description">{detail}</span>}
+      </div>
+    </div>
+  );
+}
+
+export default ProductSummaryCard;

--- a/components/ui/ProductSummaryCard/index.ts
+++ b/components/ui/ProductSummaryCard/index.ts
@@ -1,0 +1,2 @@
+export { ProductSummaryCard, type ProductSummaryCardProps } from './ProductSummaryCard';
+export { default } from './ProductSummaryCard';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -70,6 +70,7 @@ export * from './PasswordInput';
 export * from './SearchInput';
 export * from './Popover';
 export * from './PricingCard';
+export * from './ProductSummaryCard';
 export * from './ProgressBar';
 export * from './ProgressCircle';
 export * from './ProgressStepper';


### PR DESCRIPTION
## Summary

Adds **`ProductSummaryCard`** — a compact summary of a selected product/service for lead-capture flows: a leading `ServiceTag` beside a stacked **label → value → price • frequency** block. Composes the existing `ServiceTag` (icon variant); price and frequency join with a `•` and collapse cleanly when either is absent (no dangling separator).

Classifies the previously hand-styled brikdesigns "Selected plan" / "Interested in" banners as a first-class BDS object.

- `Containers/` taxonomy, `surface-shared`
- Slots from the closed allowlist: `__content` / `__label` / `__value` / `__description` / `__icon`
- Tokens only — value uses `--heading-tiny` + `--font-family-heading`; label/detail use `--label-sm` + `--text-secondary`

## Verification

- lint-tokens ✓ (0 errors) · contrast-gate ✓ · JSDoc ✓ · typecheck ✓ · `typegen:axes:check` in sync
- Verified visually in Storybook (`Containers/product-summary-card` → Default + Plan) — real `ServiceTag` glyphs render (brand crown, marketing megaphone); price-only case shows no dangling dot

## Reviewer note

Label + price/frequency render `--text-secondary` at `--label-sm` (14px) on `--surface-secondary`. This matches the existing banner + `CardTestimonial` precedent and passes the contrast-gate, but it sits adjacent to **#478** (text-secondary AA at ≤14px). Flagging for an explicit AA eyeball; happy to bump to `--text-primary` or a larger step if preferred.

## Follow-ups

- `.mdx` doc page omitted for v1 (13 existing components ship without one) — can add per the storybook-mdx-recipe if desired.
- Consumer adoption tracked at brikdesigns#600 (swaps the two banners once this releases).

Closes #963
