### PR TITLE
Breadcrumb: linkComponent escape hatch for client-side routing

### DIFF
--- a/components/ui/Breadcrumb/Breadcrumb.mdx
+++ b/components/ui/Breadcrumb/Breadcrumb.mdx
@@ -10,6 +10,8 @@ import * as Stories from './Breadcrumb.stories';
 
 Navigation breadcrumb trail showing the current page location within a hierarchy. Supports slash and chevron separators.
 
+Pass `linkComponent` (e.g. `next/link`) so linked crumbs route client-side instead of triggering a full-page reload. See [framework guides → client-side routing](/docs/getting-started/framework-guides).
+
 ## Playground
 
 <Canvas of={Stories.Playground} />

--- a/components/ui/Breadcrumb/Breadcrumb.stories.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Breadcrumb } from './Breadcrumb';
+import { type BdsLinkComponent } from '../NavItem';
+
+/* Story-only stand-in for a router `Link` (Next.js / Remix). Tags the rendered
+ * anchor so the injected-routing path is visible in the DOM. */
+const MockLink: BdsLinkComponent = ({ href, children, ...props }) => (
+  <a href={href} data-link-component="mock" {...props}>
+    {children}
+  </a>
+);
 
 /* ─── Layout Helpers (story-only) ─────────────────────────────── */
 
@@ -30,6 +39,11 @@ const meta: Meta<typeof Breadcrumb> = {
   parameters: { layout: 'padded' },
   argTypes: {
     separator: { control: 'select', options: ['slash', 'chevron'] },
+    linkComponent: {
+      description:
+        'Render each linked crumb with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. See ADR-012.',
+      control: false,
+    },
   },
 };
 
@@ -49,6 +63,18 @@ export const Playground: Story = {
       { label: 'Design System' },
     ],
     separator: 'slash',
+  },
+};
+
+/** @summary Linked crumbs routed through an injected link component for client-side routing */
+export const WithLinkComponent: Story = {
+  args: {
+    items: [
+      { label: 'Home', href: '/' },
+      { label: 'Products', href: '/products' },
+      { label: 'Design System' },
+    ],
+    linkComponent: MockLink,
   },
 };
 

--- a/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -1,4 +1,5 @@
-import { type HTMLAttributes } from 'react';
+import { type HTMLAttributes, type ReactNode } from 'react';
+import { type BdsLinkComponent } from '../NavItem';
 import { bdsClass } from '../../utils';
 import './Breadcrumb.css';
 
@@ -14,12 +15,45 @@ export interface BreadcrumbProps extends HTMLAttributes<HTMLElement> {
   items: BreadcrumbItem[];
   /** Visual separator between crumbs. Default `slash` (`/`); `chevron` renders `›`. */
   separator?: BreadcrumbSeparator;
+  /**
+   * Render each linked crumb with a router-aware component (Next.js `Link`,
+   * Remix `Link`) for client-side routing instead of the default bare `<a>`.
+   * The current (last) crumb is always plain text. See ADR-012.
+   */
+  linkComponent?: BdsLinkComponent;
 }
 
 const SEPARATOR_CHARS: Record<BreadcrumbSeparator, string> = {
   slash: '/',
   chevron: '›',
 };
+
+/**
+ * Renders a linked crumb via the injected `linkComponent` (client-side routing)
+ * or a bare `<a>` when none is provided. See ADR-012.
+ */
+function BreadcrumbLink({
+  linkComponent: LinkComponent,
+  href,
+  children,
+}: {
+  linkComponent?: BdsLinkComponent;
+  href: string;
+  children: ReactNode;
+}) {
+  if (LinkComponent) {
+    return (
+      <LinkComponent href={href} className="bds-breadcrumb__link">
+        {children}
+      </LinkComponent>
+    );
+  }
+  return (
+    <a href={href} className="bds-breadcrumb__link">
+      {children}
+    </a>
+  );
+}
 
 /**
  * Breadcrumb — navigation breadcrumb trail with separator variants.
@@ -29,6 +63,7 @@ const SEPARATOR_CHARS: Record<BreadcrumbSeparator, string> = {
 export function Breadcrumb({
   items,
   separator = 'slash',
+  linkComponent,
   className,
   style,
   ...props
@@ -59,9 +94,9 @@ export function Breadcrumb({
                 {item.label}
               </span>
             ) : (
-              <a href={item.href} className="bds-breadcrumb__link">
+              <BreadcrumbLink linkComponent={linkComponent} href={item.href}>
                 {item.label}
-              </a>
+              </BreadcrumbLink>
             )}
           </span>
         );


### PR DESCRIPTION
## Summary
- feat(breadcrumb): linkComponent escape hatch for client-side routing

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)