### PR TITLE
fix(storybook): pre-bundle runtime deps to stop dynamic-import fetch errors

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -43,6 +43,25 @@ const config: StorybookConfig = {
   docs: {
     defaultName: 'Overview',
   },
+  async viteFinal(config) {
+    const { mergeConfig } = await import('vite');
+    // Pre-bundle every third-party runtime dep our components import. Storybook
+    // lazy-loads story modules, so a dep first seen when navigating to a story
+    // (e.g. lottie-react via AnimatedIcon) triggers a mid-session dep re-optimize
+    // + full reload — which 404s any module the browser is mid-fetching and
+    // surfaces as "Failed to fetch dynamically imported module". Declaring them
+    // up front means the optimizer bundles them once at startup and never churns.
+    return mergeConfig(config, {
+      optimizeDeps: {
+        include: [
+          '@iconify/react',
+          '@radix-ui/react-collapsible',
+          '@radix-ui/react-popover',
+          'lottie-react',
+        ],
+      },
+    });
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- fix(storybook): pre-bundle runtime deps to stop dynamic-import fetch errors

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)