### PR TITLE
ci: create a GitHub Release on tag push (#919)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # create the GitHub Release on tag push
       packages: write
     steps:
       - name: Checkout code
@@ -101,3 +101,45 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           echo "npm install @brikdesigns/bds@${{ steps.version.outputs.pkg }}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      # Make the tag push also the *record* gesture: create a GitHub Release so
+      # the Releases page stays current without a manual "did we cut notes?"
+      # step. Runs after publish — a failure here never un-publishes the package.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG="v${{ steps.version.outputs.tag }}"
+          fi
+
+          # Idempotent: a re-run (workflow_dispatch, or a retried job) must not
+          # crash on an already-created Release.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping."
+            exit 0
+          fi
+
+          # Auto-generate notes from PRs/commits since the previous tag, then
+          # append the consumer-adopt install command (mirrors the job summary).
+          NOTES=$(gh api --method POST \
+            "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$TAG" --jq '.body' 2>/dev/null || true)
+          BODY=$(printf '%s\n\n## Install\n\n```\nnpm install @brikdesigns/bds@%s\n```\n' \
+            "$NOTES" "${{ steps.version.outputs.pkg }}")
+
+          # A semver prerelease tag (e.g. v1.0.0-rc.1) must not become "Latest".
+          if [[ "$TAG" == *-* ]]; then
+            LATEST_FLAGS=(--prerelease --latest=false)
+          else
+            LATEST_FLAGS=(--latest)
+          fi
+
+          gh release create "$TAG" \
+            --verify-tag \
+            "${LATEST_FLAGS[@]}" \
+            --title "$TAG" \
+            --notes "$BODY"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,6 +43,10 @@ fresh.
    - Validates that `package.json` version matches the tag.
    - Runs `lint-tokens --errors-only`, `lint-jsdoc`, `validate:blueprints`, `typecheck`.
    - Runs `npm publish` (which triggers `prepublishOnly` → `rm -rf dist && npm run build:lib`).
+   - Creates a [GitHub Release](https://github.com/brikdesigns/brik-bds/releases) for
+     the tag with auto-generated notes (PRs/commits since the previous tag) plus the
+     consumer install command. No manual note-cutting — the tag push is the record
+     gesture. Idempotent: re-runs skip an already-created Release.
 
 5. **Bump consumers.** Each consumer needs `npm install @brikdesigns/bds@0.46.0`
    in a follow-up PR. The release workflow's job summary surfaces the exact
@@ -68,3 +72,6 @@ publish — fix the underlying issue, push a new commit, re-tag.
   the maintainer assumed merging the PR also published.
 - **2026-04-28:** introduced this workflow (`task/infra-release-workflow`).
   The tag is now the explicit publish gesture — no-tag means no-publish.
+- **2026-06-29:** the workflow now also creates a GitHub Release on tag push
+  (#919). The Releases page had nothing newer than v0.68.1 while v0.97.x shipped
+  with only a git tag; the tag is now the record gesture too, not just publish.


### PR DESCRIPTION
## Summary
- ci: create a GitHub Release on tag push (#919)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)

Closes #919
