### PR TITLE
refactor(textarea): migrate inline var() to CSS (#892)

### DIFF
--- a/components/ui/TextArea/TextArea.css
+++ b/components/ui/TextArea/TextArea.css
@@ -1,13 +1,29 @@
 @layer bds-components {
 /**
- * BDS TextArea Interactive States
+ * BDS TextArea
+ *
+ * Multi-line text input. Border, radius, background, and typography tokens
+ * match TextInput / SearchInput / AddressInput for consistent form styling.
  *
  * Token reference:
- * - --border-input (default border)
- * - --border-primary (hover border — darker)
- * - --border-brand-primary (focus border — theme color)
- * - --text-muted (placeholder color)
+ * - --background-input (field fill)         - --border-input (default border)
+ * - --border-primary (hover border)         - --border-brand-primary (focus)
+ * - --border-negative (error border)        - --text-primary / --text-muted
+ * - --text-negative (error text)
  */
+
+/* Wrapper — vertical stack: label above field */
+.bds-text-area {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  width: auto;
+  color: var(--text-primary);
+}
+
+.bds-text-area--full-width {
+  width: 100%;
+}
 
 /* ─── Label ──────────────────────────────────────────────────── */
 
@@ -27,6 +43,37 @@
 }
 
 /* ─── Textarea field ─────────────────────────────────────────── */
+
+.bds-text-area-field {
+  display: block;
+  width: 100%;
+  min-width: 200px;
+  padding: var(--padding-xs);
+  font-family: var(--font-family-body);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-primary);
+  background-color: var(--background-input);
+  border: var(--border-width-md) solid var(--border-input);
+  border-radius: var(--border-radius-md);
+  outline: none;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.bds-text-area-field--sm { font-size: var(--body-sm); }
+.bds-text-area-field--md { font-size: var(--body-md); }
+.bds-text-area-field--lg { font-size: var(--body-lg); }
+
+/* Resize — driven by the `resize` prop; `:disabled` forces none (below) */
+.bds-text-area-field--resize-none { resize: none; }
+.bds-text-area-field--resize-both { resize: both; }
+.bds-text-area-field--resize-horizontal { resize: horizontal; }
+.bds-text-area-field--resize-vertical { resize: vertical; }
+
+.bds-text-area-field--error {
+  border-color: var(--border-negative);
+}
 
 .bds-text-area-field::placeholder {
   color: var(--text-muted);
@@ -50,5 +97,20 @@
 .bds-text-area-field:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  resize: none;
+}
+
+/* ─── Helper / error text ────────────────────────────────────── */
+
+.bds-text-area__helper,
+.bds-text-area__error {
+  font-family: var(--font-family-body);
+  font-size: var(--body-sm);
+  line-height: var(--font-line-height-normal);
+  color: var(--text-muted);
+}
+
+.bds-text-area__error {
+  color: var(--text-negative);
 }
 }

--- a/components/ui/TextArea/TextArea.tsx
+++ b/components/ui/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import { useId, type TextareaHTMLAttributes, type CSSProperties } from 'react';
+import { useId, type TextareaHTMLAttributes } from 'react';
 import { bdsClass } from '../../utils';
 import './TextArea.css';
 
@@ -38,98 +38,12 @@ export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
 }
 
 /**
- * Wrapper styles — vertical stack matching TextInput pattern
- *
- * Token reference:
- * - --gap-md = 8px
- */
-const wrapperStyles: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'var(--gap-md)',
-  color: 'var(--text-primary)',
-};
-
-/**
- * Size-variant styles — matches TextInput exactly
- *
- * Figma specs:
- * - sm: label 14px, body 14px
- * - md: label 16px, body 16px
- * - lg: label 18px, body 18px
- *
- * Label typography is driven by `.bds-text-area__label--{size}` in TextArea.css.
- */
-const sizeStyles: Record<TextAreaSize, { textarea: CSSProperties }> = {
-  sm: {
-    textarea: { fontSize: 'var(--body-sm)' },
-  },
-  md: {
-    textarea: { fontSize: 'var(--body-md)' },
-  },
-  lg: {
-    textarea: { fontSize: 'var(--body-lg)' },
-  },
-};
-
-/**
- * Helper/error text base styles
- *
- * Token reference:
- * - --font-family-body
- * - --body-sm (14px)
- * - --text-muted
- */
-const helperBaseStyles: CSSProperties = {
-  fontFamily: 'var(--font-family-body)',
-  fontSize: 'var(--body-sm)',
-  lineHeight: 'var(--font-line-height-normal)',
-  color: 'var(--text-muted)',
-};
-
-/**
- * TextArea styles — matches TextInput, SearchInput, AddressInput
- *
- * Token reference:
- * - --background-input (field background)
- * - --border-input (field border)
- * - --border-width-md = 1px (border thickness)
- * - --border-radius-md = 4px (corners)
- * - --padding-xs = 10px (padding)
- * - --font-family-body
- * - --body-md = 16px
- * - --font-weight-regular = 400
- * - --font-line-height-normal
- */
-const textareaStyles: CSSProperties = {
-  display: 'block',
-  width: '100%',
-  minWidth: 200,
-  padding: 'var(--padding-xs)',
-  fontFamily: 'var(--font-family-body)',
-  fontWeight: 'var(--font-weight-regular)' as unknown as number,
-  lineHeight: 'var(--font-line-height-normal)',
-  color: 'var(--text-primary)',
-  backgroundColor: 'var(--background-input)',
-  border: 'var(--border-width-md) solid var(--border-input)',
-  borderRadius: 'var(--border-radius-md)',
-  outline: 'none',
-  transition: 'border-color 0.2s',
-  resize: 'vertical',
-  boxSizing: 'border-box',
-};
-
-const textareaDisabledStyles: CSSProperties = {
-  opacity: 0.5,
-  cursor: 'not-allowed',
-  resize: 'none',
-};
-
-/**
  * TextArea - BDS themed multi-line text input component
  *
  * Uses identical border, radius, background, and typography tokens as
  * TextInput, SearchInput, and AddressInput for consistent form styling.
+ * All styling lives in TextArea.css; size, resize, error, and full-width are
+ * driven by BEM modifier classes.
  *
  * @example
  * ```tsx
@@ -161,24 +75,10 @@ export function TextArea({
   const generatedId = useId();
   const inputId = id || (label ? `textarea-${generatedId}` : undefined);
   const hasError = Boolean(error);
-  const sizeStyle = sizeStyles[size];
-
-  const combinedStyles: CSSProperties = {
-    ...textareaStyles,
-    ...sizeStyle.textarea,
-    resize,
-    ...(disabled ? textareaDisabledStyles : {}),
-    ...(hasError ? { borderColor: 'var(--border-negative)' } : {}),
-    ...style,
-  };
 
   return (
     <div
-      className="bds-text-area"
-      style={{
-        ...wrapperStyles,
-        width: fullWidth ? '100%' : 'auto',
-      }}
+      className={bdsClass('bds-text-area', fullWidth && 'bds-text-area--full-width')}
     >
       {label && (
         <label
@@ -202,8 +102,14 @@ export function TextArea({
         value={value}
         defaultValue={defaultValue}
         onChange={onChange}
-        className={bdsClass('bds-text-area-field', className)}
-        style={combinedStyles}
+        className={bdsClass(
+          'bds-text-area-field',
+          `bds-text-area-field--${size}`,
+          `bds-text-area-field--resize-${resize}`,
+          hasError && 'bds-text-area-field--error',
+          className,
+        )}
+        style={style}
         aria-invalid={hasError}
         aria-describedby={
           error ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined
@@ -213,14 +119,17 @@ export function TextArea({
       {error && (
         <span
           id={inputId ? `${inputId}-error` : undefined}
-          style={{ ...helperBaseStyles, color: 'var(--text-negative)' }}
+          className="bds-text-area__error"
           role="alert"
         >
           {error}
         </span>
       )}
       {helperText && !error && (
-        <span id={inputId ? `${inputId}-helper` : undefined} style={helperBaseStyles}>
+        <span
+          id={inputId ? `${inputId}-helper` : undefined}
+          className="bds-text-area__helper"
+        >
           {helperText}
         </span>
       )}

--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -48,7 +48,6 @@ const BDS_ROOT = resolve(__dirname, '..');
 // Paths are repo-relative, POSIX separators. Remove an entry once its component
 // is fully migrated to CSS (the gate then guards it against regression).
 const BASELINE = new Set([
-  'components/ui/TextArea/TextArea.tsx',
   'components/ui/SegmentedControl/SegmentedControl.tsx',
   'components/ui/Slider/Slider.tsx',
   'components/ui/Stepper/Stepper.tsx',

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -67,7 +67,6 @@ function repoRel(file) {
 // introduced this rule (#892, first cleanup batch).
 const INLINE_VAR_BASELINE = new Set([
   'components/ui/TabBar/TabBar.tsx',
-  'components/ui/TextArea/TextArea.tsx',
   'components/ui/SegmentedControl/SegmentedControl.tsx',
   'components/ui/Slider/Slider.tsx',
   'components/ui/Stepper/Stepper.tsx',


### PR DESCRIPTION
## Summary
- refactor(textarea): migrate inline var() to CSS (#892)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)