### PR TITLE
feat(components): Image — SEO/CLS-aware img wrapper (#967)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -340,7 +340,7 @@ const preview: Preview = {
           ],
           // 6-bucket flat taxonomy per ADR-006 Part A (2026-05-16) + #629
           'Components',
-          ['address-input', 'avatar', 'badge', 'badge-group', 'banner', 'button', 'button-group', 'checkbox', 'chip', 'completion-toggle', 'counter', 'divider', 'dot', 'empty-state', 'file-card', 'file-uploader', 'filter-bar', 'filter-button', 'filter-toggle', 'icons', 'marketing-illustration', 'meter', 'modal', 'multi-select', 'pagination', 'password-input', 'popover', 'progress-bar', 'progress-circle', 'radio', 'segmented-control', 'select', 'service-tag', 'skeleton', 'slider', 'spinner', 'stepper', 'switch', 'tag', 'tag-group', 'text-area', 'text-input', 'text-link', 'toast', 'tooltip', '*'],
+          ['address-input', 'avatar', 'badge', 'badge-group', 'banner', 'button', 'button-group', 'checkbox', 'chip', 'completion-toggle', 'counter', 'divider', 'dot', 'empty-state', 'file-card', 'file-uploader', 'filter-bar', 'filter-button', 'filter-toggle', 'icons', 'image', 'marketing-illustration', 'meter', 'modal', 'multi-select', 'pagination', 'password-input', 'popover', 'progress-bar', 'progress-circle', 'radio', 'segmented-control', 'select', 'service-tag', 'skeleton', 'slider', 'spinner', 'stepper', 'switch', 'tag', 'tag-group', 'text-area', 'text-input', 'text-link', 'toast', 'tooltip', '*'],
           'Containers',
           [
             'accordion',

--- a/components/ui/Image/Image.css
+++ b/components/ui/Image/Image.css
@@ -1,0 +1,24 @@
+@layer bds-components {
+/* ─── Image — SEO- and CLS-aware media wrapper ───────────────── */
+
+.bds-image {
+  display: block;
+  margin: 0; /* reset the default UA <figure> margin */
+}
+
+/* Bare image (no ratio) — responsive natural shape. When a ratio is set the
+   image is a Frame child and Frame's `--fit-* > img` rules take over
+   (higher specificity), sizing it to fill the locked aspect box. */
+.bds-image__image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.bds-image__caption {
+  margin-top: var(--gap-sm);
+  font-family: var(--font-family-label);
+  font-size: var(--body-sm);
+  color: var(--text-secondary);
+}
+}

--- a/components/ui/Image/Image.mdx
+++ b/components/ui/Image/Image.mdx
@@ -1,0 +1,43 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './Image.stories';
+
+<Meta of={Stories} />
+
+# Image
+
+<ComponentLinks slug="image" />
+
+SEO- and CLS-aware `<img>` wrapper. Renders a semantic `<figure>` + `<img>` (+ optional `<figcaption>`), lazy loads and async-decodes by default, and locks the shape to the `--aspect-*` token family when `ratio` is set.
+
+## Default
+
+<Canvas of={Stories.Default} />
+
+## Variants
+
+The semantic axes Image varies on are `ratio` (shape) and `fit` (fill behavior); `eager` and `caption` are Controls on every story.
+
+### Ratios
+
+<Canvas of={Stories.Ratios} />
+
+### Fit modes
+
+<Canvas of={Stories.FitModes} />
+
+### With caption
+
+<Canvas of={Stories.WithCaption} />
+
+### Eager (LCP)
+
+<Canvas of={Stories.Eager} />
+
+## Props
+
+<ArgTypes of={Stories} />
+
+## Notes
+
+> **Note** — `alt` is required; pass `alt=""` for decorative images. Supply `ratio` (or `width` + `height`) to reserve layout space and prevent CLS. This component does not resize or reformat images — pair it with `next/image` / `@astrojs/image` or a CDN. Full SEO guidance lives on the [docs-site page](https://design.brikdesigns.com/docs/components/image).

--- a/components/ui/Image/Image.stories.tsx
+++ b/components/ui/Image/Image.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Image } from './Image';
+
+/* ─── Story-only placeholders (data URI, no network) ─── */
+
+const landscape =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450"><rect width="800" height="450" fill="#e4b596"/><text x="400" y="235" text-anchor="middle" font-family="sans-serif" font-size="32" fill="#5a3a28">800 × 450</text></svg>',
+  );
+
+const portrait =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 450 800"><rect width="450" height="800" fill="#a8c8b8"/><text x="225" y="410" text-anchor="middle" font-family="sans-serif" font-size="32" fill="#2e4d3f">450 × 800</text></svg>',
+  );
+
+const meta: Meta<typeof Image> = {
+  title: 'Components/image',
+  component: Image,
+  tags: ['surface-shared'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'SEO- and CLS-aware `<img>` wrapper. Renders a semantic `<figure>` + `<img>` (+ optional `<figcaption>`); lazy loads and async-decodes by default. Set `ratio` to lock the shape to the `--aspect-*` token family (reserves layout space before load); set `eager` for the above-the-fold LCP image.',
+      },
+    },
+  },
+  argTypes: {
+    src: { control: 'text' },
+    alt: { control: 'text' },
+    ratio: {
+      control: 'select',
+      options: ['1-1', '3-2', '4-3', '3-4', '4-5', '16-9', '9-16', '21-9'],
+    },
+    fit: { control: 'select', options: ['cover', 'contain', 'fill', 'none'] },
+    position: { control: 'text' },
+    eager: { control: 'boolean' },
+    caption: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Image>;
+
+/** @summary Interactive playground */
+export const Default: Story = {
+  args: {
+    src: landscape,
+    alt: 'Team collaborating at a whiteboard',
+    ratio: '16-9',
+    fit: 'cover',
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 520 }}>
+      <Image {...args} />
+    </div>
+  ),
+};
+
+/** @summary Aspect-ratio slugs from the --aspect-* family */
+export const Ratios: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--gap-lg)' }}>
+      {(['1-1', '3-2', '4-3', '3-4', '16-9', '9-16'] as const).map((r) => (
+        <div key={r}>
+          <p
+            style={{
+              margin: '0 0 var(--gap-sm)',
+              fontFamily: 'var(--font-family-label)',
+              fontSize: 'var(--label-sm)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            ratio=&quot;{r}&quot;
+          </p>
+          <Image src={landscape} alt="" ratio={r} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** @summary object-fit modes inside a fixed ratio */
+export const FitModes: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 'var(--gap-lg)' }}>
+      {(['cover', 'contain', 'fill'] as const).map((f) => (
+        <div key={f}>
+          <p
+            style={{
+              margin: '0 0 var(--gap-sm)',
+              fontFamily: 'var(--font-family-label)',
+              fontSize: 'var(--label-sm)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            fit=&quot;{f}&quot;
+          </p>
+          {/* Portrait source in a square frame — the difference is visible */}
+          <Image src={portrait} alt="" ratio="1-1" fit={f} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** @summary Figure with a figcaption */
+export const WithCaption: Story = {
+  args: {
+    src: portrait,
+    alt: 'Dr. Alice Chen in the clinic',
+    ratio: '3-4',
+    caption: 'Dr. Alice Chen, Lead Orthodontist',
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 320 }}>
+      <Image {...args} />
+    </div>
+  ),
+};
+
+/** @summary Eager-loaded LCP hero (fetchpriority high) */
+export const Eager: Story = {
+  args: {
+    src: landscape,
+    alt: 'Above-the-fold hero image',
+    ratio: '21-9',
+    eager: true,
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 640 }}>
+      <Image {...args} />
+    </div>
+  ),
+};

--- a/components/ui/Image/Image.tsx
+++ b/components/ui/Image/Image.tsx
@@ -1,0 +1,123 @@
+import { type HTMLAttributes, type ReactNode } from 'react';
+import { bdsClass } from '../../utils';
+import { Frame, type FrameRatio, type FrameFit } from '../Frame';
+import './Image.css';
+
+export interface ImageProps extends HTMLAttributes<HTMLElement> {
+  /** Image URL. */
+  src: string;
+  /**
+   * Accessible alt text. Required — pass `alt=""` explicitly for purely
+   * decorative images so screen readers skip them.
+   */
+  alt: string;
+  /**
+   * Named aspect-ratio slug. When set, the image is wrapped in a `<Frame>`
+   * that locks the shape (via the `--aspect-*` token family) and reserves
+   * layout space before the image loads — the primary CLS-prevention lever.
+   * Omit for images that should render at their natural ratio.
+   */
+  ratio?: FrameRatio;
+  /**
+   * How the image fills its frame. Only meaningful together with `ratio`.
+   * Default `cover`. Passed through to the wrapping `<Frame>`.
+   */
+  fit?: FrameFit;
+  /**
+   * `object-position` for the image inside its frame (e.g. `"top"`,
+   * `"50% 25%"`). Only meaningful together with `ratio` + a cropping `fit`.
+   */
+  position?: string;
+  /**
+   * Load eagerly and hint high fetch priority. Use for the LCP image
+   * (above-the-fold hero) only — defeats the default lazy loading.
+   */
+  eager?: boolean;
+  /** Responsive `srcset` — pass-through to the `<img>`. */
+  srcSet?: string;
+  /** Responsive `sizes` — pass-through to the `<img>`. */
+  sizes?: string;
+  /**
+   * Intrinsic pixel `width`. Supply with `height` to prevent layout shift
+   * even when `ratio` is omitted.
+   */
+  width?: number | string;
+  /** Intrinsic pixel `height`. See `width`. */
+  height?: number | string;
+  /** Optional caption; renders as a `<figcaption>` below the image. */
+  caption?: ReactNode;
+}
+
+/**
+ * Image — SEO- and CLS-aware `<img>` wrapper.
+ *
+ * Renders a semantic `<figure>` + `<img>` (+ optional `<figcaption>`). Lazy
+ * loads and async-decodes by default; set `eager` for the LCP image. When
+ * `ratio` is set the image is wrapped in a `<Frame>` so the shape is locked
+ * to the `--aspect-*` token family and layout space is reserved before load.
+ *
+ * Not an image-optimization layer — pair with `next/image` / `@astrojs/image`
+ * or a CDN at the consumer level for resizing and format negotiation. This
+ * component owns the design-system constraints: shape, fit, and semantics.
+ *
+ * @example
+ * ```tsx
+ * <Image src="/hero.jpg" alt="Team at work" ratio="16-9" eager />
+ *
+ * <Image
+ *   src="/portrait.jpg"
+ *   alt="Dr. Alice Chen"
+ *   ratio="3-4"
+ *   caption="Dr. Alice Chen, Lead Orthodontist"
+ * />
+ * ```
+ *
+ * @summary SEO- and CLS-aware img wrapper with ratio + caption
+ */
+export function Image({
+  src,
+  alt,
+  ratio,
+  fit = 'cover',
+  position,
+  eager = false,
+  srcSet,
+  sizes,
+  width,
+  height,
+  caption,
+  className,
+  style,
+  ...props
+}: ImageProps) {
+  const img = (
+    <img
+      className="bds-image__image"
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      srcSet={srcSet}
+      sizes={sizes}
+      loading={eager ? 'eager' : 'lazy'}
+      decoding="async"
+      fetchPriority={eager ? 'high' : undefined}
+      style={position ? { objectPosition: position } : undefined}
+    />
+  );
+
+  return (
+    <figure className={bdsClass('bds-image', className)} style={style} {...props}>
+      {ratio ? (
+        <Frame className="bds-image__media" ratio={ratio} fit={fit}>
+          {img}
+        </Frame>
+      ) : (
+        img
+      )}
+      {caption != null && <figcaption className="bds-image__caption">{caption}</figcaption>}
+    </figure>
+  );
+}
+
+export default Image;

--- a/components/ui/Image/index.ts
+++ b/components/ui/Image/index.ts
@@ -1,0 +1,2 @@
+export { Image, type ImageProps } from './Image';
+export { default } from './Image';

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -56,6 +56,7 @@ export * from './Form';
 export * from './Grid';
 export * from './Icon';
 export * from './Icons';
+export * from './Image';
 export * from './InteractiveListItem';
 export * from './MarketingIllustration';
 export * from './Menu';

--- a/docs-site/content/docs/components/image.mdx
+++ b/docs-site/content/docs/components/image.mdx
@@ -1,0 +1,130 @@
+---
+title: Image
+description: SEO- and CLS-aware img wrapper with aspect-ratio enforcement, lazy loading, and responsive srcset.
+---
+
+Image renders a semantic `<figure>` + `<img>` (+ optional `<figcaption>`). It lazy loads and async-decodes by default, locks the shape to the `--aspect-*` token family when `ratio` is set, and passes `srcset` / `sizes` through for responsive breakpoints.
+
+It owns the design-system constraints — shape, fit, and semantics. It is **not** an image-optimization layer: pair it with `next/image`, `@astrojs/image`, or a CDN for resizing and format negotiation.
+
+## Use it for
+
+- Content and editorial images that must hold a fixed shape ([Frame](/docs/components/frame) is the bare aspect-ratio box; Image adds SEO + `<figure>` semantics)
+- Above-the-fold hero images that need eager, high-priority loading
+- Captioned figures (`<figcaption>`)
+- Responsive images with `srcset` / `sizes`
+
+For avatars use [Avatar](/docs/components/avatar); for illustration scenes use [Marketing Illustration](/docs/components/marketing-illustration); for a raw aspect box with no `<img>` semantics use [Frame](/docs/components/frame).
+
+## Import
+
+```tsx
+import { Image } from '@brikdesigns/bds';
+```
+
+## Variants
+
+### Aspect ratio
+
+`ratio` maps to a slug in the `--aspect-*` token family and wraps the image in a [Frame](/docs/components/frame). The frame reserves layout space before the image loads — the primary defense against cumulative layout shift (CLS).
+
+```tsx
+<Image src="/hero.jpg" alt="Team at work" ratio="16-9" />
+<Image src="/portrait.jpg" alt="Dr. Alice Chen" ratio="3-4" />
+```
+
+Omit `ratio` to render at the image's natural shape. See [Frame](/docs/components/frame) for the full slug vocabulary (`1-1`, `3-2`, `4-3`, `16-9`, `square`, `cinema`, …).
+
+### Fit
+
+When a `ratio` is set, `fit` controls how the image fills the frame (`object-fit`). `position` sets `object-position` for cropped fits.
+
+```tsx
+<Image src="/wide.jpg" alt="" ratio="1-1" fit="cover" position="top" />
+```
+
+| `fit` | Behavior |
+|---|---|
+| `cover` (default) | Fills the frame, cropping overflow |
+| `contain` | Fits inside the frame, letterboxing |
+| `fill` | Stretches to the frame, ignoring the source ratio |
+| `none` | No resizing |
+
+### Caption
+
+`caption` renders a `<figcaption>` below the image, inside the same `<figure>`.
+
+```tsx
+<Image
+  src="/portrait.jpg"
+  alt="Dr. Alice Chen"
+  ratio="3-4"
+  caption="Dr. Alice Chen, Lead Orthodontist"
+/>
+```
+
+### Eager (LCP)
+
+By default Image is `loading="lazy"` + `decoding="async"`. For the above-the-fold [Largest Contentful Paint](https://web.dev/articles/lcp) image, set `eager` — it switches to `loading="eager"` and hints `fetchpriority="high"`. Use it for one image per page at most.
+
+```tsx
+<Image src="/hero.jpg" alt="Homepage hero" ratio="21-9" eager />
+```
+
+## Responsive images
+
+`srcSet` and `sizes` pass through to the underlying `<img>`. Supply a `ratio` (or explicit `width` + `height`) so the browser reserves space regardless of which candidate it picks.
+
+```tsx
+<Image
+  src="/photo-800.jpg"
+  srcSet="/photo-400.jpg 400w, /photo-800.jpg 800w, /photo-1200.jpg 1200w"
+  sizes="(max-width: 600px) 100vw, 600px"
+  alt="Product photo"
+  ratio="3-2"
+/>
+```
+
+For automatic candidate generation and format negotiation (WebP/AVIF), let `next/image` or `@astrojs/image` emit the `<img>` and wrap layout concerns with Image's `ratio` at the [Frame](/docs/components/frame) level.
+
+## SEO checklist
+
+| Tactic | How Image supports it |
+|---|---|
+| **CLS prevention** | `ratio` (or `width` + `height`) reserves layout space before load |
+| **LCP** | `eager` sets `loading="eager"` + `fetchpriority="high"` for the hero image |
+| **Alt text** | `alt` is required — no silent empty default; pass `alt=""` deliberately for decorative images |
+| **Responsive delivery** | `srcSet` + `sizes` pass-through for consumer-defined breakpoints |
+| **Structured data** | `<figure>` + `<figcaption>` markup supports `ImageObject` schema at the consumer level |
+
+## Accessibility
+
+- `alt` is a required prop. For decorative images, pass `alt=""` so assistive tech skips them — omitting it is not allowed.
+- Renders semantic `<figure>` / `<figcaption>`; the caption is associated with the image through the shared `<figure>`.
+- Never encode meaning in the image alone — captions and surrounding copy carry the same information for non-visual users.
+
+## API
+
+| Prop | Type | Default |
+|---|---|---|
+| `src` | `string` (required) | — |
+| `alt` | `string` (required) | — |
+| `ratio` | `FrameRatio` slug | — |
+| `fit` | `'cover' \| 'contain' \| 'fill' \| 'none'` | `'cover'` |
+| `position` | `string` (`object-position`) | — |
+| `eager` | `boolean` | `false` |
+| `srcSet` | `string` | — |
+| `sizes` | `string` | — |
+| `width` | `number \| string` | — |
+| `height` | `number \| string` | — |
+| `caption` | `ReactNode` | — |
+
+Plus standard `<figure>` HTML attributes.
+
+## Related
+
+- [Frame](/docs/components/frame) — the bare aspect-ratio box Image wraps; use it directly for non-`<img>` media
+- [Avatar](/docs/components/avatar) — person identity with initials fallback
+- [Marketing Illustration](/docs/components/marketing-illustration) — composed illustration scenes
+- [Color pairings](/docs/primitives/color-pairings) — for captions and overlays on images
+- **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-image--docs)**

--- a/docs-site/content/docs/components/meta.json
+++ b/docs-site/content/docs/components/meta.json
@@ -89,6 +89,7 @@
     "---Assets + utilities---",
     "avatar",
     "icons",
+    "image",
     "footer",
     "page-header",
     "bullet-list",

--- a/docs/SLOT-ALLOWLIST.md
+++ b/docs/SLOT-ALLOWLIST.md
@@ -37,6 +37,7 @@ __error
 __strict-hint
 __hint
 __cite              # source attribution on quotes / testimonials
+__caption           # <figcaption> text on figure-based media (Image); generic to any captioned figure
 ```
 
 ## Layout + container slots


### PR DESCRIPTION
## Summary

Adds the **Image** component (#681 Media umbrella) — a semantic `<figure>` + `<img>` (+ optional `<figcaption>`) wrapper for Astro + Next.js consumers. Lazy-loads + async-decodes by default; `eager` flips to `loading="eager"` + `fetchpriority="high"` for the LCP image. Locks shape to the `--aspect-*` token family (via the `Frame` primitive) when `ratio` is set; `srcset`/`sizes`/`width`/`height` pass through for responsive delivery + CLS prevention.

**Closes #967.**

## Files
- `components/ui/Image/{Image.tsx,Image.css,index.ts}`
- `Image.stories.tsx` — `Default` + `Ratios` / `FitModes` / `WithCaption` / `Eager` (two-shape model)
- `Image.mdx` — Storybook six-section recipe
- `docs-site/content/docs/components/image.mdx` — anatomy, ratio table, Astro/Next responsive patterns, SEO checklist
- register: `components/ui/index.ts` barrel, `.storybook/preview.tsx` sort (`icons → image → marketing-illustration`), docs `meta.json`
- `docs/SLOT-ALLOWLIST.md` — **adds `__caption`** (see reviewer notes)

## Reviewer notes — decisions to scrutinize
1. **Composes `Frame` internally** rather than re-implementing aspect-ratio CSS — per the component-build "compose primitives" rule. `ratio`/`fit` pass straight through to `Frame`; no duplicate ratio CSS. When `ratio` is omitted, no `Frame` (bare responsive `<img>`).
2. **`__caption` slot added to the closed allowlist** — the AC named `.bds-image__caption` but the slot didn't exist. Added via the documented process (edit + justify): it's a generic figcaption role, not layout-specific. This is the one canon change here.
3. **SEO guidance placement** — the AC asked for an "SEO section" in the Storybook MDX, but the MDX recipe bans arbitrary H2 sections. Put a brief SEO `> Note` in Storybook and the **full SEO checklist on the docs-site page** (correct surface split). Canon over AC wording.

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [x] `npm run typecheck` / pre-push suite (10/10) passes
- [x] `npm run lint-tokens`, `lint-jsdoc`, `lint-storybook-recipe` pass
- [ ] Storybook visual review — Chromatic build 737 published (Storybook built clean, all 5 Image stories render): https://www.chromatic.com/build?appId=69b8918cac3056b39424d5d3&number=737
  - ⚠️ **Chromatic monthly snapshot quota reached** — the build published but the visual-regression **diff did not run**. Eyeball the published Storybook, or re-run `npm run chromatic` after quota reset / plan upgrade.
- [ ] Dark mode + Client Sim font-audit spot-check

## Knowledge capture
- [ ] `brik-rag remember` — Frame-composition pattern for media components; `__caption` slot addition

Generated with [Claude Code](https://claude.ai/code)