### PR TITLE
fix(tooling): chromatic auth via op run --env-file for headless sessions (#1058)

### DIFF
--- a/.env.op
+++ b/.env.op
@@ -1,0 +1,1 @@
+CHROMATIC_PROJECT_TOKEN=op://Development/golln4vuqvvf4gkzv5hmxfgvxm/credential

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ This CLAUDE.md is `@import`-ed by every consumer of `@brikdesigns/bds` — the B
 - **Pre-implementation** — DESIGN composite / new components in Paper before writing code. SKIP for simple variants of existing components or clear Figma specs.
 - **Pre-PR** — RUN `./scripts/pr-checklist.sh` before any PR touching tokens, themes, or component CSS. ONE concern per PR.
 - **Publish** — `git tag v0.X.Y && git push origin v0.X.Y` triggers [`Release` workflow](.github/workflows/release.yml). After publish, UPDATE the brik-llm submodule pointer.
-- **Chromatic** — RUN `npm run chromatic` after any component CSS or story change; local Storybook is not reachable from consumer-repo agents.
+- **Chromatic** — RUN `npm run chromatic` after any component CSS or story change; local Storybook is not reachable from consumer-repo agents. The script authenticates the Chromatic token via `op run --env-file=.env.op` (the inline `op://`-ref form does not resolve in headless/detached agent sessions — see #1058); requires the 1Password CLI signed in.
 
 ## Where deeper context lives
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ brik-bds is a public repo — GitHub's server-side push protection is also enabl
 | Full validation | `npm run validate:full` (pre-push gate) |
 | Build library | `npm run build:lib` |
 | Build content-system | `npm run build:content-system` |
-| Visual review | `npm run chromatic` |
+| Visual review | `npm run chromatic` (resolves the Chromatic token via `op run --env-file=.env.op`; needs the 1Password CLI signed in) |
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "gen:icons": "node scripts/gen-icon-collection.mjs",
     "gen:icons:check": "node scripts/gen-icon-collection.mjs --check",
     "gen:icons:update": "node scripts/gen-icon-collection.mjs && git add components/icons.generated.json",
-    "chromatic": "CHROMATIC_PROJECT_TOKEN='op://Development/golln4vuqvvf4gkzv5hmxfgvxm/credential' op run --no-masking -- npx chromatic",
+    "chromatic": "op run --no-masking --env-file=.env.op -- npx chromatic",
     "deploy:staging": "npm run build-storybook && npx netlify-cli deploy --dir=storybook-static",
     "deploy:prod": "npm run build-storybook && npx netlify-cli deploy --prod --dir=storybook-static",
     "sync:figma-mcp": "node scripts/sync-figma-mcp.js",


### PR DESCRIPTION
## Summary
- fix(tooling): chromatic auth via op run --env-file for headless sessions

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)