### PR TITLE
fix(service-tag): bump sm icon-text glyph 12→16px

### DIFF
--- a/components/ui/ServiceTag/ServiceTag.tsx
+++ b/components/ui/ServiceTag/ServiceTag.tsx
@@ -29,7 +29,9 @@ export interface ServiceTagProps extends Omit<HTMLAttributes<HTMLSpanElement>, '
 }
 
 // bds-lint-ignore — icon pixel sizes are Figma-driven
-const tagIconSizeMap: Record<ServiceBadgeSize, number> = { sm: 12, md: 16, lg: 20 };
+// sm bumped 12→16: the 12px glyph read as teensy in icon-text pills (#R7).
+// NOTE: diverges from the current Figma spec until the component is updated to match.
+const tagIconSizeMap: Record<ServiceBadgeSize, number> = { sm: 16, md: 16, lg: 20 };
 
 // bds-lint-ignore — Figma-driven badge dimensions
 const iconScaleMap: Record<ServiceBadgeSize, number> = { sm: 0.55, md: 0.6, lg: 0.6 };


### PR DESCRIPTION
## ServiceTag `sm` icon — 12 → 16px

The 12px `sm` glyph read as teensy in `icon-text` pills on brikdesigns.com plan / service pages. Bump `tagIconSizeMap.sm` 12 → 16 (matches `md`).

- Only the `icon-text` variant is affected — icon-only square badges use a separate `boxSize` / `iconScale` map.
- `typecheck` + `build:lib` pass; pre-commit gates green (token lint, JSDoc, anti-slop, gitleaks).

⚠️ **Diverges from the current Figma component spec** until Figma is updated to 16px. Flagged in the source comment.

**Release:** intentionally **no version bump / no tag**. Merging to `main` does **not** publish — `release.yml` publishes only on a `v*.*.*` tag push. The change rides the next deliberate release; all three consumers (portal, renew-pms, brikdesigns) inherit on publish.
