### PR TITLE
release: surface inverse token

### DIFF
--- a/docs/adrs/ADR-012-service-surface-inverse.md
+++ b/docs/adrs/ADR-012-service-surface-inverse.md
@@ -1,6 +1,6 @@
 # ADR-012 — Service-line surface `-inverse`: a neutral-light / service-deep theme-flip surface
 
-**Status:** Proposed
+**Status:** Accepted (shipped in v0.107.0)
 **Date:** 2026-06-28
 **Supersedes:** Partially reverses [ADR-011](./ADR-011-service-line-token-value-model.md) §Decision pt-3 ("No per-service `-inverse`") — for the **surface** purpose only.
 **Superseded by:** —

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.106.0",
+  "version": "0.107.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.106.0",
+      "version": "0.107.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.106.0",
+  "version": "0.107.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Summary
- feat(components): grouped options in MultiSelect + Menu (#955) (#976)
- feat(components): add DependentSelect cascading parent/child selects (#957) (#977)
- feat(components): custom-node chips/content in MultiSelect + Menu (#956) (#978)
- chore(release): v0.105.0 (#979)
- fix(tokens): --border-on-color-dark stays white in dark mode (#980) (#982)
- ci: gate WCAG AA contrast on pull requests (#573) (#983)
- fix(inspector): recognize all shipping BDS token families (#984)
- fix(tokens): give --background-tertiary a dark value (#916) (#986)
- feat(components): --text-input-bg override for fields on fixed-light surfaces (#914) (#987)
- feat(components): add columnHeadingLevel prop to Footer (#848) (#988)
- fix(tooling): resolve chromatic token inline via op run (#965) (#989)
- fix(tokens): AA-safe theme-responsive --text-positive (#990)
- chore(release): v0.105.1 (#991)
- feat(blueprints): consolidate bds-support-plan section primitive (#581, #589) (#992)
- fix(blueprints): scope hero-img-card icon CSS to <img> so ServiceTag centers (#873) (#994)
- fix(tooling): guard gh pr create failure in pr-task.sh (#808) (#996)
- fix(components): SegmentedControl roving tabindex + bg-shorthand warning (#993) (#997)
- fix(tooling): install Playwright browser + guard node_modules before gates (#999)
- fix(blueprints): cap h2 title clamp at --heading-xl so h2 stays below h1 (#1000)
- fix(service-tag): bump sm icon-text glyph 12→16px (#1003)
- feat(icons): ship offline-bundled Phosphor icons via <Icon> + addBrikIcons (#1004)
- docs(service-tag): correct icon-size comments — code is SoT, not Figma (#1005)
- chore(release): 0.106.0 — offline-bundled Phosphor <Icon> + addBrikIcons (#1007)
- ci: add issue-size-gate to flag new issues missing size (#1009)
- feat(close-button): centralize overlay dismiss into a CloseButton atom (#1010)
- ci: chromatic slack (#1011)
- feat(tokens): add per-service surface -inverse token family (#1013)
- docs(adr): mark ADR-012 Accepted — surface-service-inverse ships in v0.107.0
- chore(release): v0.107.0

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)