### PR TITLE
fix(blueprints): rename Features3ColBrandedDark card-body container → __content (#1024)

### DIFF
--- a/content-system/blueprints/astro/Features3ColBrandedDark.astro
+++ b/content-system/blueprints/astro/Features3ColBrandedDark.astro
@@ -108,7 +108,7 @@ const titleId = `${section.sectionKey}-title`;
                 )}
               </div>
 
-              <div class="bp-features-branded-dark__description">
+              <div class="bp-features-branded-dark__content">
                 <h3 class="bp-features-branded-dark__title">{item.title}</h3>
                 {item.description && (
                   <p class="bp-features-branded-dark__description">{item.description}</p>
@@ -266,7 +266,7 @@ const titleId = `${section.sectionKey}-title`;
 
   /* ── Card body ──────────────────────────────────────────────── */
 
-  .bp-features-branded-dark__description {
+  .bp-features-branded-dark__content {
     padding: var(--padding-lg);
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- fix(blueprints): rename Features3ColBrandedDark card-body container → __content (#1024)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)

Part of #1024 — fixes the Astro renderer; React parity stays open on the issue (entangled with #742, see issue comment).