### PR TITLE
Adopt surface-service-inverse in hero image-card blueprint

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -213,8 +213,10 @@ const cta = section.cta;
    * Background uses the `surface` family (not `background`) because the hero
    * is a broad page-level container, not a small bounded component — per the
    * service-token decision tree (`-surface-` for sections/heroes/cards;
-   * `-background-` for badges/tags/pills/buttons). This keeps the hero band
-   * the same shade as section-level surfaces below it on the same page.
+   * `-background-` for badges/tags/pills/buttons). It uses the `-inverse` step
+   * (ADR-012): the card reads as neutral chrome — white — in light mode, then
+   * carries the line's deep {hue}-darkest tint in dark mode. The companion text
+   * flip lives in the dark-mode block below (brik-bds#1017).
    *
    * `--background-inverse` stays on the `background` family: it's the
    * mode-aware companion fill consumed by the inverse `<Button>` variant
@@ -226,7 +228,7 @@ const cta = section.cta;
    * office). API-level rename `data-audience` → `data-service-line` is a
    * separate cross-repo follow-up. */
   .bp-hero-img-card[data-audience='brand'] {
-    background: var(--surface-service-brand);
+    background: var(--surface-service-brand-inverse);
     --bp-hero-img-card-headline-color: var(--text-service-brand-on-light);
     --bp-hero-img-card-eyebrow-color: var(--text-service-brand-on-light);
     --bp-hero-img-card-lead-color: var(--text-service-brand-on-light);
@@ -235,7 +237,7 @@ const cta = section.cta;
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='marketing'] {
-    background: var(--surface-service-marketing);
+    background: var(--surface-service-marketing-inverse);
     --bp-hero-img-card-headline-color: var(--text-service-marketing-on-light);
     --bp-hero-img-card-eyebrow-color: var(--text-service-marketing-on-light);
     --bp-hero-img-card-lead-color: var(--text-service-marketing-on-light);
@@ -244,7 +246,7 @@ const cta = section.cta;
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='information'] {
-    background: var(--surface-service-information);
+    background: var(--surface-service-information-inverse);
     --bp-hero-img-card-headline-color: var(--text-service-information-on-light);
     --bp-hero-img-card-eyebrow-color: var(--text-service-information-on-light);
     --bp-hero-img-card-lead-color: var(--text-service-information-on-light);
@@ -253,7 +255,7 @@ const cta = section.cta;
     --text-on-color-light: var(--color-grayscale-white);
   }
   .bp-hero-img-card[data-audience='product'] {
-    background: var(--surface-service-product);
+    background: var(--surface-service-product-inverse);
     --bp-hero-img-card-headline-color: var(--text-service-product-on-light);
     --bp-hero-img-card-eyebrow-color: var(--text-service-product-on-light);
     --bp-hero-img-card-lead-color: var(--text-service-product-on-light);
@@ -263,7 +265,7 @@ const cta = section.cta;
   }
   .bp-hero-img-card[data-audience='back-office'],
   .bp-hero-img-card[data-audience='service'] {
-    background: var(--surface-service-back-office);
+    background: var(--surface-service-back-office-inverse);
     --bp-hero-img-card-headline-color: var(--text-service-back-office-on-light);
     --bp-hero-img-card-eyebrow-color: var(--text-service-back-office-on-light);
     --bp-hero-img-card-lead-color: var(--text-service-back-office-on-light);
@@ -287,6 +289,46 @@ const cta = section.cta;
   :root[data-theme="dark"] .bp-hero-img-card[data-audience='back-office'],
   :root[data-theme="dark"] .bp-hero-img-card[data-audience='service'] {
     --text-inverse: var(--text-on-color-dark);  /* white on blue/purple/orange-darker: 5.48–9.48:1 */
+  }
+
+  /* ── Dark-mode: the inverse surface flips white → {hue}-darkest, so the card's
+   * own headline/eyebrow/lead (and the breadcrumb/link --text-brand-primary that
+   * cascade on the same surface) must flip from --text-service-{line}-on-light
+   * ({hue}-darkest — invisible on the dark surface) to the light-on-dark
+   * companion --text-service-{line}-on-dark ({hue}-lighter). AA-verified per line
+   * (6.89–9.06:1) via contrast-gate (brik-bds#1017). The inner inverse <Button>
+   * is unaffected: its label/fill ride --text-inverse / --background-inverse
+   * (surface-service-{line}-dark), handled above. */
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='brand'] {
+    --bp-hero-img-card-headline-color: var(--text-service-brand-on-dark);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-brand-on-dark);
+    --bp-hero-img-card-lead-color: var(--text-service-brand-on-dark);
+    --text-brand-primary: var(--text-service-brand-on-dark);
+  }
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='marketing'] {
+    --bp-hero-img-card-headline-color: var(--text-service-marketing-on-dark);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-marketing-on-dark);
+    --bp-hero-img-card-lead-color: var(--text-service-marketing-on-dark);
+    --text-brand-primary: var(--text-service-marketing-on-dark);
+  }
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='information'] {
+    --bp-hero-img-card-headline-color: var(--text-service-information-on-dark);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-information-on-dark);
+    --bp-hero-img-card-lead-color: var(--text-service-information-on-dark);
+    --text-brand-primary: var(--text-service-information-on-dark);
+  }
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='product'] {
+    --bp-hero-img-card-headline-color: var(--text-service-product-on-dark);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-product-on-dark);
+    --bp-hero-img-card-lead-color: var(--text-service-product-on-dark);
+    --text-brand-primary: var(--text-service-product-on-dark);
+  }
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='back-office'],
+  :root[data-theme="dark"] .bp-hero-img-card[data-audience='service'] {
+    --bp-hero-img-card-headline-color: var(--text-service-back-office-on-dark);
+    --bp-hero-img-card-eyebrow-color: var(--text-service-back-office-on-dark);
+    --bp-hero-img-card-lead-color: var(--text-service-back-office-on-dark);
+    --text-brand-primary: var(--text-service-back-office-on-dark);
   }
 
   .bp-hero-img-card__container {

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -13,9 +13,9 @@
  * `data-audience={audience}` on its root section. The cascade rules
  * below bind canonical `--background-service-{audience}` and
  * `--text-service-{audience}` tokens to:
- *   - the hero bg (audience-light)
- *   - the headline color (audience-dark)
- *   - the breadcrumb link/current color (audience-dark — passes AA on light bg)
+ *   - the hero bg (surface-inverse: white in light → {hue}-darkest in dark)
+ *   - the headline color (on-light in light → on-dark in dark; see below)
+ *   - the breadcrumb link/current color (tracks --text-brand-primary, same flip)
  *   - LinkButton variant="inverse" fill + label (audience-dark + white)
  * Consumers don't need to set any of this inline; passing `audience`
  * in the section data is sufficient.
@@ -34,8 +34,10 @@
  * Background uses the `surface` family (not `background`) because the hero
  * is a broad page-level container, not a small bounded component — per the
  * service-token decision tree (`-surface-` for sections/heroes/cards;
- * `-background-` for badges/tags/pills/buttons). This keeps the hero band
- * the same shade as section-level surfaces below it on the same page.
+ * `-background-` for badges/tags/pills/buttons). It uses the `-inverse` step
+ * (ADR-012): the card reads as neutral chrome — white — in light mode, then
+ * carries the line's deep {hue}-darkest tint in dark mode. The companion text
+ * flip lives in the dark-mode block below (brik-bds#1017).
  *
  * `--background-inverse` stays on the `background` family: it's the
  * mode-aware companion fill consumed by the inverse `<Button>` variant
@@ -48,7 +50,7 @@
  * `data-audience` → `data-service-line` is a separate cross-repo follow-up. */
 
 .bp-hero-img-card[data-audience='brand'] {
-  background: var(--surface-service-brand);
+  background: var(--surface-service-brand-inverse);
   --bp-hero-img-card-headline-color: var(--text-service-brand-on-light);
   --bp-hero-img-card-eyebrow-color: var(--text-service-brand-on-light);
   --bp-hero-img-card-lead-color: var(--text-service-brand-on-light);
@@ -58,7 +60,7 @@
 }
 
 .bp-hero-img-card[data-audience='marketing'] {
-  background: var(--surface-service-marketing);
+  background: var(--surface-service-marketing-inverse);
   --bp-hero-img-card-headline-color: var(--text-service-marketing-on-light);
   --bp-hero-img-card-eyebrow-color: var(--text-service-marketing-on-light);
   --bp-hero-img-card-lead-color: var(--text-service-marketing-on-light);
@@ -68,7 +70,7 @@
 }
 
 .bp-hero-img-card[data-audience='information'] {
-  background: var(--surface-service-information);
+  background: var(--surface-service-information-inverse);
   --bp-hero-img-card-headline-color: var(--text-service-information-on-light);
   --bp-hero-img-card-eyebrow-color: var(--text-service-information-on-light);
   --bp-hero-img-card-lead-color: var(--text-service-information-on-light);
@@ -78,7 +80,7 @@
 }
 
 .bp-hero-img-card[data-audience='product'] {
-  background: var(--surface-service-product);
+  background: var(--surface-service-product-inverse);
   --bp-hero-img-card-headline-color: var(--text-service-product-on-light);
   --bp-hero-img-card-eyebrow-color: var(--text-service-product-on-light);
   --bp-hero-img-card-lead-color: var(--text-service-product-on-light);
@@ -88,7 +90,7 @@
 }
 
 .bp-hero-img-card[data-audience='back-office'] {
-  background: var(--surface-service-back-office);
+  background: var(--surface-service-back-office-inverse);
   --bp-hero-img-card-headline-color: var(--text-service-back-office-on-light);
   --bp-hero-img-card-eyebrow-color: var(--text-service-back-office-on-light);
   --bp-hero-img-card-lead-color: var(--text-service-back-office-on-light);
@@ -99,7 +101,7 @@
 
 /* @deprecated alias of [data-audience='back-office']. */
 .bp-hero-img-card[data-audience='service'] {
-  background: var(--surface-service-back-office);
+  background: var(--surface-service-back-office-inverse);
   --bp-hero-img-card-headline-color: var(--text-service-back-office-on-light);
   --bp-hero-img-card-eyebrow-color: var(--text-service-back-office-on-light);
   --bp-hero-img-card-lead-color: var(--text-service-back-office-on-light);
@@ -123,6 +125,46 @@
 :root[data-theme="dark"] .bp-hero-img-card[data-audience='back-office'],
 :root[data-theme="dark"] .bp-hero-img-card[data-audience='service'] {
   --text-inverse: var(--text-on-color-dark);  /* white on blue/purple/orange-darker: 5.48–9.48:1 */
+}
+
+/* ── Dark-mode: the inverse surface flips white → {hue}-darkest, so the card's
+ * own headline/eyebrow/lead (and the breadcrumb/link --text-brand-primary that
+ * cascade on the same surface) must flip from --text-service-{line}-on-light
+ * ({hue}-darkest — invisible on the dark surface) to the light-on-dark
+ * companion --text-service-{line}-on-dark ({hue}-lighter). AA-verified per line
+ * (6.89–9.06:1) via contrast-gate (brik-bds#1017). The inner inverse <Button>
+ * is unaffected: its label/fill ride --text-inverse / --background-inverse
+ * (surface-service-{line}-dark), handled above. */
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='brand'] {
+  --bp-hero-img-card-headline-color: var(--text-service-brand-on-dark);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-brand-on-dark);
+  --bp-hero-img-card-lead-color: var(--text-service-brand-on-dark);
+  --text-brand-primary: var(--text-service-brand-on-dark);
+}
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='marketing'] {
+  --bp-hero-img-card-headline-color: var(--text-service-marketing-on-dark);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-marketing-on-dark);
+  --bp-hero-img-card-lead-color: var(--text-service-marketing-on-dark);
+  --text-brand-primary: var(--text-service-marketing-on-dark);
+}
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='information'] {
+  --bp-hero-img-card-headline-color: var(--text-service-information-on-dark);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-information-on-dark);
+  --bp-hero-img-card-lead-color: var(--text-service-information-on-dark);
+  --text-brand-primary: var(--text-service-information-on-dark);
+}
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='product'] {
+  --bp-hero-img-card-headline-color: var(--text-service-product-on-dark);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-product-on-dark);
+  --bp-hero-img-card-lead-color: var(--text-service-product-on-dark);
+  --text-brand-primary: var(--text-service-product-on-dark);
+}
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='back-office'],
+:root[data-theme="dark"] .bp-hero-img-card[data-audience='service'] {
+  --bp-hero-img-card-headline-color: var(--text-service-back-office-on-dark);
+  --bp-hero-img-card-eyebrow-color: var(--text-service-back-office-on-dark);
+  --bp-hero-img-card-lead-color: var(--text-service-back-office-on-dark);
+  --text-brand-primary: var(--text-service-back-office-on-dark);
 }
 
 .bp-hero-img-card__container {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.107.1",
+  "version": "0.108.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",

--- a/scripts/validate-themes.js
+++ b/scripts/validate-themes.js
@@ -12,6 +12,11 @@
  *   - A pairing flagged `darkException` whose DARK result is sub-threshold is
  *     REPORTED as a known, tracked exception (the systemic dark-mode service
  *     gap, brik-bds#823) and does NOT fail the gate.
+ *   - A pairing flagged `appliesTo: ["light"|"dark"]` is evaluated ONLY in the
+ *     listed theme(s); in any other theme it is marked n/a (mode-scoped). Use
+ *     this for components that swap fg AND bg by theme (e.g. the inverse-surface
+ *     hero card, brik-bds#1017), where the off-theme token combination never
+ *     paints and scoring it would be meaningless.
  *
  * Source of truth: tokens/contrast-pairings.json (also feeds the Storybook
  * ContrastCompliance dashboard and the primitives/color-pairings.mdx matrix).
@@ -122,7 +127,12 @@ async function main() {
       const bgVal = theme.vars[pairing.bg];
       let status, ratio = null;
 
-      if (!fgVal || !bgVal || !isHex(fgVal) || !isHex(bgVal)) {
+      if (pairing.appliesTo && !pairing.appliesTo.includes(theme.key)) {
+        // Pairing is mode-scoped: it only renders in the listed theme(s). The
+        // CSS swaps fg (or bg) by theme, so evaluating it in the off-theme
+        // would score a combination that never paints. Skip — not a failure.
+        status = 'na';
+      } else if (!fgVal || !bgVal || !isHex(fgVal) || !isHex(bgVal)) {
         status = 'unresolved';
       } else {
         ratio = round(contrastRatio(fgVal, bgVal));
@@ -186,7 +196,8 @@ function report(results, hardFailures, exceptions, aaaWarnings) {
     }
     const note = (x) =>
       x.status === 'warn' ? ' (below AAA aim)' : x.status === 'exception' ? ` (exception #${x.exception.issue})` : '';
-    const fmt = (x) => (x.status === 'unresolved' ? 'n/a' : `${ICON[x.status]} ${x.ratio}:1${note(x)}`);
+    const fmt = (x) =>
+      x.status === 'unresolved' ? 'n/a' : x.status === 'na' ? 'n/a (mode-scoped)' : `${ICON[x.status]} ${x.ratio}:1${note(x)}`;
     console.log(`  ${r.label}  [target ${r.thresholdType} ≥${r.threshold}]`);
     console.log(`      light ${fmt(r)}    dark ${fmt(dark)}`);
   }
@@ -200,6 +211,7 @@ function report(results, hardFailures, exceptions, aaaWarnings) {
 function emitMatrix(results) {
   const verdict = (r) => {
     if (r.status === 'unresolved') return 'n/a';
+    if (r.status === 'na') return '—';
     if (r.status === 'exception') return `${r.ratio}:1 ⚠ (#${r.exception.issue})`;
     const tier = r.ratio >= 7 ? 'AAA' : r.ratio >= 4.5 ? 'AA' : r.ratio >= 3 ? 'AA-lg' : 'FAIL';
     return `${r.ratio}:1 ${tier}`;

--- a/tokens/contrast-pairings.json
+++ b/tokens/contrast-pairings.json
@@ -32,6 +32,17 @@
     { "group": "service", "label": "Service back-office — text on pale surface", "fg": "--text-service-back-office-on-light", "bg": "--surface-service-back-office-light", "thresholdType": "AAA", "darkException": { "issue": 823, "reason": "ADR-011 dark-mode softening erodes service context-text contrast on fixed-light surfaces" } },
     { "group": "service", "label": "Service back-office — text on mid-tone surface", "fg": "--text-service-back-office-on-light", "bg": "--surface-service-back-office", "thresholdType": "AA", "darkException": { "issue": 823, "reason": "mid-tone base service surface is decorative; dark-mode softening erodes contrast" } },
 
+    { "group": "service", "label": "Service brand — inverse card text (light)", "fg": "--text-service-brand-on-light", "bg": "--surface-service-brand-inverse", "thresholdType": "AA", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service brand — inverse card text (dark)", "fg": "--text-service-brand-on-dark", "bg": "--surface-service-brand-inverse", "thresholdType": "AA", "appliesTo": ["dark"] },
+    { "group": "service", "label": "Service marketing — inverse card text (light)", "fg": "--text-service-marketing-on-light", "bg": "--surface-service-marketing-inverse", "thresholdType": "AA", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service marketing — inverse card text (dark)", "fg": "--text-service-marketing-on-dark", "bg": "--surface-service-marketing-inverse", "thresholdType": "AA", "appliesTo": ["dark"] },
+    { "group": "service", "label": "Service information — inverse card text (light)", "fg": "--text-service-information-on-light", "bg": "--surface-service-information-inverse", "thresholdType": "AA", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service information — inverse card text (dark)", "fg": "--text-service-information-on-dark", "bg": "--surface-service-information-inverse", "thresholdType": "AA", "appliesTo": ["dark"] },
+    { "group": "service", "label": "Service product — inverse card text (light)", "fg": "--text-service-product-on-light", "bg": "--surface-service-product-inverse", "thresholdType": "AA", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service product — inverse card text (dark)", "fg": "--text-service-product-on-dark", "bg": "--surface-service-product-inverse", "thresholdType": "AA", "appliesTo": ["dark"] },
+    { "group": "service", "label": "Service back-office — inverse card text (light)", "fg": "--text-service-back-office-on-light", "bg": "--surface-service-back-office-inverse", "thresholdType": "AA", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service back-office — inverse card text (dark)", "fg": "--text-service-back-office-on-dark", "bg": "--surface-service-back-office-inverse", "thresholdType": "AA", "appliesTo": ["dark"] },
+
     { "group": "positive", "label": "Positive/success text on surface", "fg": "--text-positive", "bg": "--surface-primary", "thresholdType": "AA" },
     { "group": "positive", "label": "Positive/success text on page", "fg": "--text-positive", "bg": "--page-primary", "thresholdType": "AA" }
   ]


### PR DESCRIPTION
Closes #1017. Implements the delegated AC #3 of brikdesigns#633.

## What
Flip `.bp-hero-img-card[data-audience='X']` background `--surface-service-X` → `--surface-service-X-inverse` (ADR-012: white in light, `{hue}-darkest` in dark) for all 5 service lines + the `service` alias, in **both** the React CSS and the Astro twin (parity held).

The surface flip alone breaks dark mode: the card's headline/eyebrow/lead — and the breadcrumb/link `--text-brand-primary` cascading on the same surface — are pinned to `--text-service-X-on-light` (`{hue}-darkest`), landing dark-on-dark (≈1:1) on the inverse surface. They're recalibrated in dark mode to the canonical light-on-dark companion `--text-service-X-on-dark` (`{hue}-lighter`). No new tokens, no raw hex.

## Contrast (AA-verified, contrast-gate exits 0)
| Line | Light: on-light / white | Dark: on-dark / {hue}-darkest |
|---|---|---|
| brand | 8.59:1 | 7.30:1 |
| marketing | 8.48:1 | 7.69:1 |
| information | 9.52:1 | 6.89:1 |
| product | 14.69:1 | 7.53:1 |
| back-office | 16.34:1 | 9.06:1 |

## Gate change
The card is the first component to swap **both** surface and text by theme, so each rendered pairing is valid in only one mode. Added 10 inverse-card pairings to `contrast-pairings.json` and a new `appliesTo: ["light"|"dark"]` field to `validate-themes.js` — a pairing is evaluated only in its listed theme(s), n/a elsewhere. This is honest about mode-scoping rather than abusing `darkException` (which means "known-fragile, tolerated").

## AC mapping (#1017)
- [x] `-inverse` background on all 5 lines + `service` alias, React + Astro
- [x] Renders white (light) / `{hue}-darkest` (dark) — verified in `dist/styles.css` + `dist/tokens.css`
- [x] Dark-mode text recalibrated; each line passes AA via contrast-gate
- [x] Inner inverse `<Button>` (`--text-inverse` / `--background-inverse`) unchanged — rides `surface-service-X-dark`, not the card surface; still ≥AA
- [x] No raw hex; `var(--token)` only
- [x] Minor bump → **v0.108.0** (one-PR-one-release); noted on #633 for consumer re-bump

## Checks
contrast-gate ✅ · lint-tokens ✅ · validate:blueprints ✅ · build:lib ✅ · typecheck ✅ (pre-commit)

Visual verification (Storybook, both themes × 5 lines) happens on the brikdesigns consumer re-bump per #633 AC #3.