### PR TITLE
chore(release): 0.121.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.120.0",
+  "version": "0.121.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.120.0",
+      "version": "0.121.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.120.0",
+  "version": "0.121.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/lib-entry.cjs",


### PR DESCRIPTION
Release bump for the divider convergence (Border Clean-Up Phase 2).

Ships #1160 (converged remaining 1px dividers → 2px across 15 components + Menu). On merge, tag `v0.121.0` from the tip of main to trigger `release.yml` publish.

Refs #1126
Follow-on consumer bumps: brikdesigns/brik-client-portal#1779, brikdesigns/brikdesigns#683