### PR TITLE
feat(components): grouped options in MultiSelect + Menu (#955)

### DIFF
--- a/components/ui/Menu/Menu.css
+++ b/components/ui/Menu/Menu.css
@@ -47,6 +47,26 @@
   user-select: none;
 }
 
+/* ─── Group (labelled section of items) ──────────────── */
+
+.bds-menu__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+}
+
+.bds-menu__title {
+  padding: var(--padding-tiny) var(--padding-tiny) 0;
+  font-family: var(--font-family-label);
+  font-size: var(--body-xs);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  user-select: none;
+}
+
 /* ─── Menu item ───────────────────────────────────────── */
 
 .bds-menu__item {

--- a/components/ui/Menu/Menu.mdx
+++ b/components/ui/Menu/Menu.mdx
@@ -20,6 +20,12 @@ With icons, text-only with disabled item, and active item highlight.
 
 <Canvas of={Stories.Variants} />
 
+### Grouped items
+
+Pass `MenuItemGroup` entries (`{ label, items }`) to segment the menu under section headers — parity with [`Select`](/?path=/docs/components-select--docs)'s `SelectOptionGroup` and [`MultiSelect`](/?path=/docs/components-multi-select--docs)'s `MultiSelectOptionGroup`. Each group renders as a `role="group"` section named by its label; flat items and groups can be mixed, and the flat-only API stays back-compatible.
+
+<Canvas of={Stories.Grouped} />
+
 ## Patterns
 
 Real-world usage: `FilterButton` trigger, `Button` trigger with action menu, and an "Add" menu where each item has a label + description (the 2-line `MenuItemData.description` variant).

--- a/components/ui/Menu/Menu.stories.tsx
+++ b/components/ui/Menu/Menu.stories.tsx
@@ -42,6 +42,24 @@ const filterOptions = sampleItems.map((item) => ({
   icon: item.icon,
 }));
 
+// Items segmented under section headers (e.g. one group per service line).
+const groupedItems = [
+  {
+    label: 'Design',
+    items: [
+      { id: 'brand', label: 'Brand design', icon: <Icon icon="ph:palette" />, onClick: () => {} },
+      { id: 'product', label: 'Product design', icon: <Icon icon="ph:package" />, onClick: () => {} },
+    ],
+  },
+  {
+    label: 'Growth',
+    items: [
+      { id: 'marketing', label: 'Marketing design', icon: <Icon icon="ph:megaphone" />, onClick: () => {} },
+      { id: 'info', label: 'Information design', icon: <Icon icon="ph:info" />, onClick: () => {} },
+    ],
+  },
+];
+
 /* ─── Meta ────────────────────────────────────────────── */
 
 const meta = {
@@ -69,6 +87,20 @@ type Story = StoryObj<typeof meta>;
 export const Playground: Story = {
   args: {
     items: sampleItems,
+    isOpen: true,
+    onClose: () => {},
+    style: { position: 'relative' },
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   GROUPED — items segmented under section headers
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Items segmented under labelled group headers */
+export const Grouped: Story = {
+  args: {
+    items: groupedItems,
     isOpen: true,
     onClose: () => {},
     style: { position: 'relative' },

--- a/components/ui/Menu/Menu.tsx
+++ b/components/ui/Menu/Menu.tsx
@@ -30,11 +30,31 @@ export interface MenuItemData {
 }
 
 /**
+ * A labelled group of menu items. Mirrors `Select`'s `SelectOptionGroup` /
+ * `MultiSelect`'s `MultiSelectOptionGroup` — the menu renders one section per
+ * group with a non-interactive header (e.g. one group per service line).
+ */
+export interface MenuItemGroup {
+  /** Group header label. */
+  label: string;
+  /** Items belonging to this group. */
+  items: MenuItemData[];
+}
+
+function isItemGroup(entry: MenuItemData | MenuItemGroup): entry is MenuItemGroup {
+  return 'items' in entry;
+}
+
+/**
  * Menu component props
  */
 export interface MenuProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
-  /** Menu items to display */
-  items: MenuItemData[];
+  /**
+   * Menu items to display. Flat items or labelled groups — mix freely; entries
+   * with an `items` key render as a `role="group"` section with a header. The
+   * flat-only API stays back-compatible.
+   */
+  items: (MenuItemData | MenuItemGroup)[];
   /** Whether the menu is visible */
   isOpen: boolean;
   /** Close handler */
@@ -172,13 +192,25 @@ export function Menu({
           {header}
         </div>
       )}
-      {items.map((item) => (
-        <MenuItem
-          key={item.id}
-          item={item}
-          isActive={activeId === item.id}
-        />
-      ))}
+      {items.map((entry) =>
+        isItemGroup(entry) ? (
+          <div
+            key={entry.label}
+            className="bds-menu__group"
+            role="group"
+            aria-label={entry.label}
+          >
+            <div className="bds-menu__title" aria-hidden="true">
+              {entry.label}
+            </div>
+            {entry.items.map((item) => (
+              <MenuItem key={item.id} item={item} isActive={activeId === item.id} />
+            ))}
+          </div>
+        ) : (
+          <MenuItem key={entry.id} item={entry} isActive={activeId === entry.id} />
+        ),
+      )}
     </div>
   );
 }

--- a/components/ui/Menu/index.ts
+++ b/components/ui/Menu/index.ts
@@ -1,2 +1,9 @@
-export { Menu, MenuItem, type MenuProps, type MenuItemProps, type MenuItemData } from './Menu';
+export {
+  Menu,
+  MenuItem,
+  type MenuProps,
+  type MenuItemProps,
+  type MenuItemData,
+  type MenuItemGroup,
+} from './Menu';
 export { default } from './Menu';

--- a/components/ui/MultiSelect/MultiSelect.mdx
+++ b/components/ui/MultiSelect/MultiSelect.mdx
@@ -26,6 +26,12 @@ MultiSelect has no semantic-variant axis — all variation (size, tagSize, error
 
 `tagSize` defaults to matching `size` but can be overridden independently.
 
+### Grouped options
+
+Pass `MultiSelectOptionGroup` entries (`{ label, options }`) to segment the dropdown under section headers — parity with [`Select`](/?path=/docs/components-select--docs)'s `SelectOptionGroup`. Each group renders as a labelled `<optgroup>`; flat and grouped entries can be mixed in the same `options` array, and the flat-only API stays back-compatible.
+
+<Canvas of={Stories.Grouped} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/MultiSelect/MultiSelect.stories.tsx
+++ b/components/ui/MultiSelect/MultiSelect.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
 import { Icon } from '@iconify/react';
-import { MultiSelect, type MultiSelectOption } from './MultiSelect';
+import {
+  MultiSelect,
+  type MultiSelectOption,
+  type MultiSelectOptionGroup,
+} from './MultiSelect';
 
 /* ─── Sample data ─────────────────────────────────────────────── */
 
@@ -11,6 +15,31 @@ const serviceOptions: MultiSelectOption[] = [
   { label: 'Information Design', value: 'information', icon: <Icon icon="ph:info" /> },
   { label: 'Product Design', value: 'product', icon: <Icon icon="ph:cube" /> },
   { label: 'Service Design', value: 'service', icon: <Icon icon="ph:gear" /> },
+];
+
+// Offerings grouped under their service line — renders one <optgroup> per group.
+const groupedOfferings: MultiSelectOptionGroup[] = [
+  {
+    label: 'Brand',
+    options: [
+      { label: 'Logo & identity', value: 'logo', icon: <Icon icon="ph:paint-brush" /> },
+      { label: 'Brand guidelines', value: 'guidelines', icon: <Icon icon="ph:book-open" /> },
+    ],
+  },
+  {
+    label: 'Marketing',
+    options: [
+      { label: 'Campaign design', value: 'campaign', icon: <Icon icon="ph:megaphone" /> },
+      { label: 'Social templates', value: 'social', icon: <Icon icon="ph:share-network" /> },
+    ],
+  },
+  {
+    label: 'Product',
+    options: [
+      { label: 'UI design', value: 'ui', icon: <Icon icon="ph:cube" /> },
+      { label: 'Design system', value: 'design-system', icon: <Icon icon="ph:stack" /> },
+    ],
+  },
 ];
 
 /* ─── Meta ────────────────────────────────────────────────────── */
@@ -58,7 +87,7 @@ const meta: Meta<typeof MultiSelect> = {
     },
     options: {
       control: false,
-      description: 'Array of `MultiSelectOption` ({ label, value, icon? }). Set in code — Storybook Controls cannot render a complex array editor usefully.',
+      description: 'Array of `MultiSelectOption` ({ label, value, icon? }) or `MultiSelectOptionGroup` ({ label, options }) — entries with an `options` key render as a labelled `<optgroup>`. Mix freely. Set in code; Storybook Controls cannot render a complex array editor usefully.',
     },
     value: {
       control: false,
@@ -103,5 +132,29 @@ export const Default: Story = {
     // Pre-selected Tag chips render below the Select — check the first one is visible.
     await expect(canvas.getByText('Brand Design')).toBeVisible();
     await expect(canvas.getByText('Marketing')).toBeVisible();
+  },
+};
+
+/** Options segmented under service-line headers — the dropdown renders one
+ *  `<optgroup>` per group; selecting from any group adds a chip as usual.
+ *  @summary Grouped options under service-line headers */
+export const Grouped: Story = {
+  args: {
+    label: 'Offerings',
+    placeholder: 'Select offerings...',
+    helperText: 'Grouped by service line',
+    size: 'md',
+    fullWidth: true,
+    options: groupedOfferings,
+    defaultValue: ['logo'],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole('combobox');
+    await expect(select).toBeVisible();
+    // <optgroup> labels render as group elements within the native select.
+    await expect(canvas.getByRole('group', { name: 'Marketing' })).toBeInTheDocument();
+    // Pre-selected option renders as a chip below.
+    await expect(canvas.getByText('Logo & identity')).toBeVisible();
   },
 };

--- a/components/ui/MultiSelect/MultiSelect.tsx
+++ b/components/ui/MultiSelect/MultiSelect.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { useState, useMemo, type CSSProperties, type ReactNode } from 'react';
-import { Select, type SelectOption, type SelectSize } from '../Select/Select';
+import {
+  Select,
+  type SelectOption,
+  type SelectOptionGroup,
+  type SelectSize,
+} from '../Select/Select';
 import { Tag } from '../Tag/Tag';
 import { bdsClass } from '../../utils';
 import './MultiSelect.css';
@@ -19,6 +24,24 @@ export interface MultiSelectOption {
 }
 
 /**
+ * Grouped options — section header + its options. Mirrors `Select`'s
+ * `SelectOptionGroup`; the dropdown renders one `<optgroup>` per group
+ * (e.g. one group per service line).
+ */
+export interface MultiSelectOptionGroup {
+  /** Group header label, rendered as the `<optgroup>` label. */
+  label: string;
+  /** Options belonging to this group. */
+  options: MultiSelectOption[];
+}
+
+function isOptionGroup(
+  opt: MultiSelectOption | MultiSelectOptionGroup,
+): opt is MultiSelectOptionGroup {
+  return 'options' in opt;
+}
+
+/**
  * MultiSelect size variants (matching Select/TextInput)
  */
 export type MultiSelectSize = SelectSize;
@@ -27,8 +50,12 @@ export type MultiSelectSize = SelectSize;
  * MultiSelect component props
  */
 export interface MultiSelectProps {
-  /** Available options to choose from */
-  options: MultiSelectOption[];
+  /**
+   * Available options to choose from. Flat options or grouped option groups —
+   * mix freely; entries with an `options` key render as a labelled `<optgroup>`
+   * in the dropdown. The flat-only API stays back-compatible.
+   */
+  options: (MultiSelectOption | MultiSelectOptionGroup)[];
   /** Currently selected values (controlled) */
   value?: string[];
   /** Default selected values (uncontrolled) */
@@ -108,22 +135,49 @@ export function MultiSelect({
 
   const resolvedTagSize = tagSize ?? size;
 
-  // Filter out already-selected options from the dropdown
-  const availableOptions: SelectOption[] = useMemo(() => {
+  // Flatten groups to a single option list for lookups + counts.
+  const flatOptions = useMemo(
+    () => options.flatMap((opt) => (isOptionGroup(opt) ? opt.options : [opt])),
+    [options],
+  );
+
+  // Filter out already-selected options from the dropdown, preserving group
+  // structure. Groups left with no remaining options are dropped entirely.
+  const availableOptions: (SelectOption | SelectOptionGroup)[] = useMemo(() => {
     const selectedSet = new Set(selectedValues);
-    return options
-      .filter((opt) => !selectedSet.has(opt.value))
-      .map((opt) => ({ label: opt.label, value: opt.value }));
+    const toSelectOption = (opt: MultiSelectOption): SelectOption => ({
+      label: opt.label,
+      value: opt.value,
+    });
+    const result: (SelectOption | SelectOptionGroup)[] = [];
+    for (const entry of options) {
+      if (isOptionGroup(entry)) {
+        const remaining = entry.options
+          .filter((opt) => !selectedSet.has(opt.value))
+          .map(toSelectOption);
+        if (remaining.length > 0) result.push({ label: entry.label, options: remaining });
+      } else if (!selectedSet.has(entry.value)) {
+        result.push(toSelectOption(entry));
+      }
+    }
+    return result;
   }, [options, selectedValues]);
+
+  // Count of selectable options left — drives the "all selected" empty state
+  // (availableOptions may hold group wrappers, so its length isn't the count).
+  const remainingCount = useMemo(() => {
+    const selectedSet = new Set(selectedValues);
+    return flatOptions.filter((opt) => !selectedSet.has(opt.value)).length;
+  }, [flatOptions, selectedValues]);
 
   // Build a lookup map for labels
   const optionMap = useMemo(() => {
     const map = new Map<string, MultiSelectOption>();
-    for (const opt of options) {
+    for (const opt of flatOptions) {
       map.set(opt.value, opt);
     }
     return map;
-  }, [options]);
+  }, [flatOptions]);
 
   function addValue(val: string) {
     if (!val || selectedValues.includes(val)) return;
@@ -149,7 +203,7 @@ export function MultiSelect({
     >
       <Select
         label={label}
-        placeholder={availableOptions.length === 0 ? 'All options selected' : placeholder}
+        placeholder={remainingCount === 0 ? 'All options selected' : placeholder}
         value=""
         onChange={(e) => {
           addValue(e.target.value);
@@ -160,7 +214,7 @@ export function MultiSelect({
         size={size}
         helperText={error ? undefined : helperText}
         error={error}
-        disabled={disabled || availableOptions.length === 0}
+        disabled={disabled || remainingCount === 0}
         fullWidth={fullWidth}
       />
 

--- a/components/ui/MultiSelect/index.ts
+++ b/components/ui/MultiSelect/index.ts
@@ -1,2 +1,8 @@
-export { MultiSelect, type MultiSelectProps, type MultiSelectOption, type MultiSelectSize } from './MultiSelect';
+export {
+  MultiSelect,
+  type MultiSelectProps,
+  type MultiSelectOption,
+  type MultiSelectOptionGroup,
+  type MultiSelectSize,
+} from './MultiSelect';
 export { default } from './MultiSelect';


### PR DESCRIPTION
## Summary

Brings optgroup-parity grouping — already in `Select` via `SelectOptionGroup` — to `MultiSelect` and `Menu`, so a flat list can be segmented under section headers (e.g. one group per service line).

- **MultiSelect** — accepts `MultiSelectOptionGroup` (`{ label, options }`). Flattens groups for the value→option map and the remaining-count, and passes filtered groups through to the inner `Select` (which already renders `<optgroup>`). Groups left empty after filtering selected options drop out.
- **Menu** — accepts `MenuItemGroup` (`{ label, items }`). Renders each as a `role="group"` section named via `aria-label`, with a non-interactive `bds-menu__group` / `bds-menu__title` header.
- **Back-compat** — both APIs are unions; flat-only `options`/`items` render exactly as before.
- Grouped Storybook stories + MDX for both; play functions assert group semantics via `getByRole('group', { name })`.

## Verification

- `typecheck` ✓ · `lint-tokens` 0 errors ✓ · `canonical-class-check` 0 slot violations ✓ · `typegen:axes:check` in sync ✓ · `pr-checklist.sh` automated ✓
- Vitest browser-mode: 10/10 pass (incl. new grouped play functions)
- Storybook visual check on both Grouped stories (port 6017): caught + fixed a slot collision where the group header reused `.bds-menu__label` and leaked uppercase/letter-spacing onto item labels — header now uses the `__title` slot. Item labels confirmed back to capitalize/16px/400/primary; group titles render as secondary-color uppercase headers.

## Test plan
- [ ] Storybook: visual verification on `Components/multi-select` → Grouped and `Containers/menu` → Grouped
- [ ] `npm test` passes
- [ ] `npm run lint-tokens` passes

Closes #955