### PR TITLE
Harden Storybook stale-chunk self-heal for hosted deploys

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -185,11 +185,16 @@
   imported module" errors caused by deploys that replace the hashed
   chunk filenames a previously-loaded HTML page references. Mirrors
   the listener in preview-head.html so both iframes self-heal.
+
+  Frame-specific cooldown key ('manager') so this frame's reload never
+  suppresses a needed preview reload within the window (both frames
+  share sessionStorage — same origin). preventDefault() keeps the
+  recovery a clean refresh instead of an error flash.
 -->
 <script>
   (function () {
     var COOLDOWN_MS = 10000;
-    var STORAGE_KEY = 'sb-chunk-reload-at';
+    var STORAGE_KEY = 'sb-chunk-reload-at:manager';
 
     function shouldReload() {
       try {
@@ -209,14 +214,18 @@
           || /Failed to load module script/.test(msg);
     }
 
-    window.addEventListener('vite:preloadError', function () {
-      if (shouldReload()) window.location.reload();
+    window.addEventListener('vite:preloadError', function (event) {
+      if (shouldReload()) {
+        if (event && event.preventDefault) event.preventDefault();
+        window.location.reload();
+      }
     });
 
     window.addEventListener('unhandledrejection', function (event) {
       var reason = event && event.reason;
       var msg = (reason && reason.message) || (typeof reason === 'string' ? reason : '');
       if (isChunkLoadError(msg) && shouldReload()) {
+        if (event && event.preventDefault) event.preventDefault();
         window.location.reload();
       }
     });

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -33,12 +33,18 @@
 
   Reload-loop guard: only reload if the previous reload was more
   than 10 seconds ago. A real network issue won't be masked into
-  a refresh loop.
+  a refresh loop. The cooldown key is frame-specific ('preview') so a
+  manager reload never suppresses a needed preview reload within the
+  window — the two frames share sessionStorage (same origin).
+
+  preventDefault() on the events stops Storybook from painting its
+  error overlay (and Vite from rethrowing) before the reload navigates,
+  so recovery is a clean refresh instead of an error flash.
 -->
 <script>
   (function () {
     var COOLDOWN_MS = 10000;
-    var STORAGE_KEY = 'sb-chunk-reload-at';
+    var STORAGE_KEY = 'sb-chunk-reload-at:preview';
 
     function shouldReload() {
       try {
@@ -59,14 +65,18 @@
           || /Failed to load module script/.test(msg);
     }
 
-    window.addEventListener('vite:preloadError', function () {
-      if (shouldReload()) window.location.reload();
+    window.addEventListener('vite:preloadError', function (event) {
+      if (shouldReload()) {
+        if (event && event.preventDefault) event.preventDefault();
+        window.location.reload();
+      }
     });
 
     window.addEventListener('unhandledrejection', function (event) {
       var reason = event && event.reason;
       var msg = (reason && reason.message) || (typeof reason === 'string' ? reason : '');
       if (isChunkLoadError(msg) && shouldReload()) {
+        if (event && event.preventDefault) event.preventDefault();
         window.location.reload();
       }
     });

--- a/netlify.toml
+++ b/netlify.toml
@@ -57,6 +57,19 @@
   [headers.values]
     Cache-Control = "public, max-age=0, must-revalidate"
 
+# vite-inject-mocker-entry.js (emitted by @storybook/addon-vitest) is a
+# STABLE-named module entry that `import`s a content-hashed chunk
+# (assets/preload-helper-*.js). It's referenced by iframe.html by its fixed
+# name, so unlike the hashed chunks it isn't self-invalidating. If a browser
+# serves a stale copy after a deploy, it points at a preload-helper hash that
+# no longer exists → a 404 that a client-side reload cannot heal (the stale
+# entry keeps resolving to the dead hash). Revalidate it on every load so a
+# reload always pulls the entry that matches the current deploy's chunks.
+[[headers]]
+  for = "/vite-inject-mocker-entry.js"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
 [[headers]]
   for = "/assets/*"
   [headers.values]


### PR DESCRIPTION
## Summary
- fix(storybook): harden stale-chunk self-heal for hosted deploys

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)