### PR TITLE
Card: avatar / 1:1 image left-media slot on the default Card

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -58,6 +58,51 @@
   color: inherit;
 }
 
+/* ─── Media (leading avatar / 1:1 image — "media object" layout) ── */
+/* Optional leading media on the default Card: an Avatar or a square 1:1 Image
+ * on the left, with content (children) stacked to the right. The card owns
+ * only the row layout + gap and the fixed-square image wrapper; the visual
+ * itself comes from the composed Avatar / Image primitive. Mirrors the
+ * TableAvatarCell / TableImageCell media cells. */
+
+.bds-card--media {
+  flex-direction: row;
+  align-items: flex-start;
+}
+
+.bds-card__media {
+  flex-shrink: 0;
+  display: flex;
+}
+
+.bds-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Fixed square wrapper for the 1:1 image variant, keyed to the Avatar size
+ * scale so an avatar and an image read at the same footprint. Avatars size
+ * themselves, so these modifiers apply only to image media. */
+.bds-card__media--sm,
+.bds-card__media--md,
+.bds-card__media--lg,
+.bds-card__media--xl {
+  overflow: hidden;
+  border-radius: var(--border-radius-sm);
+}
+
+/* bds-lint-ignore — thumbnail dimensions aligned to the Avatar size scale; no semantic size token */
+.bds-card__media--sm { width: 32px; }
+/* bds-lint-ignore — thumbnail dimensions aligned to the Avatar size scale; no semantic size token */
+.bds-card__media--md { width: 40px; }
+/* bds-lint-ignore — thumbnail dimensions aligned to the Avatar size scale; no semantic size token */
+.bds-card__media--lg { width: 48px; }
+/* bds-lint-ignore — thumbnail dimensions aligned to the Avatar size scale; no semantic size token */
+.bds-card__media--xl { width: 64px; }
+
 /* ─── Subcomponents ──────────────────────────────────────────── */
 
 .bds-card-title {

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -28,6 +28,14 @@ The default shape also takes a `variant`: `outlined` (default, secondary border)
 
 <Canvas of={Stories.Borderless} />
 
+### Leading media (avatar / image)
+
+The default shape takes an optional `media` prop that turns the card into a horizontal "media object" — an `Avatar` or a square 1:1 `Image` on the left, with `children` stacked to the right. Pass exactly one of `media={{ avatar: {…} }}` or `media={{ image: {…} }}`. Both size to the shared Avatar scale (`sm` 32px, `md` 40px, `lg` 48px, `xl` 64px) so an avatar and an image read at the same footprint. The avatar falls back to initials from `name` and can carry a presence `status`; the image takes `fit` (`contain` for logos, `cover` for photos). Mirrors the `TableAvatarCell` / `TableImageCell` media cells.
+
+<Canvas of={Stories.WithAvatar} />
+
+<Canvas of={Stories.WithImage} />
+
 ### Control preset
 
 `preset="control"` — settings/control row. Leading `logo` + `badge` + (title + description) on the left, (`connectionStatus` indicator + `action`) on the right. Use `actionAlign="top"` for long descriptions where the action should anchor to the upper-right corner.

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -32,6 +32,11 @@ const meta: Meta<typeof Card> = {
       description:
         'When set, renders the card as `<a>` instead of `<div>`. The whole card becomes the navigation target.',
     },
+    media: {
+      control: false,
+      description:
+        'Leading media (Default shape only) — `{ avatar: {…} }` or `{ image: {…} }`. Renders an `Avatar` or a square 1:1 `Image` on the left, with `children` stacked to the right. See `WithAvatar` / `WithImage`.',
+    },
   },
 };
 
@@ -110,6 +115,65 @@ export const Borderless: Story = {
           borderRadius: 'var(--border-radius-md)',
         }}
       >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * Default Card with a leading `Avatar` — the "media object" layout. Pass
+ * `media={{ avatar: {…} }}`; the avatar renders on the left and `children`
+ * (`<CardTitle>` / `<CardDescription>`) stack to the right. The avatar falls
+ * back to initials from `name` when no `src` loads, and can carry a presence
+ * `status` dot. Size keys to the Avatar scale (`sm`/`md`/`lg`/`xl`).
+ *
+ * @summary media avatar — identity card (name + detail)
+ */
+export const WithAvatar: Story = {
+  args: {
+    variant: 'outlined',
+    padding: 'md',
+    media: { avatar: { name: 'Jordan Lee', status: 'online', size: 'lg' } },
+    children: (
+      <>
+        <CardTitle as="h4">Jordan Lee</CardTitle>
+        <CardDescription>jordan.lee@brikdesigns.com</CardDescription>
+      </>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * Default Card with a leading square 1:1 `Image` — the logo / thumbnail
+ * counterpart to `WithAvatar`. Pass `media={{ image: {…} }}` with `fit`
+ * (`contain` for logos, `cover` for photos). Size keys to the same scale as
+ * the avatar so the two read at an identical footprint.
+ *
+ * @summary media image — logo / thumbnail card
+ */
+export const WithImage: Story = {
+  args: {
+    variant: 'outlined',
+    padding: 'md',
+    media: { image: { src: '/brik-logo.svg', alt: 'Brik Designs logo', fit: 'contain', size: 'lg' } },
+    children: (
+      <>
+        <CardTitle as="h4">Brik Designs</CardTitle>
+        <CardDescription>Design system · Enterprise plan</CardDescription>
+      </>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
         <Story />
       </div>
     ),

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -1,5 +1,7 @@
 import { type HTMLAttributes, type ReactNode } from 'react';
 import { bdsClass } from '../../utils';
+import { Avatar, type AvatarSize, type AvatarStatus } from '../Avatar';
+import { Image } from '../Image';
 import './Card.css';
 
 export type CardVariant = 'outlined' | 'brand' | 'elevated' | 'borderless';
@@ -29,6 +31,49 @@ export type CardControlConnectionStatus =
  */
 export type CardDisplayRowImageWidth = 'narrow' | 'standard' | 'wide' | (string & {});
 
+/**
+ * Size for the default Card's leading `media` slot — a square keyed to the
+ * `Avatar` size scale (`sm` 32px, `md` 40px, `lg` 48px, `xl` 64px) so an
+ * avatar and a 1:1 image read at the same footprint. Default `md`.
+ */
+export type CardMediaSize = AvatarSize;
+export type CardMediaImageFit = 'contain' | 'cover';
+
+/** Avatar shape for the default Card's leading `media` slot. Mirrors `Avatar`. */
+export interface CardAvatarMedia {
+  /** Avatar image URL. Falls back to initials from `name` when absent. */
+  src?: string;
+  /** Accessible alt text for the avatar image. */
+  alt?: string;
+  /** Name used for the initials fallback when no image loads. */
+  name?: string;
+  /** Square size on the `Avatar` scale (default `md`). */
+  size?: CardMediaSize;
+  /** Presence indicator on the avatar. */
+  status?: AvatarStatus;
+}
+
+/** 1:1 image shape for the default Card's leading `media` slot. Mirrors `Image`. */
+export interface CardImageMedia {
+  /** Image URL. */
+  src: string;
+  /** Accessible alt text — required. */
+  alt: string;
+  /** Square size on the `Avatar` scale (default `md`). */
+  size?: CardMediaSize;
+  /** Fit inside the square — `contain` for logos (no crop), `cover` for photos. Default `contain`. */
+  fit?: CardMediaImageFit;
+}
+
+/**
+ * Leading media for the default Card — an `Avatar` OR a square 1:1 `Image` on
+ * the left, with `children` stacked to the right. Provide exactly one of
+ * `avatar` / `image`.
+ */
+export type CardMedia =
+  | { avatar: CardAvatarMedia; image?: never }
+  | { image: CardImageMedia; avatar?: never };
+
 export interface CardSummaryTextLink {
   label: string;
   href?: string;
@@ -53,6 +98,13 @@ interface CardDefaultProps extends CardBaseProps {
   interactive?: boolean;
   /** Render as `<a>` instead of `<div>`. */
   href?: string;
+  /**
+   * Optional leading media — an `Avatar` or a square 1:1 `Image` on the left,
+   * with `children` stacked to the right (the "media object" layout). Compose
+   * `<CardTitle>` / `<CardDescription>` / `<CardFooter>` in `children` as
+   * usual; they render in the content column. Omit for a plain vertical card.
+   */
+  media?: CardMedia;
   /** Card content — composes `<CardTitle>`, `<CardDescription>`, `<CardFooter>`, etc. */
   children: ReactNode;
 }
@@ -286,6 +338,19 @@ function formatSummaryValue(value: string | number, type: CardSummaryType): stri
  * </Card>
  * ```
  *
+ * @example Default with leading media (avatar / 1:1 image on the left)
+ * ```tsx
+ * <Card media={{ avatar: { src: u.avatar, name: u.name, status: 'online' } }}>
+ *   <CardTitle as="h4">{u.name}</CardTitle>
+ *   <CardDescription>{u.email}</CardDescription>
+ * </Card>
+ *
+ * <Card media={{ image: { src: org.logo, alt: `${org.name} logo`, fit: 'contain' } }}>
+ *   <CardTitle as="h4">{org.name}</CardTitle>
+ *   <CardDescription>{org.plan}</CardDescription>
+ * </Card>
+ * ```
+ *
  * @example Control preset
  * ```tsx
  * <Card
@@ -340,9 +405,33 @@ export function Card(props: CardProps) {
 
 const NAMED_IMAGE_WIDTHS: ReadonlySet<string> = new Set(['narrow', 'standard', 'wide']);
 
+/**
+ * Render the default Card's leading media slot — an `Avatar` or a square 1:1
+ * `Image`, keyed to the shared media-size scale. The card owns only the
+ * fixed-square wrapper (for images) and shrink-to-content sizing; the visual
+ * itself comes from the composed primitive.
+ */
+function renderCardMedia(media: CardMedia) {
+  if (media.avatar) {
+    const { src, alt, name, size = 'md', status } = media.avatar;
+    return (
+      <div className="bds-card__media">
+        <Avatar src={src} alt={alt} name={name} size={size} status={status} />
+      </div>
+    );
+  }
+  const { src, alt, size = 'md', fit = 'contain' } = media.image;
+  return (
+    <div className={bdsClass('bds-card__media', `bds-card__media--${size}`)}>
+      <Image src={src} alt={alt} ratio="1-1" fit={fit} />
+    </div>
+  );
+}
+
 function renderDefault({
   variant = 'outlined',
   children,
+  media,
   interactive = false,
   href,
   padding = 'md',
@@ -355,22 +444,35 @@ function renderDefault({
     'bds-card',
     `bds-card--${variant}`,
     `bds-card--padding-${padding}`,
+    media && 'bds-card--media',
     interactive && 'bds-card--interactive',
     href && 'bds-card--link',
     className,
   );
 
+  // With media, split into a leading media wrapper + a content column so
+  // children keep their vertical rhythm beside the avatar / image. Without
+  // media, render children directly — unchanged from the original layout.
+  const content = media ? (
+    <>
+      {renderCardMedia(media)}
+      <div className="bds-card__content">{children}</div>
+    </>
+  ) : (
+    children
+  );
+
   if (href) {
     return (
       <a href={href} className={classes} style={style} {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
-        {children}
+        {content}
       </a>
     );
   }
 
   return (
     <div className={classes} style={style} {...rest}>
-      {children}
+      {content}
     </div>
   );
 }

--- a/components/ui/Card/index.ts
+++ b/components/ui/Card/index.ts
@@ -15,5 +15,11 @@ export {
   type CardSummaryTextLink,
   // Control-preset prop types for integration/connection-status cards.
   type CardControlConnectionStatus,
+  // Default-Card leading-media (avatar / 1:1 image) types.
+  type CardMedia,
+  type CardAvatarMedia,
+  type CardImageMedia,
+  type CardMediaSize,
+  type CardMediaImageFit,
 } from './Card';
 export { default } from './Card';

--- a/docs-site/content/docs/components/card.mdx
+++ b/docs-site/content/docs/components/card.mdx
@@ -64,6 +64,22 @@ Compose freely with the Title / Description / Footer subcomponents.
 </Card>
 ```
 
+### Leading media (avatar / image)
+
+The `media` prop turns the default card into a horizontal "media object" — an `Avatar` or a square 1:1 `Image` on the left, with `children` stacked to the right. Pass exactly one of `avatar` / `image`. Both size to the shared Avatar scale (`sm` 32px, `md` 40px, `lg` 48px, `xl` 64px). The avatar falls back to initials from `name` and can carry a presence `status`; the image takes `fit` (`contain` for logos, `cover` for photos).
+
+```tsx
+<Card media={{ avatar: { name: 'Jordan Lee', status: 'online', size: 'lg' } }}>
+  <CardTitle as="h4">Jordan Lee</CardTitle>
+  <CardDescription>jordan.lee@brikdesigns.com</CardDescription>
+</Card>
+
+<Card media={{ image: { src: '/brik-logo.svg', alt: 'Brik Designs logo', fit: 'contain', size: 'lg' } }}>
+  <CardTitle as="h4">Brik Designs</CardTitle>
+  <CardDescription>Design system · Enterprise plan</CardDescription>
+</Card>
+```
+
 ## Control preset
 
 `preset="control"` is the canonical settings-row card. Locked layout: leading badge + (title + description) on the left, action slot on the right.
@@ -126,6 +142,7 @@ Compose freely with the Title / Description / Footer subcomponents.
 | `padding` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'md'` |
 | `interactive` | `boolean` | `false` |
 | `href` | `string` | — |
+| `media` | `{ avatar: CardAvatarMedia } \| { image: CardImageMedia }` | — |
 | `children` | `ReactNode` *(required)* | — |
 
 ### Control preset

--- a/docs/SLOT-ALLOWLIST.md
+++ b/docs/SLOT-ALLOWLIST.md
@@ -56,6 +56,10 @@ __grid
 __top
 __bottom
 __media             # any aspect-locked media frame; pairs with Frame primitive
+__media--sm         # square leading-media size on the Avatar scale (Card media slot)
+__media--md         # square leading-media size on the Avatar scale (Card media slot)
+__media--lg         # square leading-media size on the Avatar scale (Card media slot)
+__media--xl         # square leading-media size on the Avatar scale (Card media slot)
 __media-column      # column-shaped media region
 __sidebar
 __main


### PR DESCRIPTION
## What

Mirrors the table's avatar + image media cells (#1098) on **Card**. The default (no-preset) Card gains an optional typed `media` prop — pass exactly one of `{ avatar: {…} }` or `{ image: {…} }` to render an `Avatar` or a square 1:1 `Image` on the left, with `children` stacked to the right (the "media object" layout).

```tsx
<Card media={{ avatar: { name: 'Jordan Lee', status: 'online', size: 'lg' } }}>
  <CardTitle as="h4">Jordan Lee</CardTitle>
  <CardDescription>jordan.lee@brikdesigns.com</CardDescription>
</Card>

<Card media={{ image: { src: org.logo, alt: `${org.name} logo`, fit: 'contain', size: 'lg' } }}>
  <CardTitle as="h4">{org.name}</CardTitle>
  <CardDescription>Enterprise plan</CardDescription>
</Card>
```

## Details

- Composes the existing `Avatar` / `Image` primitives; the card owns only the row layout, gap, and the fixed-square image wrapper.
- Both avatar and image size to the shared **Avatar scale** (`sm` 32 / `md` 40 / `lg` 48 / `xl` 64) so the two read at an identical footprint.
- **Backward compatible** — without `media`, children render directly as before (no DOM change for existing consumers).
- New slots `__media--sm/md/lg/xl` registered in `SLOT-ALLOWLIST.md` (ADR-008).
- New types exported: `CardMedia`, `CardAvatarMedia`, `CardImageMedia`, `CardMediaSize`, `CardMediaImageFit`.
- Stories: `WithAvatar` (initials + status) + `WithImage` (served `/brik-logo.svg`, `fit=contain`) so nothing 404s. Docs updated in `Card.mdx` + docs-site mirror.

## Verification

typecheck · lint-tokens · lint-jsdoc · lint-storybook-recipe · contrast-gate · `build-storybook` — all clean. Both new stories screenshotted rendering correctly (avatar with online dot; logo `contain`).

⚠️ **Chromatic not run** — `op`/1Password CLI has no non-interactive auth in this headless laptop session (`op` shim is brik-mini-only per CLAUDE.md). Please run `npm run chromatic` interactively or from brik-mini before merge to publish snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)