### PR TITLE
feat(hero-split): decorative icon slot — aria-hidden, no img semantics

### DIFF
--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.css
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.css
@@ -206,6 +206,19 @@ img.bp-hero-img-card__icon {
   object-fit: contain;
 }
 
+/* Decorative icon slot (brik-bds#849) — sizes a passed SVG/Image node to the
+   same footprint as the img path; the node itself carries no img/alt semantics. */
+.bp-hero-img-card__icon-slot {
+  display: block;
+  width: var(--bds-hero-img-card-icon-size, 2.5rem);
+  height: var(--bds-hero-img-card-icon-size, 2.5rem);
+}
+
+.bp-hero-img-card__icon-slot > * {
+  width: 100%;
+  height: 100%;
+}
+
 .bp-hero-img-card__subtitle {
   margin: 0;
   font-family: var(--font-family-label);

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -181,6 +181,38 @@ export const NoServiceTag: Story = {
 };
 
 /**
+ * @summary Decorative icon slot (#849) — pass `icon` (a rendered SVG/Image node)
+ * to render a purely-decorative eyebrow with no `img`/`alt` semantics. The
+ * blueprint wraps it in an `aria-hidden` span, so screen readers skip it. Takes
+ * precedence over `iconUrl` and the `audience` ServiceTag; `iconUrl` still works
+ * unchanged for callers that pass a URL.
+ */
+export const DecorativeIconSlot: Story = {
+  args: {
+    ...baseProps,
+    icon: (
+      <svg viewBox="0 0 40 40" role="presentation">
+        <circle cx="20" cy="20" r="18" fill="currentColor" />
+      </svg>
+    ),
+    section: {
+      ...interiorHeroSection,
+      sectionKey: 'hero-img-card-icon-slot',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // The decorative slot renders and is hidden from the a11y tree...
+    const slot = canvasElement.querySelector('.bp-hero-img-card__icon-slot');
+    await expect(slot).not.toBeNull();
+    await expect(slot).toHaveAttribute('aria-hidden', 'true');
+    // ...and the legacy raw-<img> eyebrow path is not used.
+    await expect(
+      canvasElement.querySelector('img.bp-hero-img-card__icon'),
+    ).toBeNull();
+  },
+};
+
+/**
  * @summary Medium price-card CTA — opt in via `priceCard.cta.size="md"`.
  * The default is `sm` (see Playground); support-plan heroes that want a
  * weightier price-card action pass `md`. brikdesigns.com #453.

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -15,7 +15,7 @@
  *
  * @summary Interior-page split hero with image card + optional price overlay.
  */
-import type { MouseEvent } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { Breadcrumb } from '../../../components/ui/Breadcrumb/Breadcrumb';
 import { Button } from '../../../components/ui/Button';
 import { Frame } from '../../../components/ui/Frame/Frame';
@@ -35,6 +35,14 @@ interface Props extends BlueprintProps {
    */
   showServiceTag?: boolean;
   /**
+   * Decorative eyebrow icon as a rendered node — pass an SVG component or a
+   * pre-configured `<Image>`. Takes precedence over `iconUrl` and the
+   * `audience` `<ServiceTag>`. Rendered inside an `aria-hidden` wrapper so
+   * purely-decorative art carries no `img`/`alt` semantics (brik-bds#849).
+   * React-only, like `onPriceCtaClick` — Astro blueprints can't pass a node.
+   */
+  icon?: ReactNode;
+  /**
    * Optional handler for the price-card CTA. When provided, the CTA's click is
    * intercepted (`preventDefault` + handler invoked) so consumers can trigger
    * an in-page action — e.g. open a modal — instead of navigating. The
@@ -49,6 +57,7 @@ export function HeroSplitImageCardOverlay({
   section,
   imageRatio = 'square',
   showServiceTag = true,
+  icon,
   onPriceCtaClick,
 }: Props) {
   const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
@@ -75,21 +84,28 @@ export function HeroSplitImageCardOverlay({
           )}
 
           {/*
-           * Eyebrow icon precedence (brik-bds#546):
-           *   1. If `iconUrl` is provided, render the raw `<img>` (legacy /
-           *      decorative-image escape hatch).
-           *   2. Otherwise, if `audience` is set, render the canonical
+           * Eyebrow icon precedence:
+           *   1. If `icon` (a rendered node) is provided, render it inside an
+           *      `aria-hidden` wrapper — decorative SVG/Image, no img/alt
+           *      semantics (brik-bds#849). React-only.
+           *   2. Else if `iconUrl` is provided, render the raw `<img>` (legacy /
+           *      decorative-image escape hatch, brik-bds#546).
+           *   3. Otherwise, if `audience` is set, render the canonical
            *      `<ServiceTag>` for that audience — the design-system path.
            *      Consumers stop supplying `iconUrl` for category badges; the
            *      blueprint resolves the icon via BDS's service-token system,
            *      keeping theme awareness intact.
-           *   3. If neither is set, no eyebrow renders.
+           *   4. If none is set, no eyebrow renders.
            *
            * `showServiceTag={false}` suppresses this whole slot while leaving
            * `data-audience` theming intact (brik-bds#871).
            */}
           {showServiceTag &&
-            (iconUrl ? (
+            (icon ? (
+              <span className="bp-hero-img-card__icon-slot" aria-hidden="true">
+                {icon}
+              </span>
+            ) : iconUrl ? (
               <img
                 src={iconUrl}
                 alt={iconAlt ?? ''}


### PR DESCRIPTION
## Summary
- feat(hero-split): decorative icon slot — aria-hidden, no img semantics

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)