### PR TITLE
feat(card): titleAs + service-tier tint hooks on display presets

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -384,6 +384,34 @@
   box-shadow: var(--box-shadow-md);
 }
 
+/* Service-line surface tint — a pale wash keyed to a service line, shared by
+ * both display presets. Sets only the surface (border / shadow unchanged), so
+ * it composes with the default outlined shape. Two-class selectors clear the
+ * single-class base fill regardless of source order. Uses the canonical
+ * `--surface-service-{line}-light` pastel step; dark mode is handled by the
+ * token cascade. Not for combining with `borderless` (transparent by design).
+ */
+.bds-card--preset-display.bds-card--tint-brand,
+.bds-card--preset-display-row.bds-card--tint-brand {
+  background-color: var(--surface-service-brand-light);
+}
+.bds-card--preset-display.bds-card--tint-marketing,
+.bds-card--preset-display-row.bds-card--tint-marketing {
+  background-color: var(--surface-service-marketing-light);
+}
+.bds-card--preset-display.bds-card--tint-information,
+.bds-card--preset-display-row.bds-card--tint-information {
+  background-color: var(--surface-service-information-light);
+}
+.bds-card--preset-display.bds-card--tint-product,
+.bds-card--preset-display-row.bds-card--tint-product {
+  background-color: var(--surface-service-product-light);
+}
+.bds-card--preset-display.bds-card--tint-back-office,
+.bds-card--preset-display-row.bds-card--tint-back-office {
+  background-color: var(--surface-service-back-office-light);
+}
+
 .bds-card--preset-display {
   background-color: var(--surface-primary);
   border: var(--border-width-md) solid var(--border-secondary);

--- a/components/ui/Card/Card.stories.tsx
+++ b/components/ui/Card/Card.stories.tsx
@@ -374,6 +374,19 @@ export const Display: Story = {
       description:
         'Surface treatment for a cell on a colored (service-tinted) grid. `borderless` = transparent, no border/shadow; `elevated` = fill + shadow, no border. Default = outlined white fill.',
     },
+    tint: {
+      control: 'select',
+      options: ['none', 'brand', 'marketing', 'information', 'product', 'back-office'],
+      mapping: { none: undefined },
+      description:
+        'Service-line surface tint — a pale wash keyed to a service line, mapping to the canonical service-line pastel surface token. Sets only the surface; border/size unchanged. Default = no tint.',
+    },
+    titleAs: {
+      control: 'inline-radio',
+      options: ['h2', 'h3', 'h4'],
+      description:
+        'Heading element for the title (default `h3`). Set to keep the document outline correct for the card context; visual size is token-driven and does not change.',
+    },
     padding: { table: { disable: true } },
     interactive: { table: { disable: true } },
   },
@@ -448,6 +461,19 @@ export const DisplayRow: Story = {
       options: ['narrow', 'standard', 'wide'],
       description:
         'Image column width. Named: `narrow` 25%, `standard` 35%, `wide` 50%. Pass a CSS length / percentage string (e.g. `"40%"`) to override.',
+    },
+    tint: {
+      control: 'select',
+      options: ['none', 'brand', 'marketing', 'information', 'product', 'back-office'],
+      mapping: { none: undefined },
+      description:
+        'Service-line surface tint — a pale wash keyed to a service line, mapping to the canonical service-line pastel surface token. Sets only the surface; border/size unchanged. Default = no tint.',
+    },
+    titleAs: {
+      control: 'inline-radio',
+      options: ['h2', 'h3', 'h4'],
+      description:
+        'Heading element for the title (default `h3`). Set to keep the document outline correct for the card context; visual size is token-driven and does not change.',
     },
   },
   decorators: [

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -4,11 +4,21 @@ import { Avatar, type AvatarSize, type AvatarStatus } from '../Avatar';
 import { Image } from '../Image';
 import { Logo, type LogoProps } from '../Logo';
 import { Dot, type DotStatus } from '../Dot';
+import type { ServiceLine } from '../ServiceTag/service-config';
 import './Card.css';
 
 export type CardVariant = 'outlined' | 'brand' | 'elevated' | 'borderless';
 export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
 export type CardPreset = 'control' | 'summary' | 'display' | 'display-row';
+/** Heading level for a card's title — decouples document outline from the token-driven visual size. */
+export type CardHeadingLevel = 'h2' | 'h3' | 'h4';
+/**
+ * Service-line surface tint for the display presets. Maps to the canonical
+ * `--surface-service-{line}-light` pastel surface token — never an invented
+ * name. Excludes the deprecated `service` alias of `ServiceLine`; pass
+ * `back-office`.
+ */
+export type CardTint = Exclude<ServiceLine, 'service'>;
 export type CardControlActionAlign = 'center' | 'top';
 export type CardSummaryType = 'numeric' | 'price';
 /**
@@ -224,8 +234,23 @@ interface CardDisplayPresetProps extends CardBaseProps {
    * `borderless`).
    */
   variant?: 'borderless' | 'elevated';
-  /** Card heading. Renders as `<h3>` with `--font-family-heading` + `--heading-md`. */
+  /**
+   * Optional service-line surface tint — a pale wash keyed to a service line
+   * (`--surface-service-{line}-light`). Use for a service-identified cell in a
+   * `CardGrid`. The visual size / border are unchanged; this only sets the
+   * surface. Orthogonal to `variant` (don't combine with `borderless`, which is
+   * transparent by design).
+   */
+  tint?: CardTint;
+  /** Card heading. Renders with `--font-family-heading` + `--heading-md`; the element is `titleAs` (default `h3`). */
   title: string;
+  /**
+   * Heading element for `title` — `h2` / `h3` / `h4`. Default `h3`. Set to keep
+   * the document outline correct for the card's context (e.g. `h3` under an
+   * `<h2>` grid-section heading). Visual size is token-driven and does not
+   * change with the level.
+   */
+  titleAs?: CardHeadingLevel;
   /**
    * Body copy under the title. Renders as `<p>` with `--font-family-body` +
    * `--body-md` (matched pair — never reach across families for size).
@@ -273,8 +298,20 @@ interface CardDisplayRowPresetProps extends CardBaseProps {
    * featured plan. Collapses to a vertical stack at ≤ 640px.
    */
   preset: 'display-row';
-  /** Card heading. Renders as `<h3>` with `--font-family-heading` + `--heading-md`. */
+  /** Card heading. Renders with `--font-family-heading` + `--heading-md`; the element is `titleAs` (default `h3`). */
   title: string;
+  /**
+   * Heading element for `title` — `h2` / `h3` / `h4`. Default `h3`. Set to keep
+   * the document outline correct for the card's context. Visual size is
+   * token-driven and does not change with the level.
+   */
+  titleAs?: CardHeadingLevel;
+  /**
+   * Optional service-line surface tint — a pale wash keyed to a service line
+   * (`--surface-service-{line}-light`). The visual size / border are unchanged;
+   * this only sets the surface. Orthogonal to layout props.
+   */
+  tint?: CardTint;
   /** Body copy under the title. Renders as `<p>` with `--font-family-body` + `--body-md`. */
   description?: string;
   /**
@@ -650,6 +687,7 @@ function renderSummaryPreset({
 
 function renderDisplayPreset({
   title,
+  titleAs: Heading = 'h3',
   description,
   image,
   tag,
@@ -657,6 +695,7 @@ function renderDisplayPreset({
   action,
   href,
   variant,
+  tint,
   className,
   style,
   preset: _preset,
@@ -666,6 +705,7 @@ function renderDisplayPreset({
     'bds-card',
     'bds-card--preset-display',
     variant && `bds-card--${variant}`,
+    tint && `bds-card--tint-${tint}`,
     href && 'bds-card--link',
     className,
   );
@@ -684,7 +724,7 @@ function renderDisplayPreset({
         {tag && (
           <span className="bds-card__preset-display-tag">{tag}</span>
         )}
-        <h3 className="bds-card__preset-display-title">{title}</h3>
+        <Heading className="bds-card__preset-display-title">{title}</Heading>
         {description && (
           <p className="bds-card__preset-display-description">{description}</p>
         )}
@@ -717,6 +757,7 @@ function renderDisplayPreset({
 
 function renderDisplayRowPreset({
   title,
+  titleAs: Heading = 'h3',
   description,
   image,
   tag,
@@ -724,6 +765,7 @@ function renderDisplayRowPreset({
   action,
   imageWidth = 'standard',
   href,
+  tint,
   className,
   style,
   preset: _preset,
@@ -734,6 +776,7 @@ function renderDisplayRowPreset({
     'bds-card',
     'bds-card--preset-display-row',
     isNamed && `bds-card--preset-display-row-${imageWidth}`,
+    tint && `bds-card--tint-${tint}`,
     href && 'bds-card--link',
     className,
   );
@@ -755,7 +798,7 @@ function renderDisplayRowPreset({
         {tag && (
           <span className="bds-card__preset-display-row-tag">{tag}</span>
         )}
-        <h3 className="bds-card__preset-display-row-title">{title}</h3>
+        <Heading className="bds-card__preset-display-row-title">{title}</Heading>
         {description && (
           <p className="bds-card__preset-display-row-description">{description}</p>
         )}
@@ -793,7 +836,7 @@ function renderDisplayRowPreset({
 
 export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {
   children: ReactNode;
-  as?: 'h2' | 'h3' | 'h4';
+  as?: CardHeadingLevel;
 }
 
 export function CardTitle({ children, as: Tag = 'h3', className, style, ...props }: CardTitleProps) {


### PR DESCRIPTION
## Summary

Follow-through on the last two ADR-018 rigidity items for the display presets ([#1159](https://github.com/brikdesigns/brik-bds/issues/1159)). Design pass was locked on the issue before coding: [#1159 (comment)](https://github.com/brikdesigns/brik-bds/issues/1159#issuecomment-4892746449).

- **`titleAs` heading-level hook** — `preset="display"` / `display-row` no longer hardcode `<h3>`. New `titleAs?: 'h2' | 'h3' | 'h4'` (default `'h3'`) lets a `CardGrid` cell keep a correct document outline for its context (e.g. `h3` under an `<h2>` section, `h2` for a standalone featured row). Visual size stays token-driven — the class is unchanged, only the element changes. **Zero DOM/visual diff for every existing call site.** Reuses a new shared `CardHeadingLevel` alias, also applied to `CardTitle['as']`.
- **`tint` service-tier surface hook** — new `tint?: CardTint` (a service line) paints a pale surface wash via a shared `bds-card--tint-{line}` BEM family mapping to the canonical **`--surface-service-{line}-light`** token. Consumers pass a *line name*, never a token/color — the component owns the mapping, so no invented `--surface-*` names leak to the consumer layer. Reuses `ServiceTag`'s canonical `ServiceLine` type (deprecated `service` alias excluded). Sets **only** the surface; border/shadow/size unchanged, so it composes with the default outlined shape. Dark mode is handled by the token cascade.

Retires the consumer-side inline `backgroundColor` tint hack that brikdesigns#482 worked around at the strip level.

## Verification
- ✅ `tsc --noEmit`, `lint-tokens`, `contrast-gate`, `canonical-check` (token names), `lint-jsdoc`, `slot-pattern-check`, `typegen:axes:check`
- ✅ DOM render (throwaway, not committed): `titleAs` swaps the heading tag with class unchanged; `tint` applies the correct `bds-card--tint-{line}` modifier; defaults preserved
- ✅ Playwright screenshots against local Storybook (headless, no 1Password): `display` tints on `information` (blue) / `brand` (yellow); `display-row` tints on `back-office` (orange, hyphenated line); border/shape unchanged
- ⏳ **Chromatic** — not run here (this host can't run the headless gate; 1Password `op` injection is brik-mini-only per #1058). Run `npm run chromatic` on brik-mini before merge for the snapshot record.

## Consumer sync plan
- [ ] Cut BDS release (→ next version) after merge, then bump the portal to adopt the tint/heading hooks (last open #1159 AC)
- [ ] renew-pms / brikdesigns: submodule bump / `bds-sync.sh` as usual

## Docs
- Props table (`Card.mdx` `<ArgTypes>`) and the `Display` / `DisplayRow` story Controls pick up both props automatically.

Refs #1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
