### PR TITLE
feat(table): headerBorderWeight — sm-weight header border (#1092)

### DIFF
--- a/components/ui/Table/Table.css
+++ b/components/ui/Table/Table.css
@@ -64,9 +64,14 @@
   background-color: var(--background-primary);
 }
 
-/* Header bottom border — opt-in (off by default). */
+/* Header bottom border — opt-in (off by default). Default weight `md`. */
 .bds-table[data-header-border="true"] .bds-table-head {
   border-bottom: var(--border-width-md) solid var(--border-muted);
+}
+
+/* Opt into `sm` weight to match the data-row divider (uniform border weight). */
+.bds-table[data-header-border="true"][data-header-border-weight="sm"] .bds-table-head {
+  border-bottom-width: var(--border-width-sm);
 }
 
 /* Size: default */

--- a/components/ui/Table/Table.mdx
+++ b/components/ui/Table/Table.mdx
@@ -14,7 +14,7 @@ Data table with composable sub-components (`TableHeader` / `TableBody` / `TableR
 
 <Canvas of={Stories.Default} />
 
-`striped`, `size` (`default` / `comfortable`, 72px cell height), `headerBorder` (off by default), `roundedTop` / `roundedBottom` (outer corners, on by default), and `headerBackground` (`secondary` / `primary`) are all Controls on this story.
+`striped`, `size` (`default` / `comfortable`, 72px cell height), `headerBorder` (off by default), `headerBorderWeight` (`md` default / `sm` to match the data-row divider), `roundedTop` / `roundedBottom` (outer corners, on by default), and `headerBackground` (`secondary` / `primary`) are all Controls on this story.
 
 ## Variants
 

--- a/components/ui/Table/Table.stories.tsx
+++ b/components/ui/Table/Table.stories.tsx
@@ -73,6 +73,12 @@ const meta: Meta<typeof Table> = {
       control: 'boolean',
       description: 'Show a bottom border under the header row. Off by default.',
     },
+    headerBorderWeight: {
+      control: 'select',
+      options: ['md', 'sm'],
+      description:
+        'Weight of the header bottom border when `headerBorder` is on — `md` (default) or `sm` to match the data-row divider. No effect when `headerBorder` is off.',
+    },
     roundedTop: {
       control: 'boolean',
       description: 'Round the top-left / top-right outer corners (draws a subtle outer border). On by default.',
@@ -97,9 +103,10 @@ type Story = StoryObj<typeof Table>;
    ═══════════════════════════════════════════════════════════════ */
 
 /**
- * Canonical table. Toggle `striped`, `size`, `headerBorder`, `roundedTop`,
- * `roundedBottom`, and `headerBackground` via Controls. Cells accept any
- * content — see the Variants stories for the composition catalog.
+ * Canonical table. Toggle `striped`, `size`, `headerBorder`,
+ * `headerBorderWeight`, `roundedTop`, `roundedBottom`, and `headerBackground`
+ * via Controls. Cells accept any content — see the Variants stories for the
+ * composition catalog.
  *
  * @summary Themed data table — striped + size are Controls
  */
@@ -108,6 +115,7 @@ export const Default: Story = {
     striped: false,
     size: 'default',
     headerBorder: false,
+    headerBorderWeight: 'md',
     roundedTop: true,
     roundedBottom: true,
     headerBackground: 'secondary',

--- a/components/ui/Table/Table.tsx
+++ b/components/ui/Table/Table.tsx
@@ -15,6 +15,8 @@ export type TableSize = 'default' | 'comfortable';
 
 export type TableHeaderBackground = 'primary' | 'secondary';
 
+export type TableHeaderBorderWeight = 'sm' | 'md';
+
 export interface TableProps extends HTMLAttributes<HTMLTableElement> {
   /** Apply alternating row backgrounds for readability on dense tables. Default `false`. */
   striped?: boolean;
@@ -24,6 +26,8 @@ export interface TableProps extends HTMLAttributes<HTMLTableElement> {
   flush?: boolean;
   /** Show a bottom border under the header row. Default `false`. */
   headerBorder?: boolean;
+  /** Weight of the header bottom border when `headerBorder` is on — `md` (default) or `sm` to match the data-row divider weight. No effect when `headerBorder` is off. */
+  headerBorderWeight?: TableHeaderBorderWeight;
   /** Round the top-left / top-right outer corners (and draw a subtle outer border). Default `true`. */
   roundedTop?: boolean;
   /** Round the bottom-left / bottom-right outer corners (and draw a subtle outer border). Default `true`. */
@@ -39,8 +43,9 @@ export interface TableProps extends HTMLAttributes<HTMLTableElement> {
  *
  * Layout config is propagated via `data-*` attributes on the table element
  * (`data-size`, `data-striped`, `data-flush`, `data-header-border`,
- * `data-rounded-top`, `data-rounded-bottom`, `data-header-bg`). CSS reads
- * those selectors, eliminating the need for React context.
+ * `data-header-border-weight`, `data-rounded-top`, `data-rounded-bottom`,
+ * `data-header-bg`). CSS reads those selectors, eliminating the need for
+ * React context.
  *
  * @summary Themed data table with striped + size variants
  */
@@ -49,6 +54,7 @@ export function Table({
   size = 'default',
   flush = false,
   headerBorder = false,
+  headerBorderWeight = 'md',
   roundedTop = true,
   roundedBottom = true,
   headerBackground = 'secondary',
@@ -65,6 +71,7 @@ export function Table({
       data-size={size}
       data-flush={flush || undefined}
       data-header-border={headerBorder || undefined}
+      data-header-border-weight={headerBorder ? headerBorderWeight : undefined}
       data-rounded-top={roundedTop || undefined}
       data-rounded-bottom={roundedBottom || undefined}
       data-header-bg={headerBackground}


### PR DESCRIPTION
## Summary

Closes #1092. Adds a non-breaking `headerBorderWeight?: 'sm' | 'md'` prop to `Table` (default `'md'`), applied only when `headerBorder` is on. Lets a consumer render the header bottom-border at the data-row divider weight (`sm`) through the BDS API alone — closes the renew-pms #221 audit **row-4** gap that #407 left open, so renew can delete its `.bds-table-head { border-bottom-width }` override.

## How it stays non-breaking

The base rule still paints `--border-width-md`; the new selector only overrides `border-bottom-width` when `[data-header-border-weight="sm"]`. Existing `headerBorder` consumers render byte-identically (default resolves to `md`, and the attribute is only emitted when `headerBorder` is on).

```css
.bds-table[data-header-border="true"] .bds-table-head { border-bottom: var(--border-width-md) solid var(--border-muted); }
.bds-table[data-header-border="true"][data-header-border-weight="sm"] .bds-table-head { border-bottom-width: var(--border-width-sm); }
```

## Acceptance criteria

- [x] Header bottom-border renders at `sm` weight via the BDS API, no `.bds-*` override needed
- [x] Default behavior unchanged — existing `headerBorder` consumers keep the `md` weight
- [x] Storybook covers the `sm`-weight state (see deviation note)
- [x] renew-pms can delete its `.bds-table-head { border-bottom-width }` override

### Deviation from AC #3 (deliberate)

AC #3 literally asked for a *one-per-state story*. Per the story-shape canon (ADR-010 Q2), a Default-shape visual axis expressible via Controls **must** be a Control, not a dedicated story — and the file's siblings `headerBorder` / `headerBackground` already follow that. A dedicated story would fail shape review, so `headerBorderWeight` is exposed as a **Control** on `Default`, satisfying the AC's observable intent (the `sm` weight is demonstrable in Storybook). The issue's design note authorizes this: *"the ACs gate the observable outcome, not the prop shape."*

## Test plan

- [x] `npm run validate:full` — all 10 checks pass (token / JSDoc / grid / theme / blueprint / BCS / canonical / **component-axes** / typecheck / **Storybook build**)
- [x] `npm run typecheck` clean · `node scripts/lint-tokens.js --errors-only` clean · recipe lint 88/88
- [x] Pre-commit hooks green (gitleaks, token, JSDoc, recipe, typecheck, anti-slop)
- [ ] **Chromatic — NOT run: snapshot quota exhausted (#771, build #756).** Per the #898 precedent the visual diff surfaces on push to `main` post-merge once quota is resolved. This is also the gate for the still-missing #407 visual baseline.

## Consumer sync plan

- [ ] renew-pms: bump BDS, delete the `.bds-table-head` border-width override (the #221 row-4 divergence)
- [ ] Portal / brikdesigns: no action required (additive, default-unchanged)

Closes #1092

🤖 Generated with [Claude Code](https://claude.com/claude-code)