### PR TITLE
fix(card): compose Dot for control status + top-align the logo

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -151,7 +151,9 @@
 
 .bds-card__preset-control-content {
   display: flex;
-  align-items: center;
+  /* Top-align the logo + badge with the title (not the vertical midline of the
+     whole text block), so the leading mark reads against the first line. */
+  align-items: flex-start;
   gap: var(--padding-lg);
   flex: 1;
   min-width: 0;
@@ -232,15 +234,8 @@
   gap: var(--gap-sm);
 }
 
-/* Dot circle */
-.bds-card__preset-control-status-dot {
-  /* bds-lint-ignore — Figma-driven dot dimensions */
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  display: inline-block;
-}
+/* The status dot is the shared `<Dot>` primitive (owns its size + per-status
+   semantic-token color); this preset only positions the label beside it. */
 
 /* Label text */
 .bds-card__preset-control-status-label {
@@ -260,42 +255,22 @@
   color: var(--text-muted);
 }
 
-/* ── Per-state colors (dot + label) ── */
-
-.bds-card__preset-control-status--not-configured .bds-card__preset-control-status-dot {
-  background-color: var(--background-status-neutral);
-}
+/* ── Per-state label color (the dot's color comes from `<Dot status>`) ── */
 
 .bds-card__preset-control-status--not-configured .bds-card__preset-control-status-label {
   color: var(--text-muted);
-}
-
-.bds-card__preset-control-status--connected .bds-card__preset-control-status-dot {
-  background-color: var(--background-positive);
 }
 
 .bds-card__preset-control-status--connected .bds-card__preset-control-status-label {
   color: var(--text-positive);
 }
 
-.bds-card__preset-control-status--syncing .bds-card__preset-control-status-dot {
-  background-color: var(--background-status-info);
-}
-
 .bds-card__preset-control-status--syncing .bds-card__preset-control-status-label {
   color: var(--text-status-info);
 }
 
-.bds-card__preset-control-status--synced .bds-card__preset-control-status-dot {
-  background-color: var(--background-positive);
-}
-
 .bds-card__preset-control-status--synced .bds-card__preset-control-status-label {
   color: var(--text-positive);
-}
-
-.bds-card__preset-control-status--error .bds-card__preset-control-status-dot {
-  background-color: var(--background-negative);
 }
 
 .bds-card__preset-control-status--error .bds-card__preset-control-status-label {

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -3,6 +3,7 @@ import { bdsClass } from '../../utils';
 import { Avatar, type AvatarSize, type AvatarStatus } from '../Avatar';
 import { Image } from '../Image';
 import { Logo, type LogoProps } from '../Logo';
+import { Dot, type DotStatus } from '../Dot';
 import './Card.css';
 
 export type CardVariant = 'outlined' | 'brand' | 'elevated' | 'borderless';
@@ -519,6 +520,19 @@ const CONNECTION_STATUS_LABELS: Record<CardControlConnectionStatus, string> = {
   error:            'Error',
 };
 
+/**
+ * Connection-status → `Dot` status. Composes the shared `<Dot>` primitive
+ * (which owns the dot's size + semantic-token color per status) instead of a
+ * bespoke dot — `not-configured` maps to Dot's `neutral`, which `Badge` lacks.
+ */
+const CONNECTION_STATUS_DOT: Record<CardControlConnectionStatus, DotStatus> = {
+  'not-configured': 'neutral',
+  connected:        'positive',
+  syncing:          'info',
+  synced:           'positive',
+  error:            'error',
+};
+
 function renderControlPreset({
   title,
   description,
@@ -564,7 +578,9 @@ function renderControlPreset({
               role="status"
               aria-label={`Connection status: ${CONNECTION_STATUS_LABELS[connectionStatus]}`}
             >
-              <span className="bds-card__preset-control-status-dot" aria-hidden="true" />
+              {/* Decorative — the wrapper's role="status" + aria-label is the
+                  single announcement; Dot is the visual mark only. */}
+              <Dot status={CONNECTION_STATUS_DOT[connectionStatus]} aria-hidden />
               <span className="bds-card__preset-control-status-label">
                 {CONNECTION_STATUS_LABELS[connectionStatus]}
               </span>


### PR DESCRIPTION
## Summary
- fix(card): compose Dot for control status + top-align the logo

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)