### PR TITLE
docs(standards): add icon-container 4-point-grid recipe to component-build

### DIFF
--- a/.claude/standards/component-build.md
+++ b/.claude/standards/component-build.md
@@ -235,6 +235,20 @@ Icons inside form controls and action buttons must be on the 4px grid. Use `font
 
 **Avoid `--icon-xs` (≈14px) and `--icon-md` (18px)** — both are off the 4px grid. Use 12, 16, or 20 instead.
 
+### Icon containers — padding composes to the 4-point grid
+
+An icon container is any square affordance wrapping a single glyph — a dismiss button, an IconButton, a badge's leading-icon slot. Size the glyph with `font-size` (never `width`/`height` — see above), then reach the 4-point grid (24 / 32 / 40 / 48 / 56) with symmetric `--padding-*`. Don't hardcode the container's `width`/`height` — let padding + font-size resolve it.
+
+Base padding primitives: `--padding-tiny` 8px · `--padding-xs` 10px · `--padding-sm` 12px. Verified on-grid recipes:
+
+| Container | Glyph (`font-size`) | Padding each side | Sum |
+| --- | --- | --- | --- |
+| 32px (`sm`) | 16px `--icon-sm` | 8px `--padding-tiny` | 8 + 16 + 8 = 32 ✓ |
+| 40px (`md`) | 20px `--icon-lg` | 10px `--padding-xs` | 10 + 20 + 10 = 40 ✓ |
+| 40px (`md`) | 16px `--icon-sm` | 12px `--padding-sm` | 12 + 16 + 12 = 40 ✓ |
+
+**Reference implementations:** `CloseButton` uses the 10 + 20 + 10 = 40 recipe; `IconButton` follows the `tiny/sm/md/lg/xl` grid in "Button & IconButton sizing" below. Match those before hand-rolling padding — the off-grid glyph sizes above are the usual cause of a container that misses the grid.
+
 ## Props — canonical shape
 
 ```

--- a/scripts/.standards-hashes
+++ b/scripts/.standards-hashes
@@ -1,4 +1,4 @@
-2df70ed0eadc26c515150c279de04b5f0afcef4079d660db4f043aa301d8f8f8  .claude/standards/component-build.md
+6a8047c44e45286885749f3b0d75a23dd84950d2f96d7fc97ae7bd75a21cce1b  .claude/standards/component-build.md
 79f34fe82693d85f7f39a2fec4160b945004e4a270ea331a2495ea1272a321b9  .claude/standards/storybook-mdx-recipe.md
 8caeddca93778c57a56b5f404e1460293e97fa02f6f01eb4057c43a9f1c07249  .claude/standards/storybook-story-shape.md
 aa041ded08faa66658d0b8e3d5c09216fd6bf72a622c125b185714a976ec0305  .claude/standards/fumadocs-content.md


### PR DESCRIPTION
## Summary
- docs(standards): add icon-container 4-point-grid recipe to component-build

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)