### PR TITLE
feat(tooling): ban inline var() in component TSX + migrate TabBar (#892)

### DIFF
--- a/.github/workflows/inline-var-check.yml
+++ b/.github/workflows/inline-var-check.yml
@@ -1,0 +1,47 @@
+name: Inline var() Check
+
+# Fails when a component TSX file introduces raw inline `var(--…)` token
+# consumption outside the baseline (brik-bds#892). CLAUDE.md + the component-build
+# standard mandate CSS-over-inline; inline style objects must not consume tokens.
+# Defining a `--bds-*` custom property inline (runtime binding) is allowed.
+#
+# Existing offenders are baselined in scripts/lint-inline-var.mjs and burned down
+# in per-component follow-up PRs; this gate blocks NEW violations and flags a
+# baseline entry that has become clean (so it can be removed).
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'components/**/*.tsx'
+      - 'scripts/lint-inline-var.mjs'
+  push:
+    branches:
+      - main
+    paths:
+      - 'components/**/*.tsx'
+      - 'scripts/lint-inline-var.mjs'
+
+concurrency:
+  group: inline-var-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  inline-var-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Inline var() check
+        run: npm run lint-inline-var

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -73,6 +73,13 @@ if [ -n "$STAGED_TSX" ] || [ -n "$STAGED_CSS" ]; then
     ${STAGED_TSX:+--files $STAGED_TSX} \
     ${STAGED_CSS:+--css-files $STAGED_CSS}
 
+  # Ban NEW raw inline var(--…) token consumption in staged TSX (brik-bds#892).
+  # Baselined offenders burn down in follow-up PRs; this blocks regressions.
+  if [ -n "$STAGED_TSX" ]; then
+    echo "Checking staged TSX for inline token consumption..."
+    node scripts/lint-inline-var.mjs --staged
+  fi
+
   # JSDoc / story-metadata gate. Whole-repo scan (fast) — fires only when a
   # component or story TSX is staged so we don't pay the cost on token-only
   # commits. Enforces @summary on every component + story export and a

--- a/components/ui/TabBar/TabBar.css
+++ b/components/ui/TabBar/TabBar.css
@@ -136,4 +136,131 @@
 .bds-tab-bar--box.bds-tab-bar--on-color .bds-tab-bar-item:active:not(:disabled):not([aria-selected="true"]) {
   opacity: 0.5;
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   Base values — migrated from inline CSSProperties builders (brik-bds#892).
+   Keyed on the variant class, [aria-selected], and the --on-color modifier so
+   they express the same active / on-color matrix the JS builders did, while
+   letting external rules override via normal cascade. Pseudo-state rules above
+   (hover/active/disabled) keep their higher specificity and are unaffected.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── Bar container ── */
+.bds-tab-bar {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+}
+
+/* `--text-underline` below is the BEM variant modifier, not a `--text-*` token —
+   bds-lint-ignore on each such selector line keeps canonical-check from reading
+   the class name as a token reference. */
+.bds-tab-bar--text,
+.bds-tab-bar--text-underline, /* bds-lint-ignore */
+.bds-tab-bar--tab {
+  gap: var(--gap-xl);
+}
+
+.bds-tab-bar--box {
+  gap: var(--gap-md);
+}
+
+/* `tab` aligns items to the bar's content-box bottom so the active indicator's
+   negative-margin overlap caps the baseline (see the tab-variant note above). */
+.bds-tab-bar--tab {
+  align-items: flex-end;
+}
+
+/* ── Shared item typography + reset ── */
+.bds-tab-bar-item {
+  font-family: var(--font-family-label);
+  font-size: var(--label-md);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-tight);
+  text-align: center;
+  white-space: nowrap;
+  cursor: pointer;
+  background: none;
+  padding: 0;
+  min-width: 0;
+}
+
+/* ── text ── */
+.bds-tab-bar--text .bds-tab-bar-item {
+  color: var(--text-secondary);
+}
+.bds-tab-bar--text .bds-tab-bar-item[aria-selected="true"] {
+  color: var(--text-brand-primary);
+}
+.bds-tab-bar--text.bds-tab-bar--on-color .bds-tab-bar-item {
+  color: var(--text-on-color-dark);
+  opacity: 0.6;
+}
+.bds-tab-bar--text.bds-tab-bar--on-color .bds-tab-bar-item[aria-selected="true"] {
+  opacity: 1;
+}
+
+/* ── text-underline ── */
+.bds-tab-bar--text-underline .bds-tab-bar-item { /* bds-lint-ignore */
+  color: var(--text-secondary);
+  border-bottom: var(--border-width-md) solid transparent;
+  padding-bottom: var(--padding-sm);
+}
+.bds-tab-bar--text-underline .bds-tab-bar-item[aria-selected="true"] { /* bds-lint-ignore */
+  color: var(--text-brand-primary);
+  border-bottom-color: var(--border-brand-primary);
+}
+.bds-tab-bar--text-underline.bds-tab-bar--on-color .bds-tab-bar-item { /* bds-lint-ignore */
+  color: var(--text-on-color-dark);
+  opacity: 0.6;
+  border-bottom-color: transparent;
+}
+.bds-tab-bar--text-underline.bds-tab-bar--on-color .bds-tab-bar-item[aria-selected="true"] { /* bds-lint-ignore */
+  opacity: 1;
+  border-bottom-color: var(--border-on-color-dark);
+}
+
+/* ── tab (border-bottom + overlap live in the tab-variant section above) ── */
+.bds-tab-bar--tab .bds-tab-bar-item {
+  color: var(--text-secondary);
+  background-color: transparent;
+  padding: 0;
+  padding-bottom: var(--padding-sm);
+}
+.bds-tab-bar--tab .bds-tab-bar-item[aria-selected="true"] {
+  color: var(--text-brand-primary);
+}
+.bds-tab-bar--tab.bds-tab-bar--on-color .bds-tab-bar-item {
+  color: var(--text-on-color-dark);
+  opacity: 0.6;
+}
+.bds-tab-bar--tab.bds-tab-bar--on-color .bds-tab-bar-item[aria-selected="true"] {
+  opacity: 1;
+}
+
+/* ── box ── */
+.bds-tab-bar--box .bds-tab-bar-item {
+  color: var(--text-secondary);
+  background-color: var(--background-primary);
+  padding: var(--padding-lg);
+  border: var(--border-width-md) solid var(--border-primary);
+}
+.bds-tab-bar--box .bds-tab-bar-item[aria-selected="true"] {
+  color: var(--text-inverse);
+  background-color: var(--background-brand-primary);
+  border-color: transparent;
+}
+.bds-tab-bar--box.bds-tab-bar--on-color .bds-tab-bar-item {
+  color: var(--text-on-color-dark);
+  border-color: var(--border-on-color-dark);
+  opacity: 0.6;
+}
+.bds-tab-bar--box.bds-tab-bar--on-color .bds-tab-bar-item[aria-selected="true"] {
+  color: var(--text-inverse);
+  background-color: var(--background-brand-primary);
+  border-color: transparent;
+  opacity: 1;
+}
 }

--- a/components/ui/TabBar/TabBar.tsx
+++ b/components/ui/TabBar/TabBar.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, type CSSProperties } from 'react';
+import { type HTMLAttributes } from 'react';
 import { bdsClass } from '../../utils';
 import { Dot, type DotStatus } from '../Dot';
 import './TabBar.css';
@@ -45,154 +45,6 @@ export interface TabBarProps extends HTMLAttributes<HTMLDivElement> {
   onColor?: boolean;
 }
 
-/* ── Bar container styles per variant ── */
-
-const barBase: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  width: '100%',
-  flexWrap: 'wrap',
-  boxSizing: 'border-box',
-};
-
-const barVariantStyles: Record<TabBarVariant, CSSProperties> = {
-  text: { ...barBase, gap: 'var(--gap-xl)' },
-  'text-underline': { ...barBase, gap: 'var(--gap-xl)' },
-  // `tab` variant baseline border lives in TabBar.css so external CSS
-  // (e.g. PageHeader's `:has(.bds-page-header__tabs)` rule) can suppress
-  // it without fighting inline-style specificity.
-  // align-items is flex-end so each item's bottom edge coincides with the
-  // bar's content-box bottom — required for the negative-margin overlap on
-  // `.bds-tab-bar-item` to actually cap the bar baseline. With the default
-  // `center` alignment items float mid-bar and the active indicator renders
-  // in a separate band below the baseline.
-  tab: { ...barBase, alignItems: 'flex-end', gap: 'var(--gap-xl)' },
-  box: { ...barBase, gap: 'var(--gap-md)' },
-};
-
-/* ── Shared tab base ──
-   Note: UA button border reset lives in `.bds-tab-bar-item` (CSS), NOT here.
-   Inline `border: 'none'` would beat any external `border-bottom` rule via
-   specificity — killing the `tab` variant's per-state active indicator. */
-
-const tabBase: CSSProperties = {
-  fontFamily: 'var(--font-family-label)',
-  fontSize: 'var(--label-md)',
-  fontWeight: 'var(--font-weight-semibold)' as unknown as number,
-  lineHeight: 'var(--font-line-height-tight)',
-  textAlign: 'center',
-  whiteSpace: 'nowrap',
-  cursor: 'pointer',
-  background: 'none',
-  padding: 0,
-  minWidth: 0,
-};
-
-/* ── Style builders per variant ── */
-
-function getTextStyles(active: boolean, onColor: boolean): CSSProperties {
-  if (onColor) {
-    return {
-      ...tabBase,
-      color: 'var(--text-on-color-dark)',
-      opacity: active ? 1 : 0.6,
-    };
-  }
-  return {
-    ...tabBase,
-    color: active ? 'var(--text-brand-primary)' : 'var(--text-secondary)',
-  };
-}
-
-function getTextUnderlineStyles(active: boolean, onColor: boolean): CSSProperties {
-  /* `text-underline` = `text` color behavior + per-tab brand-color underline.
-     No container border (unlike `tab`) and no horizontal padding — gap-xl
-     between tabs comes from the bar container. Used by app-level page
-     headers that want the brand-active text emphasis AND an underline. */
-  const borderWidth = 'var(--border-width-md)';
-  if (onColor) {
-    const borderColor = active ? 'var(--border-on-color-dark)' : 'transparent';
-    return {
-      ...tabBase,
-      color: 'var(--text-on-color-dark)',
-      opacity: active ? 1 : 0.6,
-      borderBottom: `${borderWidth} solid ${borderColor}`,
-      paddingBottom: 'var(--padding-sm)',
-    };
-  }
-  const borderColor = active ? 'var(--border-brand-primary)' : 'transparent';
-  return {
-    ...tabBase,
-    color: active ? 'var(--text-brand-primary)' : 'var(--text-secondary)',
-    borderBottom: `${borderWidth} solid ${borderColor}`,
-    paddingBottom: 'var(--padding-sm)',
-  };
-}
-
-function getTabStyles(active: boolean, onColor: boolean): CSSProperties {
-  /* Color + opacity stay inline (per-state). The active/inactive border-bottom
-     and the negative-margin overlap onto the bar baseline live in TabBar.css
-     so external rules (e.g. PageHeader's tabs slot) can override widths via
-     normal CSS specificity instead of fighting inline shorthand.
-
-     Padding shape: items have no horizontal padding (chunky 24px-each-side
-     was breaking the page-header rhythm); padding-bottom holds the breathing
-     room between text and the active indicator. Active text uses
-     `--text-brand-primary` so the active state reads as a brand affordance,
-     matching the brand-color underline. */
-  const textColor = onColor
-    ? 'var(--text-on-color-dark)'
-    : active
-      ? 'var(--text-brand-primary)'
-      : 'var(--text-secondary)';
-
-  return {
-    ...tabBase,
-    color: textColor,
-    backgroundColor: 'transparent',
-    padding: 0,
-    paddingBottom: 'var(--padding-sm)',
-    opacity: onColor && !active ? 0.6 : 1,
-  };
-}
-
-function getBoxStyles(active: boolean, onColor: boolean): CSSProperties {
-  /* All tabs get the same border width to maintain consistent sizing.
-     Active tab uses a transparent border so it doesn't shift layout. */
-  const baseBorder = 'var(--border-width-md)';
-
-  if (active) {
-    return {
-      ...tabBase,
-      color: 'var(--text-inverse)',
-      backgroundColor: 'var(--background-brand-primary)',
-      padding: 'var(--padding-lg)',
-      border: `${baseBorder} solid transparent`,
-    };
-  }
-  const borderColor = onColor
-    ? 'var(--border-on-color-dark)'
-    : 'var(--border-primary)';
-  const textColor = onColor
-    ? 'var(--text-on-color-dark)'
-    : 'var(--text-secondary)';
-  return {
-    ...tabBase,
-    color: textColor,
-    backgroundColor: 'var(--background-primary)',
-    padding: 'var(--padding-lg)',
-    border: `${baseBorder} solid ${borderColor}`,
-    opacity: onColor && !active ? 0.6 : 1,
-  };
-}
-
-const styleBuilders: Record<TabBarVariant, (active: boolean, onColor: boolean) => CSSProperties> = {
-  text: getTextStyles,
-  'text-underline': getTextUnderlineStyles,
-  tab: getTabStyles,
-  box: getBoxStyles,
-};
-
 /**
  * TabBar — BDS horizontal tab navigation
  *
@@ -203,6 +55,11 @@ const styleBuilders: Record<TabBarVariant, (active: boolean, onColor: boolean) =
  * - **box**: filled background for active, bordered for inactive
  *
  * Use `onColor` for placement on dark/brand backgrounds.
+ *
+ * All variant / active / on-color styling lives in `TabBar.css`, keyed on the
+ * variant class, `[aria-selected]`, and the `--on-color` modifier — so external
+ * rules (e.g. PageHeader's tabs slot) can override via normal cascade rather
+ * than fighting inline-style specificity.
  *
  * @example
  * ```tsx
@@ -226,15 +83,13 @@ export function TabBar({
   style,
   ...props
 }: TabBarProps) {
-  const getStyles = styleBuilders[variant];
-
   const variantClass = `bds-tab-bar--${variant}`;
   const onColorClass = onColor ? 'bds-tab-bar--on-color' : '';
 
   return (
     <div
       className={bdsClass('bds-tab-bar', variantClass, onColorClass, className)}
-      style={{ ...barVariantStyles[variant], ...style }}
+      style={style}
       role="tablist"
       {...props}
     >
@@ -246,7 +101,6 @@ export function TabBar({
           aria-selected={tab.active || false}
           disabled={tab.disabled || false}
           className={bdsClass('bds-tab-bar-item', tab.dot && 'bds-tab-bar-item--has-dot')}
-          style={getStyles(tab.active || false, onColor)}
           onClick={tab.onClick}
         >
           {tab.label}

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "bds:find": "node scripts/bds-find.mjs",
     "bcs-vocab-check": "node scripts/bcs-vocab-check.mjs",
     "token-cascade-vocab-check": "node scripts/token-cascade-vocab-check.mjs",
+    "lint-inline-var": "node scripts/lint-inline-var.mjs",
     "canonical-check": "node scripts/canonical-check.mjs --allowlist dist/tokens.css components content-system/blueprints content-system/atmospheres content-system/industries",
     "canonical-check:report": "node scripts/canonical-check.mjs --allowlist dist/tokens.css --format md components content-system stories || true",
     "canonical-class-check": "node scripts/canonical-class-check.mjs --allowlist dist/styles.css content-system/blueprints",

--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * lint-inline-var — bans raw inline `var(--…)` token consumption in component TSX.
+ *
+ * CLAUDE.md + the component-build standard mandate CSS-over-inline: a component's
+ * CSS file (BEM under `bds-`, keyed on state via class / `[data-*]` / `[aria-*]`)
+ * owns styling. Inline `style={{ … 'var(--token)' … }}` objects re-introduce
+ * untracked token references that bypass the cascade, can't express pseudo-states,
+ * and fight external overrides on specificity. See brik-bds#892.
+ *
+ * ── What's flagged vs allowed ──────────────────────────────────────────────
+ *
+ *   Flagged   — CONSUMING a token in an inline style value:
+ *                 style={{ color: 'var(--text-primary)' }}
+ *
+ *   Allowed   — DEFINING a `--bds-*` custom property inline (a runtime binding —
+ *               the sanctioned Component-tier pattern in token-anatomy.mdx):
+ *                 style={{ '--bds-slider-percent': `${pct}%` }}
+ *
+ * ── Baseline ────────────────────────────────────────────────────────────────
+ *
+ * Existing offenders are listed in BASELINE and do not fail the gate — they're
+ * burned down in per-component follow-up PRs (#892). A file NOT in the baseline
+ * that introduces a consuming inline var() fails the build. As each component is
+ * cleaned, delete its entry from BASELINE so it can never regress.
+ *
+ * ── Exit codes ───────────────────────────────────────────────────────────────
+ *   0  Clean — no un-baselined inline token consumption
+ *   1  Violations found (new offender, or a baselined file that's now clean —
+ *      remove it from BASELINE)
+ *   2  Bad invocation
+ *
+ * ── CLI ──────────────────────────────────────────────────────────────────────
+ *   lint-inline-var [dir]      Scan dir (default: components/ui)
+ *   lint-inline-var --staged   Scan only staged .tsx files (pre-commit)
+ *   lint-inline-var --help
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { resolve, join, dirname, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BDS_ROOT = resolve(__dirname, '..');
+
+// ── Baseline — known offenders, burned down per-component in #892 ────────────
+// Paths are repo-relative, POSIX separators. Remove an entry once its component
+// is fully migrated to CSS (the gate then guards it against regression).
+const BASELINE = new Set([
+  'components/ui/TextArea/TextArea.tsx',
+  'components/ui/SegmentedControl/SegmentedControl.tsx',
+  'components/ui/Slider/Slider.tsx',
+  'components/ui/Stepper/Stepper.tsx',
+  'components/ui/Switch/Switch.tsx',
+  'components/ui/PageHeader/PageHeader.tsx',
+  'components/ui/ProgressStepper/ProgressStepper.tsx',
+  'components/ui/Board/BoardColumn.tsx',
+]);
+
+// A line that DEFINES a `--bds-*` custom property (runtime binding) — allowed.
+const BDS_DEFINE_RE = /['"]--bds-[\w-]+['"]\s*:/;
+// A line that CONSUMES a token via var(--…) — the violation.
+const VAR_CONSUME_RE = /var\(\s*--/;
+
+function walkTsx(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkTsx(full, acc);
+    } else if (
+      entry.endsWith('.tsx') &&
+      !entry.endsWith('.stories.tsx') &&
+      !entry.endsWith('.test.tsx')
+    ) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function relPosix(abs) {
+  return relative(BDS_ROOT, abs).split(sep).join('/');
+}
+
+function scanFile(filePath) {
+  const rel = relPosix(filePath);
+  if (BASELINE.has(rel)) return { violations: [], baselinedButClean: false, rel };
+
+  const lines = readFileSync(filePath, 'utf8').split('\n');
+  const violations = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!VAR_CONSUME_RE.test(line)) continue;
+    if (BDS_DEFINE_RE.test(line)) continue; // runtime binding — allowed
+    violations.push({ file: rel, line: i + 1, text: line.trim() });
+  }
+  return { violations, rel };
+}
+
+// A baselined file that is now clean should be removed from the baseline.
+function baselinedFileStillDirty(rel) {
+  const abs = resolve(BDS_ROOT, rel);
+  if (!existsSync(abs)) return false;
+  const lines = readFileSync(abs, 'utf8').split('\n');
+  return lines.some((l) => VAR_CONSUME_RE.test(l) && !BDS_DEFINE_RE.test(l));
+}
+
+const GUIDANCE =
+  'Move the token into the component CSS (BEM under `bds-`, keyed on state via ' +
+  'class / [data-*] / [aria-*]); inline style objects must not consume tokens. ' +
+  'Defining a `--bds-*` custom property inline (runtime binding) is allowed. ' +
+  'See .claude/standards/component-build.md and brik-bds#892.';
+
+function render(allViolations, staleBaseline, scanned) {
+  const out = [];
+  if (allViolations.length === 0 && staleBaseline.length === 0) {
+    return `lint-inline-var: clean — ${scanned} TSX file(s) scanned, 0 un-baselined inline token consumers\n`;
+  }
+  if (allViolations.length > 0) {
+    out.push(`lint-inline-var: ${allViolations.length} inline token consumer(s) outside the baseline`);
+    out.push('');
+    for (const v of allViolations) {
+      out.push(`  ${v.file}:${v.line}  ${v.text}`);
+    }
+    out.push('');
+    out.push(`  ↳ ${GUIDANCE}`);
+  }
+  if (staleBaseline.length > 0) {
+    out.push('');
+    out.push(`lint-inline-var: ${staleBaseline.length} baseline entr(y/ies) now clean — remove from BASELINE in scripts/lint-inline-var.mjs:`);
+    for (const rel of staleBaseline) out.push(`  ${rel}`);
+  }
+  return out.join('\n') + '\n';
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(
+      'lint-inline-var [dir] | --staged\n\nBans raw inline var(--…) token consumption in component TSX (brik-bds#892).\n',
+    );
+    process.exit(0);
+  }
+
+  let files;
+  if (args.includes('--staged')) {
+    const out = execSync('git diff --cached --name-only --diff-filter=ACM', { cwd: BDS_ROOT })
+      .toString()
+      .split('\n')
+      .filter((f) => f.endsWith('.tsx') && !f.endsWith('.stories.tsx') && !f.endsWith('.test.tsx'));
+    files = out.map((f) => resolve(BDS_ROOT, f)).filter(existsSync);
+  } else {
+    const dir = args.find((a) => !a.startsWith('--')) ?? resolve(BDS_ROOT, 'components', 'ui');
+    if (!existsSync(dir)) {
+      process.stderr.write(`lint-inline-var: directory not found: ${dir}\n`);
+      process.exit(2);
+    }
+    files = walkTsx(dir);
+  }
+
+  const allViolations = [];
+  for (const file of files) {
+    allViolations.push(...scanFile(file).violations);
+  }
+
+  // Only surface stale-baseline hints on a full scan (not --staged).
+  const staleBaseline = args.includes('--staged')
+    ? []
+    : [...BASELINE].filter((rel) => !baselinedFileStillDirty(rel));
+
+  process.stdout.write(render(allViolations, staleBaseline, files.length));
+  process.exit(allViolations.length > 0 || staleBaseline.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/validate-all.js
+++ b/scripts/validate-all.js
@@ -27,6 +27,7 @@ const steps = [
   { name: 'Blueprint Library', cmd: 'node scripts/validate-blueprints.mjs' },
   { name: 'BCS Vocab',        cmd: 'node scripts/bcs-vocab-check.mjs' },
   { name: 'Cascade Vocab',    cmd: 'node scripts/token-cascade-vocab-check.mjs' },
+  { name: 'Inline var()',     cmd: 'node scripts/lint-inline-var.mjs' },
   // Canonical-check requires dist/tokens.css. Ensure it's built before scanning.
   // The build is fast (~1s) and idempotent, so re-running has near-zero cost.
   { name: 'Canonical Tokens', cmd: 'npm run build:dist-tokens >/dev/null && npm run canonical-check' },


### PR DESCRIPTION
## Summary

Enforces the CLAUDE.md / component-build **CSS-over-inline** rule: component TSX must not consume tokens via inline `style={{ … 'var(--…)' … }}`. Adds a lint gate + migrates the largest offender (TabBar). **Part of #892** — the other 8 components burn down in follow-up PRs.

> Note: #892's stated fix target (`@/lib/tokens` / `@/lib/styles`) is a **consumer-repo convention that doesn't exist in brik-bds** (tsconfig only aliases `@bds/*`). The canonical brik-bds fix is moving the token into the component CSS — that's what this does. (Flagged for the issue.)

## The gate — `scripts/lint-inline-var.mjs`

- **Flags** consuming a token inline: `color: 'var(--text-primary)'`
- **Allows** defining a `--bds-*` custom property inline (the sanctioned runtime-binding pattern per token-anatomy.mdx): `style={{ '--bds-slider-percent': `${pct}%` }}`
- **Baseline** — the 8 remaining offenders are listed in the script; the gate blocks *new* violations and flags a baseline entry that has gone clean (so it's removed as each is migrated).
- Wired into `npm run lint-inline-var`, `validate-all.js`, **pre-commit (staged TSX)**, and a paths-scoped CI workflow.

## First cleanup batch — TabBar (31 refs, the largest)

The four JS style builders (`getTextStyles` / `getTextUnderlineStyles` / `getTabStyles` / `getBoxStyles`) moved into `TabBar.css`, keyed on the variant class, `[aria-selected]`, and the `--on-color` modifier — the **same selectors the existing pseudo-state rules already used**. No behavioral change. `.bds-tab-bar--text-underline` selectors carry `bds-lint-ignore` (the BEM modifier matches token grammar but isn't a `--text-*` token).

## Verification

- [x] `validate:full` — **all 12 checks pass** (incl. the new Inline var() gate, Canonical Tokens, TypeScript, Storybook Build)
- [x] Rendered the TabBar Variants + Playground stories headless and reviewed every state (text/underline/tab/box × active/inactive × on-color, dots, disabled) — all correct
- [x] Pre-commit hook exercises the new gate on staged TSX
- [ ] **Chromatic pixel-diff: NOT run — snapshot quota exhausted (#771).** Parity verified manually via rendered screenshots; recommend a Chromatic pass once quota resets before/after merge.

## Follow-ups (tracked on #892)

TextArea (19) · SegmentedControl (17) · Slider (10) · Stepper (9) · Switch (4) · PageHeader (3) · ProgressStepper (2) · BoardColumn (1) — one PR each, each Chromatic-verified.

Part of #892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)