### PR TITLE
feat(components): add DependentSelect cascading parent/child selects (#957)

### DIFF
--- a/components/ui/DependentSelect/DependentSelect.css
+++ b/components/ui/DependentSelect/DependentSelect.css
@@ -1,0 +1,10 @@
+@layer bds-components {
+/* DependentSelect — stacked parent/child cascading selects */
+
+.bds-dependent-select {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  width: 100%;
+}
+}

--- a/components/ui/DependentSelect/DependentSelect.mdx
+++ b/components/ui/DependentSelect/DependentSelect.mdx
@@ -1,0 +1,37 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './DependentSelect.stories';
+
+<Meta of={Stories} />
+
+# Dependent-select
+
+<ComponentLinks slug="dependent-select" />
+
+Two cascading selects: a parent (driving) [`Select`](/?path=/docs/components-select--docs) whose value filters a child select's visible options. The child can be single-select ([`Select`](/?path=/docs/components-select--docs)) or multi-select ([`MultiSelect`](/?path=/docs/components-multi-select--docs)). The child's committed selection is **cumulative** — changing the parent filters the visible options but never clears what's already chosen.
+
+Codifies the hand-wired "service line → services" cascade (two `Select`s + a `useMemo` filter) that consumer apps were copying.
+
+## Playground
+
+<Canvas of={Stories.Default} />
+
+## Variants
+
+The child defaults to multi-select. Pass `child.multiple = true` for a `MultiSelect` child (Playground above) or omit it for a single `Select` child.
+
+### Single child
+
+<Canvas of={Stories.SingleChild} />
+
+## Props
+
+<ArgTypes of={Stories} />
+
+## Notes
+
+> **Filtering** — DependentSelect filters the child's *visible* options by the parent's `value`. Pass the **full** child option set to `child.options`; each option carries its parent value under the field named by `child.parentKey` (e.g. `service_line_id`). When no parent is selected, every child option is shown.
+
+> **Cumulative selection** — the parent never clears the child. Options already selected under a previous parent stay committed and keep rendering their chip/label, even though they're hidden from the dropdown while a different parent is active.
+
+> **Keep the parent controlled** — filtering tracks `parent.value`, so pair it with `parent.onChange`. Both selects share the `size` and `disabled` props.

--- a/components/ui/DependentSelect/DependentSelect.stories.tsx
+++ b/components/ui/DependentSelect/DependentSelect.stories.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within, waitFor } from 'storybook/test';
+import { DependentSelect, type DependentChildOption } from './DependentSelect';
+
+/* ─── Sample data ─────────────────────────────────────────────── */
+
+const serviceLines = [
+  { label: 'Brand', value: 'brand' },
+  { label: 'Marketing', value: 'marketing' },
+  { label: 'Product', value: 'product' },
+];
+
+// Every service, each tagged with the line it belongs to.
+const services: DependentChildOption[] = [
+  { label: 'Logo & identity', value: 'logo', service_line_id: 'brand' },
+  { label: 'Brand guidelines', value: 'guidelines', service_line_id: 'brand' },
+  { label: 'Campaign design', value: 'campaign', service_line_id: 'marketing' },
+  { label: 'Social templates', value: 'social', service_line_id: 'marketing' },
+  { label: 'UI design', value: 'ui', service_line_id: 'product' },
+  { label: 'Design system', value: 'design-system', service_line_id: 'product' },
+];
+
+/* ─── Meta ────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof DependentSelect> = {
+  title: 'Components/dependent-select',
+  component: DependentSelect,
+  tags: ['surface-shared'],
+  parameters: { layout: 'padded' },
+  decorators: [(Story) => <div style={{ width: 420 }}><Story /></div>],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size applied to both selects (sm=32px, md=40px, lg=48px). Default `md`.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disable both the parent and child selects.',
+    },
+    parent: {
+      control: false,
+      description: 'Parent (driving) select config: `{ label, options, value, onChange, placeholder }`. Keep controlled so the child filters on parent change. Set in code.',
+    },
+    child: {
+      control: false,
+      description: 'Child (dependent) select config: `{ label, options, parentKey, value, onChange, multiple? }`. `options` is the full set; each option carries the parent value under `parentKey`. Set in code.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DependentSelect>;
+
+/* ═══════════════════════════════════════════════════════════════
+   DEFAULT — multi-select child. Hook-driven (Q4): the cascade needs
+   controlled parent + child state to demonstrate the filtering +
+   cumulative-selection behavior args alone can't express.
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Cascading service-line → services (multi child) */
+export const Default: Story = {
+  render: (args) => {
+    function Cascade() {
+      const [lineId, setLineId] = useState('');
+      const [serviceIds, setServiceIds] = useState<string[]>([]);
+      return (
+        <DependentSelect
+          {...args}
+          parent={{
+            label: 'Service line',
+            placeholder: 'All service lines',
+            options: serviceLines,
+            value: lineId,
+            onChange: setLineId,
+          }}
+          child={{
+            label: 'Services',
+            placeholder: 'Select services...',
+            helperText: 'Filtered by the selected service line',
+            options: services,
+            parentKey: 'service_line_id',
+            value: serviceIds,
+            onChange: setServiceIds,
+            multiple: true,
+          }}
+        />
+      );
+    }
+    return <Cascade />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const [parent, child] = canvas.getAllByRole('combobox');
+    await expect(parent).toBeVisible();
+    await expect(child).toBeVisible();
+
+    // No parent selected → child offers every service.
+    await expect(within(child).getByRole('option', { name: 'Campaign design' })).toBeInTheDocument();
+
+    // Pick a parent line → child options narrow to that line.
+    await userEvent.selectOptions(parent, 'brand');
+    await waitFor(() =>
+      expect(within(child).queryByRole('option', { name: 'Campaign design' })).not.toBeInTheDocument(),
+    );
+    await expect(within(child).getByRole('option', { name: 'Logo & identity' })).toBeInTheDocument();
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   SINGLE CHILD — single-select child (the multiple={false} axis).
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Cascading parent → single child select */
+export const SingleChild: Story = {
+  render: (args) => {
+    function Cascade() {
+      const [lineId, setLineId] = useState('');
+      const [serviceId, setServiceId] = useState('');
+      return (
+        <DependentSelect
+          {...args}
+          parent={{
+            label: 'Service line',
+            placeholder: 'All service lines',
+            options: serviceLines,
+            value: lineId,
+            onChange: setLineId,
+          }}
+          child={{
+            label: 'Service',
+            placeholder: 'Select a service...',
+            options: services,
+            parentKey: 'service_line_id',
+            value: serviceId,
+            onChange: setServiceId,
+          }}
+        />
+      );
+    }
+    return <Cascade />;
+  },
+};

--- a/components/ui/DependentSelect/DependentSelect.tsx
+++ b/components/ui/DependentSelect/DependentSelect.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useMemo, type CSSProperties } from 'react';
+import {
+  Select,
+  type SelectOption,
+  type SelectOptionGroup,
+  type SelectSize,
+} from '../Select/Select';
+import { MultiSelect, type MultiSelectOption } from '../MultiSelect/MultiSelect';
+import { bdsClass } from '../../utils';
+import './DependentSelect.css';
+
+/**
+ * A child option. Beyond the usual `label`/`value`/`icon`, each option carries
+ * the value of the parent it belongs to under the field named by
+ * `child.parentKey` (e.g. `service_line_id`).
+ */
+export type DependentChildOption = MultiSelectOption & Record<string, unknown>;
+
+/**
+ * Parent (driving) select config. The parent should be **controlled**
+ * (`value` + `onChange`) — DependentSelect filters the child's options by the
+ * current parent `value`, so it needs to observe it.
+ */
+export interface DependentSelectParentConfig {
+  /** Visible label above the parent select. */
+  label?: string;
+  /** Parent options — flat or grouped (`SelectOptionGroup`). */
+  options: (SelectOption | SelectOptionGroup)[];
+  /** Controlled parent value. */
+  value?: string;
+  /** Uncontrolled initial value. Note: filtering tracks `value`, so pair with `onChange` for the cascade to react. */
+  defaultValue?: string;
+  /** Placeholder shown when no parent is selected. */
+  placeholder?: string;
+  /** Called with the new parent value on change. */
+  onChange?: (value: string) => void;
+}
+
+interface DependentSelectChildBase {
+  /** Visible label above the child select. */
+  label?: string;
+  /** Full child option set (all parents). DependentSelect filters the *visible* options by the parent value. */
+  options: DependentChildOption[];
+  /** Field name on each child option holding the parent value it belongs to (e.g. `service_line_id`). */
+  parentKey: string;
+  /** Placeholder shown in the child select. */
+  placeholder?: string;
+  /** Helper text below the child select. */
+  helperText?: string;
+}
+
+interface DependentSelectChildSingleConfig extends DependentSelectChildBase {
+  /** Single-select child (default). */
+  multiple?: false;
+  /** Controlled child value. */
+  value?: string;
+  /** Uncontrolled initial value. */
+  defaultValue?: string;
+  /** Called with the new child value on change. */
+  onChange?: (value: string) => void;
+}
+
+interface DependentSelectChildMultiConfig extends DependentSelectChildBase {
+  /** Multi-select child. */
+  multiple: true;
+  /** Controlled child values. */
+  value?: string[];
+  /** Uncontrolled initial values. */
+  defaultValue?: string[];
+  /** Called with the full updated array of child values on change. */
+  onChange?: (values: string[]) => void;
+}
+
+/** Child (dependent) select config — single or multi. */
+export type DependentSelectChildConfig =
+  | DependentSelectChildSingleConfig
+  | DependentSelectChildMultiConfig;
+
+export interface DependentSelectProps {
+  /** Parent (driving) select. */
+  parent: DependentSelectParentConfig;
+  /** Child (dependent) select, filtered by the parent's value. */
+  child: DependentSelectChildConfig;
+  /** Size applied to both selects. Default `md`. */
+  size?: SelectSize;
+  /** Disable both selects. */
+  disabled?: boolean;
+  /** Optional className on the wrapper. */
+  className?: string;
+  /** Optional style override on the wrapper. */
+  style?: CSSProperties;
+}
+
+function selectedValuesOf(child: DependentSelectChildConfig): string[] {
+  if (child.multiple) return child.value ?? child.defaultValue ?? [];
+  const single = child.value ?? child.defaultValue;
+  return single ? [single] : [];
+}
+
+/**
+ * DependentSelect — a parent select whose value filters a child select's
+ * visible options, with the child's committed selection kept cumulative across
+ * parent changes (the parent never clears the child).
+ *
+ * The child receives its full option set; DependentSelect shows only options
+ * matching the current parent in the dropdown, but folds already-selected
+ * options (from any parent) back in so their chips/labels still resolve.
+ *
+ * @example
+ * ```tsx
+ * <DependentSelect
+ *   parent={{ label: 'Service line', options: lines, value: lineId, onChange: setLineId }}
+ *   child={{
+ *     label: 'Services',
+ *     options: allServices,         // every service, each tagged with service_line_id
+ *     parentKey: 'service_line_id',
+ *     value: serviceIds,
+ *     onChange: setServiceIds,
+ *     multiple: true,
+ *   }}
+ * />
+ * ```
+ *
+ * @summary Cascading parent/child selects, cumulative child selection
+ */
+export function DependentSelect({
+  parent,
+  child,
+  size = 'md',
+  disabled = false,
+  className,
+  style,
+}: DependentSelectProps) {
+  const parentValue = parent.value;
+  const { options: childOptions, parentKey } = child;
+
+  // Options visible for the current parent — all options when no parent is set.
+  const visibleChildOptions = useMemo(() => {
+    if (!parentValue) return childOptions;
+    return childOptions.filter((opt) => String(opt[parentKey] ?? '') === String(parentValue));
+  }, [childOptions, parentKey, parentValue]);
+
+  // Fold already-selected options (from any parent) back in so their chip/label
+  // still resolves — the committed selection is cumulative, never filtered.
+  // Selected options are excluded from the child's dropdown by Select/MultiSelect,
+  // so this only affects label resolution, not the available list.
+  const controlOptions = useMemo(() => {
+    const selected = new Set(selectedValuesOf(child));
+    const visibleValues = new Set(visibleChildOptions.map((opt) => opt.value));
+    const extras = childOptions.filter(
+      (opt) => selected.has(opt.value) && !visibleValues.has(opt.value),
+    );
+    return [...visibleChildOptions, ...extras];
+  }, [child, childOptions, visibleChildOptions]);
+
+  return (
+    <div className={bdsClass('bds-dependent-select', className)} style={style}>
+      <Select
+        label={parent.label}
+        options={parent.options}
+        value={parent.value}
+        defaultValue={parent.defaultValue}
+        placeholder={parent.placeholder}
+        onChange={(e) => parent.onChange?.(e.target.value)}
+        size={size}
+        disabled={disabled}
+      />
+      {child.multiple ? (
+        <MultiSelect
+          label={child.label}
+          options={controlOptions}
+          value={child.value}
+          defaultValue={child.defaultValue}
+          onChange={child.onChange}
+          placeholder={child.placeholder}
+          helperText={child.helperText}
+          size={size}
+          disabled={disabled}
+        />
+      ) : (
+        <Select
+          label={child.label}
+          options={controlOptions}
+          value={child.value}
+          defaultValue={child.defaultValue}
+          placeholder={child.placeholder}
+          onChange={(e) => child.onChange?.(e.target.value)}
+          size={size}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  );
+}
+
+export default DependentSelect;

--- a/components/ui/DependentSelect/index.ts
+++ b/components/ui/DependentSelect/index.ts
@@ -1,0 +1,8 @@
+export {
+  DependentSelect,
+  type DependentSelectProps,
+  type DependentSelectParentConfig,
+  type DependentSelectChildConfig,
+  type DependentChildOption,
+} from './DependentSelect';
+export { default } from './DependentSelect';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -36,6 +36,7 @@ export * from './Counter';
 export * from './DataSection';
 export * from './DataView';
 export * from './DatePicker';
+export * from './DependentSelect';
 export * from './DevFeedbackWidget';
 export * from './Dialog';
 export * from './Divider';


### PR DESCRIPTION
## Summary

Adds `DependentSelect` — a parent (driving) [`Select`](https://design.brikdesigns.com) whose value filters a child select's *visible* options. Codifies the hand-wired "service line → services" cascade (two `Select`s + a `useMemo` filter) that consumer apps (`brik-client-portal` project/service forms, brikdesigns service picker) were copying.

- **Component filters** — pass the **full** child option set to `child.options`; each option carries its parent value under the field named by `child.parentKey` (e.g. `service_line_id`). DependentSelect shows only options matching the current parent. No parent selected → all child options shown. (Matches the portal SOT `filter(s => s.service_line_id === lineId)`.)
- **Single or multi child** — `child.multiple` toggles `Select` vs `MultiSelect`.
- **Cumulative selection** — changing the parent filters the visible options but **never clears the committed selection**. Already-selected options (any parent) fold back into the child control so their chip/label still resolves while hidden from the dropdown.

## Verification

- `typecheck` ✓ · `lint-tokens` 0 errors ✓ · `canonical-class-check` 0 violations ✓ · `typegen:axes:check` in sync ✓ · `lint-storybook-recipe` 0 violations ✓ · `lint-jsdoc` clean ✓
- Vitest browser-mode: 2/2 pass — Default play asserts parent `brand` removes "Campaign design" from the child and keeps "Logo & identity".
- Storybook visual check (port 6018): drove the cumulative case — selected a Brand service, switched parent to Marketing, added a Marketing service; both chips persisted (`[Logo & identity, Campaign design]`) while the child dropdown showed only Marketing's remaining option. Confirms "filter visible options, never the committed selection."

## Test plan
- [ ] Storybook: `Components/dependent-select` → Default + Single child
- [ ] `npm test` passes
- [ ] Adopt in `brik-client-portal` new/edit-project forms (replace two-`Select` + `useMemo`)

Closes #957