### PR TITLE
fix(icons): move Sheet/Tag/Badge glyphs onto the 4-point grid

### DIFF
--- a/components/ui/Badge/Badge.css
+++ b/components/ui/Badge/Badge.css
@@ -82,13 +82,13 @@
 
 /* Icon font-size matches container so the glyph fills the box */
 .bds-badge--xs .bds-badge__icon {
-  font-size: var(--icon-xs);
+  font-size: var(--icon-sm);
 }
 
 .bds-badge--sm .bds-badge__icon {
-  width: 14px;
-  height: 14px;
-  font-size: var(--icon-xs);
+  width: 16px;
+  height: 16px;
+  font-size: var(--icon-sm);
 }
 
 .bds-badge--md .bds-badge__icon {

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -266,7 +266,7 @@
   align-items: center;
   justify-content: center;
   color: var(--text-primary);
-  font-size: var(--icon-md);
+  font-size: var(--icon-lg);
   line-height: 1;
   border-radius: var(--border-radius-md);
   opacity: 0.6;

--- a/components/ui/Tag/Tag.css
+++ b/components/ui/Tag/Tag.css
@@ -116,13 +116,13 @@
 
 /* Icon font-size matches container so the glyph fills the box */
 .bds-tag--xs .bds-tag__icon {
-  font-size: var(--icon-xs);
+  font-size: var(--icon-sm);
 }
 
 .bds-tag--sm .bds-tag__icon {
-  width: 14px;
-  height: 14px;
-  font-size: var(--icon-xs);
+  width: 16px;
+  height: 16px;
+  font-size: var(--icon-sm);
 }
 
 .bds-tag--md .bds-tag__icon {


### PR DESCRIPTION
## Summary
- fix(icons): move Sheet/Tag/Badge glyphs onto the 4-point grid

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)