### PR TITLE
feat(tooling): gate retired token-cascade vocab in docs MDX (#748)

### DIFF
--- a/.github/workflows/token-cascade-vocab-check.yml
+++ b/.github/workflows/token-cascade-vocab-check.yml
@@ -1,0 +1,51 @@
+name: Token Cascade Vocab Check
+
+# Fails when retired token-cascade layering terms reappear in docs-site MDX prose.
+# PR #736 locked the six-concept token vocabulary (Anatomy / Tier / Library /
+# Layer / Mode / Tenet) and swept the retired terms — "Tier 1/2/3/4" (CSS-cascade
+# sense), "Layer 1-4", "four layers", "Tier/Layer N brand overrides" — out of
+# content/docs/**.mdx. This gate prevents them drifting back in.
+#
+# Sister of #534 (BCS Vocabulary Check): same canonical-name-drift class of bug on
+# a different vocabulary. Legitimate numbered-Tier usage (the Raw/Primitive/
+# Semantic/Component abstraction stack, and the CLAUDE.md doc-tier model) is
+# exempted via an inline `cascade-vocab-ok` allow-anchor, not by banning the word.
+#
+# Issue: brikdesigns/brik-bds#748
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs-site/content/docs/**'
+      - 'scripts/token-cascade-vocab-check.mjs'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs-site/content/docs/**'
+      - 'scripts/token-cascade-vocab-check.mjs'
+
+concurrency:
+  group: token-cascade-vocab-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  token-cascade-vocab-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Token cascade vocabulary check
+        run: npm run token-cascade-vocab-check

--- a/docs-site/content/docs/getting-started/cascade.mdx
+++ b/docs-site/content/docs/getting-started/cascade.mdx
@@ -29,7 +29,11 @@ Every consumer's `globals.css` declares this `@layer` order **before any imports
 @layer bds-tokens, bds-components, client-theme, client-overrides;
 ```
 
+{/* cascade-vocab-ok:start — the four named CSS @layers, not the retired cascade "layers" */}
+
 The four Layers, in cascade order (last wins):
+
+{/* cascade-vocab-ok:end */}
 
 | Layer | What lives here | Editable by consumers? |
 |---|---|---|

--- a/docs-site/content/docs/getting-started/documentation-system.mdx
+++ b/docs-site/content/docs/getting-started/documentation-system.mdx
@@ -45,6 +45,8 @@ The standard + skill pairing pattern lives at Tier 3b. brik-bds is the live prec
 
 Ask in order. First YES wins.
 
+{/* cascade-vocab-ok:start — the CLAUDE.md documentation-tier model (Tier 0–5), a different domain from the token cascade */}
+
 | Question | YES → |
 | --- | --- |
 | Is it safety-critical (data loss, broken prod, wrong MCP)? | Tier 0 — cross-repo CLAUDE.md |
@@ -71,6 +73,8 @@ Most knowledge starts as a note in a session or a comment on a PR. It earns a mo
 4. **Skill or standard** (Tier 3 / 3b) — when an agent should consult this knowledge automatically on a specific trigger (file edit, command, user phrase), promote it to a skill, optionally paired with a standard if there's a ruleset.
 5. **CLAUDE.md** (Tier 0–2) — only if the rule is a safety invariant the agent must never miss. One-line imperative or pointer, never long-form.
 6. **Fumadocs page** (this site) — when stakeholders need to read it without a Claude session.
+
+{/* cascade-vocab-ok:end */}
 
 Promotion goes UP. Demotion goes DOWN. Duplication is a bug — when you promote content, the lower-tier copy should become a pointer or get deleted.
 

--- a/docs-site/content/docs/primitives/token-anatomy.mdx
+++ b/docs-site/content/docs/primitives/token-anatomy.mdx
@@ -135,6 +135,8 @@ Every token sits at exactly one Tier. Higher tiers reference lower tiers via `va
   **Components consume Semantic tokens, never Primitives directly.** A button's CSS references `--background-brand-primary`, not `--color-poppy-dark`. Why: Semantic is the layer that varies per brand. Bypassing it locks the component to one brand.
 </Callout>
 
+{/* cascade-vocab-ok:start — the abstraction Tier stack (Raw · Primitive · Semantic · Component), not the CSS cascade */}
+
 ### About Tier 4 (Component)
 
 The Component tier is **`--bds-{component}-{property}`** — a component- or blueprint-scoped custom property, where `{component}` is the component/blueprint identifier and `{property}` is the styled aspect. Examples: `--bds-toast-shadow`, `--bds-slider-thumb-shadow`, `--bds-hero-img-card-bg`. This is the only sanctioned Component-tier namespace ([ADR-014](https://github.com/brikdesigns/brik-bds/blob/main/docs/adrs/ADR-014-component-token-hook-namespace.md)).
@@ -157,6 +159,8 @@ A Tier 4 token serves one of two roles, both under the same name:
 <Callout type="warn">
   **Tier 4 never terminates at a raw value.** A knob's fallback is a Semantic token; a runtime binding is computed from one. A literal inside a `var()` fallback on a tokenized property is Tier-1 leakage and is flagged by `scripts/lint-tokens.js`. The `--bds-` prefix is mandatory — `--bp-*` and bare `--{component}-*` are retired (see Drift patterns below).
 </Callout>
+
+{/* cascade-vocab-ok:end */}
 
 ## How the six concepts map to a real token
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "build:inspector-manifest": "node scripts/build-inspector-manifest.mjs",
     "bds:find": "node scripts/bds-find.mjs",
     "bcs-vocab-check": "node scripts/bcs-vocab-check.mjs",
+    "token-cascade-vocab-check": "node scripts/token-cascade-vocab-check.mjs",
     "canonical-check": "node scripts/canonical-check.mjs --allowlist dist/tokens.css components content-system/blueprints content-system/atmospheres content-system/industries",
     "canonical-check:report": "node scripts/canonical-check.mjs --allowlist dist/tokens.css --format md components content-system stories || true",
     "canonical-class-check": "node scripts/canonical-class-check.mjs --allowlist dist/styles.css content-system/blueprints",

--- a/scripts/token-cascade-vocab-check.mjs
+++ b/scripts/token-cascade-vocab-check.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * token-cascade-vocab-check — retired token-cascade vocabulary gate for docs-site MDX.
+ *
+ * Fails when retired token-cascade layering terms reappear in docs-site content
+ * MDX prose. PR #736 locked the six-concept token vocabulary (Anatomy / Tier /
+ * Library / Layer / Mode / Tenet) and swept the retired terms out; this gate
+ * prevents them from drifting back in.
+ *
+ * Sister of #534 (bcs-vocab-check): same canonical-name-drift class of bug on a
+ * different vocabulary. #534 validates BCS values against locked enums; this gate
+ * bans retired cascade terms. See brik-bds#748.
+ *
+ * ── What's retired vs canonical ───────────────────────────────────────────
+ *
+ *   Retired (banned)                    Canonical replacement
+ *   ─────────────────────────────────   ──────────────────────────────────────
+ *   "Tier 1/2/3/4" (CSS-cascade sense)  named CSS @layer: bds-tokens ·
+ *                                        bds-components · client-theme ·
+ *                                        client-overrides
+ *   "Layer 1/2/3/4"                     named CSS @layer (layers are never
+ *                                        numbered)
+ *   "four layers"                       four Theming Dimensions (Tokens ·
+ *                                        Atmospheres · Layout Archetypes ·
+ *                                        Blueprints); the cascade has four
+ *                                        *named* @layers
+ *   "Tier/Layer N brand overrides"      "@layer client-theme overrides"
+ *
+ * The word "Tier" is still canonical for the four-tier abstraction stack
+ * (Raw · Primitive · Semantic · Component) and "Layer" is canonical for the CSS
+ * @layer. Those legitimate usages live in a handful of canonical docs and are
+ * exempted via an inline allow-anchor (see below) — not by banning the words.
+ *
+ * ── Detection ────────────────────────────────────────────────────────────
+ *
+ *   - Scans prose lines only. Fenced code blocks (``` … ```) are skipped —
+ *     ASCII diagrams and code examples are not prose vocabulary.
+ *   - Each banned pattern is matched with word boundaries, so hyphenated forms
+ *     ("Tier-1 leakage") and named forms ("Semantic tier") never match.
+ *
+ * ── Allow-anchors (for genuinely canonical usage) ──────────────────────────
+ *
+ *   Single line:  add `cascade-vocab-ok` in an MDX/HTML comment on the line:
+ *       A Tier 4 token is component-scoped. {/* cascade-vocab-ok: anatomy stack *​/}
+ *
+ *   Region:       wrap a block whose numbered-Tier/Layer usage is a *different*
+ *                 domain (e.g. the CLAUDE.md documentation-tier model):
+ *       {/* cascade-vocab-ok:start — doc-tier model, not token cascade *​/}
+ *       | Tier 1 — BDS CLAUDE.md | … |
+ *       {/* cascade-vocab-ok:end *​/}
+ *
+ * ── Exit codes ───────────────────────────────────────────────────────────
+ *   0  Clean — no retired token-cascade vocabulary in prose
+ *   1  Violations found
+ *   2  Bad invocation (missing/unreadable MDX directory)
+ *
+ * ── CLI ──────────────────────────────────────────────────────────────────
+ *   token-cascade-vocab-check [mdx-dir]   Scan MDX dir (default: docs-site/content/docs)
+ *   token-cascade-vocab-check --help      Show this message
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { resolve, join, dirname, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BDS_ROOT = resolve(__dirname, '..');
+
+// ── Retired-term rules ─────────────────────────────────────────────────────
+//
+// Each rule: a word-boundary regex + the canonical replacement guidance printed
+// on failure. Order matters only for which message a line reports first.
+
+const RULES = [
+  {
+    re: /\b(?:Tier|Layer) [1-4] brand overrides\b/gi,
+    fix: '"Tier/Layer N brand overrides" → "`@layer client-theme` overrides"',
+  },
+  {
+    re: /\bTier [1-4]\b/g,
+    fix: 'retired CSS-cascade tier term → a named CSS `@layer` (`bds-tokens` · `bds-components` · `client-theme` · `client-overrides`). If you mean the abstraction stack, name the tier (Raw · Primitive · Semantic · Component). See primitives/token-anatomy.mdx.',
+  },
+  {
+    re: /\bLayer [1-4]\b/g,
+    fix: 'canonical CSS layers are named, never numbered → `bds-tokens` · `bds-components` · `client-theme` · `client-overrides`. See getting-started/cascade.mdx.',
+  },
+  {
+    re: /\bfour layers\b/gi,
+    fix: 'retired → the four Theming Dimensions are Tokens · Atmospheres · Layout Archetypes · Blueprints; the cascade has four *named* `@layer`s. See getting-started/cascade.mdx.',
+  },
+];
+
+// ── Allow-anchor markers ─────────────────────────────────────────────────────
+
+const ANCHOR = 'cascade-vocab-ok';
+const REGION_START = `${ANCHOR}:start`;
+const REGION_END = `${ANCHOR}:end`;
+
+// ── MDX file walking ─────────────────────────────────────────────────────────
+
+function walkMdx(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkMdx(full, acc);
+    } else if (entry.endsWith('.mdx') || entry.endsWith('.md')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// ── File scan ──────────────────────────────────────────────────────────────
+
+/**
+ * Scan a single MDX file and return an array of violation objects:
+ *   { file, line, term, fix }
+ * Skips fenced code blocks, region-anchored blocks, and single-line-anchored lines.
+ */
+function scanFile(filePath) {
+  const src = readFileSync(filePath, 'utf8');
+  const lines = src.split('\n');
+  const violations = [];
+
+  let inFence = false;
+  let inAllowRegion = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineNo = i + 1;
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Fenced code block toggle (``` or ~~~, optionally with a language).
+    if (/^(```|~~~)/.test(trimmed)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    // Region allow-anchor toggles.
+    if (line.includes(REGION_START)) { inAllowRegion = true; continue; }
+    if (line.includes(REGION_END)) { inAllowRegion = false; continue; }
+    if (inAllowRegion) continue;
+
+    // Single-line allow-anchor (but not the region markers, handled above).
+    if (line.includes(ANCHOR)) continue;
+
+    // Rules are ordered specific → generic; report the first (most-specific)
+    // match per line so "Tier 2 brand overrides" reports once, not twice.
+    for (const rule of RULES) {
+      rule.re.lastIndex = 0;
+      const m = rule.re.exec(line);
+      if (m) {
+        violations.push({ file: filePath, line: lineNo, term: m[0], fix: rule.fix });
+        break;
+      }
+    }
+  }
+
+  return violations;
+}
+
+// ── Reporter ─────────────────────────────────────────────────────────────────
+
+function renderViolations(allViolations, scannedCount, cwd) {
+  if (allViolations.length === 0) {
+    return `token-cascade-vocab-check: clean — ${scannedCount} MDX file(s) scanned, 0 retired token-cascade terms\n`;
+  }
+
+  const out = [
+    `token-cascade-vocab-check: ${allViolations.length} retired token-cascade term(s) — parallel-taxonomy drift`,
+    `  Canonical vocabulary: docs-site/content/docs/primitives/token-anatomy.mdx (locked in PR #736)`,
+    `  Scanned ${scannedCount} MDX files`,
+    ``,
+  ];
+
+  for (const v of allViolations) {
+    const rel = relative(cwd, v.file).split(sep).join('/');
+    out.push(`  ${rel}:${v.line}  "${v.term}"`);
+    out.push(`      ↳ ${v.fix}`);
+  }
+
+  out.push('');
+  out.push('  If this usage is genuinely canonical (the abstraction Tier stack, or a');
+  out.push(`  different-domain tier model), add an inline \`${ANCHOR}\` allow-anchor —`);
+  out.push('  see the header of scripts/token-cascade-vocab-check.mjs. Do not rename the vocab per-doc.');
+  return out.join('\n') + '\n';
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const USAGE = `token-cascade-vocab-check — retired token-cascade vocabulary gate for docs-site MDX
+
+Usage:
+  token-cascade-vocab-check [mdx-dir]    Scan MDX directory (default: docs-site/content/docs)
+  token-cascade-vocab-check --help       Show this message
+
+Exit codes:
+  0  Clean — no retired token-cascade vocabulary in prose
+  1  Violations found
+  2  Bad invocation
+
+Canonical vocabulary: docs-site/content/docs/primitives/token-anatomy.mdx (PR #736)
+Issue: brik-bds#748
+`;
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+
+  const mdxDir = args[0] ?? resolve(BDS_ROOT, 'docs-site', 'content', 'docs');
+
+  if (!existsSync(mdxDir)) {
+    process.stderr.write(`token-cascade-vocab-check: MDX directory not found: ${mdxDir}\n`);
+    process.exit(2);
+  }
+
+  const files = walkMdx(mdxDir);
+  if (files.length === 0) {
+    process.stderr.write(`token-cascade-vocab-check: no MDX files found in ${mdxDir}\n`);
+    process.exit(2);
+  }
+
+  const allViolations = [];
+  for (const file of files) {
+    allViolations.push(...scanFile(file));
+  }
+
+  process.stdout.write(renderViolations(allViolations, files.length, process.cwd()));
+  process.exit(allViolations.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/validate-all.js
+++ b/scripts/validate-all.js
@@ -26,6 +26,7 @@ const steps = [
   { name: 'Theme Compliance', cmd: 'node scripts/validate-themes.js' },
   { name: 'Blueprint Library', cmd: 'node scripts/validate-blueprints.mjs' },
   { name: 'BCS Vocab',        cmd: 'node scripts/bcs-vocab-check.mjs' },
+  { name: 'Cascade Vocab',    cmd: 'node scripts/token-cascade-vocab-check.mjs' },
   // Canonical-check requires dist/tokens.css. Ensure it's built before scanning.
   // The build is fast (~1s) and idempotent, so re-running has near-zero cost.
   { name: 'Canonical Tokens', cmd: 'npm run build:dist-tokens >/dev/null && npm run canonical-check' },


### PR DESCRIPTION
## Summary

Adds a CI gate that fails when **retired token-cascade vocabulary** reappears in `docs-site/content/docs/**.mdx` prose. PR #736 locked the six-concept vocabulary (Anatomy / Tier / Library / Layer / Mode / Tenet) and swept the retired terms out; nothing prevented them drifting back. This is the "canon frozen" signal for the #532 theming/canon program.

Sister of the #534 BCS-vocab gate — same canonical-name-drift class of bug, different vocabulary.

## What it bans (in prose; fenced code is skipped)

| Retired | Canonical replacement |
|---|---|
| `Tier 1/2/3/4` (CSS-cascade sense) | named CSS `@layer` (`bds-tokens` · `bds-components` · `client-theme` · `client-overrides`) |
| `Layer 1/2/3/4` | named `@layer` (layers are never numbered) |
| `four layers` | four Theming Dimensions (Tokens · Atmospheres · Layout Archetypes · Blueprints) |
| `Tier/Layer N brand overrides` | `@layer client-theme` overrides |

## Legit usage stays legit — via allow-anchor

The word **Tier** is still canonical for the Raw/Primitive/Semantic/Component abstraction stack, and **Layer** for the CSS `@layer`. Those (plus the CLAUDE.md doc-tier model) are exempted with an inline `cascade-vocab-ok` allow-anchor — not by banning the words. Three canonical docs got anchors: `token-anatomy.mdx` (abstraction stack), `documentation-system.mdx` (doc-tier model), `cascade.mdx` (four named CSS @layers). The fenced ASCII ladder in `token-anatomy.mdx` needs none.

## Wiring (matches the #534 pattern)

- `scripts/token-cascade-vocab-check.mjs` — the checker (file:line output + canonical fix per hit)
- `npm run token-cascade-vocab-check`
- `scripts/validate-all.js` → new "Cascade Vocab" step
- `.github/workflows/token-cascade-vocab-check.yml` — paths-scoped to `docs-site/content/docs/**` + the script

## Test plan

- [x] Gate clean on current tree — 142 MDX scanned, 0 violations
- [x] Plant-test: retired terms (`Tier 2 brand overrides`, `four layers`, `Layer 3`, `Tier 1`) flagged with file:line; anchored + fenced lines skipped
- [x] `docs-site` `next build` passes with anchors in place (140+ pages generated)
- [x] Pre-commit hooks pass (gitleaks, typecheck, anti-slop)

## Consumer sync

None — docs-site CI only; no change to the published `@brikdesigns/bds` runtime, tokens, or component CSS.

Closes #748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)