### PR TITLE
fix(tooling): install Playwright + guard node_modules before gates (#812)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,18 @@
+# ── Dependency guard (#812) ──
+# validate:full runs tsc / build-storybook / canonical-check, all of which need
+# node_modules. A missing or stale install (the secondary-machine drift that
+# blocked the v0.83.0 tag push) otherwise fails with opaque MODULE_NOT_FOUND /
+# "tsc not found". Fail fast with an actionable message instead.
+if [ ! -d node_modules ] || [ ! -f node_modules/.package-lock.json ]; then
+  echo "✗ node_modules is missing or incomplete — pre-push gates will fail with MODULE_NOT_FOUND."
+  echo "  Fix: run \`npm ci\` from $(pwd), then push again."
+  exit 1
+fi
+if [ package-lock.json -nt node_modules/.package-lock.json ]; then
+  echo "✗ node_modules is stale (package-lock.json is newer than the last install)."
+  echo "  Fix: run \`npm ci\` from $(pwd), then push again."
+  exit 1
+fi
+
 echo "Running full validation suite before push..."
 npm run validate:full

--- a/scripts/new-task.sh
+++ b/scripts/new-task.sh
@@ -202,6 +202,15 @@ cd "${WORKTREE_BASE}/${TASK_NAME}"
 echo -e "${YELLOW}▸ Installing dependencies (npm ci --prefer-offline)...${NC}"
 npm ci --prefer-offline 2>&1 | tail -1
 
+# ── Install the Playwright browser the Storybook gate needs ──
+# vitest --project=storybook drives `chromium` (vitest.config.ts), and the
+# visual-verification path screenshots stories with it. npm ci does NOT fetch
+# browser binaries, so a fresh worktree fails with "Executable doesn't exist …
+# run npx playwright install" until this runs (#812). Each Playwright version
+# wants its own build, so pin to the version this worktree just installed.
+echo -e "${YELLOW}▸ Installing Playwright chromium (Storybook visual gate)...${NC}"
+npx playwright install chromium chromium-headless-shell 2>&1 | tail -1
+
 # ── Summary ──
 echo ""
 echo -e "${GREEN}═══════════════════════════════════════${NC}"


### PR DESCRIPTION
## Summary

Fresh worktrees and drifted clones couldn't run the BDS gates without manual dev-env repair. Two fixes:

- **`new-task.sh`** runs `npx playwright install chromium chromium-headless-shell` after `npm ci`, so the Storybook visual gate (`vitest --project=storybook`, which drives `chromium`) works in a fresh worktree without a manual reinstall.
- **`.husky/pre-push`** fails fast with an actionable "run `npm ci`" message when `node_modules` is missing or stale (the secondary-machine drift that blocked the `v0.83.0` tag push), instead of the opaque `MODULE_NOT_FOUND` / `tsc not found` the gates otherwise throw.

Closes #812

## Test plan

- [x] `bash -n` clean on both `new-task.sh` and `pre-push`
- [x] `npx playwright install --dry-run chromium chromium-headless-shell` resolves valid browser names (v1217)
- [x] pre-push guard passes on fresh deps, exits 1 on missing/stale `node_modules`
- [x] `npm test` passes against the merged tree (pr-task.sh gate)

## Notes

No `components/` files touched — non-visual tooling change.