### PR TITLE
feat(footer): external prop on FooterColumnLink — new-tab + rel

### DIFF
--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
 import { Footer } from './Footer';
 import { type BdsLinkComponent } from '../NavItem';
 
@@ -129,6 +130,37 @@ export const WithLinkComponent: Story = {
       { label: 'Privacy', href: '/privacy' },
     ],
     linkComponent: MockLink,
+  },
+};
+
+/** @summary External column links open in a new tab with `rel="noopener noreferrer"` and bypass the router linkComponent */
+export const ExternalLinks: Story = {
+  args: {
+    logo: <LogoPlaceholder />,
+    columns: [
+      {
+        heading: 'Follow',
+        links: [
+          { label: 'Home', href: '/home' },
+          { label: 'LinkedIn', href: 'https://linkedin.com/company/brik', external: true },
+        ],
+      },
+    ],
+    copyright: '© 2026 Brik Designs.',
+    linkComponent: MockLink,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // External link → bare <a target=_blank rel=noopener noreferrer>, NOT routed.
+    const external = canvas.getByRole('link', { name: 'LinkedIn' });
+    await expect(external).toHaveAttribute('target', '_blank');
+    await expect(external).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(external).not.toHaveAttribute('data-link-component');
+    // Internal link in the same footer still routes through the linkComponent.
+    await expect(canvas.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      'data-link-component',
+      'mock',
+    );
   },
 };
 

--- a/components/ui/Footer/Footer.tsx
+++ b/components/ui/Footer/Footer.tsx
@@ -14,6 +14,13 @@ export interface FooterColumnLink {
   /** Optional inline content rendered before the label — typically a colored
    * badge dot, icon, or other small adornment that signals link category */
   adornment?: ReactNode;
+  /**
+   * Open in a new tab with `rel="noopener noreferrer"` — for off-site links
+   * (social profiles, external resources). Renders a bare `<a>` even when a
+   * `linkComponent` is set, since client-side routing doesn't apply to
+   * external URLs. Default false.
+   */
+  external?: boolean;
 }
 
 /**
@@ -99,14 +106,25 @@ export type FooterVariant = 'default' | 'brand' | 'inverse';
 function FooterLink({
   linkComponent: LinkComponent,
   href,
+  external = false,
   className,
   children,
 }: {
   linkComponent?: BdsLinkComponent;
   href: string;
+  external?: boolean;
   className: string;
   children: ReactNode;
 }) {
+  // External links open in a new tab and bypass the router `linkComponent` —
+  // client-side routing doesn't apply to off-site URLs.
+  if (external) {
+    return (
+      <a href={href} className={className} target="_blank" rel="noopener noreferrer">
+        {children}
+      </a>
+    );
+  }
   if (LinkComponent) {
     return (
       <LinkComponent href={href} className={className}>
@@ -216,6 +234,7 @@ export function Footer({
                     key={link.href + link.label}
                     linkComponent={linkComponent}
                     href={link.href}
+                    external={link.external}
                     className="bds-footer__link"
                   >
                     {link.adornment && (


### PR DESCRIPTION
## Summary
- feat(footer): external prop on FooterColumnLink — new-tab + rel

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)