### PR TITLE
Footer: linkComponent escape hatch for client-side routing

### DIFF
--- a/components/ui/Footer/Footer.mdx
+++ b/components/ui/Footer/Footer.mdx
@@ -10,6 +10,8 @@ import * as Stories from './Footer.stories';
 
 Site-wide footer with logo, navigation columns, social links, and copyright. Supports default and brand color variants.
 
+Pass `linkComponent` (e.g. `next/link`) so column and bottom-bar links route client-side instead of triggering a full-page reload. See [framework guides → client-side routing](/docs/getting-started/framework-guides).
+
 ## Playground
 
 <Canvas of={Stories.Playground} />

--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Footer } from './Footer';
+import { type BdsLinkComponent } from '../NavItem';
+
+/* Story-only stand-in for a router `Link` (Next.js / Remix). Tags the rendered
+ * anchor so the injected-routing path is visible in the DOM. */
+const MockLink: BdsLinkComponent = ({ href, children, ...props }) => (
+  <a href={href} data-link-component="mock" {...props}>
+    {children}
+  </a>
+);
 
 /* ─── Layout Helpers (story-only) ─────────────────────────────── */
 
@@ -83,6 +92,11 @@ const meta: Meta<typeof Footer> = {
       control: 'select',
       options: ['h2', 'h3', 'h4', 'h5', 'h6'],
     },
+    linkComponent: {
+      description:
+        'Render column + bottom-bar links with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. See ADR-012.',
+      control: false,
+    },
   },
 } satisfies Meta<typeof Footer>;
 
@@ -101,6 +115,20 @@ export const Playground: Story = {
     columns: sampleColumns,
     copyright: '\u00A9 2026 Brik Designs. All rights reserved.',
     variant: 'default',
+  },
+};
+
+/** @summary Column + bottom-bar links routed through an injected link component for client-side routing */
+export const WithLinkComponent: Story = {
+  args: {
+    logo: <LogoPlaceholder />,
+    columns: sampleColumns,
+    copyright: '\u00A9 2026 Brik Designs. All rights reserved.',
+    bottomLinks: [
+      { label: 'Terms', href: '/terms' },
+      { label: 'Privacy', href: '/privacy' },
+    ],
+    linkComponent: MockLink,
   },
 };
 

--- a/components/ui/Footer/Footer.tsx
+++ b/components/ui/Footer/Footer.tsx
@@ -1,4 +1,5 @@
 import { type HTMLAttributes, type ReactNode, Fragment } from 'react';
+import { type BdsLinkComponent } from '../NavItem';
 import { bdsClass } from '../../utils';
 import './Footer.css';
 
@@ -75,12 +76,50 @@ export interface FooterProps extends HTMLAttributes<HTMLElement> {
   aboveTop?: ReactNode;
   /** Footer variant */
   variant?: FooterVariant;
+  /**
+   * Render column + bottom-bar links with a router-aware component (Next.js
+   * `Link`, Remix `Link`) for client-side routing instead of the default bare
+   * `<a>`. Applies to every `columns[].links[]` and `bottomLinks[]` entry. See
+   * ADR-012.
+   */
+  linkComponent?: BdsLinkComponent;
 }
 
 /**
  * Footer variant
  */
 export type FooterVariant = 'default' | 'brand' | 'inverse';
+
+/**
+ * Renders a footer link with the injected `linkComponent` (client-side routing)
+ * or a bare `<a>` when none is provided. Footer links always carry an `href`
+ * and have no disabled state, so the dispatch is a straight fallback. See
+ * ADR-012.
+ */
+function FooterLink({
+  linkComponent: LinkComponent,
+  href,
+  className,
+  children,
+}: {
+  linkComponent?: BdsLinkComponent;
+  href: string;
+  className: string;
+  children: ReactNode;
+}) {
+  if (LinkComponent) {
+    return (
+      <LinkComponent href={href} className={className}>
+        {children}
+      </LinkComponent>
+    );
+  }
+  return (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  );
+}
 
 /**
  * Footer - BDS page footer with link columns
@@ -136,6 +175,7 @@ export function Footer({
   socialLinks,
   aboveTop,
   variant = 'default',
+  linkComponent,
   className = '',
   style,
   ...props
@@ -172,8 +212,9 @@ export function Footer({
               <div key={col.heading} className="bds-footer__column">
                 <HeadingTag className="bds-footer__heading">{col.heading}</HeadingTag>
                 {col.links.map((link) => (
-                  <a
+                  <FooterLink
                     key={link.href + link.label}
+                    linkComponent={linkComponent}
                     href={link.href}
                     className="bds-footer__link"
                   >
@@ -183,7 +224,7 @@ export function Footer({
                       </span>
                     )}
                     {link.label}
-                  </a>
+                  </FooterLink>
                 ))}
               </div>
             ))}
@@ -212,12 +253,13 @@ export function Footer({
                         </li>
                       )}
                       <li>
-                        <a
+                        <FooterLink
+                          linkComponent={linkComponent}
                           href={link.href}
                           className="bds-footer__bottom-link"
                         >
                           {link.label}
-                        </a>
+                        </FooterLink>
                       </li>
                     </Fragment>
                   ))}


### PR DESCRIPTION
## Summary
- feat(footer): linkComponent escape hatch for client-side routing

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)