### PR TITLE
fix(tokens): darken dark-mode border-secondary and gate inverse-card fills (#1026)

### DIFF
--- a/tokens/contrast-pairings.json
+++ b/tokens/contrast-pairings.json
@@ -43,6 +43,17 @@
     { "group": "service", "label": "Service back-office — inverse card text (light)", "fg": "--text-service-back-office-on-light", "bg": "--surface-service-back-office-inverse", "thresholdType": "AA", "appliesTo": ["light"] },
     { "group": "service", "label": "Service back-office — inverse card text (dark)", "fg": "--text-service-back-office-on-dark", "bg": "--surface-service-back-office-inverse", "thresholdType": "AA", "appliesTo": ["dark"] },
 
+    { "group": "service", "label": "Service brand — inverse card fill (light)", "fg": "--background-service-brand-on-light", "bg": "--surface-service-brand-inverse", "thresholdType": "AA-large", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service brand — inverse card fill (dark)", "fg": "--background-service-brand-on-dark", "bg": "--surface-service-brand-inverse", "thresholdType": "AA-large", "appliesTo": ["dark"] },
+    { "group": "service", "label": "Service marketing — inverse card fill (light)", "fg": "--background-service-marketing-on-light", "bg": "--surface-service-marketing-inverse", "thresholdType": "AA-large", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service marketing — inverse card fill (dark)", "fg": "--background-service-marketing-on-dark", "bg": "--surface-service-marketing-inverse", "thresholdType": "AA-large", "appliesTo": ["dark"] },
+    { "group": "service", "label": "Service information — inverse card fill (light)", "fg": "--background-service-information-on-light", "bg": "--surface-service-information-inverse", "thresholdType": "AA-large", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service information — inverse card fill (dark)", "fg": "--background-service-information-on-dark", "bg": "--surface-service-information-inverse", "thresholdType": "AA-large", "appliesTo": ["dark"] },
+    { "group": "service", "label": "Service product — inverse card fill (light)", "fg": "--background-service-product-on-light", "bg": "--surface-service-product-inverse", "thresholdType": "AA-large", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service product — inverse card fill (dark)", "fg": "--background-service-product-on-dark", "bg": "--surface-service-product-inverse", "thresholdType": "AA-large", "appliesTo": ["dark"] },
+    { "group": "service", "label": "Service back-office — inverse card fill (light)", "fg": "--background-service-back-office-on-light", "bg": "--surface-service-back-office-inverse", "thresholdType": "AA-large", "appliesTo": ["light"] },
+    { "group": "service", "label": "Service back-office — inverse card fill (dark)", "fg": "--background-service-back-office-on-dark", "bg": "--surface-service-back-office-inverse", "thresholdType": "AA-large", "appliesTo": ["dark"] },
+
     { "group": "positive", "label": "Positive/success text on surface", "fg": "--text-positive", "bg": "--surface-primary", "thresholdType": "AA" },
     { "group": "positive", "label": "Positive/success text on page", "fg": "--text-positive", "bg": "--page-primary", "thresholdType": "AA" }
   ]

--- a/tokens/theme-brand-brik.css
+++ b/tokens/theme-brand-brik.css
@@ -124,7 +124,12 @@
   --background-secondary-pressed: var(--color-grayscale-darker);
   /* Border */
   --border-primary: var(--color-grayscale-darker);
-  --border-secondary: var(--color-grayscale-light);
+  /* One step darker than the generated dark value (--color-grayscale-light
+   * #828282) so secondary dividers/outlines read as quieter chrome against the
+   * near-black dark surfaces instead of bright gray hairlines. --border-input
+   * deliberately stays at -dark (#5a5a5a) to preserve the 3:1 field-boundary
+   * contrast (WCAG 1.4.11) on the black --background-input dark fill. */
+  --border-secondary: var(--color-grayscale-dark);
   --border-muted: var(--color-grayscale-dark);
   --border-brand-primary: var(--color-poppy-light);
   --border-input: var(--color-grayscale-dark);


### PR DESCRIPTION
## Summary
Dark-mode token cleanup (source only — `dist/` rebuilds at publish):
- **`--border-secondary`** darkened one step in the `theme-brand-brik` dark block: `grayscale-light` (#828282) → `grayscale-dark` (#5a5a5a) so secondary dividers read as quiet chrome, not bright hairlines. `--border-input` stays at #5a5a5a to keep the 3:1 field boundary (WCAG 1.4.11) on the black `--background-input` fill.
- **10 "inverse card fill" pairings** added to `contrast-pairings.json` (5 service lines × light/dark), gating `--background-service-*-on-{light,dark}` vs `--surface-service-*-inverse` at AA-large (3:1). The fill-on-inverse collision (dark mode: both sides resolve to `{hue}-darkest`) previously had no gate — only the inverse-card *text* pairing did.

## Why
In dark mode `--surface-service-{hue}-inverse`, `--background-service-{hue}-on-light`, and `--text-service-{hue}-on-light` all resolve to `--color-{hue}-darkest`, so a service-colored fill on an inverse card is invisible. Surfaced via the brikdesigns priceCard CTA (consumer fix: brikdesigns/brikdesigns#638).

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

Note: the `--border-secondary` darkening reaches **all** `theme-brand-brik` consumers (portal, renew-pms, brikdesigns) on their next BDS bump.

## Test plan
- [x] `npm run lint-tokens` passes
- [x] `npm run contrast-gate` passes — all 10 new fill pairings clear AA-large (dark back-office fill 9.06:1)
- [x] `canonical-check` clean
- [x] `tsc --noEmit` clean (pre-commit)
- [ ] Storybook: visual verification on affected stories (dark mode)

Closes #1026

Generated with [Claude Code](https://claude.com/claude-code)