### PR TITLE
Fix avatar-cell subtitle WCAG AA contrast

### DIFF
--- a/components/ui/Table/Table.css
+++ b/components/ui/Table/Table.css
@@ -249,7 +249,9 @@
 .bds-table-avatar-cell__subtitle {
   font-family: var(--font-family-body);
   font-size: var(--body-xs);
-  color: var(--text-muted);
+  /* --text-secondary (6.9:1 on white), not --text-muted (3.84:1 — fails WCAG AA
+     at this size). See #526 contrast contract. */
+  color: var(--text-secondary);
 }
 
 /* ─── Image cell (square 1:1 logo / product thumbnail) ───────── */


### PR DESCRIPTION
## Why

The #1096 a11y pass (axe, WCAG 2 AA) flagged `TableAvatarCell`'s `__subtitle`: `--text-muted` (#828282) on white = **3.84:1**, below the 4.5:1 AA floor for small text.

## What changed

`.bds-table-avatar-cell__subtitle` → `--text-secondary` (#5a5a5a) = **6.9:1**. One-line CSS, self-contained, no token or other-component changes.

The broader `--text-muted` secondary-text convention (existing `CellTypes` cell, table headers, Avatar/Badge/TextLink) is systemic and tracked under #526 — out of scope here.

## References

- Follow-up to #1096 (Table media cells)
- Contrast contract umbrella: #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)