### PR TITLE
Seamless deploy recovery via Netlify skew protection

### DIFF
--- a/netlify/edge-functions/set-skew-cookie.ts
+++ b/netlify/edge-functions/set-skew-cookie.ts
@@ -1,0 +1,39 @@
+import type { Config, Context } from '@netlify/edge-functions';
+
+/**
+ * Skew-protection cookie stamper
+ *
+ * Pins each browsing session to the deploy it originally loaded, so the hosted
+ * Storybook never 404s a content-hashed chunk after a newer deploy lands
+ * mid-session (the "Failed to fetch dynamically imported module" overlay).
+ *
+ * Runs ONLY on the HTML entry documents (see `config.path`) — never on
+ * `/assets/*`, which are the paths pinned by `.netlify/v1/skew-protection.json`.
+ * It stamps the CURRENT deploy's skew token into the `nf-skew` cookie via a
+ * Set-Cookie header on the HTML response, so the cookie is in the jar BEFORE
+ * the browser fetches any asset referenced by that HTML — no preload-scanner
+ * race. Because the HTML documents are excluded from the skew patterns, a fresh
+ * load always gets the current deploy and this refreshes the cookie to it;
+ * an already-open tab keeps its older token until it reloads, so its lazy
+ * chunk imports resolve against the deploy it was serving.
+ *
+ * NETLIFY_SKEW_PROTECTION_TOKEN is populated by Netlify at runtime; when it is
+ * absent (e.g. skew protection disabled) the response passes through unchanged.
+ */
+export default async (_request: Request, context: Context): Promise<Response> => {
+  const response = await context.next();
+  const token = Deno.env.get('NETLIFY_SKEW_PROTECTION_TOKEN');
+
+  if (token) {
+    response.headers.append(
+      'Set-Cookie',
+      `nf-skew=${token}; Path=/; SameSite=Lax; Secure; HttpOnly`,
+    );
+  }
+
+  return response;
+};
+
+export const config: Config = {
+  path: ['/', '/index.html', '/iframe.html'],
+};

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "dev": "bash scripts/start-figma-relay.sh && npm run storybook",
     "prestorybook": "node scripts/build-health-data.js",
     "storybook": "storybook dev -p 6006",
-    "prebuild-storybook": "node scripts/build-health-data.js",
+    "prebuild-storybook": "node scripts/build-health-data.js && node scripts/write-skew-protection.mjs",
     "build-storybook": "storybook build",
     "lint-tokens": "node scripts/lint-tokens.js",
     "lint-tokens:grid": "node scripts/lint-tokens.js --check-grid",

--- a/scripts/write-skew-protection.mjs
+++ b/scripts/write-skew-protection.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * Skew-protection config writer
+ *
+ * Emits `.netlify/v1/skew-protection.json` (the Netlify Frameworks API file
+ * that enables Skew Protection). `.netlify/` is gitignored, so — following
+ * Netlify's own framework-author pattern — the file is generated at build time
+ * rather than committed. Wired into the `prebuild-storybook` npm hook so it runs
+ * on every `npm run build-storybook` (local + Netlify) with no netlify.toml
+ * build-command change.
+ *
+ * What it does: tells Netlify's CDN to pin every `/assets/*` request to the
+ * deploy named by the `nf-skew` cookie. That cookie is stamped with the current
+ * deploy's token by `netlify/edge-functions/set-skew-cookie.ts`. Together they
+ * make an already-open Storybook tab keep resolving its original deploy's
+ * content-hashed chunks after a newer deploy lands — no "Failed to fetch
+ * dynamically imported module" 404, no reload.
+ *
+ * Only `/assets/*` is pinned. The HTML entry documents (`/`, `/index.html`,
+ * `/iframe.html`) and the story index (`/index.json`) are deliberately NOT
+ * matched, so a fresh load always gets the latest deploy and refreshes the
+ * cookie to it.
+ *
+ * Usage:
+ *   node scripts/write-skew-protection.mjs
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+
+const DIR = '.netlify/v1';
+const FILE = `${DIR}/skew-protection.json`;
+
+const config = {
+  patterns: ['^/assets/.*'],
+  sources: [{ type: 'cookie', name: 'nf-skew' }],
+};
+
+await mkdir(DIR, { recursive: true });
+await writeFile(FILE, `${JSON.stringify(config, null, 2)}\n`);
+
+if (!process.argv.includes('--quiet')) {
+  console.log(`✓ wrote ${FILE}`);
+}


### PR DESCRIPTION
## Summary
- feat(storybook): seamless deploy recovery via Netlify skew protection

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)