### PR TITLE
feat(tab-bar): add optional per-item indicator dot

### DIFF
--- a/components/ui/TabBar/TabBar.css
+++ b/components/ui/TabBar/TabBar.css
@@ -29,6 +29,16 @@
   pointer-events: none;
 }
 
+/* ── Indicator dot ──
+   Items carrying a `dot` lay out label + Dot inline. Scoped to dotted items
+   so the default (text-only) item layout is untouched. */
+
+.bds-tab-bar-item--has-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-sm);
+}
+
 /* ── Text variant ── */
 
 .bds-tab-bar--text .bds-tab-bar-item:hover:not(:disabled) {

--- a/components/ui/TabBar/TabBar.stories.tsx
+++ b/components/ui/TabBar/TabBar.stories.tsx
@@ -84,7 +84,7 @@ export const Playground: Story = {
     variant: 'tab',
     items: [
       { label: 'Overview', active: true, onClick: tabClickHandler },
-      { label: 'Billing', onClick: tabClickHandler },
+      { label: 'Billing', dot: true, onClick: tabClickHandler },
       { label: 'Security', onClick: tabClickHandler },
     ],
   },
@@ -156,6 +156,20 @@ export const Variants: Story = {
       }}>
         <SectionLabel>Tab — on color</SectionLabel>
         <InteractiveTabBar variant="tab" onColor />
+      </div>
+
+      {/* Indicator dot — attention cue on a tab */}
+      <div>
+        <SectionLabel>Indicator dot — "Billing" needs attention</SectionLabel>
+        <TabBar
+          variant="tab"
+          items={[
+            { label: 'Overview', active: true },
+            { label: 'Billing', dot: true },
+            { label: 'Reporting', dot: true },
+            { label: 'Security' },
+          ]}
+        />
       </div>
 
       {/* Disabled tabs */}

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -1,5 +1,6 @@
 import { type HTMLAttributes, type CSSProperties } from 'react';
 import { bdsClass } from '../../utils';
+import { Dot } from '../Dot';
 import './TabBar.css';
 
 /**
@@ -14,6 +15,12 @@ export interface TabItem {
   disabled?: boolean;
   /** Click handler */
   onClick?: () => void;
+  /**
+   * Show a small brand-color indicator dot after the label — a decorative
+   * attention cue (e.g. the tab's section needs action). Rendered
+   * `aria-hidden`, so the tab's accessible name stays the label alone.
+   */
+  dot?: boolean;
 }
 
 /** Visual variant matching Figma spec */
@@ -235,11 +242,12 @@ export function TabBar({
           role="tab"
           aria-selected={tab.active || false}
           disabled={tab.disabled || false}
-          className="bds-tab-bar-item"
+          className={bdsClass('bds-tab-bar-item', tab.dot && 'bds-tab-bar-item--has-dot')}
           style={getStyles(tab.active || false, onColor)}
           onClick={tab.onClick}
         >
           {tab.label}
+          {tab.dot && <Dot status="default" size="sm" aria-hidden="true" />}
         </button>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- feat(tab-bar): add optional per-item indicator dot

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)