### PR TITLE
perf(build): emit per-module output so consumers tree-shake BDS (#1060)

### DIFF
--- a/docs/BLUEPRINTS-ASTRO-PACKAGE.md
+++ b/docs/BLUEPRINTS-ASTRO-PACKAGE.md
@@ -199,7 +199,7 @@ Current package.json shape ([package.json:8-32](../package.json)):
   "types": "./dist/lib-entry.d.ts",
   "files": ["dist", "blueprints/blueprint-library.json", "content-system/compliance/*.md", "content-system/atmospheres/*.css"],
   "exports": {
-    ".": { "types": "./dist/lib-entry.d.ts", "import": "./dist/index.esm.mjs", "require": "./dist/index.cjs.js" },
+    ".": { "types": "./dist/lib-entry.d.ts", "import": "./dist/lib-entry.mjs", "require": "./dist/lib-entry.cjs" },
     "./content-system": { "types": "./dist/content-system/index.d.ts", "import": "./dist/content-system/index.mjs" },
     // ... per-atmosphere CSS entries ...
   }

--- a/package.json
+++ b/package.json
@@ -3,14 +3,17 @@
   "version": "0.114.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.mjs",
+  "main": "dist/lib-entry.cjs",
+  "module": "dist/lib-entry.mjs",
   "types": "dist/lib-entry.d.ts",
+  "sideEffects": [
+    "*.css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/lib-entry.d.ts",
-      "import": "./dist/index.esm.mjs",
-      "require": "./dist/index.cjs.js"
+      "import": "./dist/lib-entry.mjs",
+      "require": "./dist/lib-entry.cjs"
     },
     "./content-system": {
       "types": "./dist/content-system/index.d.ts",

--- a/scripts/check-esm-bundle.mjs
+++ b/scripts/check-esm-bundle.mjs
@@ -26,8 +26,8 @@
  *
  * Run after `build:lib`, before publish (wired into `prepublishOnly`).
  */
-import { readFileSync, existsSync } from 'node:fs';
-import { resolve, dirname, extname } from 'node:path';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { resolve, dirname, extname, join, relative } from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -95,28 +95,44 @@ for (const [label, rel] of importTargets) {
   }
 }
 
-/* ── require()-free scan on the ESM root entry ────────────────────────────
- * Catches CJS/UMD deps inlined into the bundle (the lottie-web class). */
-const esmEntry = resolve(pkgRoot, 'dist', 'index.esm.mjs');
-if (!existsSync(esmEntry)) {
-  fail(`❌ ESM bundle check — ${esmEntry} not found. Run \`npm run build:lib\` first.`);
+/* ── require()-free scan on every emitted ESM module ──────────────────────
+ * Catches CJS/UMD deps inlined into the output (the lottie-web class). The lib
+ * build emits per-module output (#1060), so a CJS dep could be inlined into any
+ * `.mjs`, not just the root entry — scan them all. */
+const RE = /(?:^|[^A-Za-z0-9_$])(__require|require)\s*\(/;
+const distDir = resolve(pkgRoot, 'dist');
+const collectMjs = (dir) => {
+  const out = [];
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) out.push(...collectMjs(full));
+    else if (ent.name.endsWith('.mjs')) out.push(full);
+  }
+  return out;
+};
+if (!existsSync(distDir)) {
+  fail(`❌ ESM bundle check — ${distDir} not found. Run \`npm run build:lib\` first.`);
 } else {
-  const RE = /(?:^|[^A-Za-z0-9_$])(__require|require)\s*\(/;
-  const hits = [];
-  readFileSync(esmEntry, 'utf8')
-    .split('\n')
-    .forEach((line, i) => {
-      if (RE.test(line)) hits.push({ n: i + 1, text: line.trim().slice(0, 120) });
-    });
-  if (hits.length > 0) {
-    fail('❌ ESM bundle check FAILED — dist/index.esm.mjs contains require():');
+  const mjsFiles = collectMjs(distDir);
+  const offenders = [];
+  for (const file of mjsFiles) {
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .forEach((line, i) => {
+        if (RE.test(line)) {
+          offenders.push({ file: relative(pkgRoot, file), n: i + 1, text: line.trim().slice(0, 120) });
+        }
+      });
+  }
+  if (offenders.length > 0) {
+    fail(`❌ ESM bundle check FAILED — ${offenders.length} require() call(s) in emitted .mjs:`);
     console.error('   ESM-prerender consumers (turbopack / Astro) reject dynamic require.');
-    console.error('   A CJS/UMD dependency is being inlined into the ESM entry.');
+    console.error('   A CJS/UMD dependency is being inlined into an ESM module.');
     console.error('   Fix: add the offending dependency to `external` in vite.config.lib.ts.');
-    hits.slice(0, 10).forEach((h) => console.error(`   L${h.n}: ${h.text}`));
-    if (hits.length > 10) console.error(`   …and ${hits.length - 10} more.`);
+    offenders.slice(0, 10).forEach((h) => console.error(`   ${h.file}:${h.n}: ${h.text}`));
+    if (offenders.length > 10) console.error(`   …and ${offenders.length - 10} more.`);
   } else {
-    console.log('✅ ESM bundle check: dist/index.esm.mjs is require()-free.');
+    console.log(`✅ ESM bundle check: all ${mjsFiles.length} emitted .mjs modules are require()-free.`);
   }
 }
 

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -1,46 +1,75 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
+import { resolve, isAbsolute } from 'path';
+
+// 'use client' banner — Next.js App Router requires this directive for modules
+// that call React.createContext, useState, etc. Without it, SSR fails with
+// "createContext is not a function". Under preserveModules it lands on every
+// emitted module (whole bundle is client today; per-module is consistent).
+const USE_CLIENT_BANNER = "'use client';";
+
+// Rename the extracted CSS asset to a stable `styles.css` (consumers import
+// `@brikdesigns/bds/styles.css`). cssCodeSplit is false in lib mode, so a
+// single stylesheet is emitted regardless of preserveModules.
+const assetFileNames = (assetInfo: { name?: string }) => {
+  if (assetInfo.name?.endsWith('.css')) return 'styles.css';
+  return assetInfo.name ?? 'assets/[name][extname]';
+};
+
+const globals = {
+  react: 'React',
+  'react/jsx-runtime': 'ReactJSXRuntime',
+  'react-dom': 'ReactDOM',
+};
 
 export default defineConfig({
   plugins: [react()],
   build: {
     lib: {
       entry: resolve(__dirname, 'lib-entry.ts'),
-      name: 'BrikBDS',
-      formats: ['es', 'cjs'],
-      fileName: (format) => format === 'es' ? 'index.esm.mjs' : 'index.cjs.js',
     },
     rollupOptions: {
-      // Externalize peer dependencies — do NOT bundle React, Iconify, or Lottie.
-      // lottie-react/lottie-web is a UMD/CJS module; bundling it inlines a
-      // dynamic `require()` into the ESM entry, which breaks ESM-prerender
-      // consumers (turbopack / Astro). It is a declared peerDependency, so it
-      // must be external. See the ESM-no-require gate in scripts/check-esm-bundle.mjs.
-      external: [
-        'react',
-        'react/jsx-runtime',
-        'react-dom',
-        '@iconify/react',
-        'lottie-react',
-        'lottie-web',
-      ],
-      output: {
-        // Next.js App Router requires 'use client' directive for modules that
-        // call React.createContext, useState, etc. Without this, SSR fails with
-        // "createContext is not a function". The banner is added to both ESM and CJS.
-        banner: "'use client';",
-        globals: {
-          'react': 'React',
-          'react/jsx-runtime': 'ReactJSXRuntime',
-          'react-dom': 'ReactDOM',
-        },
-        // Rename CSS output to styles.css
-        assetFileNames: (assetInfo) => {
-          if (assetInfo.name?.endsWith('.css')) return 'styles.css';
-          return assetInfo.name ?? 'assets/[name][extname]';
-        },
+      // Externalize every node_modules dependency — do NOT bundle any of them
+      // into the per-module output. Consumers install BDS's runtime deps
+      // (react, @iconify/react, @radix-ui/*, lottie-*, and their transitives)
+      // through npm's dependency tree, so inlining them here would duplicate
+      // code in the consumer bundle and defeat tree-shaking. Externalizing also
+      // keeps lottie-react/lottie-web (UMD/CJS) out of the ESM output, which is
+      // what the ESM-no-require gate enforces (scripts/check-esm-bundle.mjs) —
+      // bundling a CJS dep inlines a dynamic `require()` that ESM-prerender
+      // consumers (turbopack / Astro) reject. Only relative/absolute (BDS's own
+      // source) and `@bds/*` aliases stay in the graph.
+      external: (id) => {
+        if (id.startsWith('.') || id.startsWith('/') || isAbsolute(id)) return false;
+        if (id.startsWith('@bds/')) return false; // local alias → resolved to source
+        return true; // every bare specifier is a node_modules dependency
       },
+      // Per-module output (#1060) — emit each source module as its own file
+      // preserving the source tree, so consumers tree-shake unused components
+      // instead of pulling the whole graph into their shared chunk. Two outputs:
+      // ESM (`.mjs`, the tree-shakeable path Next.js/Astro resolve via `import`)
+      // and CJS (`.cjs` under `require`) — both preserved from the same entry.
+      output: [
+        {
+          format: 'es',
+          preserveModules: true,
+          preserveModulesRoot: '.',
+          entryFileNames: '[name].mjs',
+          banner: USE_CLIENT_BANNER,
+          globals,
+          assetFileNames,
+        },
+        {
+          format: 'cjs',
+          preserveModules: true,
+          preserveModulesRoot: '.',
+          entryFileNames: '[name].cjs',
+          exports: 'named',
+          banner: USE_CLIENT_BANNER,
+          globals,
+          assetFileNames,
+        },
+      ],
     },
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
Closes #1060.

## What
Enable per-module output so consumers tree-shake unused BDS components instead of pulling the whole module graph into their shared chunk.

- **`vite.config.lib.ts`** — Rollup `preserveModules` on both outputs (ESM → `.mjs`, CJS → `.cjs`) from the single `lib-entry`. Each source module now ships as its own file preserving the source tree. Externalize **every** node_modules dependency (was: peer deps only) so `@radix-ui/*`, `@floating-ui/*`, `react-remove-scroll`, etc. aren't inlined into every module — consumers dedupe them through npm's dep tree.
- **`package.json`** — repoint `main`/`module`/`exports` to `dist/lib-entry.{cjs,mjs}`; add `"sideEffects": ["*.css"]`.
- **`scripts/check-esm-bundle.mjs`** — the require()-free gate now scans **every** emitted `.mjs` (output is per-module now), not just the old single entry. Ships the gate with the change.
- **`docs/BLUEPRINTS-ASTRO-PACKAGE.md`** — update stale exports example.

## Scope note — one AC was already done
The issue's "externalize `lottie-web`" AC was a **no-op**: `lottie-react` + `lottie-web` were already in the `external` list and declared peer deps. This PR generalizes externalization to all deps, which covers it.

## `sideEffects` — why `["*.css"]`, not `false`
Components deliver styles via co-located side-effecting imports (`import './Foo.css'`). Those are the **only** side-effecting imports in the graph (audited — zero non-CSS bare imports). Blanket `false` would let bundlers drop them and BDS's own build would emit an incomplete `styles.css`. `["*.css"]` keeps CSS while tree-shaking JS.

## Measurement — tree-shaking works
Isolated esbuild bundle of a realistic import (`{ Button, Icon, Card }`, framework + peer deps external, minified, tree-shaken), old published 0.114.0 vs this build:

| Import | OLD (single-bundle) | NEW (per-module + sideEffects) | Δ |
|---|---|---|---|
| `{ Button, Icon, Card }` | 109.4 KB | **35.1 KB** | **−68%** |
| `export *` (whole lib, sanity) | 233.0 KB | 249.0 KB | +16 KB (per-module boilerplate — expected when everything is used) |

The authoritative portal shared-chunk delta lands at consumer-bump time (the portal pulls BDS from npm, so it can't consume this until published + bumped). This isolated measurement directly proves the mechanism and magnitude.

## Verification
- ✅ ESM-no-require gate green across all **135** emitted `.mjs` modules
- ✅ `styles.css` **byte-identical** to baseline (334971 B) — no CSS dropped
- ✅ 179 named exports resolve from the built package (Button/Card/Sheet spot-checked)
- ✅ `tsc --noEmit`, full test suite (**791 tests / 148 files**), Storybook build, canonical-token check all pass

## Known cosmetic artifacts (internal-only, not consumer-visible)
- Components with co-located CSS get a `2` suffix (`MultiSelect2.mjs`) — a Vite CSS-proxy name collision under `preserveModules`. Internal filenames only; types resolve via the aggregate `lib-entry.d.ts` (source-structure names), never per-file, so no mismatch.
- The 10 source files that already declare `'use client'` get a duplicated directive (source + banner). A repeated directive prologue is legal and ignored — harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)