### PR TITLE
feat(components): add density prop to Sheet for dense surfaces (#408)

### DIFF
--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -211,6 +211,20 @@
   margin-left: auto;
 }
 
+/* ─── Density (compact — tighter vertical padding for dense sheets) ── */
+/* `density="compact"` tightens the vertical padding one step on the
+   scrolling body (padding-block xl→lg) and the footer (lg→md) for
+   data-dense surfaces that need more content per viewport. Horizontal
+   padding is unchanged, so the body/footer stay aligned with the header. */
+
+.bds-sheet--compact .bds-sheet__body {
+  padding-block: var(--padding-lg);
+}
+
+.bds-sheet--compact .bds-sheet__footer {
+  padding-block: var(--padding-md);
+}
+
 /* ─── Stack frame transitions ──────────────────────────────────── */
 
 .bds-sheet-stack__frame {

--- a/components/ui/Sheet/Sheet.mdx
+++ b/components/ui/Sheet/Sheet.mdx
@@ -36,6 +36,12 @@ Edit mode is the active form state — footer auto-renders `[Cancel] [Save]`. Pa
 
 <Canvas of={Stories.Floating} />
 
+### Compact density
+
+`density="compact"` (orthogonal to `variant`; shared axis with Tag, Badge, BulletList, Table) tightens the body and footer vertical padding one step — body `padding-block` xl→lg, footer lg→md — for data-dense sheets. Default `comfortable` is unchanged. Horizontal padding stays put, so the body/footer keep alignment with the header.
+
+<Canvas of={Stories.Compact} />
+
 ## Patterns
 
 ### Read ↔ edit toggle

--- a/components/ui/Sheet/Sheet.stories.tsx
+++ b/components/ui/Sheet/Sheet.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof Sheet> = {
   argTypes: {
     side: { control: 'select', options: ['right', 'left', 'bottom'], description: 'Screen edge the sheet anchors to.' },
     variant: { control: 'select', options: ['default', 'floating'], description: '`floating` drops the backdrop and elevates + rounds the panel.' },
+    density: { control: 'select', options: ['comfortable', 'compact'], description: '`compact` tightens body + footer vertical padding for data-dense sheets.' },
     mode: { control: 'select', options: [undefined, 'read', 'edit'], description: 'Drives the auto-footer — `read` → `[Close] [Edit]`, `edit` → `[Cancel] [Save]`.' },
     editTarget: { control: 'select', options: ['inline', 'page'], description: 'Semantic hint — `page` means `onEdit` navigates rather than flipping in place.' },
     title: { control: 'text', description: 'Header title.' },
@@ -177,6 +178,36 @@ export const Floating: Story = {
           isOpen={open}
           onClose={() => setOpen(false)}
           variant="floating"
+          subtitle="Company"
+          title="Brik Designs"
+          description="Active · Updated 2 days ago"
+          mode="read"
+          onEdit={() => alert('Switch to edit mode')}
+        >
+          <ReadOnlyFields />
+        </Sheet>
+      </>
+    );
+  },
+};
+
+/**
+ * Compact density tightens the body and footer vertical padding one step
+ * (body `padding-block` xl→lg, footer lg→md) for data-dense sheets that
+ * need more content per viewport. Horizontal padding is unchanged.
+ *
+ * @summary Compact density — tighter body + footer padding
+ */
+export const Compact: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>View company (compact)</Button>
+        <Sheet
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          density="compact"
           subtitle="Company"
           title="Brik Designs"
           description="Active · Updated 2 days ago"

--- a/components/ui/Sheet/Sheet.tsx
+++ b/components/ui/Sheet/Sheet.tsx
@@ -19,6 +19,16 @@ export type SheetVariant = 'default' | 'floating';
 export type SheetMode = 'read' | 'edit';
 
 /**
+ * Sheet density — orthogonal to `variant`, shared axis with Tag / Badge /
+ * BulletList / Table.
+ * - `comfortable` (default) — current spacing.
+ * - `compact` — tighter vertical padding on the body and footer (body
+ *   `padding-block` xl→lg, footer lg→md) for data-dense sheets that need
+ *   more content per viewport. Horizontal padding is unchanged.
+ */
+export type SheetDensity = 'comfortable' | 'compact';
+
+/**
  * Where the `[Edit]` button in the read-mode footer takes the user.
  *
  * - `inline` (default) — flips this sheet to `mode='edit'`; consumer
@@ -99,6 +109,8 @@ export interface SheetProps {
    * - `floating` — rounded floating panel with elevation, no backdrop (read-only detail views)
    */
   variant?: SheetVariant;
+  /** Density — `compact` tightens body + footer vertical padding for data-dense sheets. Default `comfortable`. */
+  density?: SheetDensity;
   /** Close when the backdrop is clicked. Default `true`. Has no effect when `variant="floating"` (no backdrop). */
   closeOnBackdrop?: boolean;
   /** Close on `Escape` keypress. Default `true`. */
@@ -186,6 +198,7 @@ export function Sheet({
   description,
   width = '400px',
   variant = 'default',
+  density = 'comfortable',
   closeOnBackdrop = true,
   closeOnEscape = true,
   showCloseButton = true,
@@ -341,7 +354,7 @@ export function Sheet({
     <>
       {!isFloating && <div className="bds-sheet-backdrop" onClick={handleBackdropClick} />}
       <div
-        className={bdsClass('bds-sheet', `bds-sheet--${side}`, isFloating ? 'bds-sheet--floating' : '')}
+        className={bdsClass('bds-sheet', `bds-sheet--${side}`, isFloating ? 'bds-sheet--floating' : '', density === 'compact' ? 'bds-sheet--compact' : '')}
         role="dialog"
         aria-modal={!isFloating}
         style={widthStyle}


### PR DESCRIPTION
## Summary

Closes #408 (under the #524 prop-API hardening project).

Adds an additive `density?: 'comfortable' | 'compact'` axis to **Sheet**:

- Default `comfortable` emits no class → existing consumers byte-identical (zero visual/DOM change).
- `compact` tightens **vertical** padding one step on the scrolling body (`padding-block` xl→lg) and footer (lg→md) via a `.bds-sheet--compact` root modifier. Horizontal padding is unchanged, so body/footer stay aligned with the header.

Reuses the `density` axis established for Tag/Badge (#406, shared with BulletList/Table) rather than the issue's proposed separate `bodyPadding`/`footerPadding` props — a single control covers renew's need and matches the axis canon.

### Exact renew-pms parity

renew-pms overrides both in `globals.css`:

```css
.bds-sheet__body   { padding: var(--padding-lg); }
.bds-sheet__footer { padding: var(--padding-md) var(--padding-lg); }
```

`density="compact"` produces exactly these values, so renew can migrate to `<Sheet density="compact">` and delete both. (Follow-up in renew-pms — one concern per PR.)

The issue's third override — `.bds-sheet__close { padding-top: 0 }` — is **already handled**: the close affordance is the `CloseButton` atom, top-aligned via the header's `align-items: flex-start`. That renew override targets a `padding-top` the current markup doesn't use (it uses negative `margin`); out of scope here.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `node scripts/lint-storybook-recipe.js --enforce` — 88/88 conforming
- [x] `node scripts/lint-tokens.js --errors-only` — 0 errors
- [x] `./scripts/pr-checklist.sh` — token lint + contrast gate pass
- [x] `vitest run` Sheet — 13/13 pass
- [x] **Visual verification** — see below

### ⚠️ Chromatic quota still exhausted — verified via Playwright

Chromatic remains out of monthly snapshots (#771), so I verified computed styles in Chromium (Playwright) against a locally-built Storybook, A/B-ing the `ReadMode` (comfortable) and `Compact` stories — identical except `density`:

| element | comfortable padY | compact padY | padX |
|---|---|---|---|
| body | 32px (`--padding-xl`) | **24px** (`--padding-lg`) | 24px (unchanged) |
| footer | 24px (`--padding-lg`) | **16px** (`--padding-md`) | 24px (unchanged) |

Confirms compact tightens vertical only, horizontal is untouched, values match renew's targets exactly, and `comfortable` defaults are unchanged.

**Reviewer note:** CI Chromatic will be quota-limited too until #771 is resolved — the table above is the visual evidence.