### PR TITLE
NavBar: linkComponent escape hatch for client-side routing

### DIFF
--- a/components/ui/NavBar/NavBar.mdx
+++ b/components/ui/NavBar/NavBar.mdx
@@ -10,6 +10,8 @@ import * as Stories from './NavBar.stories';
 
 Top-level navigation bar with logo, links, and action buttons. Supports sticky positioning for scroll-persistent navigation.
 
+Pass `linkComponent` (e.g. `next/link`) so nav links route client-side instead of triggering a full-page reload. See [framework guides → client-side routing](/docs/getting-started/framework-guides).
+
 ## Playground
 
 <Canvas of={Stories.Playground} />

--- a/components/ui/NavBar/NavBar.stories.tsx
+++ b/components/ui/NavBar/NavBar.stories.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { NavBar } from './NavBar';
 import { Button } from '../Button';
+import { type BdsLinkComponent } from '../NavItem';
+
+/* Story-only stand-in for a router `Link` (Next.js / Remix). Tags the rendered
+ * anchor so the injected-routing path is visible in the DOM. */
+const MockLink: BdsLinkComponent = ({ href, children, ...props }) => (
+  <a href={href} data-link-component="mock" {...props}>
+    {children}
+  </a>
+);
 
 /* ─── Layout Helpers (story-only) ─────────────────────────────── */
 
@@ -50,6 +59,13 @@ const meta: Meta<typeof NavBar> = {
   component: NavBar,
   tags: ['surface-web'],
   parameters: { layout: 'fullscreen' },
+  argTypes: {
+    linkComponent: {
+      description:
+        'Render each nav link with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. See ADR-012.',
+      control: false,
+    },
+  },
 } satisfies Meta<typeof NavBar>;
 
 export default meta;
@@ -65,6 +81,16 @@ export const Playground: Story = {
     logo: <LogoPlaceholder />,
     links: sampleLinks,
     actions: <Button size="sm">Get Started</Button>,
+  },
+};
+
+/** @summary Nav links routed through an injected link component for client-side routing */
+export const WithLinkComponent: Story = {
+  args: {
+    logo: <LogoPlaceholder />,
+    links: sampleLinks,
+    actions: <Button size="sm">Get Started</Button>,
+    linkComponent: MockLink,
   },
 };
 

--- a/components/ui/NavBar/NavBar.tsx
+++ b/components/ui/NavBar/NavBar.tsx
@@ -1,4 +1,5 @@
 import { type HTMLAttributes, type ReactNode } from 'react';
+import { type BdsLinkComponent } from '../NavItem';
 import { bdsClass } from '../../utils';
 import './NavBar.css';
 
@@ -26,6 +27,43 @@ export interface NavBarProps extends HTMLAttributes<HTMLElement> {
   actions?: ReactNode;
   /** Sticky positioning */
   sticky?: boolean;
+  /**
+   * Render each nav link with a router-aware component (Next.js `Link`, Remix
+   * `Link`) for client-side routing instead of the default bare `<a>`. See
+   * ADR-012.
+   */
+  linkComponent?: BdsLinkComponent;
+}
+
+/**
+ * Renders a nav link via the injected `linkComponent` (client-side routing) or
+ * a bare `<a>` when none is provided. See ADR-012.
+ */
+function NavBarLinkItem({
+  linkComponent: LinkComponent,
+  href,
+  className,
+  ariaCurrent,
+  children,
+}: {
+  linkComponent?: BdsLinkComponent;
+  href: string;
+  className: string;
+  ariaCurrent?: 'page';
+  children: ReactNode;
+}) {
+  if (LinkComponent) {
+    return (
+      <LinkComponent href={href} className={className} aria-current={ariaCurrent}>
+        {children}
+      </LinkComponent>
+    );
+  }
+  return (
+    <a href={href} className={className} aria-current={ariaCurrent}>
+      {children}
+    </a>
+  );
 }
 
 /**
@@ -54,6 +92,7 @@ export function NavBar({
   links = [],
   actions,
   sticky = false,
+  linkComponent,
   className = '',
   style,
   ...props
@@ -73,17 +112,18 @@ export function NavBar({
         {links.length > 0 && (
           <div className="bds-nav-bar__links">
             {links.map((link) => (
-              <a
+              <NavBarLinkItem
                 key={link.href}
+                linkComponent={linkComponent}
                 href={link.href}
                 className={bdsClass(
                   'bds-nav-bar__link',
                   link.active ? 'bds-nav-bar__link--active' : undefined,
                 )}
-                aria-current={link.active ? 'page' : undefined}
+                ariaCurrent={link.active ? 'page' : undefined}
               >
                 {link.label}
-              </a>
+              </NavBarLinkItem>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- feat(navbar): linkComponent escape hatch for client-side routing

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)