### PR TITLE
fix(components): fix FileCard preview height so wide ratios stay legible

### DIFF
--- a/components/ui/FileCard/FileCard.css
+++ b/components/ui/FileCard/FileCard.css
@@ -42,9 +42,11 @@
 }
 
 /* ─── Preview thumbnail ───────────────────────────────────────── */
-/* Preview box has a fixed width and an aspect-ratio modifier that drives
-   the height. Image/SVG previews fill the box via object-fit: cover; icon
-   previews center a Phosphor glyph. */
+/* Preview box has a fixed height and an aspect-ratio modifier that drives
+   the width. Image/SVG previews fill the box via object-fit: cover; icon
+   previews center a Phosphor glyph. Fixed-height keeps the vertical rhythm
+   constant across ratios so wide slugs (16-9, 21-9) stay tall enough to read
+   instead of collapsing to a thin band. */
 
 .bds-file-card__preview-link {
   display: block;
@@ -56,7 +58,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: var(--size-1400);
+  height: var(--size-1400);
   background-color: var(--surface-muted);
   flex: 0 0 auto;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- fix(components): fix FileCard preview height so wide ratios stay legible

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)