### PR TITLE
refactor(borders): converge remaining 1px dividers to 2px across BDS

### DIFF
--- a/components/ui/DataSection/DataSection.css
+++ b/components/ui/DataSection/DataSection.css
@@ -14,7 +14,7 @@
 .bds-data-section + .bds-data-section {
   margin-top: var(--padding-lg);
   padding-top: var(--padding-lg);
-  border-top: var(--border-width-sm) solid var(--border-muted);
+  border-top: var(--border-width-md) solid var(--border-muted);
 }
 
 .bds-data-section--spacing-lg + .bds-data-section {

--- a/components/ui/Dialog/Dialog.css
+++ b/components/ui/Dialog/Dialog.css
@@ -75,7 +75,7 @@
 .bds-dialog__button--cancel {
   background-color: var(--surface-secondary);
   color: var(--text-primary);
-  border: var(--border-width-sm) solid var(--border-secondary);
+  border: var(--border-width-md) solid var(--border-secondary);
 }
 
 .bds-dialog__button--confirm {

--- a/components/ui/Divider/Divider.css
+++ b/components/ui/Divider/Divider.css
@@ -11,7 +11,7 @@
 .bds-divider--horizontal {
   width: 100%;
   height: 0;
-  border-top: var(--border-width-sm) solid var(--border-muted);
+  border-top: var(--border-width-md) solid var(--border-muted);
 }
 
 /* ─── Vertical ───────────────────────────────────────────────── */
@@ -20,7 +20,7 @@
   width: 0;
   height: 100%;
   align-self: stretch;
-  border-left: var(--border-width-sm) solid var(--border-muted);
+  border-left: var(--border-width-md) solid var(--border-muted);
 }
 
 /* ─── Spacing ────────────────────────────────────────────────── */

--- a/components/ui/EmptyState/EmptyState.css
+++ b/components/ui/EmptyState/EmptyState.css
@@ -9,7 +9,7 @@
   gap: var(--gap-xl);
   padding: var(--padding-xl);
   background-color: var(--surface-secondary);
-  border: var(--border-width-sm) solid var(--border-secondary);
+  border: var(--border-width-md) solid var(--border-secondary);
   border-radius: var(--border-radius-lg);
   overflow: hidden;
   width: 100%;

--- a/components/ui/FileCard/FileCard.css
+++ b/components/ui/FileCard/FileCard.css
@@ -34,7 +34,7 @@
   display: flex;
   align-items: stretch;
   background-color: var(--surface-primary);
-  border: var(--border-width-sm) solid var(--border-secondary);
+  border: var(--border-width-md) solid var(--border-secondary);
   border-radius: var(--border-radius-md);
   overflow: hidden;
   width: 100%;
@@ -160,7 +160,7 @@
   gap: var(--gap-xs);
   padding: var(--padding-xs) var(--padding-sm);
   background-color: var(--surface-primary);
-  border: var(--border-width-sm) solid var(--border-secondary);
+  border: var(--border-width-md) solid var(--border-secondary);
   border-radius: var(--border-radius-sm);
   font-family: var(--font-family-label);
   font-size: var(--label-sm);

--- a/components/ui/Footer/Footer.css
+++ b/components/ui/Footer/Footer.css
@@ -33,7 +33,7 @@
 .bds-footer__above-top {
   width: 100%;
   padding-bottom: var(--padding-lg);
-  border-bottom: var(--border-width-sm) solid var(--border-secondary);
+  border-bottom: var(--border-width-md) solid var(--border-secondary);
 }
 
 /* ─── Variants ────────────────────────────────────────────────── */
@@ -146,7 +146,7 @@
   align-items: center;
   gap: var(--gap-lg);
   padding-top: var(--padding-md);
-  border-top: var(--border-width-sm) solid var(--border-secondary);
+  border-top: var(--border-width-md) solid var(--border-secondary);
 }
 
 .bds-footer__bottom-left {

--- a/components/ui/Menu/Menu.css
+++ b/components/ui/Menu/Menu.css
@@ -35,7 +35,7 @@
   display: flex;
   flex-direction: column;
   padding: var(--padding-tiny) var(--padding-tiny) var(--padding-md);
-  border-bottom: 1px solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
   margin-bottom: var(--gap-tiny);
   font-family: var(--font-family-label);
   font-size: var(--body-xs);

--- a/components/ui/Modal/Modal.css
+++ b/components/ui/Modal/Modal.css
@@ -47,7 +47,7 @@
 
 .bds-modal__header {
   padding: var(--padding-lg);
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/components/ui/NotificationList/NotificationList.css
+++ b/components/ui/NotificationList/NotificationList.css
@@ -17,7 +17,7 @@
   gap: var(--gap-md);
   padding: var(--padding-sm) var(--padding-md);
   cursor: pointer;
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
   transition: background-color 0.15s;
 }
 
@@ -97,7 +97,7 @@
   width: 360px; /* bds-lint-ignore — design-spec popover width */
   max-height: 480px; /* bds-lint-ignore — design-spec max scroll height */
   background-color: var(--surface-primary);
-  border: var(--border-width-sm) solid var(--border-muted);
+  border: var(--border-width-md) solid var(--border-muted);
   border-radius: var(--border-radius-md);
   box-shadow: var(--box-shadow-lg);
   display: flex;
@@ -111,7 +111,7 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--padding-sm) var(--padding-md);
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
   flex-shrink: 0;
 }
 

--- a/components/ui/Popover/Popover.css
+++ b/components/ui/Popover/Popover.css
@@ -19,7 +19,7 @@
   background-color: var(--background-primary);
   border-radius: var(--border-radius-lg);
   box-shadow: var(--shadow-lg);
-  border: var(--border-width-sm) solid var(--border-secondary);
+  border: var(--border-width-md) solid var(--border-secondary);
   padding: var(--padding-md);
   z-index: 100;
   box-sizing: border-box;

--- a/components/ui/ProgressStepper/ProgressStepper.css
+++ b/components/ui/ProgressStepper/ProgressStepper.css
@@ -79,7 +79,7 @@
 .bds-progress-stepper__circle--upcoming {
   background-color: var(--surface-secondary);
   color: var(--text-muted);
-  border: var(--border-width-sm) solid var(--border-secondary);
+  border: var(--border-width-md) solid var(--border-secondary);
 }
 
 /* ─── Label ──────────────────────────────────────────────────── */

--- a/components/ui/Sheet/Sheet.css
+++ b/components/ui/Sheet/Sheet.css
@@ -62,7 +62,7 @@
   align-items: flex-start;
   justify-content: space-between;
   padding: var(--padding-lg);
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
   flex-shrink: 0;
 }
 
@@ -189,7 +189,7 @@
   justify-content: space-between;
   flex-wrap: wrap;
   flex-shrink: 0;
-  border-top: var(--border-width-sm) solid var(--border-muted);
+  border-top: var(--border-width-md) solid var(--border-muted);
 }
 
 .bds-sheet__footer-secondary {

--- a/components/ui/Stepper/Stepper.css
+++ b/components/ui/Stepper/Stepper.css
@@ -15,7 +15,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: var(--border-width-sm) solid var(--border-secondary);
+  border: var(--border-width-md) solid var(--border-secondary);
   background-color: var(--surface-secondary);
   color: var(--text-primary);
   cursor: pointer;

--- a/components/ui/Table/Table.css
+++ b/components/ui/Table/Table.css
@@ -19,7 +19,7 @@
    background and corner cells to the radius. */
 .bds-table[data-rounded-top="true"],
 .bds-table[data-rounded-bottom="true"] {
-  border: var(--border-width-sm) solid var(--border-muted);
+  border: var(--border-width-md) solid var(--border-muted);
   overflow: hidden;
 }
 
@@ -100,7 +100,7 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: var(--padding-tiny) var(--padding-md);
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
 }
 
 /* Suppress striped background on subheader rows */
@@ -129,7 +129,7 @@
   overflow-wrap: anywhere;
   /* Row divider lives on the cell — `tr` borders don't paint under
      `border-collapse: separate`. */
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
 }
 
 /* Size: default */
@@ -152,7 +152,7 @@
   width: 1%;
   white-space: nowrap;
   /* Match the body-cell row divider (borders don't paint on `tr`). */
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
 }
 
 /* When an outer border is present (any rounded edge), the last body row
@@ -207,7 +207,7 @@
 
 .bds-table-avatar-cell {
   vertical-align: middle;
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
 }
 
 .bds-table[data-size="default"] .bds-table-avatar-cell {
@@ -261,7 +261,7 @@
   /* Shrink-to-content so the thumbnail column never competes with content cells */
   width: 1%;
   white-space: nowrap;
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
 }
 
 .bds-table[data-size="default"] .bds-table-image-cell {
@@ -299,7 +299,7 @@
 
 .bds-table-service-tag-cell {
   vertical-align: middle;
-  border-bottom: var(--border-width-sm) solid var(--border-muted);
+  border-bottom: var(--border-width-md) solid var(--border-muted);
 }
 
 .bds-table[data-size="default"] .bds-table-service-tag-cell {

--- a/components/ui/TaskConsole/TaskConsole.css
+++ b/components/ui/TaskConsole/TaskConsole.css
@@ -9,7 +9,7 @@
   display: flex;
   flex-direction: column;
   background-color: var(--surface-primary);
-  border: var(--border-width-sm) solid var(--border-primary);
+  border: var(--border-width-md) solid var(--border-primary);
   border-radius: var(--border-radius-lg);
   box-shadow: var(--shadow-xl);
   overflow: hidden;
@@ -116,7 +116,7 @@
   justify-content: space-between;
   padding: var(--padding-md) var(--padding-lg);
   gap: var(--gap-md);
-  border-bottom: var(--border-width-sm) solid var(--border-primary);
+  border-bottom: var(--border-width-md) solid var(--border-primary);
   transition: background-color var(--duration-fast) var(--ease-out);
 }
 

--- a/components/ui/TimePicker/TimePicker.css
+++ b/components/ui/TimePicker/TimePicker.css
@@ -147,7 +147,7 @@
 
 /* Column dividers (not on the last column) */
 .bds-time-picker__column:not(:last-child) {
-  border-right: var(--border-width-sm) solid var(--border-muted);
+  border-right: var(--border-width-md) solid var(--border-muted);
 }
 
 /* ─── Cell ───────────────────────────────────────────────────── */


### PR DESCRIPTION
Closes #1160
Refs #1126 (Border Clean-Up Phase 2 — divider convergence)

## Summary
- refactor(borders): converge remaining 1px dividers to 2px across BDS

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)