### PR TITLE
Dark value for --background-tertiary (invisible hover labels)

### DIFF
--- a/scripts/validate-themes.js
+++ b/scripts/validate-themes.js
@@ -79,16 +79,19 @@ function resolveAll(merged) {
 
 // ─── Theme assembly (the real Brik default cascade) ─────────────────
 // light = figma :root + gap-fills :root + .theme-brand-brik
-// dark  = light + figma dark :root[data-theme=dark] + dark .theme-brand-brik
+// dark  = light + figma dark :root[data-theme=dark] + gap-fills dark + dark .theme-brand-brik
+//   gap-fills dark sits after figma dark (equal specificity, loaded later in the
+//   import cascade) and before brandBrikDark (which pins at higher specificity).
 
 const figmaLight = extractBlock(FIGMA_LIGHT, /:root/);
 const gapFills = extractBlock(GAP_FILLS, /:root/);
+const gapFillsDark = extractBlock(GAP_FILLS, /:root\[data-theme="dark"\]/);
 const brandBrikLight = extractBlock(BRAND_BRIK, /(?:^|\})\s*\.theme-brand-brik/m);
 const figmaDark = extractBlock(FIGMA_DARK, /:root\[data-theme="dark"\]/);
 const brandBrikDark = extractBlock(BRAND_BRIK, /:root\[data-theme="dark"\]\s*\.theme-brand-brik/);
 
 const lightVars = resolveAll({ ...figmaLight, ...gapFills, ...brandBrikLight });
-const darkVars = resolveAll({ ...figmaLight, ...gapFills, ...brandBrikLight, ...figmaDark, ...brandBrikDark });
+const darkVars = resolveAll({ ...figmaLight, ...gapFills, ...brandBrikLight, ...figmaDark, ...gapFillsDark, ...brandBrikDark });
 
 const THEMES = [
   { key: 'light', label: 'Brik · Light', vars: lightVars },

--- a/tokens/contrast-pairings.json
+++ b/tokens/contrast-pairings.json
@@ -10,6 +10,7 @@
     { "group": "neutral", "label": "Muted text on page", "fg": "--text-muted", "bg": "--page-primary", "thresholdType": "AA-large" },
     { "group": "neutral", "label": "SegmentedControl inactive label on track", "fg": "--text-on-color-light", "bg": "--background-secondary", "thresholdType": "AA" },
     { "group": "neutral", "label": "Solid Tag / MultiSelect chip label on fill", "fg": "--text-on-color-light", "bg": "--background-secondary", "thresholdType": "AA" },
+    { "group": "neutral", "label": "SegmentedControl inactive hover label on tertiary fill", "fg": "--text-primary", "bg": "--background-tertiary", "thresholdType": "AA" },
 
     { "group": "brand", "label": "Brand text on page", "fg": "--text-brand-primary", "bg": "--page-primary", "thresholdType": "AA" },
     { "group": "brand", "label": "On-color label on brand fill", "fg": "--text-on-color-dark", "bg": "--background-brand-primary", "thresholdType": "AA" },

--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -61,6 +61,8 @@
   --easing-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1); /* TODO: promote to Figma */
 
   /* ── Missing Semantic Tokens ── */
+  /* Light value here; dark value in the :root[data-theme="dark"] block below.
+     Keep the two in lockstep, and move both together when promoted to Figma. */
   --background-tertiary: var(--color-grayscale-lighter);
 
   /* System color surface variants (used by TaskConsole status rows) */
@@ -260,4 +262,13 @@
      a fixed dark/colored surface stay visible. Figma source still emits black
      here — correct it and drop this line. (#980) */
   --border-on-color-dark: var(--color-grayscale-white);
+
+  /* Dark value for the --background-tertiary gap-fill (light value above, in
+     :root). It's a hover/preview fill (e.g. SegmentedControl inactive hover),
+     so in dark mode it must read as a step TOWARD the active surface
+     (--background-primary = black), not its light-mode inverse. Mirrors the
+     --background-primary-hover dark step so --text-primary clears AA on it.
+     No dark value previously existed → light #e0e0e0 fill + light #f2f2f2 text
+     = ~1.1:1, invisible. (#916) */
+  --background-tertiary: var(--color-grayscale-darkest);
 }


### PR DESCRIPTION
## Summary
- fix(tokens): --border-on-color-dark stays white in dark mode (#980) (#982)
- ci: gate WCAG AA contrast on pull requests (#573) (#983)
- fix(inspector): recognize all shipping BDS token families (#984)
- fix(tokens): give --background-tertiary a dark value (#916)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)