### PR TITLE
docs(service-tag): correct icon-size comments — code is SoT, not Figma

### DIFF
--- a/components/ui/ServiceTag/ServiceTag.tsx
+++ b/components/ui/ServiceTag/ServiceTag.tsx
@@ -28,12 +28,13 @@ export interface ServiceTagProps extends Omit<HTMLAttributes<HTMLSpanElement>, '
   serviceName?: string;
 }
 
-// bds-lint-ignore — icon pixel sizes are Figma-driven
-// sm bumped 12→16: the 12px glyph read as teensy in icon-text pills (#R7).
-// NOTE: diverges from the current Figma spec until the component is updated to match.
+// bds-lint-ignore — component-level icon px sizes. Code/Storybook is the source
+// of truth for components; Figma is a visual reference only (and uses Font
+// Awesome glyphs, not our Iconify set), so these are not Figma-driven.
+// sm bumped 12→16: the 12px glyph read as teensy in icon-text pills.
 const tagIconSizeMap: Record<ServiceBadgeSize, number> = { sm: 16, md: 16, lg: 20 };
 
-// bds-lint-ignore — Figma-driven badge dimensions
+// bds-lint-ignore — component-level badge dimensions (code is SoT; see above).
 const iconScaleMap: Record<ServiceBadgeSize, number> = { sm: 0.55, md: 0.6, lg: 0.6 };
 const boxSizeMap: Record<ServiceBadgeSize, number> = { sm: 20, md: 28, lg: 40 };
 


### PR DESCRIPTION
Comment-only cleanup. The `tagIconSizeMap` / `iconScaleMap` comments asserted the icon px sizes are "Figma-driven", and a note left by brik-bds#1003 claimed the sm bump diverged from a Figma spec. That's inverted:

- **Components → Storybook / code is the source of truth.** Figma is a visual reference only (and references Font Awesome glyphs, not our Iconify set).
- **Only Figma *variables* drive design tokens** via the token pipeline.

So these constants are code-owned, not Figma-driven. No behavior change; `bds-lint-ignore` markers preserved.

Follow-up (not in this PR): `ServiceBadgeSize` is a leftover name from the Badge→ServiceTag rename.