### PR TITLE
docs(card): align stories + docs to ADR-018; consolidate control preset

### DIFF
--- a/.claude/standards/component-build.md
+++ b/.claude/standards/component-build.md
@@ -57,6 +57,14 @@ Before writing any code, place the thing you are building in one of three tiers.
 
 See [ADR-004 §Amendment 2026-05-17](../../docs/adrs/ADR-004-component-bloat-guardrails.md) for the full purpose-test rationale and the corrected input taxonomy.
 
+### Preset boundary — the far edge of a `preset` (ADR-018)
+
+ADR-004 routes *new shape → component or preset* (prefer a preset for a same-surface layout variant). [ADR-018](../../docs/adrs/ADR-018-card-preset-boundary.md) adds the boundary on the **other** side:
+
+> A **`preset`** on a container is justified only when it renders the **same bounded surface in a different _generic, content-agnostic_ arrangement**. The moment a candidate preset (a) prescribes a **content-typed** layout (a "service card", a "pricing tier"), (b) exists to be **arranged by a parent** (a grid cell, a carousel slide), or (c) **hardcodes structure that blocks composition** (a fixed heading level, no `children` slot, an embedded responsive breakpoint) — it is a **Block**, a **Section/Layout element**, or a **standalone Component**, never a container preset.
+
+Diagnostic: if you're about to add `preset="{content-type}"` (`preset="testimonial"`, `preset="pricing"`) or a preset whose entire job is to be repeated by a layout, stop — that's a Block/Section/Component. `Card preset="display"` is grandfathered as the documented `CardGrid` cell; do not propagate the pattern to new content types.
+
 ## File structure
 
 ```

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -8,7 +8,7 @@ import * as Stories from './Card.stories';
 
 <ComponentLinks slug="card" />
 
-Flexible content container. A single primitive serves four shapes via the `preset` discriminator: a default flexible content slot (no `preset`), and three locked-down layouts — `control`, `summary`, and `display` — that subsume the legacy `CardControl` and `CardSummary` components (per ADR-004). The web-only `PricingCard` component is documented alongside these presets as part of the Card family.
+Flexible content container. A default flexible content slot (no `preset`), plus preset layouts via the `preset` discriminator: `control` (settings / integration row) and `summary` (metric) subsume the legacy `CardControl` / `CardSummary` components (per ADR-004); `display` and `display-row` are the **cells of a `CardGrid`**, not standalone cards ([ADR-018](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-018-card-preset-boundary.md)). The web-only `PricingCard` component is documented alongside these presets as part of the Card family.
 
 > **Note** — Multi-card compositions (service grids, feature grids, blog rolls) live in the [`Card Grid`](?path=/docs/theming-blueprints-card-grid--docs) blueprint, not on this page. This page documents the Card primitive itself.
 
@@ -28,33 +28,23 @@ The default shape also takes a `variant`: `outlined` (default, secondary border)
 
 <Canvas of={Stories.Borderless} />
 
-### Leading media (avatar / image)
+### Leading media (avatar / image / logo)
 
-The default shape takes an optional `media` prop that turns the card into a horizontal "media object" — an `Avatar` or a square 1:1 `Image` on the left, with `children` stacked to the right. Pass exactly one of `media={{ avatar: {…} }}` or `media={{ image: {…} }}`. Both size to the shared Avatar scale (`sm` 32px, `md` 40px, `lg` 48px, `xl` 64px) so an avatar and an image read at the same footprint. The avatar falls back to initials from `name` and can carry a presence `status`; the image takes `fit` (`contain` for logos, `cover` for photos). Mirrors the `TableAvatarCell` / `TableImageCell` media cells.
+The default shape takes an optional `media` prop that turns the card into a horizontal "media object" — an `Avatar`, a square 1:1 `Image`, or a bundled `Logo` on the left, with `children` stacked to the right. Pass exactly one of `media={{ avatar: {…} }}`, `media={{ image: {…} }}`, or `media={{ logo: { set, name } }}`. All size to the shared Avatar scale (`sm` 32px, `md` 40px, `lg` 48px, `xl` 64px) so they read at the same footprint. The avatar falls back to initials from `name` and can carry a presence `status`; the image takes `fit` (`contain` for artwork, `cover` for photos); the logo renders a full-color third-party / client brand mark. Mirrors the `TableAvatarCell` / `TableImageCell` / `TableLogoCell` media cells.
 
 <Canvas of={Stories.WithAvatar} />
 
 <Canvas of={Stories.WithImage} />
 
+<Canvas of={Stories.WithLogo} />
+
 ### Control preset
 
 `preset="control"` — settings/control row. Leading `logo` + `badge` + (title + description) on the left, (`connectionStatus` indicator + `action`) on the right. Use `actionAlign="top"` for long descriptions where the action should anchor to the upper-right corner.
 
-The `logo` slot accepts any ReactNode (typically an `<Avatar>` or `<img>`) and renders as a leading logomark before the `badge` — use it for integration or third-party service cards where a visual brand anchor makes the row scannable. The `connectionStatus` prop accepts `not-configured | connected | syncing | synced | error` and renders a dot + label in the trailing block, coexisting with the `action` slot. Pass `lastSynced` to display a timestamp beneath the status indicator.
+The `logo` slot accepts any ReactNode — a `<Logo>` for an integration / third-party service card, or an `<Avatar>` for an account — and renders as a leading logomark before the `badge`. The `connectionStatus` prop accepts `not-configured | connected | syncing | synced | error` and renders a status indicator in the trailing block, coexisting with the `action` slot; pass `lastSynced` for a timestamp beneath it. `connectionStatus` is a **state of one card, not a set of variants** — cycle it in the Controls panel on the story below rather than reaching for separate stories.
 
 <Canvas of={Stories.Control} />
-
-#### With logo
-
-<Canvas of={Stories.ControlWithLogo} />
-
-#### With connection status
-
-<Canvas of={Stories.ControlWithConnectionStatus} />
-
-#### All connection-status states
-
-<Canvas of={Stories.ControlConnectionStatuses} />
 
 ### Summary preset
 

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -1,9 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Card, CardTitle, CardDescription, CardFooter } from './Card';
-import { Avatar } from '../Avatar';
+import { Logo } from '../Logo';
 import { Button } from '../Button';
 import { Badge } from '../Badge';
 import { PricingCard } from '../PricingCard';
+
+/* Story-only 1:1 product thumbnail (data URI, no network) — a schematic
+   iPhone standing in for a real product photo in the media-image demo. */
+const iphoneThumb =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">' +
+      '<rect width="200" height="200" fill="#eef1f4"/>' +
+      '<rect x="72" y="24" width="56" height="152" rx="15" fill="#1c1c1e"/>' +
+      '<rect x="77" y="32" width="46" height="136" rx="8" fill="#3a7bd5"/>' +
+      '<rect x="90" y="28" width="20" height="5" rx="2.5" fill="#0d0d0f"/>' +
+      '<rect x="88" y="170" width="24" height="3" rx="1.5" fill="#48484a"/>' +
+      '</svg>',
+  );
 
 const meta: Meta<typeof Card> = {
   title: 'Containers/card',
@@ -35,7 +49,7 @@ const meta: Meta<typeof Card> = {
     media: {
       control: false,
       description:
-        'Leading media (Default shape only) — `{ avatar: {…} }` or `{ image: {…} }`. Renders an `Avatar` or a square 1:1 `Image` on the left, with `children` stacked to the right. See `WithAvatar` / `WithImage`.',
+        'Leading 1:1 media (Default shape only) — `{ avatar: {…} }`, `{ image: {…} }`, or `{ logo: { set, name } }`. Renders an `Avatar`, a square `Image`, or a bundled `Logo` on the left, with `children` stacked to the right. See `WithAvatar` / `WithImage` / `WithLogo`.',
     },
   },
 };
@@ -152,22 +166,23 @@ export const WithAvatar: Story = {
 };
 
 /**
- * Default Card with a leading square 1:1 `Image` — the logo / thumbnail
+ * Default Card with a leading square 1:1 `Image` — an arbitrary thumbnail
  * counterpart to `WithAvatar`. Pass `media={{ image: {…} }}` with `fit`
- * (`contain` for logos, `cover` for photos). Size keys to the same scale as
- * the avatar so the two read at an identical footprint.
+ * (`cover` for photos, `contain` for artwork). Size keys to the same scale as
+ * the avatar so the two read at an identical footprint. For a bundled brand
+ * mark, prefer `media={{ logo }}` (see `WithLogo`) over a raw image `src`.
  *
- * @summary media image — logo / thumbnail card
+ * @summary media image — square 1:1 thumbnail card
  */
 export const WithImage: Story = {
   args: {
     variant: 'outlined',
     padding: 'md',
-    media: { image: { src: '/brik-logo.svg', alt: 'Brik Designs logo', fit: 'contain', size: 'lg' } },
+    media: { image: { src: iphoneThumb, alt: 'iPhone 15 Pro', fit: 'cover', size: 'lg' } },
     children: (
       <>
-        <CardTitle as="h4">Brik Designs</CardTitle>
-        <CardDescription>Design system · Enterprise plan</CardDescription>
+        <CardTitle as="h4">iPhone 15 Pro</CardTitle>
+        <CardDescription>Device · In stock</CardDescription>
       </>
     ),
   },
@@ -181,114 +196,53 @@ export const WithImage: Story = {
 };
 
 /**
- * `preset="control"` — locked-down settings/control card layout. Replaces
- * the legacy `CardControl` component (ADR-004). Renders a leading badge +
- * (title + description) on the left, action slot on the right. Toggle
- * `actionAlign` to anchor the action to the upper-right corner instead of
- * the vertical midline.
+ * Default Card with a leading square 1:1 bundled `Logo` — the third-party /
+ * integration counterpart to `WithAvatar`. Pass `media={{ logo: { set, name } }}`;
+ * the full-color brand mark renders contained in the square at the shared media
+ * scale. Use this for integration and payment rows instead of a raw image `src`.
  *
- * @summary preset="control" — settings/control card
+ * @summary media logo — integration / brand card
+ */
+export const WithLogo: Story = {
+  args: {
+    variant: 'outlined',
+    padding: 'md',
+    media: { logo: { set: 'integration', name: 'notion', size: 'lg' } },
+    children: (
+      <>
+        <CardTitle as="h4">Notion</CardTitle>
+        <CardDescription>Meetings database · Connected</CardDescription>
+      </>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * `preset="control"` — locked-down settings / integration-row layout (replaces
+ * the legacy `CardControl` component, ADR-004). A leading `logo` + `badge` +
+ * (title + description) on the left; a trailing `connectionStatus` indicator +
+ * `action` on the right. Shown here as the canonical integration card.
+ *
+ * `connectionStatus`, `lastSynced`, and `actionAlign` are **Controls** — the
+ * status is a *state of one card*, not a set of card variants, so cycle it in
+ * the Controls panel (`not-configured` → `connected` → `syncing` → `synced` →
+ * `error`) rather than reaching for separate stories.
+ *
+ * @summary preset="control" — integration card (status = Control)
  */
 export const Control: Story = {
   args: {
     preset: 'control',
-    title: 'Email notifications',
-    description: 'Send a weekly digest to your inbox.',
-    badge: <Badge status="positive">On</Badge>,
-    action: (
-      <Button variant="outline" size="sm">
-        Configure
-      </Button>
-    ),
-    actionAlign: 'center',
-  },
-  argTypes: {
-    variant: { table: { disable: true } },
-    padding: { table: { disable: true } },
-    interactive: { table: { disable: true } },
-    href: { table: { disable: true } },
-    actionAlign: {
-      control: 'radio',
-      options: ['center', 'top'],
-      description:
-        'Vertical alignment of the action slot. `top` anchors the action to the upper-right corner; `center` (default) aligns to the vertical midline.',
-    },
-    logo: {
-      control: false,
-      description:
-        'Optional leading logo / avatar slot — for integration logomarks or brand icons. Renders before `badge` in the content row.',
-    },
-    connectionStatus: {
-      control: 'select',
-      options: ['not-configured', 'connected', 'syncing', 'synced', 'error'],
-      description:
-        'Connection-status state. Renders a dot + label in the trailing block alongside the `action` slot.',
-    },
-    lastSynced: {
-      control: 'text',
-      description:
-        'Human-readable "last synced" label displayed below the status indicator. Only shown when `connectionStatus` is set and is not `not-configured`.',
-    },
-  },
-  decorators: [
-    (Story) => (
-      <div style={{ width: 560 }}>
-        <Story />
-      </div>
-    ),
-  ],
-};
-
-/**
- * `preset="control"` with the `logo` slot — an `<Avatar>` logomark leading
- * the content row. The logo renders before the `badge` and is sized by the
- * consumer element (Avatar `size` prop). Use for integration / third-party
- * service cards where a visual brand identifier anchors the row.
- *
- * @summary preset="control" with avatar logo slot
- */
-export const ControlWithLogo: Story = {
-  args: {
-    preset: 'control',
-    title: 'Google Analytics',
-    description: 'Pull session and conversion data into your dashboard.',
-    logo: <Avatar name="GA" size="sm" />,
-    action: (
-      <Button variant="outline" size="sm">
-        Configure
-      </Button>
-    ),
-    actionAlign: 'center',
-  },
-  argTypes: {
-    variant: { table: { disable: true } },
-    padding: { table: { disable: true } },
-    interactive: { table: { disable: true } },
-    href: { table: { disable: true } },
-  },
-  decorators: [
-    (Story) => (
-      <div style={{ width: 560 }}>
-        <Story />
-      </div>
-    ),
-  ],
-};
-
-/**
- * `preset="control"` with `connectionStatus="synced"` and `lastSynced` — the
- * full integration card shape. The trailing block stacks the status indicator
- * above the action. All five status states (`not-configured`, `connected`,
- * `syncing`, `synced`, `error`) are exercised in `ControlConnectionStatuses`.
- *
- * @summary preset="control" — integration card with status + action
- */
-export const ControlWithConnectionStatus: Story = {
-  args: {
-    preset: 'control',
-    title: 'Google Analytics',
-    description: 'Pull session and conversion data into your dashboard.',
-    logo: <Avatar name="GA" size="sm" />,
+    logo: <Logo set="integration" name="notion" size="sm" />,
+    title: 'Notion Meetings Database',
+    description: 'Discovery-call meeting notes for proposal generation.',
     connectionStatus: 'synced',
     lastSynced: 'Last synced 3 min ago',
     action: (
@@ -303,14 +257,27 @@ export const ControlWithConnectionStatus: Story = {
     padding: { table: { disable: true } },
     interactive: { table: { disable: true } },
     href: { table: { disable: true } },
+    actionAlign: {
+      control: 'radio',
+      options: ['center', 'top'],
+      description:
+        'Vertical alignment of the trailing block. `top` anchors it to the upper-right corner; `center` aligns to the vertical midline.',
+    },
+    logo: {
+      control: false,
+      description:
+        'Leading logo slot — a `<Logo>` for an integration / third-party service, or an `<Avatar>` for an account. Renders before `badge` in the content row.',
+    },
     connectionStatus: {
       control: 'select',
       options: ['not-configured', 'connected', 'syncing', 'synced', 'error'],
-      description: 'Connection-status state.',
+      description:
+        'Connection-status state (a state of this one card, not a variant). Renders a status indicator in the trailing block alongside the `action`.',
     },
     lastSynced: {
       control: 'text',
-      description: 'Last-synced timestamp label.',
+      description:
+        'Human-readable "last synced" label below the status indicator. Shown only when `connectionStatus` is set and is not `not-configured`.',
     },
   },
   decorators: [
@@ -320,45 +287,6 @@ export const ControlWithConnectionStatus: Story = {
       </div>
     ),
   ],
-};
-
-/**
- * All five `connectionStatus` states side-by-side — `not-configured`,
- * `connected`, `syncing`, `synced`, `error`. Each row carries the same logo
- * and action slot so the only variable is the status indicator.
- *
- * @summary connectionStatus — all five states (axis gallery)
- */
-export const ControlConnectionStatuses: Story = {
-  render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)', width: 600 }}>
-      {(
-        [
-          { status: 'not-configured', lastSynced: undefined } ,
-          { status: 'connected',      lastSynced: undefined } ,
-          { status: 'syncing',        lastSynced: undefined } ,
-          { status: 'synced',         lastSynced: 'Last synced 3 min ago' } ,
-          { status: 'error',          lastSynced: 'Failed 12 min ago' } ,
-        ] as const
-      ).map(({ status, lastSynced }) => (
-        <Card
-          key={status}
-          preset="control"
-          title="Google Analytics"
-          description="Pull session and conversion data into your dashboard."
-          logo={<Avatar name="GA" size="sm" />}
-          connectionStatus={status}
-          lastSynced={lastSynced}
-          actionAlign="top"
-          action={
-            <Button variant="outline" size="sm">
-              Configure
-            </Button>
-          }
-        />
-      ))}
-    </div>
-  ),
 };
 
 /**
@@ -399,13 +327,16 @@ export const Summary: Story = {
 };
 
 /**
- * `preset="display"` — generic content card for `bds-card-grid`. Optional
- * slot props (`image`, `tag`, `badge`, `action`, `href`) so a single
- * primitive serves any content type — service, blog post, customer story,
- * property listing, team bio, support plan. Toggle each slot via Controls
- * to see the minimal and clickable variants.
+ * `preset="display"` — the **cell of a `CardGrid`**, not a standalone card
+ * (see [ADR-018](../../../docs/adrs/ADR-018-card-preset-boundary.md)): a display
+ * card only exists inside a `CardGrid` Section, which owns the columns. One
+ * malleable cell serves any content type — service, blog post, customer story,
+ * property listing, team bio, support plan — via optional slot props (`image`,
+ * `tag`, `badge`, `action`, `href`). The `variant` Control switches the surface
+ * treatment for cells on a colored (service-tinted) grid: `borderless`
+ * (transparent) or `elevated` (fill + shadow).
  *
- * @summary preset="display" — content-grid card
+ * @summary preset="display" — CardGrid cell
  */
 export const Display: Story = {
   args: {
@@ -436,7 +367,13 @@ export const Display: Story = {
     ),
   },
   argTypes: {
-    variant: { table: { disable: true } },
+    variant: {
+      control: 'inline-radio',
+      options: ['default', 'borderless', 'elevated'],
+      mapping: { default: undefined, borderless: 'borderless', elevated: 'elevated' },
+      description:
+        'Surface treatment for a cell on a colored (service-tinted) grid. `borderless` = transparent, no border/shadow; `elevated` = fill + shadow, no border. Default = outlined white fill.',
+    },
     padding: { table: { disable: true } },
     interactive: { table: { disable: true } },
   },
@@ -450,110 +387,18 @@ export const Display: Story = {
 };
 
 /**
- * `preset="display"` + `variant="borderless"` — transparent fill, no border,
- * no shadow. Use when the card grid sits on a service-tinted colored surface
- * where the default white fill + border ring reads as visual noise. The card
- * inherits the parent surface; shown here on a service-product (purple) tint.
+ * `preset="display-row"` — the **horizontal `CardGrid` cell / section row**
+ * (see [ADR-018](../../../docs/adrs/ADR-018-card-preset-boundary.md)), not a
+ * standalone card. Image on the left, content (tag, title, description,
+ * optional `extras`, action) on the right. Use for single-row sections where a
+ * vertical layout wastes horizontal space: Related Customer Story, Recommended
+ * Add-On, featured plan, company-segment overview. Toggle `imageWidth` between
+ * `narrow` / `standard` / `wide` (or pass a custom CSS length / percentage) to
+ * size the media column. The `extras` slot drops in any supporting content
+ * (bullet list, pill row, gallery) between description and action. Collapses to
+ * vertical stacking at ≤ 640px.
  *
- * @summary preset="display" variant="borderless" — on a colored surface
- */
-export const DisplayBorderless: Story = {
-  args: {
-    preset: 'display',
-    variant: 'borderless',
-    title: 'Brand strategy',
-    description:
-      'A two-line card description that sets the type rhythm without trying to tell the whole story.',
-    tag: <Badge>Marketing</Badge>,
-    action: (
-      <Button variant="on-color" size="sm">
-        Learn more
-      </Button>
-    ),
-  },
-  argTypes: {
-    padding: { table: { disable: true } },
-    interactive: { table: { disable: true } },
-  },
-  decorators: [
-    (Story) => (
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(3, 200px)',
-          gap: 'var(--gap-md)',
-          padding: 'var(--padding-xl)',
-          backgroundColor: 'var(--surface-service-product)',
-          borderRadius: 'var(--border-radius-md)',
-        }}
-      >
-        <Story />
-        <Story />
-        <Story />
-      </div>
-    ),
-  ],
-};
-
-/**
- * `preset="display"` + `variant="elevated"` — surface-primary fill +
- * `box-shadow-md`, no border. The restored-fill counterpart to `borderless`:
- * use when a card grid on a service-tinted surface still needs a contained
- * "card" read but the default border ring is unwanted. Shown here on a
- * service-product (purple) tint.
- *
- * @summary preset="display" variant="elevated" — on a colored surface
- */
-export const DisplayElevated: Story = {
-  args: {
-    preset: 'display',
-    variant: 'elevated',
-    title: 'Brand strategy',
-    description:
-      'A two-line card description that sets the type rhythm without trying to tell the whole story.',
-    tag: <Badge>Marketing</Badge>,
-    action: (
-      <Button variant="on-color" size="sm">
-        Learn more
-      </Button>
-    ),
-  },
-  argTypes: {
-    padding: { table: { disable: true } },
-    interactive: { table: { disable: true } },
-  },
-  decorators: [
-    (Story) => (
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(3, 200px)',
-          gap: 'var(--gap-md)',
-          padding: 'var(--padding-xl)',
-          backgroundColor: 'var(--surface-service-product)',
-          borderRadius: 'var(--border-radius-md)',
-        }}
-      >
-        <Story />
-        <Story />
-        <Story />
-      </div>
-    ),
-  ],
-};
-
-/**
- * `preset="display-row"` — horizontal sibling of `preset="display"`. Image
- * on the left, content (tag, title, description, optional `extras`, action)
- * on the right. Use for single-card sections where a vertical layout wastes
- * horizontal space: Related Customer Story, Recommended Add-On, featured
- * plan, company-segment overview. Toggle `imageWidth` between `narrow` /
- * `standard` / `wide` (or pass a custom CSS length / percentage) to size
- * the media column. The `extras` slot lets the consumer drop in any
- * supporting content (bullet list, pill row, gallery) between description
- * and action. Collapses to vertical stacking at ≤ 640px.
- *
- * @summary preset="display-row" — horizontal content-grid card
+ * @summary preset="display-row" — horizontal CardGrid cell
  */
 export const DisplayRow: Story = {
   args: {

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -203,11 +203,13 @@ interface CardSummaryPresetProps extends CardBaseProps {
 
 interface CardDisplayPresetProps extends CardBaseProps {
   /**
-   * Display preset — generic content card for any item rendered in a
-   * card grid (service, blog post, customer story, property listing,
-   * team bio, support plan). All affordances are optional + prop-toggled
-   * so a single primitive serves every content type. Used by the
-   * `bds-card-grid` blueprint.
+   * Display preset — the **cell of a `CardGrid`**, not a standalone card. Per
+   * [ADR-018](../../../docs/adrs/ADR-018-card-preset-boundary.md) a display card
+   * only exists inside a `CardGrid` Section (which owns the columns); this
+   * preset is the malleable, content-agnostic cell it repeats. All affordances
+   * are optional + prop-toggled so one cell serves any content type — service,
+   * blog post, customer story, property listing, team bio, support plan.
+   * Compose `<CardGrid>` + `<Card preset="display">`.
    */
   preset: 'display';
   /**
@@ -262,11 +264,12 @@ interface CardDisplayPresetProps extends CardBaseProps {
 
 interface CardDisplayRowPresetProps extends CardBaseProps {
   /**
-   * Display-row preset — horizontal sibling of `preset="display"`. Image on
-   * the left, content (tag, title, description, action) on the right. Use
-   * for single-card sections where vertical layout wastes horizontal space:
-   * Related Customer Story, Recommended Add-On, featured plan. Collapses
-   * to a vertical stack at ≤ 640px.
+   * Display-row preset — the horizontal `CardGrid` cell / section row (per
+   * [ADR-018](../../../docs/adrs/ADR-018-card-preset-boundary.md)), not a
+   * standalone card. Image on the left, content (tag, title, description,
+   * action) on the right. Use for single-row sections where a vertical layout
+   * wastes horizontal space: Related Customer Story, Recommended Add-On,
+   * featured plan. Collapses to a vertical stack at ≤ 640px.
    */
   preset: 'display-row';
   /** Card heading. Renders as `<h3>` with `--font-family-heading` + `--heading-md`. */

--- a/scripts/.standards-hashes
+++ b/scripts/.standards-hashes
@@ -1,5 +1,5 @@
-2cc7d5c27fb6a1ecac067004492e6f1f5ee81662e4ba3b97e6725fb1996b70fe  .claude/standards/component-build.md
 79f34fe82693d85f7f39a2fec4160b945004e4a270ea331a2495ea1272a321b9  .claude/standards/storybook-mdx-recipe.md
 8caeddca93778c57a56b5f404e1460293e97fa02f6f01eb4057c43a9f1c07249  .claude/standards/storybook-story-shape.md
+938f1bec493ff276f6f0596607519689e3c9578b1f481ee5d153beed63adeaed  .claude/standards/component-build.md
 aa041ded08faa66658d0b8e3d5c09216fd6bf72a622c125b185714a976ec0305  .claude/standards/fumadocs-content.md
 b4db3ec98bb1dec16b509c5a400fe5e465fd3840d36f549c0da1b0669b72b1ea  .claude/standards/storybook-toolbar-globals.md


### PR DESCRIPTION
## Summary
- docs(card): align stories + docs to ADR-018; consolidate control preset

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)