### PR TITLE
chore(release): 0.119.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.118.0",
+      "version": "0.119.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/lib-entry.cjs",


### PR DESCRIPTION
Batched version bump for the Round 8 BDS work already merged to `main`:
- #1129 — fill ServiceTag glyphs by countering mask inset (449/515)
- #1131 — accent-knob Switch variant (479)

Minor bump 0.118.0 → 0.119.0 (new Switch prop). Tag `v0.119.0` will be pushed from main after merge to trigger the Release workflow (publish to GitHub Packages).

Umbrella: brikdesigns/brikdesigns#657