### PR TITLE
Swap sub-AA small brand text to text-primary (#1103)

### DIFF
--- a/components/ui/NotificationList/NotificationList.css
+++ b/components/ui/NotificationList/NotificationList.css
@@ -131,7 +131,7 @@
   font-family: var(--font-family-label);
   font-size: var(--body-xs);
   font-weight: var(--font-weight-medium);
-  color: var(--text-brand-primary); /* bds-lint-ignore — small brand affordance at body-xs; tracked #1103, resolved by #1065 near-Poppy AA step */
+  color: var(--text-primary); /* AA-safe on white at body-xs (#1103); brand affordance returns via the #1065 near-Poppy AA step */
   padding: 0;
   transition: opacity 0.15s;
 }

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -164,7 +164,7 @@
   font-size: var(--body-sm);
   font-weight: var(--font-weight-semibold);
   line-height: var(--font-line-height-normal);
-  color: var(--text-brand-primary); /* bds-lint-ignore — small brand affordance at body-sm; tracked #1103, resolved by #1065 near-Poppy AA step */
+  color: var(--text-primary); /* AA-safe on white at body-sm (#1103); brand affordance returns via the #1065 near-Poppy AA step */
   text-decoration: none;
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- fix(a11y): swap sub-AA small brand text to text-primary (#1103)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)