### PR TITLE
feat(components): --text-input-bg override for fields on fixed-light surfaces (#914)

### DIFF
--- a/components/ui/TextInput/TextInput.css
+++ b/components/ui/TextInput/TextInput.css
@@ -57,13 +57,14 @@
 .bds-text-input-field {
   /* ─── Component-scoped override surface ── */
   --text-input-focus-ring-width: 1px; /* bds-lint-ignore — component-scoped CSS variable, not a design token */
+  --text-input-bg: var(--background-input); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
   width: 100%;
   padding: 0 var(--padding-xs);
   font-family: var(--font-family-body);
   font-weight: var(--font-weight-regular);
   line-height: var(--font-line-height-normal);
   color: var(--text-primary);
-  background-color: var(--background-input);
+  background-color: var(--text-input-bg); /* bds-lint-ignore — component-scoped CSS variable, not a design token; defaults to --background-input */
   border: var(--border-width-md) solid var(--border-input);
   border-radius: var(--border-radius-md);
   outline: none;

--- a/components/ui/TextInput/TextInput.mdx
+++ b/components/ui/TextInput/TextInput.mdx
@@ -35,10 +35,29 @@ Component-scoped CSS variables exposed on `.bds-text-input-field`. Set on a wrap
 | Variable | Default | Controls |
 |---|---|---|
 | `--text-input-focus-ring-width` | `1px` | Width of the focus ring shadow spread |
+| `--text-input-bg` | `var(--background-input)` | Field fill. Override when a single field sits on a surface that doesn't convert with the theme |
 
 ```css
 /* Example: thicker focus ring in a high-contrast context */
 .my-form {
   --text-input-focus-ring-width: 2px;
+}
+```
+
+### Fields on a fixed-light surface
+
+`--background-input` is theme-responsive — white in light, black in dark. On a
+**fixed-light surface** (e.g. the `--surface-service-*-light` service tints, which
+stay pale in both themes by design — ADR-011), that flip puts a black field on a
+pale surface in dark mode.
+
+- **One field** — set `--text-input-bg` on a wrapping element to pin its fill light.
+- **A whole region** (a form on a service surface) — re-pin the `--background-input`
+  token in that scope; every field inside inherits it, no per-component override:
+
+```css
+/* Keep field fills light inside a fixed-light service section, both themes */
+[data-theme="dark"] .service-surface {
+  --background-input: var(--color-grayscale-white);
 }
 ```


### PR DESCRIPTION
## Summary

#914: `--background-input` is theme-responsive (white→black), so a field placed on a **fixed-light** service surface (`--surface-service-*-light`, pale in both themes per ADR-011) renders a black field on a pale surface in dark mode.

**Contract decision — AC#1, Option 2 (component slot):**
- TextInput exposes `--text-input-bg` (default `var(--background-input)` → zero behavior change). Covers PasswordInput / NumberInput / SearchInput via the shared `.bds-text-input-field` contract.
- MDX documents **both** patterns: the per-field `--text-input-bg` override, and the surface-wide fix — re-pin `--background-input` in a fixed-light scope so every field inside inherits it (the realistic fix for a whole service section, no per-component override).

**AC#2 (gate the pairing) — rejected with rationale:** the contrast gate measures *minimum text readability*, but this is a *fill-vs-surface inversion* that runs backwards through that model — the broken dark case scores **18.82:1** (passes) and the fine light case scores **1.05:1** (would falsely fail). A pairing would be false green coverage. See issue comment for the proof.

**Residual:** the systemic auto-aware variant (a Surface primitive that re-pins field fills by context) has no BDS container today and belongs to the #850 cross-component program. The documented `--background-input` re-pin covers the need until then — no orphaned work.

## Test plan
- [x] `npm run lint-tokens` clean
- [x] `npm run typecheck` clean
- [x] Storybook MDX recipe lint (ADR-007) — 87/87 conforming
- [x] `contrast-gate` ✓ (via pr-checklist)
- [x] Non-visual diff: default resolves to `var(--background-input)`, identical render in all existing stories (skipped the visual gate via the sanctioned `SKIP_STORY_CHECK` for non-visual diffs)

## Consumer sync plan
- [ ] Portal / renew-pms / brikdesigns: pick up on next `@brikdesigns/bds` publish — additive, no migration needed

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)