### PR TITLE
fix(docs-site): static search index — eliminate serverless cold start

### DIFF
--- a/docs-site/app/api/search/route.ts
+++ b/docs-site/app/api/search/route.ts
@@ -1,4 +1,16 @@
 import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
 
-export const { GET } = createFromSource(source);
+// Static search index. `staticGET` serializes the whole Orama index once at
+// build time; the route prerenders to a static JSON asset served from the CDN,
+// and the client (search={{ options: { type: 'static' } }} in app/layout.tsx)
+// downloads it once and searches in-browser.
+//
+// The previous `GET` handler rebuilt the index in-memory on every request and
+// ran as a Netlify serverless function. Cold starts took ~6s (measured on
+// design.brikdesigns.com/api/search), so the first as-you-type search after the
+// function went idle appeared broken — results only surfaced once the function
+// warmed and the query was client-cached (i.e. after re-typing / paste).
+// Static indexing removes the serverless dependency and the cold start.
+export const revalidate = false;
+export const { staticGET: GET } = createFromSource(source);

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -12,7 +12,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="theme-brand-brik" suppressHydrationWarning>
       <body>
-        <RootProvider theme={{ attribute: ['class', 'data-theme'] }}>
+        {/* search type 'static' pairs with staticGET in app/api/search/route.ts:
+            the client downloads the prebuilt index once and searches in-browser,
+            avoiding the serverless cold start that made as-you-type search feel
+            broken on first use. */}
+        <RootProvider
+          theme={{ attribute: ['class', 'data-theme'] }}
+          search={{ options: { type: 'static' } }}
+        >
           {children}
         </RootProvider>
       </body>


### PR DESCRIPTION
## Summary
- fix(docs-site): static search index — eliminate serverless cold start

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)