### PR TITLE
feat(feedback): always-on DevFeedbackWidget on docs site + Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,6 +13,7 @@ addCollection(phData as Parameters<typeof addCollection>[0]);
 
 // Feedback widget — floating FAB in preview iframe
 import { FeedbackWidget } from './FeedbackWidget';
+import isChromatic from 'chromatic/isChromatic';
 
 // Import token CSS in cascade order:
 // 1. Figma tokens (SD output — primitives + semantic defaults)
@@ -279,7 +280,11 @@ const preview: Preview = {
     devWidgets: {
       name: 'Dev Widgets',
       description: 'Show the Brik DevBar + Feedback widget in the preview',
-      defaultValue: 'off',
+      // Default 'on' so the feedback widget collects design-system feedback
+      // from every visitor without requiring the toolbar toggle. Flip to 'off'
+      // via the wrench toolbar when a story needs a clean canvas (e.g. visual
+      // regression snapshots).
+      defaultValue: 'on',
       toolbar: {
         icon: 'wrench',
         items: [
@@ -292,12 +297,16 @@ const preview: Preview = {
   },
   decorators: [
     withTheme,
-    // Feedback widget — opt-in via the Dev Widgets toolbar toggle so it
-    // doesn't register into the DevBar on every story by default.
+    // Feedback widget — on by default (devWidgets global) so every visitor to
+    // storybook.brikdesigns.com can submit design-system feedback. Suppressed
+    // under Chromatic so the FAB never appears in visual-regression snapshots;
+    // toggle off via the wrench toolbar for a clean canvas locally.
     (Story, context) => (
       <>
         <Story />
-        {context.globals.devWidgets === 'on' && <FeedbackWidget />}
+        {context.globals.devWidgets === 'on' && !isChromatic() && (
+          <FeedbackWidget />
+        )}
       </>
     ),
   ],

--- a/docs-site/app/api/feedback/route.ts
+++ b/docs-site/app/api/feedback/route.ts
@@ -1,0 +1,112 @@
+/**
+ * POST /api/feedback → Notion Backlog.
+ *
+ * Docs-site sibling of the Storybook feedback function
+ * (brik-bds/netlify/functions/feedback.mjs). Same Notion Backlog database,
+ * tagged Product = "BDS Docs" so submissions from design.brikdesigns.com are
+ * distinguishable from Storybook feedback.
+ *
+ * Reads NOTION_TOKEN from the brik-bds-docs Netlify site's environment.
+ */
+
+const NOTION_API = 'https://api.notion.com/v1';
+const NOTION_VERSION = '2022-06-28';
+const BACKLOG_DATABASE_ID = '32097d34-ed28-8051-8225-eb6800c2e05a';
+const PRODUCT_NAME = 'BDS Docs';
+const SITE_ORIGIN = 'https://design.brikdesigns.com';
+
+const SCOPE_MAP: Record<string, string> = {
+  bug: 'Critical',
+  ui: 'Normal',
+  suggestion: 'Low',
+  question: 'Low',
+};
+
+const FEEDBACK_TYPE_MAP: Record<string, string> = {
+  bug: 'Bug',
+  ui: 'UI Issue',
+  suggestion: 'Suggestion',
+  question: 'Question',
+};
+
+const EMOJI_MAP: Record<string, string> = {
+  bug: '🐛',
+  ui: '🎨',
+  suggestion: '💡',
+  question: '❓',
+};
+
+const json = (status: number, data: unknown) =>
+  Response.json(data, { status });
+
+export async function POST(request: Request) {
+  const notionToken = process.env.NOTION_TOKEN;
+  if (!notionToken) {
+    return json(500, { error: 'NOTION_TOKEN not configured' });
+  }
+
+  let body: {
+    page_url?: string;
+    feedback_type?: string;
+    description?: string;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return json(400, { error: 'Invalid JSON body' });
+  }
+
+  const { page_url, feedback_type, description } = body;
+  if (!description) {
+    return json(400, { error: 'description is required' });
+  }
+
+  const type = feedback_type ?? 'bug';
+  const emoji = EMOJI_MAP[type] ?? '📝';
+  const title = `${emoji} ${description.slice(0, 80)}${
+    description.length > 80 ? '...' : ''
+  }`;
+  const pagePath = page_url ?? '';
+  const url = pagePath.startsWith('http')
+    ? pagePath
+    : `${SITE_ORIGIN}${pagePath}`;
+
+  try {
+    const notionRes = await fetch(`${NOTION_API}/pages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${notionToken}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        parent: { database_id: BACKLOG_DATABASE_ID },
+        properties: {
+          Name: { title: [{ text: { content: title } }] },
+          Description: { rich_text: [{ text: { content: description } }] },
+          Submitter: { rich_text: [{ text: { content: PRODUCT_NAME } }] },
+          'Feedback Type': {
+            select: { name: FEEDBACK_TYPE_MAP[type] ?? 'Bug' },
+          },
+          Product: { select: { name: PRODUCT_NAME } },
+          Client: { select: { name: 'Brik Designs' } },
+          Status: { status: { name: 'Not Started' } },
+          Scope: { select: { name: SCOPE_MAP[type] ?? 'Normal' } },
+          URL: { url },
+        },
+      }),
+    });
+
+    if (!notionRes.ok) {
+      const err = await notionRes.json().catch(() => ({}));
+      console.error('[feedback] Notion API error:', JSON.stringify(err));
+      return json(500, { error: 'Failed to submit to Notion', details: err });
+    }
+
+    const page = await notionRes.json();
+    return json(200, { id: page.id, status: 'submitted' });
+  } catch (err) {
+    console.error('[feedback] route error:', err);
+    return json(500, { error: 'Internal server error' });
+  }
+}

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -1,5 +1,6 @@
 import './global.css';
 import { RootProvider } from 'fumadocs-ui/provider/next';
+import { DevFeedbackWidget } from '@brikdesigns/bds';
 import type { ReactNode } from 'react';
 
 export const metadata = {
@@ -15,6 +16,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <RootProvider theme={{ attribute: ['class', 'data-theme'] }}>
           {children}
         </RootProvider>
+        {/* Always-on feedback capture → /api/feedback → Notion Backlog.
+            No BrikDevBar on the docs site, so render the standalone FAB. */}
+        <DevFeedbackWidget
+          endpoint="/api/feedback"
+          variant="fab"
+          contextLabel="Page"
+          fabPosition={{ bottom: '16px', right: '16px' }}
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- feat(feedback): always-on DevFeedbackWidget on docs site + Storybook

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)