### PR TITLE
chore(release): 0.110.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.109.0",
+  "version": "0.110.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.109.0",
+      "version": "0.110.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.109.0",
+  "version": "0.110.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Version bump to publish the TabBar per-item indicator dot (#1034) so the portal page-tab consolidation can consume it.

Tag `v0.110.0` will be pushed from main once this merges, triggering the Release workflow.

Consumer: brikdesigns/brik-client-portal#1571

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>