### PR TITLE
feat(forms): add accent-knob Switch variant

### DIFF
--- a/components/ui/Switch/Switch.stories.tsx
+++ b/components/ui/Switch/Switch.stories.tsx
@@ -32,6 +32,7 @@ const meta: Meta<typeof Switch> = {
   argTypes: {
     label: { control: 'text' },
     size: { control: 'radio', options: ['lg', 'md', 'sm'] },
+    variant: { control: 'radio', options: ['default', 'accent-knob'] },
     checked: { control: 'boolean' },
     disabled: { control: 'boolean' },
   },
@@ -118,6 +119,36 @@ export const Variants: Story = {
           <Switch label="Disabled" disabled />
           <Switch label="Disabled checked" disabled defaultChecked />
           <Switch defaultChecked />
+        </Stack>
+      </div>
+    </Stack>
+  ),
+};
+
+/**
+ * Accent-knob variant — the track stays a neutral gray in both states and the
+ * knob carries state (brand-fill when on, muted-gray when off). Used where a
+ * subtler track reads better, e.g. an inline theme toggle.
+ * @summary Accent-knob variant across sizes and states
+ */
+export const AccentKnob: Story = {
+  render: () => (
+    <Stack gap="var(--gap-huge)">
+      <div>
+        <SectionLabel>Accent knob — unchecked</SectionLabel>
+        <Stack gap="var(--gap-lg)">
+          <Switch variant="accent-knob" size="lg" label="Large" />
+          <Switch variant="accent-knob" size="md" label="Medium" />
+          <Switch variant="accent-knob" size="sm" label="Small" />
+        </Stack>
+      </div>
+
+      <div>
+        <SectionLabel>Accent knob — checked</SectionLabel>
+        <Stack gap="var(--gap-lg)">
+          <Switch variant="accent-knob" size="lg" label="Large" defaultChecked />
+          <Switch variant="accent-knob" size="md" label="Medium" defaultChecked />
+          <Switch variant="accent-knob" size="sm" label="Small" defaultChecked />
         </Stack>
       </div>
     </Stack>

--- a/components/ui/Switch/Switch.tsx
+++ b/components/ui/Switch/Switch.tsx
@@ -10,10 +10,20 @@ import './Switch.css';
 
 export type SwitchSize = 'lg' | 'md' | 'sm';
 
+export type SwitchVariant = 'default' | 'accent-knob';
+
 export interface SwitchProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> {
   label?: ReactNode;
   size?: SwitchSize;
+  /**
+   * Visual variant. `default` carries state on the track (brand-fill when on,
+   * neutral when off) with a surface knob. `accent-knob` keeps the track a
+   * neutral gray in both states and carries state on the knob instead
+   * (brand-fill when on, muted-gray when off) — used where a subtler track
+   * reads better, e.g. an inline theme toggle. Default: `default`.
+   */
+  variant?: SwitchVariant;
   checked?: boolean;
   defaultChecked?: boolean;
   disabled?: boolean;
@@ -40,6 +50,7 @@ const sizes = {
 export function Switch({
   label,
   size = 'lg',
+  variant = 'default',
   checked,
   defaultChecked = false,
   disabled = false,
@@ -63,28 +74,44 @@ export function Switch({
   );
 
   const s = sizes[size];
+  const isAccentKnob = variant === 'accent-knob';
 
-  // Runtime-calculated track dimensions
+  // Runtime-calculated track dimensions.
+  // default: track carries state (brand-fill on / neutral off).
+  // accent-knob: track stays neutral in both states; the knob carries state.
   const trackStyle: CSSProperties = {
     width: `${s.trackW}px`, // bds-lint-ignore — Figma-driven switch dimensions
     height: `${s.trackH}px`, // bds-lint-ignore
-    backgroundColor: isChecked
-      ? 'var(--background-brand-primary)'
-      : 'var(--border-muted)', // bds-lint-ignore — no semantic switch-track-inactive token
+    backgroundColor:
+      isAccentKnob || !isChecked
+        ? 'var(--border-muted)' // bds-lint-ignore — no semantic switch-track-inactive token
+        : 'var(--background-brand-primary)',
   };
 
-  // Runtime-calculated knob dimensions + position
+  // Runtime-calculated knob dimensions + position. For accent-knob the knob
+  // carries state (brand-fill on / muted-gray off); default leaves the fill to
+  // Switch.css (--surface-primary).
   const knobStyle: CSSProperties = {
     top: `${s.pad}px`, // bds-lint-ignore
     left: `${s.pad}px`, // bds-lint-ignore
     width: `${s.knob}px`, // bds-lint-ignore
     height: `${s.knob}px`, // bds-lint-ignore
     transform: isChecked ? `translateX(${s.travel}px)` : 'translateX(0)',
+    ...(isAccentKnob && {
+      backgroundColor: isChecked
+        ? 'var(--background-brand-primary)'
+        : 'var(--text-secondary)',
+    }),
   };
 
   return (
     <label
-      className={bdsClass('bds-switch', disabled && 'bds-switch--disabled', className)}
+      className={bdsClass(
+        'bds-switch',
+        isAccentKnob && 'bds-switch--accent-knob',
+        disabled && 'bds-switch--disabled',
+        className,
+      )}
       style={style}
     >
       <input

--- a/manifest/component-axes.json
+++ b/manifest/component-axes.json
@@ -324,6 +324,10 @@
       "lg",
       "md",
       "sm"
+    ],
+    "variant": [
+      "default",
+      "accent-knob"
     ]
   },
   "TabBar": {


### PR DESCRIPTION
Part of the Round 8 BDS release (umbrella brikdesigns/brikdesigns#657). Second of two PRs; #1129 (ServiceTag glyph fill) already merged.

## What
New opt-in `variant?: 'default' | 'accent-knob'` on Switch:
- **default** — unchanged: track carries state (brand-fill on / neutral off), surface knob.
- **accent-knob** — track stays neutral (`--border-muted`) both states; the knob carries state: `--background-brand-primary` when on, `--text-secondary` when off. For uses where a subtler track reads better (e.g. an inline theme toggle). State reads via both knob color and position.

## Fixes
- **BACKLOG-479** — "toggle background light gray with a poppy circle." Implemented as a new variant rather than changing the base, so portal + renew-pms consumers are untouched.

## Verification
- Local Storybook (port 6018, new `AccentKnob` story): renders correctly light theme at lg/md/sm, checked + unchecked.
- **default** variant confirmed byte-identical (measured: off track `#e0e0e0` / white knob; on track poppy / white knob) — no regression to existing consumers.
- Token names validated (`--border-muted`, `--background-brand-primary`, `--text-secondary`); typecheck ✓, token-lint ✓, JSDoc lint ✓, component-axes manifest regenerated. Chromatic CI will diff both themes.

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)