### PR TITLE
fix(blueprints): scope hero icon CSS to img so ServiceTag centers

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -317,7 +317,11 @@ const cta = section.cta;
     margin-bottom: var(--gap-sm);
   }
 
-  .bp-hero-img-card__icon {
+  /* Scoped to `img` only: this slot also carries the ServiceTag icon variant
+     (a `<span class="bds-service-tag--icon …">`), whose inline-flex centering
+     must survive. The span self-sizes via `bds-service-tag--icon-lg` (40px =
+     2.5rem). See brik-bds#873. */
+  img.bp-hero-img-card__icon {
     display: block;
     width: var(--bp-hero-img-card-icon-size, 2.5rem);
     height: var(--bp-hero-img-card-icon-size, 2.5rem);

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -153,7 +153,11 @@
   margin-bottom: var(--gap-sm);
 }
 
-.bp-hero-img-card__icon {
+/* Scoped to `img` only: this slot also carries `<ServiceTag variant="icon">`,
+   whose `.bds-service-tag--icon` centering (inline-flex) must not be clobbered
+   by `display: block`. The ServiceTag self-sizes via `.bds-service-tag--icon-lg`
+   (40px = 2.5rem). See brik-bds#873. */
+img.bp-hero-img-card__icon {
   display: block;
   width: var(--bp-hero-img-card-icon-size, 2.5rem);
   height: var(--bp-hero-img-card-icon-size, 2.5rem);


### PR DESCRIPTION
## Summary
- feat(blueprints): consolidate bds-support-plan section primitive (#581, #589) (#992)
- fix(blueprints): scope hero-img-card icon CSS to <img> so ServiceTag centers (#873)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)