### PR TITLE
refactor(service-tag): rename ServiceBadgeSize type → ServiceTagSize (#1006)

### DIFF
--- a/components/ui/ServiceTag/ServiceTag.tsx
+++ b/components/ui/ServiceTag/ServiceTag.tsx
@@ -5,7 +5,7 @@ import {
   getServiceIconPath,
   getServiceLineIconPath,
   type ServiceLine,
-  type ServiceBadgeSize,
+  type ServiceTagSize,
 } from './service-config';
 import './ServiceTag.css';
 
@@ -17,7 +17,7 @@ export interface ServiceTagProps extends Omit<HTMLAttributes<HTMLSpanElement>, '
   /** Display variant. Default: 'text' */
   variant?: ServiceTagVariant;
   /** Size variant. Default: 'md' */
-  size?: ServiceBadgeSize;
+  size?: ServiceTagSize;
   /** Display label — defaults to the category name (e.g. "Back Office"). Pass a service name to label a specific service. */
   label?: string;
   /**
@@ -32,11 +32,11 @@ export interface ServiceTagProps extends Omit<HTMLAttributes<HTMLSpanElement>, '
 // of truth for components; Figma is a visual reference only (and uses Font
 // Awesome glyphs, not our Iconify set), so these are not Figma-driven.
 // sm bumped 12→16: the 12px glyph read as teensy in icon-text pills.
-const tagIconSizeMap: Record<ServiceBadgeSize, number> = { sm: 16, md: 16, lg: 20 };
+const tagIconSizeMap: Record<ServiceTagSize, number> = { sm: 16, md: 16, lg: 20 };
 
 // bds-lint-ignore — component-level badge dimensions (code is SoT; see above).
-const iconScaleMap: Record<ServiceBadgeSize, number> = { sm: 0.55, md: 0.6, lg: 0.6 };
-const boxSizeMap: Record<ServiceBadgeSize, number> = { sm: 20, md: 28, lg: 40 };
+const iconScaleMap: Record<ServiceTagSize, number> = { sm: 0.55, md: 0.6, lg: 0.6 };
+const boxSizeMap: Record<ServiceTagSize, number> = { sm: 20, md: 28, lg: 40 };
 
 /**
  * ServiceTag — text label or icon badge for a Brik service category or individual service.

--- a/components/ui/ServiceTag/index.ts
+++ b/components/ui/ServiceTag/index.ts
@@ -4,4 +4,6 @@ export type { ServiceTagProps, ServiceTagVariant } from './ServiceTag';
 
 // Shared service-tag domain config — re-exported for consumer convenience
 export { categoryConfig, serviceIconOverrides, normalizeServiceName, getServiceIconPath } from './service-config';
-export type { ServiceLine, ServiceBadgeSize } from './service-config';
+export type { ServiceLine, ServiceTagSize } from './service-config';
+// @deprecated alias of ServiceTagSize — removable next major. See service-config.ts.
+export type { ServiceBadgeSize } from './service-config';

--- a/components/ui/ServiceTag/service-config.ts
+++ b/components/ui/ServiceTag/service-config.ts
@@ -14,11 +14,16 @@
 export type ServiceLine = 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
 
 /**
- * Size scale shared with ServiceTag. Kept as `ServiceBadgeSize` for
- * non-breaking package-API stability; structurally identical to a future
- * `ServiceTagSize` if the dir is renamed.
+ * Size scale shared with ServiceTag.
  */
-export type ServiceBadgeSize = 'sm' | 'md' | 'lg';
+export type ServiceTagSize = 'sm' | 'md' | 'lg';
+
+/**
+ * @deprecated Renamed to `ServiceTagSize` after the Badge → ServiceTag rename
+ * (dir renamed in #731). Kept for one release as a non-breaking package-API
+ * hatch; removable in the next major version.
+ */
+export type ServiceBadgeSize = ServiceTagSize;
 
 export const categoryConfig: Record<ServiceLine, { token: string; label: string }> = {
   brand: { token: 'yellow', label: 'Brand' },


### PR DESCRIPTION
## Summary
- refactor(service-tag): rename ServiceBadgeSize type → ServiceTagSize (#1006)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)

Closes #1006
