### PR TITLE
Neutralize closing-keywords in submodule-bump PR bodies

### DIFF
--- a/scripts/__tests__/neutralize-closing-keywords.test.mjs
+++ b/scripts/__tests__/neutralize-closing-keywords.test.mjs
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { neutralizeClosingKeywords } from "../lib/neutralize-closing-keywords.mjs";
+
+/**
+ * Regression guard for brik-llm#1240 / the #729 collision.
+ *
+ * propagate.sh pastes brik-bds commit subjects into the consumer PR body. Any
+ * `closes #N` in those subjects references a brik-bds issue, but on merge
+ * GitHub resolves the number against the *consumer* tracker and closes the
+ * wrong issue. neutralizeClosingKeywords() must break every keyword-adjacent
+ * reference while leaving innocent prose and bare PR-links untouched.
+ */
+
+const ZWSP = "​";
+/** GitHub's own closing-keyword + reference grammar, for the "no longer
+ *  matches" assertion. Kept independent of the implementation regex. */
+const GH_AUTOCLOSE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+#\d+/i;
+
+describe("neutralizeClosingKeywords", () => {
+  it("neutralizes the exact commit subjects that broke #729", () => {
+    // From PR #729's pasted BDS changelog — these closed brik-llm #605/#607/#608.
+    const line1 =
+      "- feat(components): Banner ... (#587 Phase 2, closes #605, closes #608) (#610)";
+    const line2 =
+      "- docs(standards): @deprecated component retirement rule (closes #607) (#612)";
+
+    const out1 = neutralizeClosingKeywords(line1);
+    const out2 = neutralizeClosingKeywords(line2);
+
+    // No residual auto-close pattern survives.
+    expect(GH_AUTOCLOSE.test(out1)).toBe(false);
+    expect(GH_AUTOCLOSE.test(out2)).toBe(false);
+    // The break is a zero-width space right after the `#`.
+    expect(out1).toContain(`closes #${ZWSP}605`);
+    expect(out1).toContain(`closes #${ZWSP}608`);
+    expect(out2).toContain(`closes #${ZWSP}607`);
+  });
+
+  it("renders identically once the zero-width space is stripped", () => {
+    const input = "- fix(x): thing (closes #607) (#612)";
+    expect(neutralizeClosingKeywords(input).replaceAll(ZWSP, "")).toBe(input);
+  });
+
+  it("covers every conjugation and casing", () => {
+    for (const kw of [
+      "close",
+      "closes",
+      "closed",
+      "fix",
+      "fixes",
+      "fixed",
+      "resolve",
+      "resolves",
+      "resolved",
+      "Closes",
+      "FIXES",
+      "Resolved",
+    ]) {
+      const out = neutralizeClosingKeywords(`${kw} #42`);
+      expect(GH_AUTOCLOSE.test(out), `${kw} not neutralized`).toBe(false);
+    }
+  });
+
+  it("handles colon, no-space, owner/repo and GH- reference forms", () => {
+    const cases = [
+      "closes: #12",
+      "fixes#34",
+      "resolves brikdesigns/brik-bds#56",
+      "Closes GH-78",
+    ];
+    for (const c of cases) {
+      const out = neutralizeClosingKeywords(c);
+      // A break was actually inserted (guards against a form the regex misses).
+      expect(out, `not neutralized: ${c}`).toContain(ZWSP);
+      // …and only a ZWSP — the reference digits survive verbatim.
+      expect(out.replaceAll(ZWSP, "")).toBe(c);
+    }
+  });
+
+  it("leaves bare PR-links and non-keyword references untouched", () => {
+    // The trailing `(#610)` in a bump changelog is the BDS PR number, not a
+    // close directive — #1240 scopes reference-noise as out of scope.
+    const input = "- feat(x): thing (#610)";
+    expect(neutralizeClosingKeywords(input)).toBe(input);
+    expect(neutralizeClosingKeywords("See #99 for context.")).toBe(
+      "See #99 for context.",
+    );
+  });
+
+  it("does not match keywords embedded in larger words", () => {
+    for (const s of [
+      "prefixes #1",
+      "foreclosed #2",
+      "unresolved #3",
+      "closed-form #4",
+    ]) {
+      expect(neutralizeClosingKeywords(s)).toBe(s);
+    }
+  });
+
+  it("is idempotent", () => {
+    const once = neutralizeClosingKeywords("closes #607");
+    expect(neutralizeClosingKeywords(once)).toBe(once);
+  });
+
+  it("neutralizes multiple references across a multi-line changelog", () => {
+    const changelog = [
+      "### Features",
+      "- feat: a (closes #1)",
+      "### Fixes",
+      "- fix: b (fixes #2) (#3)",
+    ].join("\n");
+    const out = neutralizeClosingKeywords(changelog);
+    expect(GH_AUTOCLOSE.test(out)).toBe(false);
+    // The standalone `(#3)` PR-link is preserved.
+    expect(out).toContain("(#3)");
+  });
+});

--- a/scripts/lib/neutralize-closing-keywords.mjs
+++ b/scripts/lib/neutralize-closing-keywords.mjs
@@ -1,0 +1,84 @@
+/**
+ * Neutralize GitHub closing-keywords in pasted changelog text.
+ *
+ * Single source of truth for the propagate.sh submodule track. Consumed by:
+ *   - scripts/propagate.sh  (pipes the generated changelog through the CLI
+ *     before embedding it in the consumer PR body)
+ *   - scripts/__tests__/neutralize-closing-keywords.test.mjs
+ *
+ * Why: a submodule-bump PR pastes brik-bds commit subjects into the *consumer*
+ * repo's PR body. Those subjects carry `closes #N` / `fixes #N` referencing
+ * brik-bds issues, but on merge GitHub resolves the numbers against the
+ * *consumer* tracker and silently closes the wrong issues (brik-llm #729 →
+ * spuriously closed #607/#608/#533/#383/#384/#725). See brik-llm#1240.
+ *
+ * Fix: for any issue reference that directly follows a closing keyword, insert
+ * a zero-width space (U+200B) after the `#` (or after `GH-`). The reference
+ * renders identically to a human but is no longer a syntactically valid
+ * `#<digits>` reference, so GitHub neither auto-closes nor cross-links it.
+ * Idempotent — a second pass finds no bare `#<digit>` to break.
+ *
+ * Grammar reference: GitHub linked-issue keywords —
+ * https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+ */
+
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/** Zero-width space — invisible on render, breaks the reference token. */
+const ZWSP = "​";
+
+/**
+ * Closing keywords (case-insensitive), every conjugation GitHub honors.
+ * Word-boundary anchored so `prefixes` / `closed-form` never match.
+ */
+const KEYWORDS = "close[sd]?|fix(?:e[sd])?|resolve[sd]?";
+
+/**
+ * A reference GitHub would resolve against the tracker on merge:
+ *   #123 · owner/repo#123 · GH-123
+ */
+const REF = "(?:[\\w.-]+/[\\w.-]+)?#\\d+|GH-\\d+";
+
+/**
+ * keyword · optional colon · optional whitespace · reference.
+ * The separator is deliberately permissive (`:?\s*`) so `fixes: #1`,
+ * `fixes #1`, and `fixes#1` are all neutralized — over-breaking a reference
+ * is harmless; missing one closes an issue.
+ */
+const PATTERN = new RegExp(`\\b(${KEYWORDS})(:?\\s*)(${REF})`, "gi");
+
+/** Break a single matched reference so it is no longer a valid GitHub ref. */
+function breakRef(ref) {
+  return ref.includes("#")
+    ? ref.replace(/#(\d+)/, `#${ZWSP}$1`)
+    : ref.replace(/^(GH-)(\d+)$/i, `$1${ZWSP}$2`);
+}
+
+/**
+ * Return `text` with every closing-keyword-adjacent issue reference
+ * neutralized. Non-keyword references (e.g. a bare `(#610)` PR link) and all
+ * other prose are left untouched.
+ */
+export function neutralizeClosingKeywords(text) {
+  return String(text).replace(
+    PATTERN,
+    (_m, kw, sep, ref) => `${kw}${sep}${breakRef(ref)}`,
+  );
+}
+
+// ── CLI: stdin → stdout filter (how propagate.sh invokes it) ──
+const invokedDirectly =
+  process.argv[1] &&
+  realpathSync(process.argv[1]) ===
+    realpathSync(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  const chunks = [];
+  process.stdin.on("data", (c) => chunks.push(c));
+  process.stdin.on("end", () => {
+    process.stdout.write(
+      neutralizeClosingKeywords(Buffer.concat(chunks).toString("utf8")),
+    );
+  });
+}

--- a/scripts/propagate.sh
+++ b/scripts/propagate.sh
@@ -141,6 +141,16 @@ if ! command -v jq &>/dev/null; then
   exit 1
 fi
 
+# node powers the closing-keyword neutralizer the submodule track pipes its
+# changelog through (see scripts/lib/neutralize-closing-keywords.mjs). Without
+# it, a pasted `closes #N` would auto-close the wrong consumer issue on merge
+# (brik-llm#1240 / the #729 collision) — so fail loud rather than ship a raw
+# changelog. The npm track already needs node for `npm install`.
+if ! command -v node &>/dev/null; then
+  err "node not found — required to neutralize closing-keywords in PR bodies (brik-llm#1240)."
+  exit 1
+fi
+
 # Headless signing path must be live before we mutate anything (real run only).
 # Fails loud + early here instead of mid-propagation with a half-opened PR.
 if [ "$(hostname -s 2>/dev/null)" = "brik-mini" ] && [ "$DRY_RUN" = false ]; then
@@ -258,8 +268,14 @@ propagate_submodule() {
   fi
 
   info "$name is $new_commits commits behind"
+  # Neutralize closing-keywords BEFORE the changelog is shown or embedded: the
+  # BDS commit subjects carry `closes #N` for BDS issues, but pasted into the
+  # consumer PR body GitHub resolves them against the consumer's tracker and
+  # auto-closes the wrong issue on merge (brik-llm#1240 / the #729 collision).
+  # pipefail (set -euo) aborts the run if node fails — never ship a raw body.
   local changelog
-  changelog=$(generate_changelog "$current_sha" "$LOCAL_HEAD")
+  changelog=$(generate_changelog "$current_sha" "$LOCAL_HEAD" \
+    | node "$BDS_DIR/scripts/lib/neutralize-closing-keywords.mjs")
   echo -e "${DIM}─── Changelog ───${NC}"
   echo -e "$changelog"
   echo -e "${DIM}─────────────────${NC}"


### PR DESCRIPTION
## Why

`scripts/propagate.sh` (submodule track) pastes BDS commit subjects verbatim into the **consumer** repo's bump-PR body. Subjects that carry a `close`/`fix`/`resolve` keyword + issue number reference **BDS** issues — but on merge GitHub resolves the numbers against the **consumer's** tracker and auto-closes the wrong issues.

Confirmed instance: brik-llm#729 spuriously shut six brik-llm sub-issues (all since reopened). Tracked as brik-llm#1240.

## What

- **`scripts/lib/neutralize-closing-keywords.mjs`** — pure `neutralizeClosingKeywords(text)` + a stdin→stdout CLI. For any issue reference directly following a closing keyword (`#N`, `owner/repo#N`, `GH-N`), it inserts a zero-width space after the `#`. The reference renders identically to a human but is no longer a syntactically valid `#<digits>` reference, so GitHub neither auto-closes nor cross-links it. Idempotent; leaves bare PR-links (e.g. a trailing `(#NNNN)`) and ordinary prose untouched. Matches GitHub's keyword grammar (word-boundary anchored) so innocent words like `prefixes` never trip it.
- **`scripts/propagate.sh`** — the submodule track pipes its generated changelog through the neutralizer before the PR body is built. `node` added to preflight; `set -euo pipefail` aborts the run if it fails, so a raw changelog can never ship.
- **`scripts/__tests__/neutralize-closing-keywords.test.mjs`** — vitest regression guard (runs in `test.yml`). Covers the exact commit subjects from the original collision, every keyword conjugation/casing, the colon / no-space / `owner/repo` / `GH-` reference forms, idempotency, and the negative cases (bare PR-links + prose left intact).

## Verification

- `npx vitest run scripts/__tests__/neutralize-closing-keywords.test.mjs` → 8/8 pass.
- CLI hex-checked: `printf 'closes #607 and (#612)' | node scripts/lib/neutralize-closing-keywords.mjs` inserts exactly one ZWSP after `#607` and leaves `(#612)` untouched.
- `./scripts/propagate.sh --only brik-llm --dry-run` runs the real pipe end-to-end; output has zero un-neutralized `closes|fixes|resolves #N`.

## Scope

Root-cause fix for brik-llm#1240 — acceptance criteria 1 (neutralize at PR-creation) + 2 (regression check). The consumer-side CI guard (AC 3, defense-in-depth for hand-created bump PRs) ships in a companion brik-llm PR. Repairing already-mis-closed issues is out of scope (handled under brik-llm#604).

Only the submodule track is affected; the npm track builds its body without a pasted changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
