### PR TITLE
fix(inspector): recognize all shipping BDS token families

### DIFF
--- a/.storybook/public/brik-inspect.js
+++ b/.storybook/public/brik-inspect.js
@@ -62,15 +62,21 @@
   // Token prefixes considered valid BDS tokens. Anything not starting with
   // one of these is treated as an unknown custom var (still surfaced, but
   // flagged so agents can decide whether to canonicalize it).
+  // Keep in sync with the families defined in @brikdesigns/bds dist/tokens.css.
   const VALID_TOKEN_PREFIXES = [
     '--color-', '--text-', '--background-', '--surface-', '--border-',
     '--padding-', '--space-', '--spacing-', '--gap-', '--margin-',
-    '--font-family-', '--typography-', '--font-size-', '--font-weight-',
-    '--body-', '--heading-', '--display-', '--label-',
+    '--font-family-', '--font-casing-', '--typography-', '--font-size-', '--font-weight-',
+    '--body-', '--heading-', '--display-', '--label-', '--subtitle-',
     '--font-line-height-', '--letter-spacing-',
     '--border-radius-', '--radius-',
-    '--shadow-', '--elevation-',
-    '--transition-', '--motion-', '--duration-', '--easing-',
+    '--shadow-', '--box-shadow-', '--elevation-',
+    // Motion: --duration-/--ease-/--delay-/--iteration- are semantic tokens;
+    // --easing- is the Style-Dictionary primitive export. See tokens.css.
+    '--transition-', '--motion-', '--duration-', '--easing-', '--ease-',
+    '--delay-', '--iteration-', '--stagger-',
+    '--icon-', '--size-', '--content-width-', '--aspect-', '--blur-radius-',
+    '--layout-', '--page-', '--state-', '--tooltip-', '--bds-',
     '--breakpoint-', '--z-', '--interaction-',
   ];
 
@@ -407,7 +413,7 @@
     }
 
     .bi-actions {
-      display: flex; gap: ${T.space200};
+      display: flex; gap: ${T.space200}; flex-wrap: wrap;
       padding: ${T.space300} ${T.space400};
     }
     .bi-action-btn {
@@ -651,6 +657,179 @@
       node = node.parentElement;
     }
     return null;
+  }
+
+  // ── Element-context detection (ADR-007) ─────────────────────────────────
+  //
+  // The inspector is the single element-selection + context detector; feedback
+  // surfaces consume what it emits rather than maintaining parallel pickers.
+  // Resolves { page, section, component, element_tag } for a selected element.
+  // Ported from the former DevFeedbackWidget/detectContext.ts (brik-bds#880);
+  // component reuses findBdsRoot above so there is one component detector.
+  //
+  // Two environments are covered in one pass:
+  //   - Astro client mockups use the BDS `section--{type}` class convention.
+  //   - Product apps resolve section from semantic landmarks (`<section>`,
+  //     `<main>`, `[role=region]`, `[data-section]`) + aria-label / nearest
+  //     heading / id fallback.
+  // Every field is best-effort and may be absent — consumers treat the result
+  // as optional context, never required.
+
+  function detectPage() {
+    // The URL pathname is the canonical page identity and is preferred — product
+    // apps (portal, renew-pms) share one templated <title> across every route, so
+    // document.title is non-discriminating there (every page reported the same
+    // name; brik-llm#979). The slug ("admin", "settings/services") is what a
+    // triager needs. document.title is kept only as a fallback for the root path,
+    // where the slug is empty.
+    if (typeof location !== 'undefined' && location.pathname) {
+      const slug = location.pathname.replace(/^\/+|\/+$/g, '');
+      if (slug) return slug;
+    }
+    const title = document.title?.trim();
+    if (title) return title;
+    return undefined;
+  }
+
+  function firstText(...candidates) {
+    for (const c of candidates) {
+      const t = c?.trim();
+      if (t) return t;
+    }
+    return undefined;
+  }
+
+  // The page's primary heading — the first <h1> (preferring one inside <main>).
+  // Used to stop the section detector from reporting the page title as a
+  // "section" (brik-bds#886).
+  function isPageHeading(heading) {
+    const pageH1 = document.querySelector('main h1') || document.querySelector('h1');
+    return !!pageH1 && heading === pageH1;
+  }
+
+  function sectionLabel(section) {
+    // Mockup convention first: "section section--hero" → "hero".
+    const typeMatch = section.className.match(/section--([a-z0-9-]+)/i);
+    if (typeMatch) return typeMatch[1];
+
+    // Explicit, author-provided labels, most-explicit first. These deliberately
+    // name a region, so they're trusted even on <main>.
+    const ariaLabel = section.getAttribute('aria-label');
+    const dataSection = section.getAttribute('data-section');
+    const labelledBy = section.getAttribute('aria-labelledby');
+    const labelledByText = labelledBy ? document.getElementById(labelledBy)?.textContent : undefined;
+    const explicit = firstText(ariaLabel, dataSection, labelledByText);
+    if (explicit) return explicit;
+
+    // <main> is the page-level landmark, not a section. Product-app pages
+    // typically have a single <main> whose first heading is the page H1 and
+    // whose id is a skip-link target ("main-content"); deriving a section name
+    // from either is misleading (brik-bds#886). Without an explicit label
+    // above, <main> names no section — let the caller omit it.
+    if (section.tagName === 'MAIN') return undefined;
+
+    // Non-landmark regions: nearest heading, then id. Never the page H1 — a
+    // <section> whose only heading is the document title is effectively
+    // page-level and would mislead a triager.
+    const heading = section.querySelector('h1, h2, h3, h4');
+    if (heading && !isPageHeading(heading)) {
+      const text = heading.textContent?.trim();
+      if (text) return text;
+    }
+    return firstText(section.id || undefined);
+  }
+
+  // Structured section metadata for the Astro mockup environment. Mockups
+  // annotate sections with `section--{type}` / `layout--{name}` classes and a
+  // preceding `<!-- Source: home.md Section-XX -->` comment; the pin-drop
+  // feedback widget records these in Supabase design_feedback.section_context.
+  // Surfacing them here (all undefined in product apps, which have none of these
+  // conventions) lets the pin-drop widget consume this one detector instead of a
+  // parallel detectSectionContext() copy — brik-client-portal#1132 / ADR-007.
+  function detectSectionMeta(el) {
+    const meta = {};
+
+    const section = el.closest('section[class*="section--"], [class*="section--"]');
+    if (section) {
+      const typeMatch = section.className.match(/section--([a-z0-9-]+)/i);
+      if (typeMatch) meta.section_type = typeMatch[1];
+
+      const ariaLabel = section.getAttribute('aria-label');
+      if (ariaLabel) meta.section_label = ariaLabel;
+
+      if (section.id) meta.section_id = section.id;
+
+      // Walk back over text nodes to the nearest preceding comment / element.
+      let prev = section.previousSibling;
+      while (prev) {
+        if (prev.nodeType === 8) {
+          const m = prev.textContent.trim().match(/Source:\s*(.+)/);
+          if (m) { meta.content_source = m[1].trim(); break; }
+        }
+        if (prev.nodeType === 1) break;
+        prev = prev.previousSibling;
+      }
+
+      // 1-based position among all `section--` blocks in document order.
+      const all = document.querySelectorAll('section[class*="section--"]');
+      const idx = Array.from(all).indexOf(section);
+      if (idx >= 0) meta.section_number = idx + 1;
+    }
+
+    const layout = el.closest('[class*="layout--"]');
+    if (layout) {
+      const m = layout.className.match(/layout--([a-z0-9-]+)/i);
+      if (m) meta.layout = m[1];
+    }
+
+    return meta;
+  }
+
+  function detectReportContext(el) {
+    const ctx = {};
+
+    const page = detectPage();
+    if (page) ctx.page = page;
+
+    const section =
+      el.closest('[class*="section--"]') ||
+      el.closest('section, article, main, [role="region"], [data-section]');
+    if (section) {
+      const label = sectionLabel(section);
+      if (label) ctx.section = label;
+    }
+
+    // Component detection the inspector already owns (block class, e.g. "bds-button").
+    const bds = findBdsRoot(el);
+    if (bds) ctx.component = bds.component;
+
+    const meaningful = el.closest(
+      'a, button, h1, h2, h3, h4, img, video, input, textarea, select, p, li, span',
+    );
+    if (meaningful) ctx.element_tag = meaningful.tagName.toLowerCase();
+
+    // Mockup-environment structured fields (superset; undefined elsewhere).
+    Object.assign(ctx, detectSectionMeta(el));
+
+    return ctx;
+  }
+
+  // Emit the selected element's context so a host page (e.g. the product app's
+  // feedback form) can pre-fill a submission. Returns the detail for callers
+  // that want to act locally too.
+  function emitReport(el) {
+    const detail = detectReportContext(el);
+    window.dispatchEvent(new CustomEvent('brik:inspect:report', { detail }));
+    return detail;
+  }
+
+  // Expose the shared detector for surfaces that resolve element context without
+  // entering inspect mode or listening for brik:inspect:report — the mockup
+  // pin-drop feedback widget calls this synchronously on click. ADR-007 makes
+  // this the single detector; consumers must not reimplement it (#1132).
+  if (typeof window !== 'undefined') {
+    window.BrikInspect = window.BrikInspect || {};
+    window.BrikInspect.detectContext = detectReportContext;
   }
 
   // ── Stylesheet rule index ───────────────────────────────────────────────
@@ -968,6 +1147,7 @@
         ${audits.map(renderAuditRow).join('')}
       </div>
       <div class="bi-actions">
+        <button class="bi-action-btn" type="button" data-action="report-feedback" title="Report feedback on this element">Feedback</button>
         <button class="bi-action-btn" type="button" data-action="copy-selector">Copy selector</button>
         <button class="bi-action-btn" type="button" data-action="copy-report">Copy report</button>
         <button class="bi-action-btn" type="button" data-action="scan-page">Scan page</button>
@@ -990,6 +1170,17 @@
     });
     panelEl.querySelector('[data-action="scan-page"]').addEventListener('click', () => {
       scanAndCopyReport();
+    });
+    // Emit element context for any feedback surface listening for
+    // `brik:inspect:report` (e.g. the product app's DevFeedbackWidget), then
+    // hand off: exit inspect mode so the inspector stops intercepting page
+    // clicks (its capture-phase onClick preventDefaults every non-chrome click)
+    // and the user can interact with the feedback form that just opened. If no
+    // host is wired (standalone mockup pages), the event is simply unobserved.
+    const reportBtn = panelEl.querySelector('[data-action="report-feedback"]');
+    reportBtn.addEventListener('click', () => {
+      emitReport(el);
+      if (active) toggleActive();
     });
     panelEl.style.display = 'block';
   }

--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -62,15 +62,21 @@
   // Token prefixes considered valid BDS tokens. Anything not starting with
   // one of these is treated as an unknown custom var (still surfaced, but
   // flagged so agents can decide whether to canonicalize it).
+  // Keep in sync with the families defined in @brikdesigns/bds dist/tokens.css.
   const VALID_TOKEN_PREFIXES = [
     '--color-', '--text-', '--background-', '--surface-', '--border-',
     '--padding-', '--space-', '--spacing-', '--gap-', '--margin-',
-    '--font-family-', '--typography-', '--font-size-', '--font-weight-',
-    '--body-', '--heading-', '--display-', '--label-',
+    '--font-family-', '--font-casing-', '--typography-', '--font-size-', '--font-weight-',
+    '--body-', '--heading-', '--display-', '--label-', '--subtitle-',
     '--font-line-height-', '--letter-spacing-',
     '--border-radius-', '--radius-',
-    '--shadow-', '--elevation-',
-    '--transition-', '--motion-', '--duration-', '--easing-',
+    '--shadow-', '--box-shadow-', '--elevation-',
+    // Motion: --duration-/--ease-/--delay-/--iteration- are semantic tokens;
+    // --easing- is the Style-Dictionary primitive export. See tokens.css.
+    '--transition-', '--motion-', '--duration-', '--easing-', '--ease-',
+    '--delay-', '--iteration-', '--stagger-',
+    '--icon-', '--size-', '--content-width-', '--aspect-', '--blur-radius-',
+    '--layout-', '--page-', '--state-', '--tooltip-', '--bds-',
     '--breakpoint-', '--z-', '--interaction-',
   ];
 

--- a/scripts/__tests__/inspect-widget-tokens.test.mjs
+++ b/scripts/__tests__/inspect-widget-tokens.test.mjs
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * Inspect-widget token-allowlist coverage gate.
+ *
+ * The inspector (components/ui/BrikDevBar/widgets/inspect-widget.js) classifies
+ * a CSS custom property as a known BDS token by prefix-matching its name against
+ * VALID_TOKEN_PREFIXES. That hand-maintained list silently drifted from the real
+ * token taxonomy and began flagging shipping tokens — --ease-*, --box-shadow-*,
+ * --icon-*, --size-*, --layout-*, --stagger-*, … — as "UNKNOWN TOKENS".
+ *
+ * This gate fails when a token declared in the committed token sources isn't
+ * recognized by the prefix list. Add the prefix to VALID_TOKEN_PREFIXES to fix.
+ * Lives with the other file-reading .mjs gates (the `scripts` vitest project) so
+ * it runs in node without dragging @types/node into the components tsconfig.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..', '..');
+
+// Committed token sources that declare BDS custom properties: the Style
+// Dictionary export plus the two hand-authored semantic layers (bridge.css owns
+// --ease-*; gap-fills.css owns --content-width-*/--layout-*). dist/tokens.css is
+// a build artifact and not committed, so we read source.
+const TOKEN_SOURCES = [
+  'tokens/figma-tokens.css',
+  'tokens/bridge.css',
+  'tokens/gap-fills.css',
+];
+
+// Standalone breakpoint primitives — numeric values consumed in media-query
+// math, never as `var(--web)`. Not worth a prefix; documented as exceptions.
+const EXCEPTIONS = new Set(['--web', '--tablet', '--mobile']);
+
+const widgetSrc = readFileSync(
+  join(repoRoot, 'components/ui/BrikDevBar/widgets/inspect-widget.js'),
+  'utf8',
+);
+const block = widgetSrc.match(/const VALID_TOKEN_PREFIXES = \[([\s\S]*?)\];/);
+if (!block) throw new Error('VALID_TOKEN_PREFIXES not found in inspect-widget.js');
+const PREFIXES = [...block[1].matchAll(/'(--[a-z-]+)'/g)].map((m) => m[1]);
+
+/** Mirror of the inspector's classifier (inspect-widget.js): startsWith match. */
+const isKnown = (name) => PREFIXES.some((p) => name.startsWith(p));
+
+const declaredNames = new Set();
+for (const rel of TOKEN_SOURCES) {
+  const css = readFileSync(join(repoRoot, rel), 'utf8');
+  for (const m of css.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)) declaredNames.add(m[1]);
+}
+
+describe('inspect widget — token allowlist coverage', () => {
+  it('recognizes every token declared in the committed token sources', () => {
+    const unrecognized = [...declaredNames]
+      .filter((n) => !isKnown(n) && !EXCEPTIONS.has(n))
+      .sort();
+    expect(unrecognized).toEqual([]);
+  });
+
+  // Explicit regression markers for the families that were silently dropped.
+  it.each([
+    '--ease-out',
+    '--ease-in',
+    '--ease-in-out',
+    '--ease-spring',
+    '--box-shadow-md',
+    '--icon-md',
+    '--size-1000',
+    '--content-width-wide',
+    '--layout-md',
+    '--stagger-3',
+    '--page-primary',
+    '--duration-normal',
+  ])('classifies %s as a known token', (token) => {
+    expect(isKnown(token)).toBe(true);
+  });
+
+  it('still flags genuine non-BDS custom properties as unknown', () => {
+    for (const fake of ['--nav-height', '--site-gutter', '--my-random-var']) {
+      expect(isKnown(fake)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fix(tokens): --border-on-color-dark stays white in dark mode (#980) (#982)
- fix(inspector): recognize all shipping BDS token families

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)