### PR TITLE
feat(board): compact density + brand check-accent on BoardCard

### DIFF
--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -244,6 +244,16 @@
   margin: 0;
 }
 
+/* Compact density — tighter card for multi-card-per-column boards.
+   Title drops one step; subtitle reads as label-family metadata. */
+.bds-board-card--compact .bds-board-card__title {
+  font-size: var(--label-md);
+}
+.bds-board-card--compact .bds-board-card__subtitle {
+  font-family: var(--font-family-label);
+  text-transform: var(--text-transform-label);
+}
+
 /* Circular completion toggle styling lives in CompletionToggle.css —
    BoardCard delegates to <CompletionToggle> internally. The
    .bds-board-card__check class on the toggle is retained as a

--- a/components/ui/Board/Board.stories.tsx
+++ b/components/ui/Board/Board.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
 import { Board } from './Board';
 import { BoardColumn } from './BoardColumn';
 import { BoardHeader } from './BoardHeader';
@@ -211,6 +212,71 @@ export const CardAccentColors: Story = {
       </BoardColumn>
     </Board>
   ),
+};
+
+/** @summary Card density — default vs compact */
+export const CardDensity: Story = {
+  name: 'Card — Density',
+  render: () => (
+    <Board style={{ height: '440px' }}>
+      <BoardColumn title="Default density" count={2}>
+        <BoardCard
+          title="Check and refill hand sanitizer stations"
+          subtitle="Due today"
+          accentColor="var(--background-accent-blue)"
+          checked={false}
+          onCheckedChange={() => {}}
+          tags={<Tag size="sm">Engineering</Tag>}
+          trailingTag={<Badge status="error" size="sm">Critical</Badge>}
+        />
+        <BoardCard
+          title="Clean countertops and surfaces"
+          subtitle="Due today"
+          accentColor="var(--background-accent-blue)"
+          tags={<Tag size="sm">Cleaning</Tag>}
+        />
+      </BoardColumn>
+      <BoardColumn title="Compact density" count={2}>
+        <BoardCard
+          density="compact"
+          checkAccent="brand"
+          title="Check and refill hand sanitizer stations"
+          subtitle="Due today"
+          accentColor="var(--background-accent-blue)"
+          checked={false}
+          onCheckedChange={() => {}}
+          tags={<Tag size="sm">Engineering</Tag>}
+          trailingTag={<Badge status="error" size="sm">Critical</Badge>}
+        />
+        <BoardCard
+          density="compact"
+          checkAccent="brand"
+          title="Clean countertops and surfaces"
+          subtitle="Due today"
+          accentColor="var(--background-accent-blue)"
+          tags={<Tag size="sm">Cleaning</Tag>}
+        />
+      </BoardColumn>
+    </Board>
+  ),
+  // Computed-style regression guard for the density typography contract —
+  // #412. Chromatic snapshot deferred (quota #771).
+  play: async ({ canvasElement }) => {
+    const defaultTitle = canvasElement.querySelector(
+      '.bds-board-card:not(.bds-board-card--compact) .bds-board-card__title',
+    ) as HTMLElement;
+    const compactTitle = canvasElement.querySelector(
+      '.bds-board-card--compact .bds-board-card__title',
+    ) as HTMLElement;
+    const compactSubtitle = canvasElement.querySelector(
+      '.bds-board-card--compact .bds-board-card__subtitle',
+    ) as HTMLElement;
+
+    await expect(getComputedStyle(defaultTitle).fontSize).toBe('18px'); // --label-lg
+    await expect(getComputedStyle(compactTitle).fontSize).toBe('16px'); // --label-md
+    // Compact subtitle reads as label-family metadata (capitalize).
+    await expect(getComputedStyle(compactSubtitle).textTransform).toBe('capitalize');
+  },
 };
 
 // ─── Full board (headers + cards) ────────────────────────────────────────────

--- a/components/ui/Board/BoardCard.tsx
+++ b/components/ui/Board/BoardCard.tsx
@@ -41,6 +41,17 @@ export interface BoardCardProps extends HTMLAttributes<HTMLDivElement> {
   tags?: ReactNode;
   /** Tag rendered in the bottom-right (priority) */
   trailingTag?: ReactNode;
+  /**
+   * Density. `default` uses the standard title/subtitle scale; `compact`
+   * drops the title one step (label-md) and renders the subtitle in
+   * label-family metadata style — for dense, multi-card-per-column boards.
+   */
+  density?: 'default' | 'compact';
+  /**
+   * Hover affordance on the completion toggle. Forwarded to
+   * `<CompletionToggle accent>` — `brand` reads as "interactive". Default `neutral`.
+   */
+  checkAccent?: 'neutral' | 'brand';
 }
 
 export function BoardCard({
@@ -51,6 +62,8 @@ export function BoardCard({
   onCheckedChange,
   tags,
   trailingTag,
+  density = 'default',
+  checkAccent = 'neutral',
   className,
   style,
   ...props
@@ -60,6 +73,7 @@ export function BoardCard({
       className={bdsClass(
         'bds-board-card',
         checked && 'bds-board-card--checked',
+        density === 'compact' && 'bds-board-card--compact',
         className
       )}
       style={{
@@ -79,6 +93,7 @@ export function BoardCard({
             className="bds-board-card__check"
             checked={checked}
             onCheckedChange={onCheckedChange}
+            accent={checkAccent}
           />
         )}
       </div>

--- a/components/ui/CompletionToggle/CompletionToggle.css
+++ b/components/ui/CompletionToggle/CompletionToggle.css
@@ -30,6 +30,13 @@
     border-color: var(--border-primary);
   }
 
+  /* Brand-accent hover — tints only the incomplete (unchecked) state so a
+     checked toggle keeps its stable brand-primary fill on hover. */
+  .bds-completion-toggle--accent-brand:not(.bds-completion-toggle--checked):hover {
+    border-color: var(--border-brand-primary);
+    background-color: var(--background-brand-secondary);
+  }
+
   .bds-completion-toggle:focus-visible {
     outline: var(--border-width-lg, 2px) solid var(--state-focus, currentColor);
     outline-offset: 2px;

--- a/components/ui/CompletionToggle/CompletionToggle.stories.tsx
+++ b/components/ui/CompletionToggle/CompletionToggle.stories.tsx
@@ -19,6 +19,11 @@ const meta: Meta<typeof CompletionToggle> = {
       control: 'boolean',
       description: 'Locks the toggle — non-interactive, muted appearance.',
     },
+    accent: {
+      control: 'radio',
+      options: ['neutral', 'brand'],
+      description: 'Hover affordance on the incomplete state. `brand` tints the hover with a brand-primary border + brand-secondary fill.',
+    },
     onCheckedChange: {
       action: 'checked-changed',
       description: 'Called with the new boolean state when the toggle is clicked.',
@@ -41,6 +46,7 @@ export const Single: Story = {
   args: {
     checked: false,
     disabled: false,
+    accent: 'neutral',
   },
   render: (args) => {
     const [checked, setChecked] = useState(args.checked);

--- a/components/ui/CompletionToggle/CompletionToggle.tsx
+++ b/components/ui/CompletionToggle/CompletionToggle.tsx
@@ -10,6 +10,12 @@ export interface CompletionToggleProps
   onCheckedChange: (checked: boolean) => void;
   /** Disabled — locks the toggle and applies muted styling. */
   disabled?: boolean;
+  /**
+   * Hover affordance for the incomplete (unchecked) state. `neutral`
+   * (default) borders in `--border-primary`; `brand` tints the hover with a
+   * brand-primary border + brand-secondary fill, reading as "interactive".
+   */
+  accent?: 'neutral' | 'brand';
 }
 
 /**
@@ -41,6 +47,7 @@ export const CompletionToggle = forwardRef<HTMLButtonElement, CompletionTogglePr
       checked,
       onCheckedChange,
       disabled = false,
+      accent = 'neutral',
       className,
       'aria-label': ariaLabel,
       onClick,
@@ -56,6 +63,7 @@ export const CompletionToggle = forwardRef<HTMLButtonElement, CompletionTogglePr
           'bds-completion-toggle',
           checked && 'bds-completion-toggle--checked',
           disabled && 'bds-completion-toggle--disabled',
+          accent === 'brand' && 'bds-completion-toggle--accent-brand',
           className,
         )}
         disabled={disabled}


### PR DESCRIPTION
## Summary
- feat(board): compact density + brand check-accent on BoardCard

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)