### PR TITLE
feat(switch): scale label typography with size prop

### DIFF
--- a/components/ui/Switch/Switch.css
+++ b/components/ui/Switch/Switch.css
@@ -7,8 +7,6 @@
   gap: var(--gap-md);
   cursor: pointer;
   user-select: none;
-  font-family: var(--font-family-body);
-  font-size: var(--body-md);
   color: var(--text-primary);
   text-transform: capitalize;
 }
@@ -17,6 +15,18 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ─── Label ──────────────────────────────────────────────────── */
+/* Label-family + per-size scale, matching the form-input family
+   (TextInput / Select / TextArea labels). */
+
+.bds-switch__label {
+  font-family: var(--font-family-label);
+}
+
+.bds-switch__label--sm { font-size: var(--label-sm); }
+.bds-switch__label--md { font-size: var(--label-md); }
+.bds-switch__label--lg { font-size: var(--label-lg); }
 
 /* ─── Hidden input ───────────────────────────────────────────── */
 

--- a/components/ui/Switch/Switch.stories.tsx
+++ b/components/ui/Switch/Switch.stories.tsx
@@ -59,6 +59,12 @@ export const Playground: Story = {
     // passes on it. getByRole('switch') itself asserts it's in the DOM.
     const toggle = canvas.getByRole('switch');
 
+    // Label typography scales with size + uses label-family, matching the
+    // form-input family (TextInput / Select / TextArea) — #409. Default lg → label-lg (18px).
+    const label = canvas.getByText('Enable feature');
+    await expect(label).toHaveClass('bds-switch__label--lg');
+    await expect(getComputedStyle(label).fontSize).toBe('18px');
+
     await expect(toggle).not.toBeChecked();
     await userEvent.click(toggle);
     await waitFor(() => expect(args.onChange).toHaveBeenCalledTimes(1));

--- a/components/ui/Switch/Switch.tsx
+++ b/components/ui/Switch/Switch.tsx
@@ -100,7 +100,11 @@ export function Switch({
       <span className="bds-switch__track" style={trackStyle}>
         <span className="bds-switch__knob" style={knobStyle} />
       </span>
-      {label && <span>{label}</span>}
+      {label && (
+        <span className={bdsClass('bds-switch__label', `bds-switch__label--${size}`)}>
+          {label}
+        </span>
+      )}
     </label>
   );
 }


### PR DESCRIPTION
## Summary
- feat(switch): scale label typography with size prop

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)