### PR TITLE
fix(css): layer-wrap 5 unlayered component stylesheets

### DIFF
--- a/.github/workflows/layer-wrap-check.yml
+++ b/.github/workflows/layer-wrap-check.yml
@@ -1,0 +1,42 @@
+name: Layer Wrap Check
+
+# Enforces that every component CSS file (components/ui/**/*.css) is wrapped in
+# `@layer bds-components`. An unlayered component stylesheet loses the cascade
+# in consumers that layer BDS (e.g. the portal's
+# `[class*="bds-"] { all: revert-layer }` bridge), so the component renders
+# unstyled while looking fine in Storybook — the invisible-Logo bug in
+# brik-client-portal#1808. The wrap step (scripts/wrap-component-layers.mjs)
+# mutates sources and must be re-run when a component lands; this gate catches
+# the case where it wasn't.
+#
+# Cheap by design: the guard is a plain Node script over source files — no
+# `npm ci`, no build.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: layer-wrap-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  layer-wrap-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Check component CSS is layered
+        run: node scripts/wrap-component-layers.mjs --check

--- a/components/ui/AddableEntryList/AddableEntryList.css
+++ b/components/ui/AddableEntryList/AddableEntryList.css
@@ -1,3 +1,4 @@
+@layer bds-components {
 .bds-addable-entry-list {
   display: flex;
   flex-direction: column;
@@ -240,4 +241,5 @@
   font-family: var(--font-family-body);
   font-size: var(--body-sm);
   color: var(--text-muted);
+}
 }

--- a/components/ui/AddableTextList/AddableTextList.css
+++ b/components/ui/AddableTextList/AddableTextList.css
@@ -1,3 +1,4 @@
+@layer bds-components {
 .bds-addable-text-list {
   display: flex;
   flex-direction: column;
@@ -43,4 +44,5 @@
   font-size: var(--body-sm);
   line-height: var(--font-line-height-normal);
   color: var(--text-muted);
+}
 }

--- a/components/ui/CatalogPicker/CatalogPicker.css
+++ b/components/ui/CatalogPicker/CatalogPicker.css
@@ -1,3 +1,4 @@
+@layer bds-components {
 /* CatalogPicker — thin wrapper around AddableEntryList.
  * Most visual styling lives on the inner AddableEntryList primitive.
  * The wrapper class is reserved as a hook for consumer overrides and
@@ -7,4 +8,5 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+}
 }

--- a/components/ui/CloseButton/CloseButton.css
+++ b/components/ui/CloseButton/CloseButton.css
@@ -1,3 +1,4 @@
+@layer bds-components {
 /* CloseButton — canonical icon-only dismiss affordance.
  *
  * Glyph-dominant by design: a 20px (--icon-lg) bold "X" inside ~4px padding
@@ -39,4 +40,5 @@
 .bds-close-button:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
 }

--- a/components/ui/Logo/Logo.css
+++ b/components/ui/Logo/Logo.css
@@ -1,3 +1,4 @@
+@layer bds-components {
 .bds-logo {
   display: inline-flex;
   align-items: center;
@@ -26,3 +27,4 @@
 .bds-logo--md { width: 40px; height: 40px; }
 .bds-logo--lg { width: 48px; height: 48px; }
 .bds-logo--xl { width: 64px; height: 64px; }
+}

--- a/scripts/wrap-component-layers.mjs
+++ b/scripts/wrap-component-layers.mjs
@@ -7,7 +7,9 @@
  *
  * Safe to re-run — skips files that already contain `@layer bds-components`.
  *
- * Usage: node scripts/wrap-component-layers.mjs
+ * Usage:
+ *   node scripts/wrap-component-layers.mjs           # wrap any unlayered files
+ *   node scripts/wrap-component-layers.mjs --check   # CI guard: exit 1 if any unlayered (no writes)
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
@@ -40,16 +42,27 @@ function collectCssFiles(dir) {
 
 const cssFiles = collectCssFiles(componentsDir);
 
+// --check: report-only. Exits non-zero if any component CSS is unlayered, so CI
+// can gate it (without mutating files). This is the guard for the #1808 bug —
+// unlayered component CSS loses the cascade in consumers that layer BDS.
+const CHECK = process.argv.includes('--check');
+
 let wrapped = 0;
 let skipped = 0;
+const unwrapped = [];
 
 for (const filePath of cssFiles) {
   const rel = relative(rootDir, filePath);
   const content = readFileSync(filePath, 'utf8');
 
   if (content.includes('@layer bds-components')) {
-    console.log(`  skip   ${rel}`);
+    if (!CHECK) console.log(`  skip   ${rel}`);
     skipped++;
+    continue;
+  }
+
+  if (CHECK) {
+    unwrapped.push(rel);
     continue;
   }
 
@@ -57,6 +70,22 @@ for (const filePath of cssFiles) {
   writeFileSync(filePath, wrapped_content, 'utf8');
   console.log(`  wrap   ${rel}`);
   wrapped++;
+}
+
+if (CHECK) {
+  if (unwrapped.length > 0) {
+    console.error(
+      `\n✗ ${unwrapped.length} component CSS file(s) are NOT wrapped in @layer bds-components:\n` +
+        unwrapped.map((f) => `    ${f}`).join('\n') +
+        `\n\nUnlayered component CSS loses the cascade in consumers that layer BDS (e.g. the\n` +
+        `portal's \`[class*="bds-"] { all: revert-layer }\` bridge), so the component renders\n` +
+        `unstyled — the #1808 invisible-Logo bug. Run \`node scripts/wrap-component-layers.mjs\`\n` +
+        `and commit.`,
+    );
+    process.exit(1);
+  }
+  console.log(`✓ All ${skipped} component CSS files are layered.`);
+  process.exit(0);
 }
 
 console.log(`\nDone. Wrapped: ${wrapped}  Skipped (already layered): ${skipped}  Total: ${cssFiles.length}`);


### PR DESCRIPTION
## Summary
- fix(css): layer-wrap 5 unlayered component stylesheets

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)