### PR TITLE
components: close button

### DIFF
--- a/components/ui/Banner/Banner.css
+++ b/components/ui/Banner/Banner.css
@@ -59,25 +59,8 @@
   flex-shrink: 0;
 }
 
-/* ─── Close button ───────────────────────────────────────────── */
-
-.bds-banner__close {
-  background: none;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  padding: var(--padding-tiny);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  font-size: var(--body-sm);
-  opacity: 0.8;
-}
-
-.bds-banner__close:hover {
-  opacity: 1;
-}
+/* Close button — visual contract lives in CloseButton, whose `color: inherit`
+ * adapts to the announcement tone's on-color surface. No overrides needed. */
 
 /* ─── Tone: announcement (brand-primary surface) ──────────────── */
 

--- a/components/ui/Banner/Banner.tsx
+++ b/components/ui/Banner/Banner.tsx
@@ -1,8 +1,9 @@
 import { type ReactNode, type HTMLAttributes } from 'react';
 import { Icon } from '@iconify/react';
-import { Warning, Info, XBold } from '../../icons';
+import { Warning, Info } from '../../icons';
 import { Badge } from '../Badge';
 import { bdsClass } from '../../utils';
+import { CloseButton } from '../CloseButton';
 import './Banner.css';
 
 export type BannerTone = 'announcement' | 'warning' | 'error' | 'information';
@@ -92,14 +93,7 @@ export function Banner({
         <div className="bds-banner__actions">
           {action}
           {onDismiss && (
-            <button
-              type="button"
-              onClick={onDismiss}
-              aria-label="Dismiss banner"
-              className="bds-banner__close"
-            >
-              <Icon icon={XBold} />
-            </button>
+            <CloseButton label="Dismiss banner" onClick={onDismiss} />
           )}
         </div>
       )}

--- a/components/ui/CloseButton/CloseButton.css
+++ b/components/ui/CloseButton/CloseButton.css
@@ -1,0 +1,42 @@
+/* CloseButton — canonical icon-only dismiss affordance.
+ *
+ * Glyph-dominant by design: a 20px (--icon-lg) bold "X" inside ~4px padding
+ * fills its box, fixing the "small icon in a big container" drift. Overlays
+ * own only positioning (e.g. negative margin to sit flush); the visual contract
+ * lives here.
+ *
+ * `color: inherit` keeps the glyph surface-adaptive — it picks up
+ * `--text-primary` on neutral overlays (Modal / Sheet / Toast) and the
+ * on-color text of a tinted surface (Banner announcement tone). */
+
+.bds-close-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: var(--padding-xs);
+  background-color: transparent;
+  border: none;
+  border-radius: var(--border-radius-md);
+  color: inherit;
+  font-size: var(--icon-lg);
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+}
+
+.bds-close-button:hover:not(:disabled) {
+  opacity: 1;
+}
+
+.bds-close-button:focus-visible {
+  outline: var(--border-width-lg) solid var(--state-focus);
+  outline-offset: 2px;
+  opacity: 1;
+}
+
+.bds-close-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/components/ui/CloseButton/CloseButton.stories.tsx
+++ b/components/ui/CloseButton/CloseButton.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn, expect, userEvent, within } from 'storybook/test';
+import { CloseButton } from './CloseButton';
+
+const meta: Meta<typeof CloseButton> = {
+  title: 'Components/close-button',
+  component: CloseButton,
+  tags: ['surface-shared'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Accessible label applied as `aria-label`. Defaults to `"Close"`.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Native disabled state — dims the glyph and blocks interaction.',
+    },
+    onClick: {
+      action: 'clicked',
+      description: 'Click handler — wire to the overlay\'s close/dismiss callback.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CloseButton>;
+
+/* ─── Playground ─────────────────────────────────────────────── */
+
+/** @summary Interactive playground for prop tweaking */
+export const Playground: Story = {
+  args: {
+    label: 'Close',
+  },
+};
+
+/* ─── Interaction test (Q5 — hidden from MCP) ────────────────── */
+
+/** @summary Verifies the click handler fires on activation */
+export const InteractionTestClick: Story = {
+  tags: ['!manifest'],
+  args: {
+    label: 'Close',
+    onClick: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByLabelText('Close'));
+    await expect(args.onClick).toHaveBeenCalled();
+  },
+};

--- a/components/ui/CloseButton/CloseButton.tsx
+++ b/components/ui/CloseButton/CloseButton.tsx
@@ -1,0 +1,56 @@
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import { Icon } from '@iconify/react';
+import { XBold } from '../../icons';
+import { bdsClass } from '../../utils';
+import './CloseButton.css';
+
+/**
+ * CloseButton props — icon-only dismiss affordance.
+ *
+ * Inherits all native `<button>` attributes (`onClick`, `disabled`, `type`,
+ * `data-*`, …) except `children` — the glyph is fixed.
+ */
+export interface CloseButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  /** Accessible label announced by screen readers. Defaults to `"Close"`. */
+  label?: string;
+}
+
+/**
+ * CloseButton — the canonical dismiss affordance for overlays (Modal, Sheet,
+ * Toast, Banner) and any panel that can be closed.
+ *
+ * Renders a bold Phosphor "X" at `--icon-lg` (20px) inside a compact,
+ * glyph-dominant ghost box — so the mark reads as the dominant element of its
+ * container rather than a small icon floating in empty space. Centralizing the
+ * close glyph here means weight/size/state tweaks land once and every overlay
+ * absorbs them.
+ *
+ * Icon-only, so `label` is always applied as `aria-label` (defaults to
+ * `"Close"`; override for context, e.g. `"Dismiss notification"`).
+ *
+ * @example
+ * <CloseButton onClick={onClose} />
+ * <CloseButton label="Dismiss notification" onClick={onDismiss} />
+ *
+ * @summary Canonical icon-only dismiss affordance for overlays
+ */
+export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(
+  function CloseButton({ label = 'Close', type = 'button', className, ...rest }, ref) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={bdsClass('bds-close-button', className)}
+        aria-label={label}
+        {...rest}
+      >
+        <Icon icon={XBold} aria-hidden="true" />
+      </button>
+    );
+  },
+);
+
+CloseButton.displayName = 'CloseButton';
+
+export default CloseButton;

--- a/components/ui/CloseButton/index.ts
+++ b/components/ui/CloseButton/index.ts
@@ -1,0 +1,2 @@
+export { CloseButton, type CloseButtonProps } from './CloseButton';
+export { default } from './CloseButton';

--- a/components/ui/Modal/Modal.css
+++ b/components/ui/Modal/Modal.css
@@ -67,31 +67,10 @@
 
 /* ─── Close button ───────────────────────────────────────────── */
 
+/* Layout only — visual contract lives in CloseButton. Negative margin pulls the
+ * padded hit-target so the glyph sits flush with the header's trailing edge. */
 .bds-modal__close {
-  background: none;
-  border: none;
-  font-size: var(--icon-md);
-  line-height: var(--font-line-height-tight);
-  cursor: pointer;
-  padding: var(--padding-md);
-  margin-right: calc(-1 * var(--padding-md));
-  color: var(--text-primary);
-  opacity: 0.6;
-  transition: opacity 0.2s;
-  border-radius: var(--border-radius-md);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.bds-modal__close:hover {
-  opacity: 1;
-}
-
-.bds-modal__close:focus-visible {
-  outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
-  outline-offset: 2px;
-  opacity: 1;
+  margin-right: calc(-1 * var(--padding-xs));
 }
 
 /* ─── Body ───────────────────────────────────────────────────── */

--- a/components/ui/Modal/Modal.tsx
+++ b/components/ui/Modal/Modal.tsx
@@ -1,8 +1,7 @@
 import { type ReactNode, useEffect, useId } from 'react';
 import { createPortal } from 'react-dom';
-import { Icon } from '@iconify/react';
-import { X } from '../../icons';
 import { Button } from '../Button';
+import { CloseButton } from '../CloseButton';
 import { bdsClass } from '../../utils';
 import './Modal.css';
 
@@ -180,14 +179,7 @@ function renderDefault(
         <div className="bds-modal__header">
           {title && <h2 id={titleId} className="bds-modal__title">{title}</h2>}
           {showCloseButton && (
-            <button
-              type="button"
-              className="bds-modal__close"
-              onClick={onClose}
-              aria-label="Close"
-            >
-              <Icon icon={X} />
-            </button>
+            <CloseButton className="bds-modal__close" onClick={onClose} />
           )}
         </div>
       )}

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -129,34 +129,11 @@
   margin: 0;
 }
 
-/* ─── Close button (matches Modal) ──────────────────────────── */
-
+/* ─── Close button ──────────────────────────────────────────── */
+/* Layout only — visual contract lives in CloseButton. Negative margin pulls the
+ * padded hit-target so the glyph sits flush with the header edges. */
 .bds-sheet__close {
-  background: none;
-  border: none;
-  font-size: var(--icon-md);
-  line-height: 1;
-  cursor: pointer;
-  padding: var(--padding-xs);
   margin: calc(-1 * var(--padding-xs));
-  color: var(--text-primary);
-  opacity: 0.6;
-  transition: opacity 0.2s;
-  border-radius: var(--border-radius-md);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.bds-sheet__close:hover {
-  opacity: 1;
-}
-
-.bds-sheet__close:focus-visible {
-  outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
-  outline-offset: 2px;
-  opacity: 1;
 }
 
 /* ─── Tabs (optional, renders below title row) ──────────────── */

--- a/components/ui/Sheet/Sheet.tsx
+++ b/components/ui/Sheet/Sheet.tsx
@@ -1,8 +1,9 @@
 import { type ReactNode, type CSSProperties, useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Icon } from '@iconify/react';
-import { XBold, ArrowLeftBold, Pen } from '../../icons';
+import { ArrowLeftBold, Pen } from '../../icons';
 import { Button } from '../Button';
+import { CloseButton } from '../CloseButton';
 import { bdsClass } from '../../utils';
 import './Sheet.css';
 
@@ -368,14 +369,7 @@ export function Sheet({
                 </div>
               </div>
               {showCloseButton && (
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="bds-sheet__close"
-                  aria-label="Close"
-                >
-                  <Icon icon={XBold} />
-                </button>
+                <CloseButton className="bds-sheet__close" onClick={onClose} />
               )}
             </div>
             {tabs && (

--- a/components/ui/Toast/Toast.css
+++ b/components/ui/Toast/Toast.css
@@ -68,21 +68,6 @@
   margin: 0;
 }
 
-/* ─── Close button ───────────────────────────────────────────── */
-
-.bds-toast__close {
-  background: none;
-  border: none;
-  font-size: var(--icon-md);
-  line-height: var(--font-line-height-tight);
-  cursor: pointer;
-  padding: var(--padding-md);
-  color: var(--text-primary);
-  opacity: 0.6;
-  flex-shrink: 0;
-}
-
-.bds-toast__close:hover {
-  opacity: 1;
-}
+/* Close button — visual contract lives in CloseButton; Toast aligns it to the
+ * top via the container's `align-items: flex-start`. No overrides needed. */
 }

--- a/components/ui/Toast/Toast.tsx
+++ b/components/ui/Toast/Toast.tsx
@@ -1,8 +1,9 @@
 import { type ReactNode, type HTMLAttributes } from 'react';
 import { Icon } from '@iconify/react';
-import { CheckCircle, WarningCircle, Warning, Info, X } from '../../icons';
+import { CheckCircle, WarningCircle, Warning, Info } from '../../icons';
 import { bdsClass } from '../../utils';
 import { Badge } from '../Badge';
+import { CloseButton } from '../CloseButton';
 import './Toast.css';
 
 export type ToastVariant = 'default' | 'success' | 'error' | 'warning' | 'info';
@@ -60,14 +61,7 @@ export function Toast({
         </div>
       </div>
       {onDismiss && (
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="Dismiss notification"
-          className="bds-toast__close"
-        >
-          <Icon icon={X} />
-        </button>
+        <CloseButton label="Dismiss notification" onClick={onDismiss} />
       )}
     </div>
   );

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -28,6 +28,7 @@ export * from './Testimonial';
 export * from './Checkbox';
 export * from './Checklist';
 export * from './Chip';
+export * from './CloseButton';
 export * from './Cluster';
 export * from './Collapsible';
 export * from './CollapsibleCard';


### PR DESCRIPTION
## Summary
- ci: add issue-size-gate to flag new issues missing size (#1009)
- feat(close-button): centralize overlay dismiss into a CloseButton atom

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)