### PR TITLE
fix(build): ship ESM export subpaths as .mjs (#1008)

### DIFF
--- a/.github/workflows/esm-bundle-check.yml
+++ b/.github/workflows/esm-bundle-check.yml
@@ -46,11 +46,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Only the Vite lib build is needed to produce dist/index.esm.js — skip
-      # the rest of build:lib (types, content-system, tokens, inspector) which
-      # add time without affecting the ESM require() surface.
+      # The gate now resolves every ESM export subpath under Node-ESM, so it
+      # needs the Vite root bundle (dist/index.esm.mjs) AND the content-system
+      # emit (dist/content-system/*.mjs). Skip only tokens/inspector, which
+      # don't affect the ESM export surface.
       - name: Build library bundle (Vite ESM/CJS)
         run: npx vite build --config vite.config.lib.ts
 
-      - name: ESM bundle require() gate
+      - name: Build content-system ESM emit
+        run: npm run build:content-system
+
+      - name: ESM export gate (require()-free + Node-ESM subpath resolution)
         run: npm run check:esm

--- a/docs/BLUEPRINTS-ASTRO-PACKAGE.md
+++ b/docs/BLUEPRINTS-ASTRO-PACKAGE.md
@@ -199,8 +199,8 @@ Current package.json shape ([package.json:8-32](../package.json)):
   "types": "./dist/lib-entry.d.ts",
   "files": ["dist", "blueprints/blueprint-library.json", "content-system/compliance/*.md", "content-system/atmospheres/*.css"],
   "exports": {
-    ".": { "types": "./dist/lib-entry.d.ts", "import": "./dist/index.esm.js", "require": "./dist/index.cjs.js" },
-    "./content-system": { "types": "./dist/content-system/index.d.ts", "import": "./dist/content-system/index.js" },
+    ".": { "types": "./dist/lib-entry.d.ts", "import": "./dist/index.esm.mjs", "require": "./dist/index.cjs.js" },
+    "./content-system": { "types": "./dist/content-system/index.d.ts", "import": "./dist/content-system/index.mjs" },
     // ... per-atmosphere CSS entries ...
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.107.0",
+  "version": "0.107.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.esm.mjs",
   "types": "dist/lib-entry.d.ts",
   "exports": {
     ".": {
       "types": "./dist/lib-entry.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js"
     },
     "./content-system": {
@@ -23,7 +23,8 @@
     },
     "./blueprints-astro/types": {
       "types": "./dist/content-system/blueprints/astro/types.d.ts",
-      "import": "./dist/content-system/blueprints/astro/types.js"
+      "import": "./dist/content-system/blueprints/astro/types.mjs",
+      "require": "./dist/content-system/blueprints/astro/types.js"
     },
     "./blueprints-astro/*.astro": "./content-system/blueprints/astro/*.astro",
     "./blueprints": "./blueprints/blueprint-library.json",
@@ -146,7 +147,7 @@
     "build:modes": "node scripts/generate-modes-css.mjs",
     "build:all-tokens": "npm run build:sd-figma && npm run build:sd-dark && npm run build:modes",
     "build:lib": "vite build --config vite.config.lib.ts && npm run build:types && npm run build:content-system && npm run build:dist-tokens && npm run build:inspector-manifest",
-    "build:content-system": "tsc --project tsconfig.content-system.json && esbuild content-system/index.ts --bundle --format=esm --platform=neutral --outfile=dist/content-system/index.mjs",
+    "build:content-system": "tsc --project tsconfig.content-system.json && esbuild content-system/index.ts --bundle --format=esm --platform=neutral --outfile=dist/content-system/index.mjs && esbuild content-system/blueprints/astro/types.ts --bundle --format=esm --platform=neutral --outfile=dist/content-system/blueprints/astro/types.mjs",
     "build:inspector-manifest": "node scripts/build-inspector-manifest.mjs",
     "bds:find": "node scripts/bds-find.mjs",
     "bcs-vocab-check": "node scripts/bcs-vocab-check.mjs",

--- a/scripts/check-esm-bundle.mjs
+++ b/scripts/check-esm-bundle.mjs
@@ -1,57 +1,127 @@
 #!/usr/bin/env node
 /**
- * check-esm-bundle.js — assert the published ESM entry is import-clean.
+ * check-esm-bundle.mjs — assert the published package is import-clean for
+ * plain Node-ESM consumers (Netlify functions, Astro/Vite SSR, turbopack).
  *
- * Why this gate exists:
- *   `@brikdesigns/bds` is consumed as ESM by SSR/prerender builds (Next.js
- *   turbopack, Astro/Vite). If a CJS/UMD dependency (e.g. lottie-web) gets
- *   inlined into `dist/index.esm.js`, the bundle carries a dynamic `require()`
- *   that those builds reject with "dynamic usage of require is not supported"
- *   — breaking every downstream consumer, even though BDS's own CI is green
- *   (BDS never builds itself as an SSR app).
+ * Two failure classes this gate covers:
  *
- *   v0.97.2 shipped exactly this regression after a vite 6→8 bump inlined
- *   lottie-web into the ESM entry (peerDependency missing from rollup
- *   `external`). This check makes that class of break publish-blocking.
+ * 1. require() inlined into the ESM root entry.
+ *    `@brikdesigns/bds` is consumed as ESM by SSR/prerender builds. If a
+ *    CJS/UMD dependency (e.g. lottie-web) gets inlined into the root ESM
+ *    bundle, it carries a dynamic `require()` those builds reject with
+ *    "dynamic usage of require is not supported". v0.97.2 shipped exactly
+ *    this after a vite 6→8 bump.
  *
- * What it does: scans the built ESM entry for `require(` / `__require` and
- * fails if any are present. Run after `build:lib`, before publish.
+ * 2. A `.js`/`.cjs` file exposed under an `import` condition.
+ *    The package has no `"type": "module"`, so Node treats any `.js` as CJS
+ *    regardless of its contents. A subpath whose `import` condition points at
+ *    a tsc-emitted `.js` (ESM syntax, CJS extension) loads as CJS under
+ *    Node-ESM and named imports fail with
+ *    `SyntaxError: Named export '…' not found`. webpack/vitest tolerate it
+ *    (looser interop), so it only bites the plain-Node-ESM runtime — which is
+ *    how `blueprints-astro/types` silently broke the portal background-function
+ *    fleet (brik-client-portal#1465, brik-bds#1008). This gate makes any
+ *    CJS-under-`import` subpath publish-blocking, and proves each ESM subpath
+ *    actually loads under Node-ESM.
+ *
+ * Run after `build:lib`, before publish (wired into `prepublishOnly`).
  */
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve, dirname, extname } from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const esmEntry = resolve(__dirname, '..', 'dist', 'index.esm.js');
+const pkgRoot = resolve(__dirname, '..');
+const pkg = JSON.parse(readFileSync(resolve(pkgRoot, 'package.json'), 'utf8'));
 
+const isModulePkg = pkg.type === 'module';
+let failed = false;
+const fail = (msg) => {
+  failed = true;
+  console.error(msg);
+};
+
+/* ── Collect every target exposed under an `import` condition ──────────────
+ * (plus the top-level `module` field). These are the entries Node-ESM
+ * consumers resolve. `require`/`default`/asset entries are out of scope. */
+const importTargets = new Map(); // subpath label -> relative file path
+const addTarget = (label, val) => {
+  if (typeof val === 'string') importTargets.set(label, val);
+  else if (val && typeof val === 'object' && typeof val.import === 'string') {
+    importTargets.set(label, val.import);
+  }
+};
+for (const [subpath, val] of Object.entries(pkg.exports ?? {})) {
+  if (subpath.includes('*')) continue; // wildcard subpaths can't be smoke-loaded
+  // string-valued exports are bare files (json/css/md) — only flag executable JS
+  if (typeof val === 'string') {
+    if (['.js', '.cjs', '.mjs'].includes(extname(val))) addTarget(subpath, val);
+  } else {
+    addTarget(subpath, val);
+  }
+}
+if (pkg.module) importTargets.set('(module field)', pkg.module);
+
+const isJs = (p) => ['.js', '.mjs', '.cjs'].includes(extname(p));
+
+/* ── Static rule: no CJS extension under an `import` condition ─────────────
+ * Deterministic; would have caught blueprints-astro/types without running. */
+for (const [label, rel] of importTargets) {
+  const ext = extname(rel);
+  if (!isModulePkg && (ext === '.js' || ext === '.cjs')) {
+    fail(
+      `❌ ESM export check — \`${label}\` resolves to \`${rel}\` (${ext}). ` +
+        `Without "type":"module", Node loads it as CJS under \`import\`, so ` +
+        `named imports fail. Emit it as \`.mjs\` (see build:content-system).`,
+    );
+  }
+}
+
+/* ── Runtime smoke: actually import each ESM subpath under Node-ESM ────────
+ * AC3 of brik-bds#1008 — proves named exports resolve in a plain-Node-ESM
+ * context, not just under webpack/vitest. */
+for (const [label, rel] of importTargets) {
+  if (!isJs(rel)) continue;
+  const abs = resolve(pkgRoot, rel);
+  if (!existsSync(abs)) {
+    fail(`❌ ESM export check — \`${label}\` target \`${rel}\` does not exist (run \`npm run build:lib\`).`);
+    continue;
+  }
+  try {
+    await import(pathToFileURL(abs).href);
+    console.log(`✅ ESM import OK — ${label} (${rel})`);
+  } catch (err) {
+    fail(`❌ ESM import FAILED — \`${label}\` (${rel}): ${err.message.split('\n')[0]}`);
+  }
+}
+
+/* ── require()-free scan on the ESM root entry ────────────────────────────
+ * Catches CJS/UMD deps inlined into the bundle (the lottie-web class). */
+const esmEntry = resolve(pkgRoot, 'dist', 'index.esm.mjs');
 if (!existsSync(esmEntry)) {
-  console.error(`\n❌ ESM bundle check: ${esmEntry} not found.`);
-  console.error('   Run `npm run build:lib` before this check.\n');
-  process.exit(1);
+  fail(`❌ ESM bundle check — ${esmEntry} not found. Run \`npm run build:lib\` first.`);
+} else {
+  const RE = /(?:^|[^A-Za-z0-9_$])(__require|require)\s*\(/;
+  const hits = [];
+  readFileSync(esmEntry, 'utf8')
+    .split('\n')
+    .forEach((line, i) => {
+      if (RE.test(line)) hits.push({ n: i + 1, text: line.trim().slice(0, 120) });
+    });
+  if (hits.length > 0) {
+    fail('❌ ESM bundle check FAILED — dist/index.esm.mjs contains require():');
+    console.error('   ESM-prerender consumers (turbopack / Astro) reject dynamic require.');
+    console.error('   A CJS/UMD dependency is being inlined into the ESM entry.');
+    console.error('   Fix: add the offending dependency to `external` in vite.config.lib.ts.');
+    hits.slice(0, 10).forEach((h) => console.error(`   L${h.n}: ${h.text}`));
+    if (hits.length > 10) console.error(`   …and ${hits.length - 10} more.`);
+  } else {
+    console.log('✅ ESM bundle check: dist/index.esm.mjs is require()-free.');
+  }
 }
 
-const src = readFileSync(esmEntry, 'utf8');
-const lines = src.split('\n');
-
-// Match a require call: `require(`, `__require(`, `require_<x>(` — but NOT the
-// substring inside identifiers like `requireConfig` that are followed by a
-// letter. The offending patterns all call require as a function.
-const RE = /(?:^|[^A-Za-z0-9_$])(__require|require)\s*\(/;
-
-const hits = [];
-lines.forEach((line, i) => {
-  if (RE.test(line)) hits.push({ n: i + 1, text: line.trim().slice(0, 120) });
-});
-
-if (hits.length > 0) {
-  console.error('\n❌ ESM bundle check FAILED — dist/index.esm.js contains require():');
-  console.error('   ESM-prerender consumers (turbopack / Astro) reject dynamic require.');
-  console.error('   A CJS/UMD dependency is being inlined into the ESM entry.');
-  console.error('   Fix: add the offending dependency to `external` in vite.config.lib.ts.\n');
-  hits.slice(0, 10).forEach((h) => console.error(`   L${h.n}: ${h.text}`));
-  if (hits.length > 10) console.error(`   …and ${hits.length - 10} more.`);
-  console.error('');
+if (failed) {
+  console.error('\nESM checks failed — see above.\n');
   process.exit(1);
 }
-
-console.log('✅ ESM bundle check: dist/index.esm.js is require()-free.');
+console.log('\n✅ All ESM export checks passed.');

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'lib-entry.ts'),
       name: 'BrikBDS',
       formats: ['es', 'cjs'],
-      fileName: (format) => format === 'es' ? 'index.esm.js' : 'index.cjs.js',
+      fileName: (format) => format === 'es' ? 'index.esm.mjs' : 'index.cjs.js',
     },
     rollupOptions: {
       // Externalize peer dependencies — do NOT bundle React, Iconify, or Lottie.


### PR DESCRIPTION
## What

`@brikdesigns/bds` has no `"type": "module"`, so any `.js` exposed under an `import` condition loads as **CJS** under plain Node-ESM — named imports then fail with `SyntaxError: Named export '…' not found`. webpack/vitest tolerate it (looser interop); only the plain-Node-ESM runtime (Netlify functions, Astro/Vite SSR) breaks.

This silently took down the **brik-client-portal background-function fleet** — `mockup-revision-background` + ~10 siblings reach `blueprints-astro/types` (named export `WIRED_BLUEPRINT_KEYS`) transitively via `task-output-schemas`, returned 202, and never ran. See brik-client-portal#1465.

## Changes

- **`blueprints-astro/types`** → emitted as `.mjs` (esbuild, mirroring `content-system`); `import` repointed; `.js` kept under a new `require` (CJS dual).
- **root `.`** (audit sweep, AC5) → Vite ES output renamed `index.esm.js` → `index.esm.mjs`; `.`.`import` + the `module` field repointed. Same CJS-under-`import` shape.
- **`check:esm` gate** (ship-the-gate, wired into `prepublishOnly` + the `esm-bundle-check` CI job) → now publish-blocking on the whole class:
  - **static** reject of any `.js`/`.cjs` under an `import` condition while the package isn't `type:module` — deterministic. (Newer Node *auto-reparses* an ESM-syntax `.js` and hides the bug, so a runtime-only check is unreliable across Node versions.)
  - **runtime** import of every ESM subpath under Node-ESM.
  - Verified **fail-closed**: reverting the export to `.js` → `exit 1`.

## AC — brik-bds#1008
- [x] `import { WIRED_BLUEPRINT_KEYS } from '@brikdesigns/bds/blueprints-astro/types'` resolves under plain Node-ESM
- [x] No `.js`/`.cjs` under any `import` condition (root + types swept)
- [x] Verified by importing each subpath under Node-ESM + a fail-closed gate test
- [ ] Published + propagated to portal; `mockup-revision-background` completes on a deploy-preview ← after merge + tag + portal bump
- [x] Audit sweep covers all CJS-under-`import` subpaths

`Refs #1008` — kept open until the portal deploy-preview verifies AC4.

## Consumer sync (after publish)
- [ ] **portal** — bump `@brikdesigns/bds` → 0.107.1 (supersedes the open 0.106.0 bump #1531); verify the bg-fn fleet on the deploy-preview
- [ ] renew-pms / brikdesigns — not broken (webpack/Vite tolerant); routine bump as a follow-up

## Release
Version bumped to **0.107.1** here → after merge, `git tag v0.107.1 && git push origin v0.107.1` triggers `release.yml` (CI publish to GitHub Packages).

## Flag (out of scope)
brik-bds's `scripts/pr-task.sh` titled this PR from the merge commit / branch slug when `main` had advanced — the same bug fixed portal-side in brik-client-portal#1444. Title corrected by hand; worth porting the `--no-merges` fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
