### PR TITLE
feat(card): add logo + connectionStatus slots to control preset

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -140,6 +140,123 @@
   flex-shrink: 0;
 }
 
+/* ─── Preset control — logo slot ─────────────────────────────── */
+/* Leading avatar / logomark slot for integration cards.
+ * Renders before any `badge` in the content row.
+ * The slot applies no intrinsic size — the consumer controls
+ * image dimensions via the Avatar or img element inside. */
+
+.bds-card__preset-control-logo {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+/* ─── Preset control — trailing block ────────────────────────────
+ * Wraps `connectionStatus` indicator + `action` as a flex column
+ * so both can coexist. When only `action` is set (no status),
+ * the trailing block collapses to a single-item column and
+ * preserves the original action-only alignment behaviour. */
+
+.bds-card__preset-control-trailing {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--gap-sm);
+  flex-shrink: 0;
+}
+
+/* ─── Preset control — connection-status indicator ─────────────
+ * A compact dot + label status affordance.
+ * Composed from canonical semantic tokens — no invented names.
+ *
+ * State → token mapping:
+ *   not-configured → --background-status-neutral / --text-muted (label)
+ *   connected      → --background-positive / --text-positive
+ *   syncing        → --background-status-info / --text-status-info
+ *   synced         → --background-positive / --text-positive
+ *   error          → --background-negative / --text-negative
+ */
+
+.bds-card__preset-control-status {
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--gap-sm);
+}
+
+/* Dot circle */
+.bds-card__preset-control-status-dot {
+  /* bds-lint-ignore — Figma-driven dot dimensions */
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+/* Label text */
+.bds-card__preset-control-status-label {
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--font-line-height-tight);
+}
+
+/* Last-synced line — drops below the dot+label row */
+.bds-card__preset-control-status-synced {
+  width: 100%;
+  text-align: right;
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+}
+
+/* ── Per-state colors (dot + label) ── */
+
+.bds-card__preset-control-status--not-configured .bds-card__preset-control-status-dot {
+  background-color: var(--background-status-neutral);
+}
+
+.bds-card__preset-control-status--not-configured .bds-card__preset-control-status-label {
+  color: var(--text-muted);
+}
+
+.bds-card__preset-control-status--connected .bds-card__preset-control-status-dot {
+  background-color: var(--background-positive);
+}
+
+.bds-card__preset-control-status--connected .bds-card__preset-control-status-label {
+  color: var(--text-positive);
+}
+
+.bds-card__preset-control-status--syncing .bds-card__preset-control-status-dot {
+  background-color: var(--background-status-info);
+}
+
+.bds-card__preset-control-status--syncing .bds-card__preset-control-status-label {
+  color: var(--text-status-info);
+}
+
+.bds-card__preset-control-status--synced .bds-card__preset-control-status-dot {
+  background-color: var(--background-positive);
+}
+
+.bds-card__preset-control-status--synced .bds-card__preset-control-status-label {
+  color: var(--text-positive);
+}
+
+.bds-card__preset-control-status--error .bds-card__preset-control-status-dot {
+  background-color: var(--background-negative);
+}
+
+.bds-card__preset-control-status--error .bds-card__preset-control-status-label {
+  color: var(--text-negative);
+}
+
 /* ─── Preset: summary ─────────────────────────────────────────── */
 /* Compact metric/stat card layout — replaces the legacy CardSummary
  * component. Label (top) + large value (bottom) + optional secondary

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -30,9 +30,23 @@ The default shape also takes a `variant`: `outlined` (default, secondary border)
 
 ### Control preset
 
-`preset="control"` — settings/control row. Leading badge + (title + description) on the left, action on the right. Use `actionAlign="top"` for long descriptions where the action should anchor to the upper-right corner.
+`preset="control"` — settings/control row. Leading `logo` + `badge` + (title + description) on the left, (`connectionStatus` indicator + `action`) on the right. Use `actionAlign="top"` for long descriptions where the action should anchor to the upper-right corner.
+
+The `logo` slot accepts any ReactNode (typically an `<Avatar>` or `<img>`) and renders as a leading logomark before the `badge` — use it for integration or third-party service cards where a visual brand anchor makes the row scannable. The `connectionStatus` prop accepts `not-configured | connected | syncing | synced | error` and renders a dot + label in the trailing block, coexisting with the `action` slot. Pass `lastSynced` to display a timestamp beneath the status indicator.
 
 <Canvas of={Stories.Control} />
+
+#### With logo
+
+<Canvas of={Stories.ControlWithLogo} />
+
+#### With connection status
+
+<Canvas of={Stories.ControlWithConnectionStatus} />
+
+#### All connection-status states
+
+<Canvas of={Stories.ControlConnectionStatuses} />
 
 ### Summary preset
 

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Card, CardTitle, CardDescription, CardFooter } from './Card';
+import { Avatar } from '../Avatar';
 import { Button } from '../Button';
 import { Badge } from '../Badge';
 import { PricingCard } from '../PricingCard';
@@ -148,6 +149,22 @@ export const Control: Story = {
       description:
         'Vertical alignment of the action slot. `top` anchors the action to the upper-right corner; `center` (default) aligns to the vertical midline.',
     },
+    logo: {
+      control: false,
+      description:
+        'Optional leading logo / avatar slot — for integration logomarks or brand icons. Renders before `badge` in the content row.',
+    },
+    connectionStatus: {
+      control: 'select',
+      options: ['not-configured', 'connected', 'syncing', 'synced', 'error'],
+      description:
+        'Connection-status state. Renders a dot + label in the trailing block alongside the `action` slot.',
+    },
+    lastSynced: {
+      control: 'text',
+      description:
+        'Human-readable "last synced" label displayed below the status indicator. Only shown when `connectionStatus` is set and is not `not-configured`.',
+    },
   },
   decorators: [
     (Story) => (
@@ -156,6 +173,128 @@ export const Control: Story = {
       </div>
     ),
   ],
+};
+
+/**
+ * `preset="control"` with the `logo` slot — an `<Avatar>` logomark leading
+ * the content row. The logo renders before the `badge` and is sized by the
+ * consumer element (Avatar `size` prop). Use for integration / third-party
+ * service cards where a visual brand identifier anchors the row.
+ *
+ * @summary preset="control" with avatar logo slot
+ */
+export const ControlWithLogo: Story = {
+  args: {
+    preset: 'control',
+    title: 'Google Analytics',
+    description: 'Pull session and conversion data into your dashboard.',
+    logo: <Avatar name="GA" size="sm" />,
+    action: (
+      <Button variant="outline" size="sm">
+        Configure
+      </Button>
+    ),
+    actionAlign: 'center',
+  },
+  argTypes: {
+    variant: { table: { disable: true } },
+    padding: { table: { disable: true } },
+    interactive: { table: { disable: true } },
+    href: { table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 560 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * `preset="control"` with `connectionStatus="synced"` and `lastSynced` — the
+ * full integration card shape. The trailing block stacks the status indicator
+ * above the action. All five status states (`not-configured`, `connected`,
+ * `syncing`, `synced`, `error`) are exercised in `ControlConnectionStatuses`.
+ *
+ * @summary preset="control" — integration card with status + action
+ */
+export const ControlWithConnectionStatus: Story = {
+  args: {
+    preset: 'control',
+    title: 'Google Analytics',
+    description: 'Pull session and conversion data into your dashboard.',
+    logo: <Avatar name="GA" size="sm" />,
+    connectionStatus: 'synced',
+    lastSynced: 'Last synced 3 min ago',
+    action: (
+      <Button variant="outline" size="sm">
+        Configure
+      </Button>
+    ),
+    actionAlign: 'top',
+  },
+  argTypes: {
+    variant: { table: { disable: true } },
+    padding: { table: { disable: true } },
+    interactive: { table: { disable: true } },
+    href: { table: { disable: true } },
+    connectionStatus: {
+      control: 'select',
+      options: ['not-configured', 'connected', 'syncing', 'synced', 'error'],
+      description: 'Connection-status state.',
+    },
+    lastSynced: {
+      control: 'text',
+      description: 'Last-synced timestamp label.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 560 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * All five `connectionStatus` states side-by-side — `not-configured`,
+ * `connected`, `syncing`, `synced`, `error`. Each row carries the same logo
+ * and action slot so the only variable is the status indicator.
+ *
+ * @summary connectionStatus — all five states (axis gallery)
+ */
+export const ControlConnectionStatuses: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)', width: 600 }}>
+      {(
+        [
+          { status: 'not-configured', lastSynced: undefined } ,
+          { status: 'connected',      lastSynced: undefined } ,
+          { status: 'syncing',        lastSynced: undefined } ,
+          { status: 'synced',         lastSynced: 'Last synced 3 min ago' } ,
+          { status: 'error',          lastSynced: 'Failed 12 min ago' } ,
+        ] as const
+      ).map(({ status, lastSynced }) => (
+        <Card
+          key={status}
+          preset="control"
+          title="Google Analytics"
+          description="Pull session and conversion data into your dashboard."
+          logo={<Avatar name="GA" size="sm" />}
+          connectionStatus={status}
+          lastSynced={lastSynced}
+          actionAlign="top"
+          action={
+            <Button variant="outline" size="sm">
+              Configure
+            </Button>
+          }
+        />
+      ))}
+    </div>
+  ),
 };
 
 /**

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -8,6 +8,21 @@ export type CardPreset = 'control' | 'summary' | 'display' | 'display-row';
 export type CardControlActionAlign = 'center' | 'top';
 export type CardSummaryType = 'numeric' | 'price';
 /**
+ * Connection-status state for the `preset="control"` integration card.
+ * Maps to canonical semantic token pairs:
+ * - `not-configured` → `--text-muted` / `--background-status-neutral` (neutral/unconfigured)
+ * - `connected`      → `--text-positive` / `--background-positive`
+ * - `syncing`        → `--text-status-info` / `--background-status-info` (blue/in-progress)
+ * - `synced`         → `--text-positive` / `--background-positive`
+ * - `error`          → `--text-negative` / `--background-negative`
+ */
+export type CardControlConnectionStatus =
+  | 'not-configured'
+  | 'connected'
+  | 'syncing'
+  | 'synced'
+  | 'error';
+/**
  * Image-column width for `preset="display-row"`. Named values resolve to
  * fixed percentages (`narrow` 25%, `standard` 35%, `wide` 50%); pass a CSS
  * length / percentage string to override (e.g. `"40%"`, `"320px"`).
@@ -46,8 +61,8 @@ interface CardControlPresetProps extends CardBaseProps {
   /**
    * Control preset — locked-down settings/control card layout. Replaces the
    * legacy `CardControl` component (per ADR-004 §"Resolve the existing
-   * instances"). Renders: badge + (title + description) on the left,
-   * action on the right.
+   * instances"). Renders: logo + badge + (title + description) on the left,
+   * (connection-status + action) on the right.
    */
   preset: 'control';
   /** Bold control label */
@@ -56,6 +71,13 @@ interface CardControlPresetProps extends CardBaseProps {
   description?: string;
   /** Optional leading badge (e.g. status icon, ServiceTag) */
   badge?: ReactNode;
+  /**
+   * Optional leading logo / avatar slot — for integration logomarks or brand
+   * icons. Renders before the `badge` in the content row. Pass any ReactNode
+   * (e.g. `<Avatar>`, `<img>`, or an `<Icon>`). The slot does not apply its
+   * own size; the consumer controls the image dimensions.
+   */
+  logo?: ReactNode;
   /** Optional trailing action element (Button, Switch, Link) */
   action?: ReactNode;
   /**
@@ -63,6 +85,25 @@ interface CardControlPresetProps extends CardBaseProps {
    * upper-right corner; `center` (default) aligns to the vertical midline.
    */
   actionAlign?: CardControlActionAlign;
+  /**
+   * Connection-status state for integration / third-party service cards.
+   * Renders a labelled status indicator in the trailing block, coexisting
+   * with the `action` slot.
+   *
+   * - `not-configured` — not yet set up (muted/gray)
+   * - `connected`      — OAuth/API key accepted, not yet synced
+   * - `syncing`        — sync in progress (blue/info)
+   * - `synced`         — last sync completed successfully (green)
+   * - `error`          — last sync failed (red)
+   */
+  connectionStatus?: CardControlConnectionStatus;
+  /**
+   * Human-readable "last synced" timestamp or label rendered below the
+   * connection-status indicator. Only displayed when `connectionStatus` is
+   * provided and has a value other than `not-configured`. Example:
+   * `"Last synced 3 min ago"`.
+   */
+  lastSynced?: string;
 }
 
 interface CardSummaryPresetProps extends CardBaseProps {
@@ -255,6 +296,19 @@ function formatSummaryValue(value: string | number, type: CardSummaryType): stri
  * />
  * ```
  *
+ * @example Control preset — integration card with logo + connection status
+ * ```tsx
+ * <Card
+ *   preset="control"
+ *   title="Google Analytics"
+ *   description="Pull session and conversion data into your dashboard."
+ *   logo={<Avatar src="/logos/google-analytics.png" alt="Google Analytics" size="sm" />}
+ *   connectionStatus="synced"
+ *   lastSynced="Last synced 3 min ago"
+ *   action={<Button variant="outline" size="sm">Configure</Button>}
+ * />
+ * ```
+ *
  * @example Summary preset
  * ```tsx
  * <Card
@@ -321,17 +375,29 @@ function renderDefault({
   );
 }
 
+const CONNECTION_STATUS_LABELS: Record<CardControlConnectionStatus, string> = {
+  'not-configured': 'Not configured',
+  connected:        'Connected',
+  syncing:          'Syncing',
+  synced:           'Synced',
+  error:            'Error',
+};
+
 function renderControlPreset({
   title,
   description,
   badge,
+  logo,
   action,
   actionAlign = 'center',
+  connectionStatus,
+  lastSynced,
   className,
   style,
   preset: _preset,
   ...rest
 }: CardControlPresetProps) {
+  const hasTrailing = action || connectionStatus;
   return (
     <div
       className={bdsClass(
@@ -344,13 +410,36 @@ function renderControlPreset({
       {...rest}
     >
       <div className="bds-card__preset-control-content">
+        {logo && <div className="bds-card__preset-control-logo">{logo}</div>}
         {badge}
         <div className="bds-card__preset-control-text">
           <p className="bds-card__preset-control-title">{title}</p>
           {description && <p className="bds-card__preset-control-description">{description}</p>}
         </div>
       </div>
-      {action && <div className="bds-card__preset-control-action">{action}</div>}
+      {hasTrailing && (
+        <div className="bds-card__preset-control-trailing">
+          {connectionStatus && (
+            <div
+              className={bdsClass(
+                'bds-card__preset-control-status',
+                `bds-card__preset-control-status--${connectionStatus}`,
+              )}
+              role="status"
+              aria-label={`Connection status: ${CONNECTION_STATUS_LABELS[connectionStatus]}`}
+            >
+              <span className="bds-card__preset-control-status-dot" aria-hidden="true" />
+              <span className="bds-card__preset-control-status-label">
+                {CONNECTION_STATUS_LABELS[connectionStatus]}
+              </span>
+              {lastSynced && connectionStatus !== 'not-configured' && (
+                <span className="bds-card__preset-control-status-synced">{lastSynced}</span>
+              )}
+            </div>
+          )}
+          {action && <div className="bds-card__preset-control-action">{action}</div>}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/ui/Card/index.ts
+++ b/components/ui/Card/index.ts
@@ -13,5 +13,7 @@ export {
   // was removed in 0.88.0 — these now live on Card's `preset="summary"` props).
   type CardSummaryType,
   type CardSummaryTextLink,
+  // Control-preset prop types for integration/connection-status cards.
+  type CardControlConnectionStatus,
 } from './Card';
 export { default } from './Card';

--- a/manifest/component-axes.json
+++ b/manifest/component-axes.json
@@ -102,6 +102,13 @@
       "brand",
       "elevated",
       "borderless"
+    ],
+    "status": [
+      "not-configured",
+      "connected",
+      "syncing",
+      "synced",
+      "error"
     ]
   },
   "CardTestimonial": {


### PR DESCRIPTION
Closes #1074

## Summary

Extends `Card preset="control"` with two additive, backward-compatible slots needed by the integration config cards in brik-client-portal#1677 (Batch 1).

- **`logo?: ReactNode`** — leading avatar/logomark slot rendered before the existing `badge` in the content row. The slot owns no intrinsic size; the consumer controls dimensions via the element passed in (typically `<Avatar>` or `<img>`). Maps to BEM class `bds-card__preset-control-logo`.

- **`connectionStatus?: CardControlConnectionStatus`** — connection-status indicator rendered in the trailing block alongside the existing `action` slot. Supports five states: `not-configured | connected | syncing | synced | error`. Renders a dot + label in a flex row; a `lastSynced` line drops below when provided.

- **`lastSynced?: string`** — optional timestamp line below the status indicator. Hidden when `connectionStatus` is `not-configured`.

## Token mapping (all canonical — no invented names)

| State | Dot background | Label text |
|---|---|---|
| `not-configured` | `--background-status-neutral` | `--text-muted` |
| `connected` | `--background-positive` | `--text-positive` |
| `syncing` | `--background-status-info` | `--text-status-info` |
| `synced` | `--background-positive` | `--text-positive` |
| `error` | `--background-negative` | `--text-negative` |

## Backward compatibility

All three new props are optional. Existing `preset="control"` usages pass through `renderControlPreset` unchanged — the `logo` slot renders nothing if absent, and the entire trailing block is omitted when neither `action` nor `connectionStatus` is set.

## New stories

| Story | What it shows |
|---|---|
| `ControlWithLogo` | Avatar logomark in the leading slot |
| `ControlWithConnectionStatus` | Full integration card: logo + synced status + lastSynced + action |
| `ControlConnectionStatuses` | All five status states as an axis gallery |

## Checks

- TypeScript: pass (tsc --noEmit)
- Token lint errors-only: pass (0 errors)
- JSDoc lint: pass
- Storybook recipe lint: pass (88/88 conforming)
- Tests: 148 files / 794 tests — all pass
- pre-push validate:full: 10/10 pass (token lint, JSDoc, grid, theme compliance, blueprint library, BCS vocab, canonical tokens, component axes, TypeScript, Storybook build)

## Release note

This PR does not publish. The portal version-bump and consumption happen in brik-client-portal#1681 (Batch 3). Per `docs/RELEASE.md`, release is triggered by `git tag v0.X.Y && git push origin v0.X.Y` once the integration window for this batch closes — **not** a manual `npm publish`.