### PR TITLE
fix(blueprints): split Features3ColBrandedDark __content + tokenize aspect-ratio

### DIFF
--- a/content-system/blueprints/astro/Features3ColBrandedDark.astro
+++ b/content-system/blueprints/astro/Features3ColBrandedDark.astro
@@ -241,7 +241,7 @@ const titleId = `${section.sectionKey}-title`;
   /* ── Media (top illustration area) ──────────────────────────── */
 
   .bp-features-branded-dark__media {
-    aspect-ratio: 1 / 1;
+    aspect-ratio: var(--aspect-1-1);
     padding: var(--bp-features-branded-dark-image-pad, var(--padding-xl));
     display: flex;
     align-items: center;
@@ -258,7 +258,7 @@ const titleId = `${section.sectionKey}-title`;
 
   .bp-features-branded-dark__image-fallback {
     width: 60%;
-    aspect-ratio: 1;
+    aspect-ratio: var(--aspect-1-1);
     border-radius: 50%;
     background: var(--text-on-color-dark);
     opacity: 0.15;

--- a/content-system/blueprints/react/Features3ColBrandedDark.css
+++ b/content-system/blueprints/react/Features3ColBrandedDark.css
@@ -127,7 +127,7 @@
 /* ── Media (top illustration area) ─────────────────────────────── */
 
 .bp-features-branded-dark__media {
-  aspect-ratio: 1 / 1;
+  aspect-ratio: var(--aspect-1-1);
   padding: var(--bp-features-branded-dark-image-pad, var(--padding-xl));
   display: flex;
   align-items: center;
@@ -153,7 +153,7 @@
 
 .bp-features-branded-dark__image-fallback--blank {
   width: 60%;
-  aspect-ratio: 1;
+  aspect-ratio: var(--aspect-1-1);
   border-radius: 50%;
   background: var(--text-on-color-dark);
   opacity: 0.15;
@@ -162,7 +162,7 @@
 
 /* ── Card body ─────────────────────────────────────────────────── */
 
-.bp-features-branded-dark__description {
+.bp-features-branded-dark__content {
   padding: var(--padding-lg);
   display: flex;
   flex-direction: column;

--- a/content-system/blueprints/react/Features3ColBrandedDark.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.tsx
@@ -131,7 +131,7 @@ export function Features3ColBrandedDark({ section }: Props) {
                       )}
                     </div>
 
-                    <div className="bp-features-branded-dark__description">
+                    <div className="bp-features-branded-dark__content">
                       <h3 className="bp-features-branded-dark__title">
                         {item.title}
                       </h3>


### PR DESCRIPTION
## Summary

React parity for the `__description` class collision fixed on the Astro side in #1029.

- **#1024 (React) — fix:** the card-body container `<div>` and the description `<p>` both carried `bp-features-branded-dark__description`, so each element picked up the other's rule block — the `<p>` wrongly inheriting the container's `padding` + `flex`. Renamed the container `<div>` and its layout rule block to `__content`; the paragraph keeps canonical `__description`. (`react/Features3ColBrandedDark.{tsx,css}`)
- **#742 (Features3Col portion) — cleanup:** migrated this component's two hand-rolled aspect-ratio rules to `var(--aspect-1-1)` in both `react/.css` and `astro/.astro`. Required to clear the blueprint Boy-Scout naming gate once the file is staged.

## Scope / deferred

- **HeroSplit6040's `4 / 5` ratio** (the other half of #742) is **not** in this PR — it needs a token-family decision (extend `--aspect-*` with `--aspect-4-5` vs. keep inline). Tracked under #742.

## Test plan

- [x] `lint-blueprint-naming.mjs --files <staged>` clean (3 files, exit 0) — the original blocker
- [x] `npm run typecheck` passes
- [x] `npm run validate:blueprints` passes
- [ ] Storybook / Chromatic visual check on Features3ColBrandedDark
- [ ] `canonical-class-check` (needs `dist/styles.css` build — runs in CI; `__content` already accepted via #1029)

Closes #1024.
Advances #742 (Features3Col done; HeroSplit6040 `4/5` deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)