### PR TITLE
fix(indicators): fill ServiceTag glyphs by countering mask inset

### DIFF
--- a/components/ui/ServiceTag/ServiceTag.css
+++ b/components/ui/ServiceTag/ServiceTag.css
@@ -63,17 +63,23 @@
 /* Per-service glyph rendered via mask so the fill is CSS-recolorable (#574).
    The glyph SVG is the mask; `currentColor` paints it the tag's service text
    token, so the icon always matches the label and retones per theme. The glyph
-   URL + box size are set inline (runtime values) on the element. */
+   URL + box size are set inline (runtime values) on the element.
+
+   The System-2 glyphs are 20×20 SVGs with a ~30% built-in transparent inset,
+   so `mask-size: contain` left the visible mark at only ~70% of the box and it
+   read too small in tags/badges (a prior px bump didn't fix the root). Scaling
+   the mask to 140% consumes the symmetric inset — the visible glyph now fills
+   ~100% of the box, centered, without clipping actual glyph content. */
 .bds-service-tag__icon {
   display: block;
   flex-shrink: 0;
   background-color: currentColor;
   mask-repeat: no-repeat;
   mask-position: center;
-  mask-size: contain;
+  mask-size: 140%;
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;
-  -webkit-mask-size: contain;
+  -webkit-mask-size: 140%;
 }
 
 /* ─── Icon-only variant (square badge) ───────────────────────── */


### PR DESCRIPTION
Part of the Round 8 BDS release (umbrella brikdesigns/brikdesigns#657).

## What
The System-2 service glyphs are 20×20 SVGs with a ~30% built-in transparent inset, so `.bds-service-tag__icon { mask-size: contain }` left the visible mark at ~70% of its box. Scaling the mask to **140%** consumes the inset so the glyph fills ~100% of its box, centered, without clipping content. One rule; uniform across sm/md/lg, pill + icon-only badge, both themes.

## Fixes
- **BACKLOG-449** — icons read "teensy" in tags/badges (a prior px-map bump missed the root; the inset was the lever).
- **BACKLOG-515** — sm icon-text tag's left lead-in looked heavy: the inset sat the glyph ~3px inside a symmetric 12px `padding-inline`, so the visible left gap read ~15px. Now flush → 12px, symmetric.

## Verification
- Local Storybook (`components/service-tag` Variants + icon stories): glyphs fill cleanly at all sizes, both pill and badge; no clipping.
- Measured: sm icon-text visible left gap = **12px** = `padding-inline-end` (515 resolved at root, no separate padding change).
- Token lint ✓ · JSDoc lint ✓ · typecheck ✓ · anti-slop ✓. Chromatic CI will run for visual diff review.

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)