### PR TITLE
ci: gate WCAG AA contrast on pull requests (#573)

### DIFF
--- a/.github/workflows/contrast-gate.yml
+++ b/.github/workflows/contrast-gate.yml
@@ -1,0 +1,57 @@
+name: Contrast Gate
+
+# Enforces the canonical WCAG AA contrast-pairing set on every PR and on every
+# push to main. Resolves every pairing in `tokens/contrast-pairings.json`
+# against its foreground + background token in the Brik LIGHT and DARK default
+# themes and fails the build if any real pairing drops below its WCAG threshold
+# (AAA 7:1 / AA 4.5:1 / AA-large 3:1). Tracked `darkException` pairings are
+# reported, not failed (see scripts/validate-themes.js).
+#
+# Why this is a CI gate (not just pre-push):
+#   - validate-themes.js already runs on local pre-push via `validate:full`
+#     (scripts/validate-all.js → "Theme Compliance") and at release
+#     (release.yml → contrast-gate). Neither stops a regression from *merging*.
+#   - Cloud-agent commits (OpenClaw, scheduled routines) bypass local hooks.
+#   - PRs from forks or fresh clones may not have husky installed.
+# This workflow is the cross-machine guarantee that no AA regression lands on
+# main between releases — closing the gap that let the #563 contrast regression
+# (10 service pairings, only 1 passing AA) merge and ship.
+#
+# Source of truth: tokens/contrast-pairings.json
+# Docs: https://design.brikdesigns.com/docs/primitives/color-pairings
+# Issue: brikdesigns/brik-bds#573 (parent #526 — WCAG AA contrast contract)
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: contrast-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contrast-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The gate reads committed source tokens (tokens/figma-tokens.css,
+      # tokens/figma-tokens-dark.css, tokens/gap-fills.css,
+      # tokens/theme-brand-brik.css) + tokens/contrast-pairings.json directly —
+      # no dist build required (unlike canonical-check, which parses dist/).
+      - name: Contrast pairing gate
+        run: npm run contrast-gate


### PR DESCRIPTION
## Why

The contrast gate (`scripts/validate-themes.js`, `npm run contrast-gate`) already runs:
- **locally on pre-push** — `validate:full` → `validate-all.js` "Theme Compliance"
- **at release** — `release.yml`

Neither stops an AA regression from **merging**. Cloud-agent commits and fork/fresh-clone PRs bypass local hooks, and there is no PR-time enforcement. That gap is exactly how the #563 regression (10 service-line pairings, only 1 passing AA) merged and shipped — caught only in manual Storybook review.

This is the leak: contrast fixes ship, but nothing holds the line, so the backlog refills (#478, #479, #691, #835, #913, #914, #579 …).

## What

Adds `.github/workflows/contrast-gate.yml` running `npm run contrast-gate` on every `pull_request` and `push` to `main` — the cross-machine guarantee, mirroring the established `canonical-check.yml` pattern (and its documented rationale for CI-over-local-hooks).

- **No build step** — the gate reads committed `tokens/figma-tokens.css`, `figma-tokens-dark.css`, `gap-fills.css`, `theme-brand-brik.css` + `contrast-pairings.json` directly (unlike canonical-check, which parses gitignored `dist/`).
- **Tracked `darkException` pairings are reported, not failed** — preserves the existing gate semantics.
- **Gate passes clean on `main` today** (✅ PASS, AA floor) — existing open PRs are unaffected; only genuine AA regressions will fail.

## Note on #573 scope

#573 was filed (2026-05) as "blocked on #544 (`check_contrast` helper)" and targeting a husky hook. That premise is now stale: `validate-themes.js` already implements the pairing resolution #573 wanted, and already runs on pre-push. The only missing layer was PR-time CI enforcement — which this delivers without needing #544. Followed the `canonical-check.yml` precedent (CI gate as the authoritative cross-machine guarantee) rather than a local-only hook.

## Test plan
- [x] `npm run contrast-gate` passes on this branch (exit 0)
- [x] Workflow YAML validated (triggers: pull_request + push; job runs `npm run contrast-gate`)
- [ ] CI: this PR's own `Contrast Gate` check goes green

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)