### PR TITLE
refactor(story-shape): Menu, Tooltip, Toast — gold-standard shape (#656)

### DIFF
--- a/components/ui/Menu/Menu.mdx
+++ b/components/ui/Menu/Menu.mdx
@@ -10,37 +10,35 @@ import * as Stories from './Menu.stories';
 
 Floating dropdown panel for navigation and action menus. Contains selectable items with optional icons. Closes on outside click or Escape key.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
+
+Items carry an icon + label. Pass `activeId` to highlight one, `header` for a non-interactive label row, and `item.disabled` to lock a row.
 
 ## Variants
 
-With icons, text-only with disabled item, and active item highlight.
-
-<Canvas of={Stories.Variants} />
-
 ### Grouped items
 
-Pass `MenuItemGroup` entries (`{ label, items }`) to segment the menu under section headers — parity with [`Select`](/?path=/docs/components-select--docs)'s `SelectOptionGroup` and [`MultiSelect`](/?path=/docs/components-multi-select--docs)'s `MultiSelectOptionGroup`. Each group renders as a `role="group"` section named by its label; flat items and groups can be mixed, and the flat-only API stays back-compatible.
+Pass `MenuItemGroup` entries (`{ label, items }`) to segment the menu under section headers — parity with [`Select`](/?path=/docs/components-select--docs)'s `SelectOptionGroup`. Each group renders as a `role="group"` section named by its label; flat items and groups can be mixed, and the flat-only API stays back-compatible.
 
 <Canvas of={Stories.Grouped} />
 
 ### Custom content
 
-Set `content` on a `MenuItemData` to render a custom node — e.g. a line-colored [`ServiceTag`](/?path=/docs/components-service-tag--docs) — as the item's content instead of the default icon + label + description. The item stays a `role="menuitem"` button; its `label` is used as the accessible name.
+Set `content` on a `MenuItemData` to render a custom node — e.g. a line-colored [`ServiceTag`](/?path=/docs/components-service-tag--docs) — as the item's content instead of the default icon + label. The item stays a `role="menuitem"` button; its `label` is used as the accessible name.
 
 <Canvas of={Stories.CustomContent} />
 
 ## Patterns
 
-Real-world usage: `FilterButton` trigger, `Button` trigger with action menu, and an "Add" menu where each item has a label + description (the 2-line `MenuItemData.description` variant).
+A Menu needs a trigger and open state. The canonical integrations: a `FilterButton` trigger, a `Button` trigger with an action menu, and an "Add" menu whose items carry a `description`.
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.WithTrigger} />
 
 ### Header slot
 
-Pass `header?: ReactNode` to render a non-interactive label above the items inside the menu panel — practice name, user identity block, filter group label, etc. The header sits inside Menu's outside-click ref so pressing it does not close the menu.
+Pass `header?: ReactNode` to render a non-interactive label above the items inside the menu panel — practice name, user identity block, filter group label. The header sits inside Menu's outside-click ref so pressing it does not close the menu.
 
 ```tsx
 <Menu
@@ -54,11 +52,9 @@ Pass `header?: ReactNode` to render a non-interactive label above the items insi
 />
 ```
 
-Default styling (`bds-menu__header` class) is uppercase label-style on `--text-secondary` with a subtle bottom border. Pass any `ReactNode` (multiple lines, mixed typography) to fully override the visual treatment.
-
 ### Items with description
 
-Pass `description?: string` on a `MenuItemData` to render a second-line description below the label. Used for "what does this option do?" affordance — common in "Add new ___" menus where each option is a different kind of thing (e.g. *Checklist — Recurring to-do lists*, *Procedure — Step-by-step workflows*).
+Pass `description?: string` on a `MenuItemData` to render a second-line description below the label — common in "Add new ___" menus where each option is a different kind of thing.
 
 ```tsx
 <Menu
@@ -71,9 +67,6 @@ Pass `description?: string` on a `MenuItemData` to render a second-line descript
 />
 ```
 
-When `description` is absent, the item renders as a single-line label (existing behavior, unchanged).
-
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/Menu/Menu.stories.tsx
+++ b/components/ui/Menu/Menu.stories.tsx
@@ -7,7 +7,7 @@ import { FilterButton } from '../FilterButton';
 import { Button } from '../Button';
 import { ServiceTag } from '../ServiceTag/ServiceTag';
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
+/* ─── Layout helpers (story-only) ─────────────────────────────── */
 
 const SectionLabel = ({ children }: { children: string }) => (
   <div style={{
@@ -26,7 +26,7 @@ const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode;
   <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
 );
 
-/* ─── Shared Data ─────────────────────────────────────── */
+/* ─── Shared data ─────────────────────────────────────── */
 
 const sampleItems = [
   { id: '1', label: 'Brand design', icon: <Icon icon="ph:palette" />, onClick: () => {} },
@@ -88,11 +88,17 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Static open menu for Controls panel
+   DEFAULT — static open menu for the Controls panel
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Canonical menu, rendered open. Items carry an icon + label; pass
+ * `activeId` to highlight one, `header` for a non-interactive label row,
+ * and `item.disabled` to lock a row.
+ *
+ * @summary Floating dropdown of selectable items
+ */
+export const Default: Story = {
   args: {
     items: sampleItems,
     isOpen: true,
@@ -102,10 +108,17 @@ export const Playground: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   GROUPED — items segmented under section headers
+   VARIANTS — item-structure compositions
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Items segmented under labelled group headers */
+/**
+ * Pass `MenuItemGroup` entries (`{ label, items }`) to segment the menu
+ * under section headers. Each group renders as a `role="group"` named by
+ * its label; flat items and groups can be mixed. Irreducible — the group
+ * structure lives in the `items` array.
+ *
+ * @summary Items segmented under labelled group headers
+ */
 export const Grouped: Story = {
   args: {
     items: groupedItems,
@@ -115,11 +128,13 @@ export const Grouped: Story = {
   },
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   CUSTOM CONTENT — line-colored ServiceTag as item content
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Custom node (ServiceTag) as item content */
+/**
+ * Set `content` on a `MenuItemData` to render a custom node — e.g. a
+ * line-colored `ServiceTag` — instead of the default icon + label. The
+ * item stays a `role="menuitem"`; its `label` is the accessible name.
+ *
+ * @summary Custom node (ServiceTag) as item content
+ */
 export const CustomContent: Story = {
   args: {
     items: serviceTagItems,
@@ -130,100 +145,21 @@ export const CustomContent: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — With icons, text-only, active item, disabled
+   PATTERNS — trigger + open-state compositions
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  args: { items: sampleItems, isOpen: true, onClose: () => {} },
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>With icons</SectionLabel>
-        <Menu
-          isOpen
-          onClose={() => {}}
-          items={sampleItems}
-          style={{ position: 'relative' }}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Text-only with disabled item</SectionLabel>
-        <Menu
-          isOpen
-          onClose={() => {}}
-          items={[
-            { id: '1', label: 'Edit', onClick: () => {} },
-            { id: '2', label: 'Duplicate', onClick: () => {} },
-            { id: '3', label: 'Archive', onClick: () => {} },
-            { id: '4', label: 'Delete', disabled: true },
-          ]}
-          style={{ position: 'relative' }}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>With active item</SectionLabel>
-        <Menu
-          isOpen
-          onClose={() => {}}
-          items={sampleItems}
-          activeId="2"
-          style={{ position: 'relative' }}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>With header (string)</SectionLabel>
-        <Menu
-          isOpen
-          onClose={() => {}}
-          header="Northstar Dental"
-          items={[
-            { id: '1', label: 'Account settings', icon: <Icon icon="ph:gear" />, onClick: () => {} },
-            { id: '2', label: 'Switch practice', icon: <Icon icon="ph:swap" />, onClick: () => {} },
-            { id: '3', label: 'Sign out', icon: <Icon icon="ph:sign-out" />, onClick: () => {} },
-          ]}
-          style={{ position: 'relative' }}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>With header (custom node)</SectionLabel>
-        <Menu
-          isOpen
-          onClose={() => {}}
-          header={
-            <>
-              <span style={{ fontFamily: 'var(--font-family-heading)', fontSize: 'var(--body-md)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--text-primary)', textTransform: 'none', letterSpacing: 0 }}>
-                Dr. Sara Patel
-              </span>
-              <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-xs)', fontWeight: 'var(--font-weight-regular)', color: 'var(--text-secondary)', textTransform: 'none', letterSpacing: 0 }}>
-                sara@northstardental.com
-              </span>
-            </>
-          }
-          items={[
-            { id: '1', label: 'Profile', icon: <Icon icon="ph:user" />, onClick: () => {} },
-            { id: '2', label: 'Sign out', icon: <Icon icon="ph:sign-out" />, onClick: () => {} },
-          ]}
-          style={{ position: 'relative' }}
-        />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — FilterButton trigger + Button trigger
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
+/**
+ * A Menu needs a trigger and open state. These are the canonical
+ * integrations: a `FilterButton` trigger, a `Button` trigger with an
+ * action menu, and an "Add" menu whose items carry a `description`.
+ * Irreducible — each wires `isOpen` / `onClose` through a hook.
+ *
+ * @summary Trigger integrations (FilterButton / Button / Add menu)
+ */
+export const WithTrigger: Story = {
   args: { items: sampleItems, isOpen: true, onClose: () => {} },
   render: () => {
-    function MenuPatterns() {
+    function MenuTriggers() {
       const [filterValue, setFilterValue] = useState<string | undefined>();
       const [actionOpen, setActionOpen] = useState(false);
       const [addOpen, setAddOpen] = useState(false);
@@ -281,6 +217,6 @@ export const Patterns: Story = {
         </Stack>
       );
     }
-    return <MenuPatterns />;
+    return <MenuTriggers />;
   },
 };

--- a/components/ui/Toast/Toast.mdx
+++ b/components/ui/Toast/Toast.mdx
@@ -10,27 +10,31 @@ import * as Stories from './Toast.stories';
 
 White surface notification with optional colored `Badge` icon indicating status. The surface never changes color — only the badge communicates success, error, warning, or info.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
+
+Edit `title` / `description`, switch `variant`, and omit `onDismiss` for a non-dismissible toast — all via Controls.
 
 ## Variants
 
-All status variants, title-only, and non-dismissible configurations.
+One story per status tone. Each pairs a colored `Badge` icon with the white surface.
 
-<Canvas of={Stories.Variants} />
+### Success
 
-- **`default`** — No badge, no icon
-- **`success`** — Positive badge, `circle-check` icon
-- **`error`** — Error badge, `circle-exclamation` icon
-- **`warning`** — Warning badge, `triangle-exclamation` icon
-- **`info`** — Info badge, `circle-info` icon
+<Canvas of={Stories.Success} />
 
-## Patterns
+### Error
 
-Real-world usage: interactive toggle, error context, and informational messages.
+<Canvas of={Stories.Error} />
 
-<Canvas of={Stories.Patterns} />
+### Warning
+
+<Canvas of={Stories.Warning} />
+
+### Info
+
+<Canvas of={Stories.Info} />
 
 ## Props
 
@@ -50,4 +54,3 @@ Component-scoped CSS variables exposed on `.bds-toast`. Set on a wrapping elemen
   --bds-toast-shadow: 0px 2px 8px rgba(0, 0, 0, 0.12);
 }
 ```
-

--- a/components/ui/Toast/Toast.stories.tsx
+++ b/components/ui/Toast/Toast.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
 import { Toast } from './Toast';
-import { Button } from '../Button';
 
 const meta: Meta<typeof Toast> = {
   title: 'Components/toast',
@@ -9,33 +7,30 @@ const meta: Meta<typeof Toast> = {
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
-    title: { control: 'text' },
-    description: { control: 'text' },
-    variant: { control: 'select', options: ['default', 'success', 'error', 'warning', 'info'] },
+    title: { control: 'text', description: 'Primary message line.' },
+    description: { control: 'text', description: 'Optional secondary line; omit for a title-only toast.' },
+    variant: {
+      control: 'select',
+      options: ['default', 'success', 'error', 'warning', 'info'],
+      description: 'Status tone — selects the colored `Badge` icon. The surface stays white.',
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Toast>;
 
-/* ─── Layout helpers ─────────────────────────────────────────── */
+/* ═══════════════════════════════════════════════════════════════
+   DEFAULT — args-driven sandbox
+   ═══════════════════════════════════════════════════════════════ */
 
-const SectionLabel = ({ children }: { children: string }) => (
-  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-    {children}
-  </span>
-);
-
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%', maxWidth: '500px' }}>
-    {children}
-  </div>
-);
-
-/* ─── Playground ─────────────────────────────────────────────── */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Neutral toast — no badge. Edit `title` / `description`, switch `variant`,
+ * and omit `onDismiss` for a non-dismissible toast via Controls.
+ *
+ * @summary White-surface notification with optional status badge
+ */
+export const Default: Story = {
   args: {
     title: 'Title goes here',
     description: 'Description goes here',
@@ -44,72 +39,26 @@ export const Playground: Story = {
   },
 };
 
-/* ─── Variants ───────────────────────────────────────────────── */
+/* ═══════════════════════════════════════════════════════════════
+   VARIANTS — one story per status tone
+   ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <SectionLabel>Default</SectionLabel>
-      <Toast title="Default toast" description="No status badge — neutral notification" onDismiss={() => {}} />
-
-      <SectionLabel>Success</SectionLabel>
-      <Toast title="Changes saved" description="Your settings have been updated successfully." variant="success" onDismiss={() => {}} />
-
-      <SectionLabel>Error</SectionLabel>
-      <Toast title="Something went wrong" description="Please try again or contact support." variant="error" onDismiss={() => {}} />
-
-      <SectionLabel>Warning</SectionLabel>
-      <Toast title="Session expiring" description="Your session will expire in 5 minutes." variant="warning" onDismiss={() => {}} />
-
-      <SectionLabel>Info</SectionLabel>
-      <Toast title="New update available" description="Version 2.1 is ready to install." variant="info" onDismiss={() => {}} />
-
-      <SectionLabel>Title only</SectionLabel>
-      <Toast title="Changes saved successfully" variant="success" onDismiss={() => {}} />
-
-      <SectionLabel>Non-dismissible</SectionLabel>
-      <Toast title="Processing" description="Please wait while we complete your request" variant="info" />
-    </Stack>
-  ),
+/** @summary Success — positive badge, circle-check icon */
+export const Success: Story = {
+  args: { title: 'Changes saved', description: 'Your settings have been updated successfully.', variant: 'success', onDismiss: () => {} },
 };
 
-/* ─── Patterns ───────────────────────────────────────────────── */
+/** @summary Error — error badge, circle-exclamation icon */
+export const Error: Story = {
+  args: { title: 'Something went wrong', description: 'Please try again or contact support.', variant: 'error', onDismiss: () => {} },
+};
 
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Patterns',
-  render: () => {
-    const [visible, setVisible] = useState(false);
+/** @summary Warning — warning badge, triangle-exclamation icon */
+export const Warning: Story = {
+  args: { title: 'Session expiring', description: 'Your session will expire in 5 minutes.', variant: 'warning', onDismiss: () => {} },
+};
 
-    return (
-      <Stack>
-        <SectionLabel>Interactive toggle</SectionLabel>
-        <Button variant="primary" size="sm" onClick={() => setVisible(true)}>Show toast</Button>
-        {visible && (
-          <Toast
-            title="Action completed"
-            description="Your changes have been saved"
-            variant="success"
-            onDismiss={() => setVisible(false)}
-          />
-        )}
-
-        <SectionLabel>Error with context</SectionLabel>
-        <Toast
-          title="Upload failed"
-          description="The file exceeds the maximum size of 10MB. Please compress and try again."
-          variant="error"
-          onDismiss={() => {}}
-        />
-
-        <SectionLabel>Informational</SectionLabel>
-        <Toast
-          title="Syncing in progress"
-          description="Your data is being synchronized across devices. This may take a moment."
-          variant="info"
-        />
-      </Stack>
-    );
-  },
+/** @summary Info — info badge, circle-info icon */
+export const Info: Story = {
+  args: { title: 'New update available', description: 'Version 2.1 is ready to install.', variant: 'info', onDismiss: () => {} },
 };

--- a/components/ui/Tooltip/Tooltip.mdx
+++ b/components/ui/Tooltip/Tooltip.mdx
@@ -10,21 +10,17 @@ import * as Stories from './Tooltip.stories';
 
 Contextual information revealed on hover or focus. Four placements with arrow indicator.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
+
+Edit `content` and switch `placement` via Controls; the trigger is whatever you pass as `children`.
 
 ## Variants
 
-All four placements (`top`, `bottom`, `left`, `right`) plus a keyboard-shortcut example.
+All four placements (`top`, `bottom`, `left`, `right`) around the trigger — side-by-side because the Controls panel shows only one at a time.
 
-<Canvas of={Stories.Variants} />
-
-## Patterns
-
-Real-world usage: icon-button toolbar and form help text.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.Placements} />
 
 ## Props
 

--- a/components/ui/Tooltip/Tooltip.stories.tsx
+++ b/components/ui/Tooltip/Tooltip.stories.tsx
@@ -3,26 +3,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Tooltip } from './Tooltip';
 import { Button } from '../Button';
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
+/* ─── Layout helper (story-only) ──────────────────────────────── */
 
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-const Row = ({ children, gap = 'var(--gap-lg)' }: { children: React.ReactNode; gap?: string }) => (
+const Row = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
   <div style={{ display: 'flex', flexWrap: 'wrap', gap, alignItems: 'center' }}>{children}</div>
 );
 
@@ -41,10 +24,11 @@ const meta: Meta<typeof Tooltip> = {
     ),
   ],
   argTypes: {
-    content: { control: 'text' },
+    content: { control: 'text', description: 'Tooltip text revealed on hover / focus.' },
     placement: {
       control: 'select',
       options: ['top', 'bottom', 'left', 'right'],
+      description: 'Side the tooltip and its arrow anchor to.',
     },
   },
 } satisfies Meta<typeof Tooltip>;
@@ -53,11 +37,16 @@ export default meta;
 type Story = StoryObj<typeof Tooltip>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Canonical tooltip. Edit `content` and switch `placement` via Controls;
+ * the trigger is whatever you pass as `children`.
+ *
+ * @summary Contextual hover/focus tooltip with arrow
+ */
+export const Default: Story = {
   args: {
     content: 'This is a tooltip',
     placement: 'top',
@@ -66,106 +55,30 @@ export const Playground: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — All placements
+   VARIANTS — placement axis gallery
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
+/**
+ * All four placements around the trigger. Side-by-side is the point —
+ * the Controls panel can only show one placement at a time.
+ *
+ * @summary All four placements side by side
+ */
+export const Placements: Story = {
   render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Placements</SectionLabel>
-        <Row gap="var(--gap-xl)">
-          <Tooltip content="Top placement" placement="top">
-            <Button variant="outline" size="sm">Top</Button>
-          </Tooltip>
-          <Tooltip content="Bottom placement" placement="bottom">
-            <Button variant="outline" size="sm">Bottom</Button>
-          </Tooltip>
-          <Tooltip content="Left placement" placement="left">
-            <Button variant="outline" size="sm">Left</Button>
-          </Tooltip>
-          <Tooltip content="Right placement" placement="right">
-            <Button variant="outline" size="sm">Right</Button>
-          </Tooltip>
-        </Row>
-      </div>
-
-      <div>
-        <SectionLabel>With keyboard shortcut</SectionLabel>
-        <Tooltip content="Save (Cmd+S)" placement="bottom">
-          <Button size="sm">Save</Button>
-        </Tooltip>
-      </div>
-    </Stack>
+    <Row>
+      <Tooltip content="Top placement" placement="top">
+        <Button variant="outline" size="sm">Top</Button>
+      </Tooltip>
+      <Tooltip content="Bottom placement" placement="bottom">
+        <Button variant="outline" size="sm">Bottom</Button>
+      </Tooltip>
+      <Tooltip content="Left placement" placement="left">
+        <Button variant="outline" size="sm">Left</Button>
+      </Tooltip>
+      <Tooltip content="Right placement" placement="right">
+        <Button variant="outline" size="sm">Right</Button>
+      </Tooltip>
+    </Row>
   ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Icon buttons + form help text
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => {
-    const iconBtnStyle = {
-      width: '32px', // bds-lint-ignore — icon button touch target
-      height: '32px', // bds-lint-ignore
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      backgroundColor: 'var(--background-secondary)',
-      border: 'var(--border-width-md) solid var(--border-secondary)',
-      borderRadius: 'var(--border-radius-md)',
-      cursor: 'pointer',
-    };
-
-    return (
-      <Stack>
-        <div>
-          <SectionLabel>Icon button toolbar</SectionLabel>
-          <Row gap="var(--gap-md)">
-            <Tooltip content="Edit item">
-              <button style={iconBtnStyle}>✏️</button>
-            </Tooltip>
-            <Tooltip content="Delete item">
-              <button style={iconBtnStyle}>🗑️</button>
-            </Tooltip>
-            <Tooltip content="Share">
-              <button style={iconBtnStyle}>📤</button>
-            </Tooltip>
-          </Row>
-        </div>
-
-        <div>
-          <SectionLabel>Form help text</SectionLabel>
-          <div style={{
-            fontFamily: 'var(--font-family-body)',
-            fontSize: 'var(--body-md)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--gap-md)',
-          }}>
-            <span>Username</span>
-            <Tooltip content="Must be 3-20 characters" placement="right">
-              <span style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: '16px', // bds-lint-ignore — help icon size
-                height: '16px', // bds-lint-ignore
-                backgroundColor: 'var(--background-secondary)',
-                color: 'var(--text-secondary)',
-                borderRadius: '50%',
-                fontSize: 'var(--label-sm)',
-                cursor: 'help',
-              }}>
-                ?
-              </span>
-            </Tooltip>
-          </div>
-        </div>
-      </Stack>
-    );
-  },
 };


### PR DESCRIPTION
## Summary
- refactor(story-shape): Menu, Tooltip, Toast — gold-standard shape (#656)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)