### PR TITLE
refactor(blueprints): HeroSplitImageCardOverlay → FrameRatio slug API

### DIFF
--- a/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
+++ b/content-system/blueprints/astro/HeroSplitImageCardOverlay.astro
@@ -52,15 +52,38 @@
  */
 import type { BlueprintProps } from './types';
 
-type FrameRatio = 'square' | 'portrait' | 'landscape' | 'wide' | 'ultrawide';
+/**
+ * Aspect-ratio slug — mirrors the BDS `FrameRatio` vocabulary backed by the
+ * `--aspect-*` token family (#486). Defined locally rather than imported from
+ * the Frame component so this shipped blueprint stays self-contained for
+ * consumer Astro builds.
+ */
+type FrameRatio =
+  // Primitives
+  | '1-1' | '3-2' | '2-3' | '4-3' | '3-4' | '4-5' | '16-9' | '9-16' | '21-9'
+  // Semantic aliases
+  | 'square' | 'photo-landscape' | 'photo-portrait' | 'cinema'
+  // Deprecated mode-words (resolved via DEPRECATED_RATIO_ALIAS for one minor version)
+  /** @deprecated Use `3-4`. */ | 'portrait'
+  /** @deprecated Use `4-3`. */ | 'landscape'
+  /** @deprecated Use `16-9` or `cinema`. */ | 'wide'
+  /** @deprecated Use `21-9`. */ | 'ultrawide';
 
-const RATIO_ASPECT: Record<FrameRatio, string> = {
-  square: '1 / 1',
-  portrait: '3 / 4',
-  landscape: '4 / 3',
-  wide: '16 / 9',
-  ultrawide: '21 / 9',
+/**
+ * Deprecated mode-words → canonical aspect primitive. Canonical slugs
+ * (primitives + semantic aliases) resolve to `--aspect-{slug}` directly and
+ * need no entry here. Delete this map when the mode-words are removed.
+ */
+const DEPRECATED_RATIO_ALIAS: Partial<Record<FrameRatio, string>> = {
+  portrait: '3-4',
+  landscape: '4-3',
+  wide: '16-9',
+  ultrawide: '21-9',
 };
+
+/** Resolves a FrameRatio slug to its `--aspect-*` token reference. */
+const aspectToken = (ratio: FrameRatio): string =>
+  `var(--aspect-${DEPRECATED_RATIO_ALIAS[ratio] ?? ratio})`;
 
 interface Props extends BlueprintProps {
   imageRatio?: FrameRatio;
@@ -158,7 +181,7 @@ const cta = section.cta;
       <aside class="bp-hero-img-card__media-card">
         <div
           class="bp-hero-img-card__image-frame"
-          style={imageRatio !== 'square' ? `--_bp-image-ratio: ${RATIO_ASPECT[imageRatio]}` : undefined}
+          style={imageRatio !== 'square' ? `--_bp-image-ratio: ${aspectToken(imageRatio)}` : undefined}
         >
           <img
             src={priceCard.imageUrl}
@@ -189,7 +212,7 @@ const cta = section.cta;
         class="bp-hero-img-card__missing"
         data-content-needed="hero_image_url"
         role="presentation"
-        style={imageRatio !== 'square' ? `--_bp-image-ratio: ${RATIO_ASPECT[imageRatio]}` : undefined}
+        style={imageRatio !== 'square' ? `--_bp-image-ratio: ${aspectToken(imageRatio)}` : undefined}
       >
         <p class="bp-hero-img-card__missing-label">
           Hero image card missing for this page.
@@ -409,7 +432,7 @@ const cta = section.cta;
   }
 
   .bp-hero-img-card__image-frame {
-    aspect-ratio: var(--_bp-image-ratio, 1 / 1);
+    aspect-ratio: var(--_bp-image-ratio, var(--aspect-1-1));
     overflow: hidden;
     border-radius: var(--border-radius-md);
     background: var(--surface-secondary);
@@ -448,7 +471,7 @@ const cta = section.cta;
   }
 
   .bp-hero-img-card__missing {
-    aspect-ratio: var(--_bp-image-ratio, 1 / 1);
+    aspect-ratio: var(--_bp-image-ratio, var(--aspect-1-1));
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary

Migrates the `HeroSplitImageCardOverlay` **Astro** blueprint off its runtime `RATIO_ASPECT[imageRatio]` CSS-value lookup to token resolution via `var(--aspect-{slug})` — the long-term shape per #486 / #734. The React sibling already consumes the `FrameRatio` slug API; this brings the Astro side in line.

## Changes
- Remove the `RATIO_ASPECT` table
- Expand the local `imageRatio` union from 5 mode-words to the full canonical `FrameRatio` slug vocabulary (primitives + semantic aliases + the 4 mode-words kept as `@deprecated`)
- `aspectToken()` resolves any slug → `var(--aspect-*)`; `DEPRECATED_RATIO_ALIAS` maps the 4 deprecated mode-words → canonical primitive (one minor version)
- Tokenize the `--_bp-image-ratio` CSS fallback: `1 / 1` → `var(--aspect-1-1)`

## Why local type (not import)
The shipped `.astro` blueprint deliberately keeps `FrameRatio` local rather than importing from `components/ui/Frame` — importing a component path into a shipped blueprint risks resolution failures in consumer Astro builds. Comment in-file notes it mirrors the canonical vocabulary.

## No value drift (pure refactor)
`portrait`→3/4, `landscape`→4/3, `wide`→16/9, `ultrawide`→21/9, `square`→1/1 — all computed ratios unchanged. The slug vocabulary is purely additive.

## Test plan
- [x] `RATIO_ASPECT` removed; no stale refs
- [x] `validate:blueprints` ✓
- [x] blueprint-naming lint clean on the staged file
- [x] `typecheck` ✓

Closes #741

Generated with [Claude Code](https://claude.ai/code)