### PR TITLE
fix(blueprints): cap h2 title clamp at --heading-xl so h2 stays below h1 (#591)

### DIFF
--- a/content-system/blueprints/astro/AboutStorySplit.astro
+++ b/content-system/blueprints/astro/AboutStorySplit.astro
@@ -107,7 +107,7 @@ const callout = section.items[0];
   .bp-about-story-split__title {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-xl));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-about-story-split-heading-color, var(--text-primary));

--- a/content-system/blueprints/astro/CardGrid.astro
+++ b/content-system/blueprints/astro/CardGrid.astro
@@ -15,7 +15,7 @@
  *
  * Token pairs — paired family ↔ size only:
  *   subtitle    : --font-family-subtitle + --subtitle-lg + --text-transform-subtitle
- *   title (h2)  : --font-family-heading  + clamp(--heading-lg, ..., --heading-huge)
+ *   title (h2)  : --font-family-heading  + clamp(--heading-lg, ..., --heading-xl)
  *   description : --font-family-body     + --body-md
  */
 export interface Props {
@@ -88,7 +88,7 @@ const titleId = `${sectionKey}-title`;
   .bds-card-grid__title {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-xl));
     font-weight: var(--font-weight-semi-bold);
     line-height: var(--font-line-height-tight);
     color: var(--text-primary);

--- a/content-system/blueprints/astro/CtaSplitContact.astro
+++ b/content-system/blueprints/astro/CtaSplitContact.astro
@@ -118,7 +118,7 @@ const email = clientFacts.email;
   .bp-cta-split-contact__title {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-xl));
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-tight);
     color: var(--bp-cta-split-contact-heading-color, var(--text-primary));

--- a/content-system/blueprints/astro/SupportPlan.astro
+++ b/content-system/blueprints/astro/SupportPlan.astro
@@ -128,7 +128,7 @@ const ctaUrl = cta && 'url' in cta ? cta.url : undefined;
   .bds-support-plan__header .bds-support-plan__title {
     margin: 0;
     font-family: var(--font-family-heading);
-    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
+    font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-xl));
     font-weight: var(--font-weight-semibold);
     line-height: var(--font-line-height-tight);
     color: var(--text-primary);


### PR DESCRIPTION
## Summary

Four Astro blueprint titles clamped their `h2` up to `--heading-huge` (40.5px) — larger than the page `h1`'s own ceiling `--heading-xxl` (36px) — so at wide viewports the section `h2` rendered bigger than the page `h1`, breaking the `h2 ≤ h1` hierarchy.

Capped the clamp ceiling at `--heading-xl` (32px, the `h1`'s floor) across the family, preserving the fluid `clamp()` scaling every other heading keeps:

- `CardGrid.astro` (+ doc comment)
- `AboutStorySplit.astro`
- `SupportPlan.astro` (the `.bds-support-plan__header .bds-support-plan__title`, h2 only — the scoped `__main` h3 is untouched)
- `CtaSplitContact.astro`

`Features3ColBrandedDark.astro` is **intentionally excluded**: its `__title` clamp is dead code (two identical unscoped selectors, the later `--heading-md` rule wins for both h2 and h3), so it has no live violation. Tracked separately in #998 — fix is to scope the selectors like `SupportPlan` does.

Closes #591

## Test plan

- [x] `npm run validate:blueprints` passes
- [x] `npm test` passes against the merged tree (pr-task.sh gate)
- [x] Token names verified against `dist/tokens.css` (`--heading-lg`, `--heading-xl` both canonical)
- [ ] Storybook / Chromatic visual check on the four blueprint stories (reviewer)

## Token discipline

Both `--heading-lg` and `--heading-xl` are canonical Semantic-tier names in `dist/tokens.css`. No new token names; no raw HEX; no consumer-layer override.