### PR TITLE
fix(devbar): skip cascade-reset keywords in inspector value read

### DIFF
--- a/.storybook/public/brik-inspect.js
+++ b/.storybook/public/brik-inspect.js
@@ -830,6 +830,9 @@
   if (typeof window !== 'undefined') {
     window.BrikInspect = window.BrikInspect || {};
     window.BrikInspect.detectContext = detectReportContext;
+    // Exposed for regression tests (cascade-keyword skip — #1615). Not part of
+    // the public surface; consumers use detectContext / the report event.
+    window.BrikInspect.getDeclaredValue = getDeclaredValue;
   }
 
   // ── Stylesheet rule index ───────────────────────────────────────────────
@@ -879,6 +882,14 @@
       if (!matches) continue;
       const val = rule.style.getPropertyValue(prop);
       if (!val) continue;
+      // `revert` / `revert-layer` are cascade-control keywords, not design
+      // decisions — they explicitly defer to a lower layer/origin. Consumers
+      // that bridge Tailwind preflight back to BDS layers (the portal's
+      // `[class*="bds-"] { all: revert-layer }`) otherwise mask every real
+      // token, surfacing a wall of "revert-layer" in the panel. Skip them so
+      // the underlying token rule wins. See brik-client-portal#1615.
+      const trimmed = val.trim();
+      if (trimmed === 'revert' || trimmed === 'revert-layer') continue;
       if (!best || rule.specificity >= best.specificity) {
         best = { value: val, origin: rule.selector, specificity: rule.specificity };
       }

--- a/components/ui/BrikDevBar/widgets/inspect-widget.js
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.js
@@ -830,6 +830,9 @@
   if (typeof window !== 'undefined') {
     window.BrikInspect = window.BrikInspect || {};
     window.BrikInspect.detectContext = detectReportContext;
+    // Exposed for regression tests (cascade-keyword skip — #1615). Not part of
+    // the public surface; consumers use detectContext / the report event.
+    window.BrikInspect.getDeclaredValue = getDeclaredValue;
   }
 
   // ── Stylesheet rule index ───────────────────────────────────────────────
@@ -879,6 +882,14 @@
       if (!matches) continue;
       const val = rule.style.getPropertyValue(prop);
       if (!val) continue;
+      // `revert` / `revert-layer` are cascade-control keywords, not design
+      // decisions — they explicitly defer to a lower layer/origin. Consumers
+      // that bridge Tailwind preflight back to BDS layers (the portal's
+      // `[class*="bds-"] { all: revert-layer }`) otherwise mask every real
+      // token, surfacing a wall of "revert-layer" in the panel. Skip them so
+      // the underlying token rule wins. See brik-client-portal#1615.
+      const trimmed = val.trim();
+      if (trimmed === 'revert' || trimmed === 'revert-layer') continue;
       if (!best || rule.specificity >= best.specificity) {
         best = { value: val, origin: rule.selector, specificity: rule.specificity };
       }

--- a/components/ui/BrikDevBar/widgets/inspect-widget.revert-layer.browser.test.ts
+++ b/components/ui/BrikDevBar/widgets/inspect-widget.revert-layer.browser.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression test for the cascade-keyword skip in getDeclaredValue
+ * (brik-client-portal#1615).
+ *
+ * The inspector reads the *declared* (specified) value off the highest-specificity
+ * matched rule. Consumers that bridge Tailwind preflight back to BDS cascade layers
+ * declare `[class*="bds-"] { all: revert-layer }`, which surfaces `revert-layer` for
+ * every property and masks the real token in the panel. `revert` / `revert-layer`
+ * are cascade-control keywords (they defer to a lower layer/origin), not design
+ * decisions, so getDeclaredValue must skip them and fall through to the token rule.
+ *
+ * Runs under the `widgets` browser vitest project (real chromium DOM) — `revert-layer`
+ * has no meaning in jsdom.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+// Raw source so we can execute the IIFE in the page's global scope.
+import widgetSource from './inspect-widget.js?raw';
+
+let getDeclaredValue: (el: Element, prop: string) => { value: string; origin: string } | null;
+
+beforeAll(() => {
+  // The widget self-disables unless ?inspect=1 / data-auto-enable is present.
+  history.replaceState(null, '', `${location.pathname}?inspect=1`);
+  // eslint-disable-next-line no-eval
+  (0, eval)(widgetSource);
+  const api = (window as unknown as {
+    BrikInspect?: { getDeclaredValue?: typeof getDeclaredValue };
+  }).BrikInspect;
+  if (!api?.getDeclaredValue) throw new Error('widget did not expose BrikInspect.getDeclaredValue');
+  getDeclaredValue = api.getDeclaredValue;
+
+  // Inject the fixture stylesheet once, before any getDeclaredValue call —
+  // buildRulesIndex caches on first invocation. The revert rule is authored
+  // LAST so that, absent the skip, it would win the >= specificity tie (both
+  // selectors score one class/attribute = 100) and mask the token.
+  const style = document.createElement('style');
+  style.textContent = `
+    .token-rule { color: var(--text-primary); }
+    [class*="bds-"] { color: revert-layer; }
+    .only-revert { background-color: revert-layer; }
+  `;
+  document.head.appendChild(style);
+});
+
+describe('inspect widget — cascade-keyword skip (#1615)', () => {
+  it('returns the real token, not the revert-layer reset rule', () => {
+    document.body.innerHTML = `<div id="t" class="bds-x token-rule">x</div>`;
+    const declared = getDeclaredValue(document.getElementById('t')!, 'color');
+    expect(declared?.value.trim()).toBe('var(--text-primary)');
+  });
+
+  it('returns null when the only matching rule is a cascade reset', () => {
+    document.body.innerHTML = `<div id="t2" class="bds-z only-revert">y</div>`;
+    expect(getDeclaredValue(document.getElementById('t2')!, 'background-color')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- fix(devbar): skip cascade-reset keywords in inspector value read

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)