### PR TITLE
feat(tab-bar): allow TabItem.dot to take a DotStatus

### DIFF
--- a/components/ui/TabBar/TabBar.stories.tsx
+++ b/components/ui/TabBar/TabBar.stories.tsx
@@ -172,6 +172,20 @@ export const Variants: Story = {
         />
       </div>
 
+      {/* Status dot — color the cue by DotStatus */}
+      <div>
+        <SectionLabel>Status dot — "Feedback" has open items (warning)</SectionLabel>
+        <TabBar
+          variant="tab"
+          items={[
+            { label: 'Overview', active: true },
+            { label: 'Feedback', dot: 'warning' },
+            { label: 'Files', dot: 'positive' },
+            { label: 'Activity' },
+          ]}
+        />
+      </div>
+
       {/* Disabled tabs */}
       <div>
         <SectionLabel>Disabled — "Marketing" and "Other"</SectionLabel>

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -1,6 +1,6 @@
 import { type HTMLAttributes, type CSSProperties } from 'react';
 import { bdsClass } from '../../utils';
-import { Dot } from '../Dot';
+import { Dot, type DotStatus } from '../Dot';
 import './TabBar.css';
 
 /**
@@ -16,11 +16,14 @@ export interface TabItem {
   /** Click handler */
   onClick?: () => void;
   /**
-   * Show a small brand-color indicator dot after the label — a decorative
-   * attention cue (e.g. the tab's section needs action). Rendered
-   * `aria-hidden`, so the tab's accessible name stays the label alone.
+   * Show a small indicator dot after the label — a decorative attention cue
+   * (e.g. the tab's section needs action). Rendered `aria-hidden`, so the
+   * tab's accessible name stays the label alone.
+   *
+   * `true` renders the brand-default dot; pass a {@link DotStatus}
+   * (`'warning'`, `'positive'`, `'error'`, …) to color the cue by status.
    */
-  dot?: boolean;
+  dot?: boolean | DotStatus;
 }
 
 /** Visual variant matching Figma spec */
@@ -247,7 +250,9 @@ export function TabBar({
           onClick={tab.onClick}
         >
           {tab.label}
-          {tab.dot && <Dot status="default" size="sm" aria-hidden="true" />}
+          {tab.dot && (
+            <Dot status={tab.dot === true ? 'default' : tab.dot} size="sm" aria-hidden="true" />
+          )}
         </button>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- feat(tab-bar): allow TabItem.dot to take a DotStatus

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)