### PR TITLE
fix(devbar): repoint brikdesigns widget sync to brik/ repo path

### DIFF
--- a/scripts/sync-devbar-widgets.sh
+++ b/scripts/sync-devbar-widgets.sh
@@ -73,10 +73,13 @@ sync_one "$WIDGETS/inspect-widget.js" "$RENEW_PUBLIC/brik-inspect.js"       "ren
 sync_one "$WIDGETS/events-widget.js"  "$RENEW_PUBLIC/brik-events-widget.js" "renew-pms public/ brik-events-widget.js"
 
 # brikdesigns public/ (browser-served, staging dev-tools)
-BRIKDESIGNS_PUBLIC="$GH_ROOT/web/brikdesigns/public"
+# brikdesigns is Brik's own Next.js marketing-site repo under brik/, NOT web/
+# (web/brikdesigns was a stale build husk — no repo, no public/). #1047
+# No feedback-widget.js here: brikdesigns DevTools uses the React
+# DevFeedbackWidget from BDS, not the vanilla widget (brikdesigns#479 / #644).
+BRIKDESIGNS_PUBLIC="$GH_ROOT/brik/brikdesigns/public"
 sync_one "$WIDGETS/devbar.js"          "$BRIKDESIGNS_PUBLIC/brik-devbar.js"           "brikdesigns public/ brik-devbar.js"
 sync_one "$WIDGETS/inspect-widget.js"  "$BRIKDESIGNS_PUBLIC/brik-inspect.js"          "brikdesigns public/ brik-inspect.js"
-sync_one "$WIDGETS/feedback-widget.js" "$BRIKDESIGNS_PUBLIC/brik-feedback-widget.js"  "brikdesigns public/ brik-feedback-widget.js"
 
 # BDS Storybook preview iframe — write to the *current* checkout (worktree or
 # primary) so commits from a task worktree capture these files. Previously this


### PR DESCRIPTION
## Summary
- fix(devbar): repoint brikdesigns widget sync to brik/ repo path

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)

Closes #1047
