### PR TITLE
fix(page-header): drop default divider; move tab-bar baseline to 2px

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -9,7 +9,7 @@
   --page-header-section-gap: var(--gap-xl);     /* between root sections (inner/metadata/tabs) */
   --page-header-content-gap: var(--gap-sm);     /* between title-row and subtitle */
   --page-header-actions-gap: var(--gap-sm);     /* between content column and actions column */
-  --page-header-padding-bottom: var(--padding-md); /* breathing room before the bottom divider */
+  --page-header-padding-bottom: 0; /* set to a padding token if a consumer restores a manual divider */
 
   display: flex;
   flex-direction: column;
@@ -18,18 +18,9 @@
   justify-content: center;
   width: 100%;
   padding-bottom: var(--page-header-padding-bottom); /* bds-lint-ignore — component-scoped CSS variable, not a design token */
-  /* Single 1px divider hands the page header off to the body. When the `tabs`
-     slot is filled, TabBar's own baseline takes over (suppressed below) so we
-     don't stack two borders. */
-  border-bottom: var(--border-width-sm) solid var(--border-secondary);
-}
-
-/* Suppress root divider + bottom padding when tabs are present — TabBar provides
-   its own baseline and rhythm, so the breathing-room padding (which exists to
-   space the subtitle off the divider) would otherwise just push the tabs down. */
-.bds-page-header:has(.bds-page-header__tabs) {
-  border-bottom: none;
-  padding-bottom: 0; /* bds-lint-ignore — zeroing the component-scoped override */
+  /* No default divider. The header only draws a baseline when a `tabs` slot is
+     filled — TabBar renders its own 2px baseline. A header with no tabs ends
+     flush against the body (brik-bds#… / PORTAL-72). */
 }
 
 /* ─── Title row ──────────────────────────────────────────────── */

--- a/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/components/ui/PageHeader/PageHeader.stories.tsx
@@ -326,20 +326,20 @@ export const TunableSpacing: Story = {
       <Stack gap="var(--gap-huge)">
         {/* Defaults */}
         <div>
-          <SectionLabel>Defaults — gap-sm content gap, padding-md divider breathing room</SectionLabel>
+          <SectionLabel>Defaults — gap-sm content gap, no default divider (padding-bottom 0)</SectionLabel>
           <PageHeader
             title="Default Header"
-            subtitle="Title↔subtitle gap = gap-sm. Default padding-md breathing room before the divider."
+            subtitle="Title↔subtitle gap = gap-sm. No default divider — a header with no tabs ends flush (padding-bottom 0)."
             actions={<Button variant="primary" size="sm">Action</Button>}
           />
         </div>
 
         {/* Tuned for clinical density (renew-pms) */}
         <div>
-          <SectionLabel>Tuned — wider content gap + extra divider breathing room</SectionLabel>
+          <SectionLabel>Tuned — wider content gap + restored bottom padding</SectionLabel>
           <PageHeader
             title="Tuned Header"
-            subtitle="Content gap widened to padding-sm; divider breathing room bumped past the default to padding-lg."
+            subtitle="Content gap widened to padding-sm; padding-bottom restored to padding-lg (e.g. when a consumer adds a manual divider)."
             actions={<Button variant="primary" size="sm">Action</Button>}
             style={{
               // bds-lint-ignore — component-scoped CSS variables, not design tokens

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -85,9 +85,11 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
  *   the title-row and the subtitle.
  * - `--page-header-actions-gap` (default `var(--gap-sm)` = 6px) — between
  *   the content column (title + subtitle) and the actions column.
- * - `--page-header-padding-bottom` (default `var(--padding-md)`) — breathing
- *   room between the subtitle and the bottom divider. Auto-zeroed when the
- *   `tabs` slot is filled (TabBar owns its own baseline + rhythm).
+ * - `--page-header-padding-bottom` (default `0`) — bottom padding below the
+ *   header. The header draws no default divider (a header with no `tabs` ends
+ *   flush against the body; a `tabs` slot renders TabBar's own 2px baseline),
+ *   so this is `0` unless a consumer restores a manual divider and wants
+ *   breathing room above it.
  *
  * @summary Page-level header — title, breadcrumbs, actions, tabs
  */

--- a/components/ui/TabBar/TabBar.css
+++ b/components/ui/TabBar/TabBar.css
@@ -60,15 +60,15 @@
 }
 
 /* ── Tab variant ──
-   Bar baseline + per-tab indicator both live here (not inline) so that:
-   1. PageHeader can suppress its own root border when tabs are present via
-      `:has(.bds-page-header__tabs)` without inline-style specificity fights.
-   2. Width is consistent at `--border-width-sm` (1px) — chrome divider scale,
-      not the chunky xl scale this used to render at.
+   Bar baseline + per-tab indicator both live here (not inline) so that the
+   baseline is a real element border (not an inline style), keeping specificity
+   predictable when a tab bar is dropped into a PageHeader `tabs` slot.
+   Baseline width is `--border-width-md` (2px) — the brik structural default, so
+   the tab bar divider matches cards/inputs/nav rather than a 1px hairline.
 */
 
 .bds-tab-bar--tab {
-  border-bottom: var(--border-width-sm) solid var(--border-secondary);
+  border-bottom: var(--border-width-md) solid var(--border-secondary);
 }
 
 /* Items reserve the active-indicator's width (--border-width-lg = 4px) as a


### PR DESCRIPTION
## Summary
- fix(page-header): drop default divider; move tab-bar baseline to 2px

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)