### PR TITLE
Enlarge ServiceTag icons + trim lg icon-text padding

### DIFF
--- a/components/ui/ServiceTag/ServiceTag.css
+++ b/components/ui/ServiceTag/ServiceTag.css
@@ -38,6 +38,14 @@
   font-size: var(--label-md);
 }
 
+/* lg is the only size with extra inline padding (--padding-md vs --padding-sm).
+   With an icon present that reads as too much lead-in space before the glyph,
+   so icon-text lg drops back to the sm/md inline padding. Two-class selector
+   outranks the single-class --lg rule, so order is irrelevant. */
+.bds-service-tag--lg.bds-service-tag--has-icon {
+  padding-inline: var(--padding-sm);
+}
+
 /* ─── Category colors ────────────────────────────────────────── */
 
 .bds-service-tag--brand       { background-color: var(--background-service-brand);       color: var(--text-service-brand-on-light); }

--- a/components/ui/ServiceTag/ServiceTag.tsx
+++ b/components/ui/ServiceTag/ServiceTag.tsx
@@ -31,11 +31,13 @@ export interface ServiceTagProps extends Omit<HTMLAttributes<HTMLSpanElement>, '
 // bds-lint-ignore — component-level icon px sizes. Code/Storybook is the source
 // of truth for components; Figma is a visual reference only (and uses Font
 // Awesome glyphs, not our Iconify set), so these are not Figma-driven.
-// sm bumped 12→16: the 12px glyph read as teensy in icon-text pills.
-const tagIconSizeMap: Record<ServiceTagSize, number> = { sm: 16, md: 16, lg: 20 };
+// Glyphs are filled 20×20 SVGs with ~30% built-in inset, so the visible mark is
+// only ~70% of the box — sizes are set generously vs tag height (28/32/40) to
+// read clearly at small scale. sm==md previously, so md never looked larger.
+const tagIconSizeMap: Record<ServiceTagSize, number> = { sm: 18, md: 22, lg: 24 };
 
 // bds-lint-ignore — component-level badge dimensions (code is SoT; see above).
-const iconScaleMap: Record<ServiceTagSize, number> = { sm: 0.55, md: 0.6, lg: 0.6 };
+const iconScaleMap: Record<ServiceTagSize, number> = { sm: 0.65, md: 0.7, lg: 0.7 };
 const boxSizeMap: Record<ServiceTagSize, number> = { sm: 20, md: 28, lg: 40 };
 
 /**


### PR DESCRIPTION
## Summary
- `icon-text` glyph boxes bumped `16/16/20` → **`18/22/24`** (sm/md/lg). sm and md previously shared 16px, so md never looked larger.
- `icon`-only badge glyph scale bumped `0.55/0.6/0.6` → **`0.65/0.7/0.7`**. Filled 20×20 glyphs carry ~30% built-in inset, so the visible mark was only ~70% of the box — small tags read tiny.
- `lg` `icon-text` inline padding dropped `--padding-md` (10px) → **`--padding-sm`** (8px), scoped to `.bds-service-tag--lg.bds-service-tag--has-icon`. Text-only `lg` pills are untouched.

Addresses small-scale icon legibility in `sm`/`md` service tags and the over-indented glyph in `lg` icon+text tags. Ships to the website + client portal via the next `@brikdesigns/bds` publish.

### Note on "thicker stroke"
The original request asked for a thicker icon *stroke*. All 45 service glyphs are **filled** SVGs (`fill="currentColor"`), not stroked — there is no `stroke-width` to thicken, and filled is already the heaviest icon form. Size is the legibility lever, which is what this PR changes. A genuinely heavier drawing would require re-exporting all 45 assets at a bolder weight (separate cross-repo task).

## Test plan
- [x] `npm run lint-tokens --errors-only` passes (no token violations)
- [x] Change is type-safe (numeric literals in a typed `Record<ServiceTagSize, number>` + one CSS rule)
- [ ] **⚠️ Chromatic / Storybook visual verification PENDING** — `op run` (1Password CLI) couldn't authenticate in the headless session that opened this PR, so `npm run chromatic` did not run. Run it interactively before merge.
- [ ] Dark mode spot-check (icons use `currentColor`, so no token change — low risk)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] brikdesigns: `./scripts/bds-sync.sh`

Branch is behind `main` (~15 commits); GitHub merge / CI will reconcile.

Generated with [Claude Code](https://claude.ai/code)