### PR TITLE
chore(release): 0.119.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.119.0",
+  "version": "0.119.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.119.0",
+      "version": "0.119.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.119.0",
+  "version": "0.119.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/lib-entry.cjs",


### PR DESCRIPTION
Patch release for the #1136 dark `--surface-secondary` AA fix ([#1142](https://github.com/brikdesigns/brik-bds/pull/1142)).

Bumps `package.json` + `package-lock.json` 0.119.0 → 0.119.1. After merge, main is tagged `v0.119.1` to trigger the Release workflow (publish to GitHub Packages).

Per RELEASE.md: separate `chore(release)` PR (not bundled into the fix PR).