### PR TITLE
feat(components): add density prop to Tag + Badge for dense rows (#406)

### DIFF
--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -56,6 +56,21 @@
   height: 40px;
 }
 
+/* ─── Density (compact — tighter horizontal padding for dense rows) ── */
+/* Mirrors Tag so a compact Badge and compact Tag stay aligned side by
+   side. `density="compact"` shifts horizontal padding one token-step
+   down per size (sm→xs, md/lg→sm); height and vertical padding are
+   unchanged. xs is icon-only and is unaffected. */
+
+.bds-badge--compact.bds-badge--sm {
+  padding-inline: var(--padding-xs);
+}
+
+.bds-badge--compact.bds-badge--md,
+.bds-badge--compact.bds-badge--lg {
+  padding-inline: var(--padding-sm);
+}
+
 /* ─── Icon Wrapper (shared sizing with Tag) ──────────────────── */
 
 .bds-badge__icon {

--- a/components/ui/Badge/Badge.mdx
+++ b/components/ui/Badge/Badge.mdx
@@ -50,6 +50,12 @@ Four size tokens at a single status. `xs` is icon-only by design — text doesn'
 
 <Canvas of={Stories.Sizes} />
 
+### Density
+
+`comfortable` (default) vs `compact` — compact tightens horizontal padding one token-step down for dense rows. Mirrors Tag so the two align side by side.
+
+<Canvas of={Stories.Density} />
+
 ### With icon
 
 <Canvas of={Stories.WithIcon} />

--- a/components/ui/Badge/Badge.stories.tsx
+++ b/components/ui/Badge/Badge.stories.tsx
@@ -25,6 +25,10 @@ const meta: Meta<typeof Badge> = {
       control: 'select',
       options: ['solid', 'subtle'],
     },
+    density: {
+      control: 'select',
+      options: ['comfortable', 'compact'],
+    },
   },
 };
 
@@ -125,6 +129,28 @@ export const Sizes: Story = {
       <Badge size="md" status="positive">Medium</Badge>
       <Badge size="lg" status="positive">Large</Badge>
     </Row>
+  ),
+};
+
+/**
+ * Density axis — `comfortable` (default) vs `compact` at each text size.
+ * Compact tightens horizontal padding one token-step down so more badges
+ * fit inline in a dense table row; height is unchanged. `xs` is icon-only
+ * and unaffected, so it's omitted here.
+ *
+ * @summary Comfortable vs compact density across sizes
+ */
+export const Density: Story = {
+  render: () => (
+    <Stack gap="var(--gap-lg)">
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <Row key={size}>
+          <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--body-xs)', color: 'var(--text-muted)', width: '24px' }}>{size}</span>
+          <Badge size={size} status="positive" density="comfortable">Comfortable</Badge>
+          <Badge size={size} status="positive" density="compact">Compact</Badge>
+        </Row>
+      ))}
+    </Stack>
   ),
 };
 

--- a/components/ui/Badge/Badge.tsx
+++ b/components/ui/Badge/Badge.tsx
@@ -9,6 +9,14 @@ export type BadgeStatus = 'positive' | 'warning' | 'error' | 'info' | 'progress'
 export type BadgeSize = 'xs' | 'sm' | 'md' | 'lg';
 
 /**
+ * Badge density — orthogonal to `size`, shared axis with Tag / BulletList / Table.
+ * - `comfortable` (default) — current spacing.
+ * - `compact` — tighter horizontal padding (one token-step down per size),
+ *   kept in sync with Tag so both align in dense rows. Height is unchanged.
+ */
+export type BadgeDensity = 'comfortable' | 'compact';
+
+/**
  * Badge fill appearance — shared axis with Chip (`solid | outline`) and
  * Tag (`solid | subtle`). Badge supports the two pastel-capable values.
  * - `solid`  — saturated status-color background, high emphasis.
@@ -24,6 +32,8 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   size?: BadgeSize;
   /** Fill appearance — solid (saturated bg) or subtle (pastel bg). */
   appearance?: BadgeAppearance;
+  /** Density — `compact` tightens horizontal padding for dense rows. Default `comfortable`. */
+  density?: BadgeDensity;
   /** Children content (optional for xs/icon-only size) */
   children?: ReactNode;
   /** Optional icon before text (required for xs size) */
@@ -56,6 +66,7 @@ export function Badge({
   status = 'info',
   size = 'md',
   appearance = 'solid',
+  density = 'comfortable',
   children,
   icon,
   className,
@@ -69,6 +80,7 @@ export function Badge({
     `bds-badge--${status}`,
     `bds-badge--${size}`,
     `bds-badge--${appearance}`,
+    density === 'compact' && 'bds-badge--compact',
     className
   );
 

--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -82,6 +82,22 @@
   border-radius: var(--border-radius-md);
 }
 
+/* ─── Density (compact — tighter horizontal padding for dense rows) ── */
+/* `density="compact"` shifts horizontal padding one token-step down at
+   each text size (sm→xs, md/lg→sm) so more Tags fit inline in a dense
+   table row. Height and vertical padding are unchanged, preserving
+   side-by-side row alignment with Badge. xs is icon-only (no horizontal
+   padding) and is unaffected. */
+
+.bds-tag--compact.bds-tag--sm {
+  padding-inline: var(--padding-xs);
+}
+
+.bds-tag--compact.bds-tag--md,
+.bds-tag--compact.bds-tag--lg {
+  padding-inline: var(--padding-sm);
+}
+
 /* ─── Disabled ────────────────────────────────────────────────── */
 
 .bds-tag--disabled {

--- a/components/ui/Tag/Tag.mdx
+++ b/components/ui/Tag/Tag.mdx
@@ -25,6 +25,11 @@ Sizes, appearances, icon positions, and states in one view.
 - **`solid`** (default) — Neutral filled background. Matches existing Tag styling.
 - **`subtle`** — Transparent background with a hairline border. Lower visual weight when Tags sit on a colored surface.
 
+**Density** (orthogonal to `size`; shared axis with Badge, BulletList, Table):
+
+- **`comfortable`** (default) — Current spacing.
+- **`compact`** — Tighter horizontal padding (one token-step down per size) so more Tags fit inline in a dense table row. Height is unchanged.
+
 ## Patterns
 
 Real-world compositions for categorization and filtering.

--- a/components/ui/Tag/Tag.stories.tsx
+++ b/components/ui/Tag/Tag.stories.tsx
@@ -21,6 +21,10 @@ const meta: Meta<typeof Tag> = {
       control: 'select',
       options: ['solid', 'subtle'],
     },
+    density: {
+      control: 'select',
+      options: ['comfortable', 'compact'],
+    },
     disabled: { control: 'boolean' },
     onRemove: { action: 'removed' },
   },
@@ -86,6 +90,16 @@ export const Variants: Story = {
           <Tag appearance="solid" icon={<Icon icon="ph:tag" />}>Solid + icon</Tag>
           <Tag appearance="subtle" icon={<Icon icon="ph:tag" />}>Subtle + icon</Tag>
         </Row>
+      </div>
+      <div>
+        <SectionLabel>Density (comfortable vs compact)</SectionLabel>
+        {(['sm', 'md', 'lg'] as const).map((size) => (
+          <div key={size} style={{ display: 'flex', gap: 'var(--gap-md)', alignItems: 'center', marginBottom: 'var(--gap-md)' }}>
+            <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--body-xs)', color: 'var(--text-muted)', width: '24px' }}>{size}</span>
+            <Tag size={size} density="comfortable">Comfortable</Tag>
+            <Tag size={size} density="compact">Compact</Tag>
+          </div>
+        ))}
       </div>
       <div>
         <SectionLabel>With icons</SectionLabel>

--- a/components/ui/Tag/Tag.tsx
+++ b/components/ui/Tag/Tag.tsx
@@ -8,6 +8,14 @@ import './Tag.css';
 export type TagSize = 'xs' | 'sm' | 'md' | 'lg';
 
 /**
+ * Tag density — orthogonal to `size`, shared axis with BulletList / Table.
+ * - `comfortable` (default) — current spacing.
+ * - `compact` — tighter horizontal padding (one token-step down per size)
+ *   so more Tags fit inline in a dense table row. Height is unchanged.
+ */
+export type TagDensity = 'comfortable' | 'compact';
+
+/**
  * Tag fill appearance — shared axis with Badge (`solid | subtle`) and
  * Chip (`solid | outline`). Tag supports the two pastel-capable values.
  * - `solid`  — neutral filled background (current default styling).
@@ -23,6 +31,8 @@ export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
   size?: TagSize;
   /** Fill appearance — solid (neutral fill) or subtle (transparent + border). */
   appearance?: TagAppearance;
+  /** Density — `compact` tightens horizontal padding for dense rows. Default `comfortable`. */
+  density?: TagDensity;
   /** Optional leading icon (left) — required for xs size */
   icon?: ReactNode;
   /** Optional trailing icon (right) */
@@ -64,6 +74,7 @@ export function Tag({
   children,
   size = 'md',
   appearance = 'solid',
+  density = 'comfortable',
   icon,
   trailingIcon,
   onRemove,
@@ -78,6 +89,7 @@ export function Tag({
     'bds-tag',
     `bds-tag--${size}`,
     `bds-tag--${appearance}`,
+    density === 'compact' && 'bds-tag--compact',
     disabled && 'bds-tag--disabled',
     className
   );


### PR DESCRIPTION
## Summary

Closes #406 (under the #524 prop-API hardening project).

Adds an additive `density?: 'comfortable' | 'compact'` axis to **Tag** and **Badge**:

- Default `comfortable` emits **no class** → existing consumers are byte-identical (zero visual change, zero DOM change).
- `compact` shifts **horizontal** padding one token-step down per size (`sm`→`--padding-xs`, `md`/`lg`→`--padding-sm`). Height and vertical padding are unchanged, so Tags/Badges stay row-aligned.
- Mirrored onto Badge because the two share a size scale for side-by-side alignment.

### Why `comfortable | compact` (not the issue's `default | compact`)

`density` is already a system axis (BulletList, Table). Per the [prop-axes canon](https://design.brikdesigns.com/docs/build-standards/prop-axes) axis **names and values** are reused, not reinvented. BulletList is the exact analog — a tighter option below a roomy default — and uses `comfortable | compact`, so Tag/Badge match it. Not one of the four visual axes tracked by `manifest/component-axes.json`, so no `typegen:axes` change.

### Exact renew-pms parity

renew-pms still overrides Tag padding in `globals.css`:

```css
.bds-tag--sm { padding-inline: var(--padding-xs); }
.bds-tag--md, .bds-tag--lg { padding-inline: var(--padding-sm); }
```

`density="compact"` uses the **same token refs**, so after this ships renew can migrate to `<Tag density="compact">` and delete the override. (Follow-up in renew-pms, not this PR — one concern per PR.)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `node scripts/lint-storybook-recipe.js --enforce` — 88/88 conforming
- [x] `npm run typegen:axes:check` — manifest in sync (density not tracked)
- [x] `node scripts/lint-tokens.js --errors-only` — 0 errors
- [x] `./scripts/pr-checklist.sh` — token lint + contrast gate pass
- [x] `vitest run` Tag + Badge — 27/27 pass
- [x] **Visual verification** — see note below

### ⚠️ Chromatic quota exhausted — verified via Playwright instead

`npm run chromatic` (build 774) **published** the Storybook but ran **zero visual snapshots**: _"Snapshot quota reached — out of snapshots for the month"_ (the parked #771 quota problem). So Chromatic did **not** verify this diff.

Rather than rubber-stamp `STORY_VERIFIED=1`, I verified the actual computed styles in a real browser (Chromium via Playwright) against a locally-built Storybook:

| size | comfortable padL | compact padL | height | vertical pad |
|---|---|---|---|---|
| sm | 12px | **10px** (`--padding-xs`) | 28px (unchanged) | unchanged |
| md | 16px | **12px** (`--padding-sm`) | 32px (unchanged) | unchanged |
| lg | 16px | **12px** (`--padding-sm`) | 40px (unchanged) | unchanged |

Confirms (a) compact tightens horizontal padding only, (b) height + vertical padding never move, (c) compact values match renew's targets exactly, (d) `comfortable` defaults are unchanged from current BDS.

**Reviewer note:** CI Chromatic will also be quota-limited until #771 is resolved — the Playwright table above is the visual evidence for this PR.