### PR TITLE
chore(release): 0.113.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.112.0",
+  "version": "0.113.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.112.0",
+      "version": "0.113.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.112.0",
+  "version": "0.113.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Lands the `0.113.0` version bump that was **dropped by #1045's squash-merge**.

The bump commit was pushed to #1045's branch, but GitHub's PR head pointer lagged the push (eventual-consistency), so the squash captured the pre-bump tree (`feac94c`) — `main` stayed at **0.112.0**. Without this, a `v0.113.0` tag fails the Release workflow's version-match guard (docs/RELEASE.md).

- `package.json` + `package-lock.json`: 0.112.0 → **0.113.0**
- Minor (not major) per practice — ADR-011's breaking token rename also shipped as a 0.x minor; the package stays in 0.x. (RELEASE.md's literal "→1.0.0" wording is doc-vs-practice drift, tracked for a separate one-line fix.)

Follows #1045 (Tier 4 `--bds-*` hook convention, breaking `--bp-*`/#41 rename) / closed #1043.

**After merge:** `git tag v0.113.0 && git push origin v0.113.0` → publish + GitHub Release, then bump consumers to `@brikdesigns/bds@0.113.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
