### PR TITLE
docs(standards): correct the inline-var rule in component-build (#892)

### DIFF
--- a/.claude/standards/component-build.md
+++ b/.claude/standards/component-build.md
@@ -137,18 +137,19 @@ All values come from **semantic** tokens. The canonical registry is `dist/tokens
 .bds-card { padding: var(--space--700); font-size: var(--font-size--400); }
 ```
 
-**Tokens in TS/TSX** — import from `@/lib/tokens` and `@/lib/styles`. Never write raw `var(--...)` strings inline (this is a brik-bds CLAUDE.md non-negotiable).
+**Tokens in TS/TSX** — never write raw `var(--...)` strings in an inline `style={{…}}` object. In a BDS component the fix is **CSS-over-inline**: move the token into the component's CSS file, keyed on state via class / `[data-*]` / `[aria-*]` (see [§ Styles live in CSS](#styles-live-in-css--never-inline)). Enforced by `scripts/lint-inline-var.mjs` (brik-bds#892) — the gate fails the build on a new inline token consumer.
+
+The **one** inline use that is allowed: *defining* a `--bds-*` custom property as a runtime binding — a value the component computes at render and the CSS reads back. This is the sanctioned Component-tier pattern in [token-anatomy](../../docs-site/content/docs/primitives/token-anatomy.mdx), not a token *consumer*.
 
 ```tsx
-/* Right */
-import { color, font } from '@/lib/tokens';
-import { text } from '@/lib/styles';
-style={{ color: color.text.primary, fontSize: font.size.body.md }}
-style={text.body}  // family + size + lineHeight as one preset
-
-/* Wrong — raw var() string defeats the token import discipline */
+/* Wrong — consuming a token in an inline style value → move it to the component CSS */
 style={{ color: 'var(--text-primary)', fontSize: '16px' }}
+
+/* Right — defining a --bds-* custom property inline is a runtime binding, not consumption */
+style={{ '--bds-slider-percent': `${pct}%` }}  // CSS reads var(--bds-slider-percent)
 ```
+
+> **Not `@/lib/tokens`.** Consumer apps (portal / renew / freedom) have a typed token layer imported from `@/lib/tokens` + `@/lib/styles` for their *app* code — that alias does **not** exist in brik-bds itself. Here, a component's tokens live in its CSS file.
 
 Validate every token reference against `dist/tokens.css` before using it — the [`validate-token-names`](../../) skill auto-invokes on relevant edits.
 

--- a/scripts/.standards-hashes
+++ b/scripts/.standards-hashes
@@ -1,5 +1,5 @@
 79f34fe82693d85f7f39a2fec4160b945004e4a270ea331a2495ea1272a321b9  .claude/standards/storybook-mdx-recipe.md
 8caeddca93778c57a56b5f404e1460293e97fa02f6f01eb4057c43a9f1c07249  .claude/standards/storybook-story-shape.md
-938f1bec493ff276f6f0596607519689e3c9578b1f481ee5d153beed63adeaed  .claude/standards/component-build.md
 aa041ded08faa66658d0b8e3d5c09216fd6bf72a622c125b185714a976ec0305  .claude/standards/fumadocs-content.md
 b4db3ec98bb1dec16b509c5a400fe5e465fd3840d36f549c0da1b0669b72b1ea  .claude/standards/storybook-toolbar-globals.md
+e1075e82e2f9fd3981388d78da4eea67aa366ce4b82d19b1b518d3655cd0dfe6  .claude/standards/component-build.md


### PR DESCRIPTION
## Summary

Corrects the **component-build standard**'s "Tokens in TS/TSX" rule. It told authors to `import from @/lib/tokens` / `@/lib/styles` as the canonical way — but **that alias doesn't exist in brik-bds** (it's a consumer-app convention). Surfaced while building the #892 inline-var gate.

## Change

Rewrites the block to state the actual brik-bds rule:
- Never consume a token in an inline `style={{…}}` object → **move it to the component CSS** (now enforced by `scripts/lint-inline-var.mjs`, #892).
- Documents the **one allowed inline use**: defining a `--bds-*` custom property as a runtime binding.
- Clarifies `@/lib/tokens` is the consumer-app token layer, not brik-bds.

Re-ingested into brik-rag; `scripts/.standards-hashes` updated so the `standards-rag-drift` gate passes (all 12 validate checks green).

Related to #892. Docs/standard only — no runtime or component change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)