### PR TITLE
feat(tokens): add brand-text-size lint enforcing ADR-015 usage rule (#1064)

### DIFF
--- a/.github/workflows/contrast-gate.yml
+++ b/.github/workflows/contrast-gate.yml
@@ -60,3 +60,9 @@ jobs:
       # generator (measured ratios included) so it can't drift as tokens change.
       - name: Contrast matrix drift check
         run: npm run contrast-matrix:check
+
+      # ADR-015 brand-text rule: --text-brand-primary (3.78:1) never on small
+      # body copy. Advisory in the pairing gate (scores pairings, not sizes) —
+      # asserted here (#1064 AC1).
+      - name: Brand-text usage lint
+        run: npm run lint-brand-text

--- a/components/ui/NotificationList/NotificationList.css
+++ b/components/ui/NotificationList/NotificationList.css
@@ -131,7 +131,7 @@
   font-family: var(--font-family-label);
   font-size: var(--body-xs);
   font-weight: var(--font-weight-medium);
-  color: var(--text-brand-primary);
+  color: var(--text-brand-primary); /* bds-lint-ignore — small brand affordance at body-xs; tracked #1103, resolved by #1065 near-Poppy AA step */
   padding: 0;
   transition: opacity 0.15s;
 }

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -164,7 +164,7 @@
   font-size: var(--body-sm);
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-normal);
-  color: var(--text-brand-primary);
+  color: var(--text-brand-primary); /* bds-lint-ignore — small brand affordance at body-sm; tracked #1103, resolved by #1065 near-Poppy AA step */
   text-decoration: none;
   cursor: pointer;
 }

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "validate:blueprints": "node scripts/validate-blueprints.mjs",
     "contrast-gate": "node scripts/validate-themes.js",
     "contrast-matrix:check": "node scripts/validate-themes.js --check-matrix",
+    "lint-brand-text": "node scripts/lint-brand-text-size.js",
     "validate": "node scripts/lint-tokens.js --errors-only && npm run contrast-gate && npm run lint-jsdoc && npm run validate:blueprints && npm run typecheck && npm run build-storybook",
     "validate:full": "node scripts/validate-all.js",
     "precommit": "npm run validate",

--- a/scripts/lint-brand-text-size.js
+++ b/scripts/lint-brand-text-size.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * lint-brand-text-size — enforce ADR-015's brand-text usage rule.
+ *
+ * ADR-015 (§ Advisory claim) + tokens/contrast-pairings.json state:
+ *   "small body copy NEVER uses --text-brand-primary, it uses --text-primary."
+ * That rule was advisory-only — the contrast gate scores token *pairings*, not
+ * rendered font sizes, so it can't catch `--text-brand-primary` bound to small
+ * body text (3.78:1 on white — below the AA-normal 4.5:1 floor). This lint makes
+ * the rule CI-asserted (#1064 / BDS-18, AC1).
+ *
+ * Scope decision — body vs label:
+ *   `--text-brand-primary` is legitimately used across the library for LINK / TAB /
+ *   BREADCRUMB affordances, which ADR-015 gates at AA-large (3:1) as brand accent.
+ *   BDS's type system separates `--body-*` (paragraph copy) from `--label-*` (UI
+ *   labels/links). This lint flags brand-primary co-occurring with a SMALL BODY
+ *   size (`--body-xs` / `--body-sm`) — the exact "small body copy" the rule bans —
+ *   and deliberately leaves `--label-*` affordances alone. Whether small `--label-*`
+ *   brand text is acceptable is the #1064 AC3 policy reconciliation, not this lint.
+ *
+ * Escape hatch: put `bds-lint-ignore` on the `--text-brand-primary` line (tracked
+ * cases live in #1103).
+ *
+ * Usage:
+ *   node scripts/lint-brand-text-size.js   # exit 1 on any un-ignored violation
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..');
+const COMPONENTS = path.join(ROOT, 'components');
+const BRAND = '--text-brand-primary';
+const SMALL_BODY = /--body-(xs|sm)\b/; // paragraph copy at a small size
+
+function componentCssFiles() {
+  const out = execSync(`grep -rlE -e "${BRAND}" "${COMPONENTS}" || true`, { encoding: 'utf8' });
+  return out.split('\n').filter((f) => f && f.endsWith('.css'));
+}
+
+// The enclosing rule for a declaration: nearest `{`-bearing line above, nearest
+// `}`-bearing line below. Correct for flat rules and rules nested in @media.
+function enclosingBlock(lines, i) {
+  let start = i;
+  while (start >= 0 && !lines[start].includes('{')) start--;
+  let end = i;
+  while (end < lines.length && !lines[end].includes('}')) end++;
+  return { start, text: lines.slice(Math.max(start, 0), end + 1).join('\n') };
+}
+
+function main() {
+  const violations = [];
+  for (const file of componentCssFiles()) {
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      if (!line.includes(BRAND)) return;
+      if (line.includes('bds-lint-ignore')) return;
+      const { start, text } = enclosingBlock(lines, i);
+      const m = text.match(SMALL_BODY);
+      if (!m) return;
+      const selector = start >= 0 ? lines[start].replace('{', '').trim() : '(unknown)';
+      violations.push({ file: path.relative(ROOT, file), line: i + 1, selector, size: m[0] });
+    });
+  }
+
+  if (violations.length === 0) {
+    console.log('✓ brand-text-size: no --text-brand-primary on small body copy.');
+    process.exit(0);
+  }
+
+  console.error('✗ brand-text-size: --text-brand-primary used on small body copy (ADR-015 says use --text-primary).\n');
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  ${v.selector}`);
+    console.error(`     color: var(--text-brand-primary) in a rule sized ${v.size} — 3.78:1 on white, fails AA-normal.`);
+  }
+  console.error('\n  Fix: use --text-primary for body copy, or promote to a --label-* affordance role (AA-large per ADR-015).');
+  console.error('  Escape hatch (tracked): add `bds-lint-ignore` on the line — see #1103.');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

**AC1 of #1064 (BDS-18)** — makes ADR-015's brand-text usage rule CI-asserted.

`--text-brand-primary` is vibrant `poppy-light` (**3.78:1** on white) — below AA-normal. ADR-015's advisory rule ("small body copy never uses `--text-brand-primary`") couldn't be enforced by the contrast gate (it scores token *pairings*, not rendered sizes). This adds `scripts/lint-brand-text-size.js` (`npm run lint-brand-text`, wired into the contrast-gate workflow) that flags `--text-brand-primary` co-occurring with a small body size (`--body-xs`/`--body-sm`) in a component CSS rule.

**Scope — body vs label.** The library uses `--text-brand-primary` widely for link / tab / breadcrumb affordances, which ADR-015 gates at **AA-large (3:1)** as brand accent. BDS's type system separates `--body-*` (paragraph copy) from `--label-*` (UI labels/links), so the lint keys on `--body-*` — the exact "small body copy" the rule bans — and leaves `--label-*` affordances alone. Whether small `--label-*` brand text is acceptable is #1064 **AC3** (policy reconciliation), not this lint.

## Known cases (allowlisted + tracked)

Two current body-tier occurrences carry `bds-lint-ignore` and are tracked in **#1103** (resolved by #1065's near-Poppy AA step): `NotificationList` (`--body-xs`), `TaskConsole` (`--body-sm`). The lint blocks *new* violations immediately.

## Verification

- `lint-brand-text` passes with the 2 allowlisted; **exits 1 on a fresh `--body-*` + brand-primary rule** (negative-tested).
- pr-task gates green: token lint, JSDoc, typecheck, anti-slop.

## Linkage

Refs #1064 — **partial** (AC1). AC3 (brand-vs-client AA policy contract) remains. Sub-issue of #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)