### PR TITLE
feat(components): custom-node chips/content in MultiSelect + Menu (#956)

### DIFF
--- a/components/ui/Menu/Menu.mdx
+++ b/components/ui/Menu/Menu.mdx
@@ -26,6 +26,12 @@ Pass `MenuItemGroup` entries (`{ label, items }`) to segment the menu under sect
 
 <Canvas of={Stories.Grouped} />
 
+### Custom content
+
+Set `content` on a `MenuItemData` to render a custom node — e.g. a line-colored [`ServiceTag`](/?path=/docs/components-service-tag--docs) — as the item's content instead of the default icon + label + description. The item stays a `role="menuitem"` button; its `label` is used as the accessible name.
+
+<Canvas of={Stories.CustomContent} />
+
 ## Patterns
 
 Real-world usage: `FilterButton` trigger, `Button` trigger with action menu, and an "Add" menu where each item has a label + description (the 2-line `MenuItemData.description` variant).

--- a/components/ui/Menu/Menu.stories.tsx
+++ b/components/ui/Menu/Menu.stories.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@iconify/react';
 import { Menu } from './Menu';
 import { FilterButton } from '../FilterButton';
 import { Button } from '../Button';
+import { ServiceTag } from '../ServiceTag/ServiceTag';
 
 /* ─── Layout Helpers (story-only) ─────────────────────────────── */
 
@@ -60,6 +61,13 @@ const groupedItems = [
   },
 ];
 
+// Items whose content is a line-colored ServiceTag node instead of icon+label.
+const serviceTagItems = [
+  { id: 'brand', label: 'Brand', content: <ServiceTag category="brand" variant="icon-text" label="Brand" />, onClick: () => {} },
+  { id: 'marketing', label: 'Marketing', content: <ServiceTag category="marketing" variant="icon-text" label="Marketing" />, onClick: () => {} },
+  { id: 'product', label: 'Product', content: <ServiceTag category="product" variant="icon-text" label="Product" />, onClick: () => {} },
+];
+
 /* ─── Meta ────────────────────────────────────────────── */
 
 const meta = {
@@ -101,6 +109,20 @@ export const Playground: Story = {
 export const Grouped: Story = {
   args: {
     items: groupedItems,
+    isOpen: true,
+    onClose: () => {},
+    style: { position: 'relative' },
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   CUSTOM CONTENT — line-colored ServiceTag as item content
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Custom node (ServiceTag) as item content */
+export const CustomContent: Story = {
+  args: {
+    items: serviceTagItems,
     isOpen: true,
     onClose: () => {},
     style: { position: 'relative' },

--- a/components/ui/Menu/Menu.tsx
+++ b/components/ui/Menu/Menu.tsx
@@ -23,6 +23,12 @@ export interface MenuItemData {
   description?: string;
   /** Optional icon before the label */
   icon?: ReactNode;
+  /**
+   * Custom node rendered as the item's content instead of the default
+   * icon + label + description — e.g. a line-colored `ServiceTag`. The item
+   * stays a `role="menuitem"` button; `label` is used as its accessible name.
+   */
+  content?: ReactNode;
   /** Disabled state */
   disabled?: boolean;
   /** Click handler */
@@ -84,13 +90,15 @@ export interface MenuItemProps extends HTMLAttributes<HTMLButtonElement> {
  * MenuItem - Single menu option (exported for direct use)
  */
 export function MenuItem({ item, isActive, className, style, ...props }: MenuItemProps) {
-  const hasDescription = !!item.description;
+  const hasContent = item.content != null;
+  const hasDescription = !hasContent && !!item.description;
   return (
     <button
       type="button"
       role="menuitem"
       disabled={item.disabled}
       onClick={item.onClick}
+      aria-label={hasContent ? item.label : undefined}
       className={bdsClass(
         'bds-menu__item',
         isActive && 'bds-menu__item--active',
@@ -101,13 +109,19 @@ export function MenuItem({ item, isActive, className, style, ...props }: MenuIte
       style={style}
       {...props}
     >
-      {item.icon && <span className="bds-menu__icon">{item.icon}</span>}
-      <span className="bds-menu__text">
-        <span className="bds-menu__label">{item.label}</span>
-        {hasDescription && (
-          <span className="bds-menu__description">{item.description}</span>
-        )}
-      </span>
+      {hasContent ? (
+        item.content
+      ) : (
+        <>
+          {item.icon && <span className="bds-menu__icon">{item.icon}</span>}
+          <span className="bds-menu__text">
+            <span className="bds-menu__label">{item.label}</span>
+            {hasDescription && (
+              <span className="bds-menu__description">{item.description}</span>
+            )}
+          </span>
+        </>
+      )}
     </button>
   );
 }

--- a/components/ui/MultiSelect/MultiSelect.css
+++ b/components/ui/MultiSelect/MultiSelect.css
@@ -19,4 +19,34 @@
   gap: var(--gap-sm);
   margin-top: var(--gap-md);
 }
+
+/* ─── Custom-chip item (node + owned remove control) ──── */
+
+.bds-multi-select__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-xs);
+}
+
+.bds-multi-select__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--icon-sm);
+  border-radius: var(--border-radius-sm);
+}
+
+.bds-multi-select__remove:hover {
+  color: var(--text-primary);
+}
+
+.bds-multi-select__remove:focus-visible {
+  outline: var(--border-width-md) solid var(--border-focus);
+  outline-offset: var(--border-width-sm);
+}
 }

--- a/components/ui/MultiSelect/MultiSelect.mdx
+++ b/components/ui/MultiSelect/MultiSelect.mdx
@@ -32,6 +32,12 @@ Pass `MultiSelectOptionGroup` entries (`{ label, options }`) to segment the drop
 
 <Canvas of={Stories.Grouped} />
 
+### Custom chips
+
+Set `chip` on an option to render a custom node — e.g. a line-colored [`ServiceTag`](/?path=/docs/components-service-tag--docs) — as the selected pill instead of the neutral default `Tag`. MultiSelect supplies its own remove control beside the node, so the node itself need not be removable. The native dropdown still shows the plain `label` (a native `<option>` can't render a node); use `icon` for a dropdown glyph.
+
+<Canvas of={Stories.CustomChips} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/MultiSelect/MultiSelect.stories.tsx
+++ b/components/ui/MultiSelect/MultiSelect.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
 import { Icon } from '@iconify/react';
+import { ServiceTag } from '../ServiceTag/ServiceTag';
 import {
   MultiSelect,
   type MultiSelectOption,
@@ -41,6 +42,19 @@ const groupedOfferings: MultiSelectOptionGroup[] = [
     ],
   },
 ];
+
+// Options whose selected chip is a line-colored ServiceTag (not a neutral Tag).
+const serviceTagOptions: MultiSelectOption[] = [
+  { label: 'Brand identity', value: 'brand-id', category: 'brand' },
+  { label: 'Email campaign', value: 'email', category: 'marketing' },
+  { label: 'Design system', value: 'design-system', category: 'product' },
+].map((o) => ({
+  label: o.label,
+  value: o.value,
+  chip: (
+    <ServiceTag category={o.category as 'brand' | 'marketing' | 'product'} variant="icon-text" serviceName={o.label} label={o.label} size="sm" />
+  ),
+}));
 
 /* ─── Meta ────────────────────────────────────────────────────── */
 
@@ -87,7 +101,7 @@ const meta: Meta<typeof MultiSelect> = {
     },
     options: {
       control: false,
-      description: 'Array of `MultiSelectOption` ({ label, value, icon? }) or `MultiSelectOptionGroup` ({ label, options }) — entries with an `options` key render as a labelled `<optgroup>`. Mix freely. Set in code; Storybook Controls cannot render a complex array editor usefully.',
+      description: 'Array of `MultiSelectOption` ({ label, value, icon?, chip? }) or `MultiSelectOptionGroup` ({ label, options }). `chip` renders a custom node (e.g. a line-colored `ServiceTag`) as the selected pill; entries with an `options` key render as a labelled `<optgroup>`. Mix freely. Set in code; Storybook Controls cannot render a complex array editor usefully.',
     },
     value: {
       control: false,
@@ -156,5 +170,26 @@ export const Grouped: Story = {
     await expect(canvas.getByRole('group', { name: 'Marketing' })).toBeInTheDocument();
     // Pre-selected option renders as a chip below.
     await expect(canvas.getByText('Logo & identity')).toBeVisible();
+  },
+};
+
+/** Selected items render as line-colored `ServiceTag` chips (via `option.chip`)
+ *  instead of the neutral default `Tag`, each with an owned remove control.
+ *  @summary Custom ServiceTag chips for selections */
+export const CustomChips: Story = {
+  args: {
+    label: 'Services you’re interested in',
+    placeholder: 'Select services...',
+    size: 'md',
+    fullWidth: true,
+    options: serviceTagOptions,
+    defaultValue: ['brand-id', 'email'],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('combobox')).toBeVisible();
+    // Selected items render as ServiceTag pills (not neutral Tags) + a remove button.
+    await expect(canvas.getByRole('button', { name: 'Remove Brand identity' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Remove Email campaign' })).toBeVisible();
   },
 };

--- a/components/ui/MultiSelect/MultiSelect.tsx
+++ b/components/ui/MultiSelect/MultiSelect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, type CSSProperties, type ReactNode } from 'react';
+import { Icon } from '@iconify/react';
 import {
   Select,
   type SelectOption,
@@ -8,6 +9,7 @@ import {
   type SelectSize,
 } from '../Select/Select';
 import { Tag } from '../Tag/Tag';
+import { X } from '../../icons';
 import { bdsClass } from '../../utils';
 import './MultiSelect.css';
 
@@ -21,6 +23,14 @@ export interface MultiSelectOption {
   value: string;
   /** Optional leading icon for selected tag */
   icon?: ReactNode;
+  /**
+   * Custom node rendered as the selected chip instead of the default neutral
+   * `Tag` — e.g. a line-colored `ServiceTag`. MultiSelect supplies its own
+   * remove control beside the node (the node itself need not be removable).
+   * The native dropdown still shows the plain `label` (a native `<option>`
+   * can't render a node); use the `icon` for a dropdown glyph.
+   */
+  chip?: ReactNode;
 }
 
 /**
@@ -223,6 +233,25 @@ export function MultiSelect({
           {selectedValues.map((val) => {
             const opt = optionMap.get(val);
             if (!opt) return null;
+            // Custom chip node (e.g. a line-colored ServiceTag): render it as the
+            // pill and supply our own remove control alongside.
+            if (opt.chip) {
+              return (
+                <span key={val} className="bds-multi-select__item">
+                  {opt.chip}
+                  {!disabled && (
+                    <button
+                      type="button"
+                      className="bds-multi-select__remove"
+                      aria-label={`Remove ${opt.label}`}
+                      onClick={() => removeValue(val)}
+                    >
+                      <Icon icon={X} />
+                    </button>
+                  )}
+                </span>
+              );
+            }
             return (
               <Tag
                 key={val}


### PR DESCRIPTION
## Summary

Lets `MultiSelect` and `Menu` render a custom node — e.g. a line-colored [`ServiceTag`](https://design.brikdesigns.com) — instead of the neutral default `Tag` / icon+label. Unblocks brikdesigns#602 (Get Started picker chips read as the design intends).

- **MultiSelect** — new optional `MultiSelectOption.chip`. When set, the selected item renders that node as the pill with an **owned remove control** (`bds-multi-select__item` + `__remove`); the default neutral `Tag` path is unchanged when `chip` is absent. The native dropdown still shows the plain `label` — a native `<option>` can't render a node (see scope note below).
- **Menu** — new optional `MenuItemData.content`. When set, the item renders the node instead of icon + label + description; it stays a `role="menuitem"` button with `label` as its accessible name.
- ServiceTag honors service-line color in both themes itself (#574, shipped + consumer-verified in brikdesigns#358) — these changes just pass the node through.

## Scope note (native-select limitation)

MultiSelect's dropdown is a native `<select>`, so options can't render a ServiceTag *node* — only the chip can. "ServiceTag indicator in dropdown options" (one of brikdesigns#602's ACs) would require a custom ARIA listbox (a MultiSelect rewrite, out of scope for this `size:m`). I'll flag that AC on #602 for descope/defer.

## Verification

- `typecheck` ✓ · `lint-tokens` 0 errors ✓ · `canonical-class-check` 0 slot violations ✓ (`__item`/`__remove` allowlisted) · `lint-storybook-recipe` ✓ · `lint-jsdoc` ✓
- Vitest browser-mode: 8/8 pass (incl. CustomChips remove-button assertions).
- Storybook visual check (port 6019): MultiSelect CustomChips renders **0 neutral Tags** — selections are pure line-colored ServiceTag pills (brand `#f4d364`, marketing `#bcff8c`) each with a remove button; clicking remove drops the chip (2→1). Menu CustomContent renders ServiceTag nodes as `role="menuitem"` with `aria-label` = label, default label slot omitted.

## Test plan
- [ ] Storybook: `Components/multi-select` → Custom chips, `Containers/menu` → Custom content
- [ ] `npm test` passes
- [ ] Adopt in brikdesigns `ServiceMultiSelect` (#602): pass `chip: <ServiceTag …/>` per option

Closes #956