### PR TITLE
feat(table): headerBorder + corner rounding + header bg (#407)

### DIFF
--- a/components/ui/Table/Table.css
+++ b/components/ui/Table/Table.css
@@ -3,16 +3,37 @@
 
 .bds-table {
   width: 100%;
-  border-collapse: collapse;
+  /* `separate` (not `collapse`) so border-radius on the table renders —
+     under `collapse` every browser drops the corner radius. Row dividers
+     move onto the cells (below) because `tr` borders don't paint here. */
+  border-collapse: separate;
+  border-spacing: 0;
   font-family: var(--font-family-body);
   color: var(--text-primary);
 }
 
-/* ─── Row ────────────────────────────────────────────────────── */
+/* ─── Rounded outer corners + boundary ───────────────────────── */
 
-.bds-table-row {
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+/* A visible outer border makes the rounded corners read; only drawn when
+   at least one edge is rounded. `overflow: hidden` clips the header
+   background and corner cells to the radius. */
+.bds-table[data-rounded-top="true"],
+.bds-table[data-rounded-bottom="true"] {
+  border: var(--border-width-sm) solid var(--border-muted);
+  overflow: hidden;
 }
+
+.bds-table[data-rounded-top="true"] {
+  border-top-left-radius: var(--border-radius-md);
+  border-top-right-radius: var(--border-radius-md);
+}
+
+.bds-table[data-rounded-bottom="true"] {
+  border-bottom-left-radius: var(--border-radius-md);
+  border-bottom-right-radius: var(--border-radius-md);
+}
+
+/* ─── Row ────────────────────────────────────────────────────── */
 
 .bds-table-row--selected {
   background-color: var(--background-secondary);
@@ -31,9 +52,21 @@
   font-weight: var(--font-weight-semibold);
   color: var(--text-muted);
   text-align: left;
-  border-bottom: var(--border-width-md) solid var(--border-muted);
-  background-color: var(--background-secondary);
   white-space: nowrap;
+}
+
+/* Header background — default `secondary`, opt into `primary` to match body. */
+.bds-table[data-header-bg="secondary"] .bds-table-head {
+  background-color: var(--background-secondary);
+}
+
+.bds-table[data-header-bg="primary"] .bds-table-head {
+  background-color: var(--background-primary);
+}
+
+/* Header bottom border — opt-in (off by default). */
+.bds-table[data-header-border="true"] .bds-table-head {
+  border-bottom: var(--border-width-md) solid var(--border-muted);
 }
 
 /* Size: default */
@@ -89,6 +122,9 @@
   color: var(--text-primary);
   vertical-align: middle;
   overflow-wrap: anywhere;
+  /* Row divider lives on the cell — `tr` borders don't paint under
+     `border-collapse: separate`. */
+  border-bottom: var(--border-width-sm) solid var(--border-muted);
 }
 
 /* Size: default */
@@ -110,6 +146,18 @@
   /* Shrink-to-content so action column never competes with content cells */
   width: 1%;
   white-space: nowrap;
+  /* Match the body-cell row divider (borders don't paint on `tr`). */
+  border-bottom: var(--border-width-sm) solid var(--border-muted);
+}
+
+/* When an outer border is present (any rounded edge), the last body row
+   drops its divider so the boundary isn't doubled. Without rounding there
+   is no outer border, so the trailing divider stays (matches legacy look). */
+.bds-table[data-rounded-top="true"] .bds-table-body .bds-table-row:last-child > .bds-table-cell,
+.bds-table[data-rounded-top="true"] .bds-table-body .bds-table-row:last-child > .bds-table-actions-cell,
+.bds-table[data-rounded-bottom="true"] .bds-table-body .bds-table-row:last-child > .bds-table-cell,
+.bds-table[data-rounded-bottom="true"] .bds-table-body .bds-table-row:last-child > .bds-table-actions-cell {
+  border-bottom: none;
 }
 
 /* Match TableCell padding rhythm */

--- a/components/ui/Table/Table.mdx
+++ b/components/ui/Table/Table.mdx
@@ -14,7 +14,7 @@ Data table with composable sub-components (`TableHeader` / `TableBody` / `TableR
 
 <Canvas of={Stories.Default} />
 
-`striped` and `size` (`default` / `comfortable`, 72px cell height) are Controls on this story.
+`striped`, `size` (`default` / `comfortable`, 72px cell height), `headerBorder` (off by default), `roundedTop` / `roundedBottom` (outer corners, on by default), and `headerBackground` (`secondary` / `primary`) are all Controls on this story.
 
 ## Variants
 

--- a/components/ui/Table/Table.stories.tsx
+++ b/components/ui/Table/Table.stories.tsx
@@ -69,6 +69,23 @@ const meta: Meta<typeof Table> = {
       options: ['default', 'comfortable'],
       description: 'Row density — `default` (compact) or `comfortable` (72px cell height).',
     },
+    headerBorder: {
+      control: 'boolean',
+      description: 'Show a bottom border under the header row. Off by default.',
+    },
+    roundedTop: {
+      control: 'boolean',
+      description: 'Round the top-left / top-right outer corners (draws a subtle outer border). On by default.',
+    },
+    roundedBottom: {
+      control: 'boolean',
+      description: 'Round the bottom-left / bottom-right outer corners (draws a subtle outer border). On by default.',
+    },
+    headerBackground: {
+      control: 'select',
+      options: ['secondary', 'primary'],
+      description: 'Header row background fill — `secondary` (default) or `primary` to match the body.',
+    },
   },
 };
 
@@ -80,13 +97,21 @@ type Story = StoryObj<typeof Table>;
    ═══════════════════════════════════════════════════════════════ */
 
 /**
- * Canonical table. Toggle `striped` and `size` via Controls. Cells accept
- * any content — see the Variants stories for the composition catalog.
+ * Canonical table. Toggle `striped`, `size`, `headerBorder`, `roundedTop`,
+ * `roundedBottom`, and `headerBackground` via Controls. Cells accept any
+ * content — see the Variants stories for the composition catalog.
  *
  * @summary Themed data table — striped + size are Controls
  */
 export const Default: Story = {
-  args: { striped: false, size: 'default' },
+  args: {
+    striped: false,
+    size: 'default',
+    headerBorder: false,
+    roundedTop: true,
+    roundedBottom: true,
+    headerBackground: 'secondary',
+  },
   render: (args) => (
     <Table {...args}>
       <TableHeader>

--- a/components/ui/Table/Table.tsx
+++ b/components/ui/Table/Table.tsx
@@ -13,6 +13,8 @@ import './Table.css';
 
 export type TableSize = 'default' | 'comfortable';
 
+export type TableHeaderBackground = 'primary' | 'secondary';
+
 export interface TableProps extends HTMLAttributes<HTMLTableElement> {
   /** Apply alternating row backgrounds for readability on dense tables. Default `false`. */
   striped?: boolean;
@@ -20,6 +22,14 @@ export interface TableProps extends HTMLAttributes<HTMLTableElement> {
   size?: TableSize;
   /** Remove left padding on first cell, right padding on last cell */
   flush?: boolean;
+  /** Show a bottom border under the header row. Default `false`. */
+  headerBorder?: boolean;
+  /** Round the top-left / top-right outer corners (and draw a subtle outer border). Default `true`. */
+  roundedTop?: boolean;
+  /** Round the bottom-left / bottom-right outer corners (and draw a subtle outer border). Default `true`. */
+  roundedBottom?: boolean;
+  /** Header row background fill. Default `secondary`. */
+  headerBackground?: TableHeaderBackground;
   /** Table content — typically `TableHead` and `TableBody` from this same module. */
   children: ReactNode;
 }
@@ -27,9 +37,10 @@ export interface TableProps extends HTMLAttributes<HTMLTableElement> {
 /**
  * Table — themed data table with striped and size variants.
  *
- * Size is propagated via `data-size` attribute on the table element.
- * CSS uses `[data-size]` selectors for cell padding, eliminating the
- * need for React context.
+ * Layout config is propagated via `data-*` attributes on the table element
+ * (`data-size`, `data-striped`, `data-flush`, `data-header-border`,
+ * `data-rounded-top`, `data-rounded-bottom`, `data-header-bg`). CSS reads
+ * those selectors, eliminating the need for React context.
  *
  * @summary Themed data table with striped + size variants
  */
@@ -37,6 +48,10 @@ export function Table({
   striped = false,
   size = 'default',
   flush = false,
+  headerBorder = false,
+  roundedTop = true,
+  roundedBottom = true,
+  headerBackground = 'secondary',
   children,
   className,
   style,
@@ -49,6 +64,10 @@ export function Table({
       data-striped={striped || undefined}
       data-size={size}
       data-flush={flush || undefined}
+      data-header-border={headerBorder || undefined}
+      data-rounded-top={roundedTop || undefined}
+      data-rounded-bottom={roundedBottom || undefined}
+      data-header-bg={headerBackground}
       {...props}
     >
       {children}


### PR DESCRIPTION
Closes #407

## Summary

Adds four Controls to `<Table>`, implementing the API proposed in #407:

| Prop | Type | Default | Effect |
|---|---|---|---|
| `headerBorder` | boolean | `false` | Bottom border under the header row (previously always-on 2px — now opt-in) |
| `roundedTop` | boolean | `true` | Rounds top-left/top-right outer corners |
| `roundedBottom` | boolean | `true` | Rounds bottom-left/bottom-right outer corners |
| `headerBackground` | `'secondary'` \| `'primary'` | `'secondary'` | Header fill (closes #407's third lever) |

All four are wired as Controls on the `Default` story (ADR-010 Q2 — args-expressible, no new story exports).

## Implementation note (load-bearing)

`border-radius` is ignored under `border-collapse: collapse`, so `.bds-table` switches to `border-collapse: separate; border-spacing: 0`. Knock-on changes, all internal:
- Row dividers move off `<tr>` (borders don't paint on rows under `separate`) onto `.bds-table-cell` / `.bds-table-actions-cell`.
- Rounding uses an `overflow: hidden` + subtle outer `--border-muted` border on the table so corners clip cleanly (verified in chromium — Chromatic's engine).
- The last body row drops its divider **only when rounded** (outer border closes the table); non-rounded edge-to-edge tables keep the legacy trailing divider.

Token-only throughout (`--border-radius-md`, `--border-muted`, `--background-primary/secondary`); no raw values.

## ⚠️ Default visual change for existing tables

Two defaults change the appearance of **every existing table** on the next `@brikdesigns/bds` bump (intended, per design decision):
- header 2px underline **disappears** (`headerBorder` off by default);
- all tables gain **rounded corners + a subtle outer border** (`roundedTop`/`roundedBottom` on by default).

Reviewers: confirm this is the desired default. Chromatic will show the movement across the Table stories.

## Known #407 gap (not a blocker)

#407 row 3 was renew wanting a *thin (1px)* header border matching row dividers. This ships header border as **off / 2px-on** (boolean), not a weight. With the border now off by default, renew's "lighter header" goal is met by leaving it off; a `headerBorderWeight` lever can be a follow-up if a thin-but-present header border is later needed.

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump — then **delete** the `.bds-table` / `.bds-table-head` overrides from `globals.css` (the #407 acceptance cleanup)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `vitest run Table` — 6/6 story tests pass (real browser render + play fns)
- [x] `npm run validate` — 10/10 (incl. token lint, contrast-gate, JSDoc, recipe, Storybook build)
- [x] Visual render of all 5 control states verified in chromium
- [ ] Chromatic snapshot review (expected movement: rounded corners + no header border by default)

Generated with [Claude Code](https://claude.ai/code)
