### PR TITLE
refactor(segmented-control): migrate inline var() to CSS (#892)

### DIFF
--- a/components/ui/SegmentedControl/SegmentedControl.css
+++ b/components/ui/SegmentedControl/SegmentedControl.css
@@ -1,14 +1,86 @@
 @layer bds-components {
-/* SegmentedControl — pseudo-state styles (hover, pressed, disabled)
-   Inline CSSProperties can't handle :hover/:active/:disabled,
-   so these live in CSS. */
+/**
+ * BDS SegmentedControl
+ *
+ * Pill-shaped container with mutually-exclusive segments. All styling lives
+ * here; size and full-width are container BEM modifiers, active is an item
+ * modifier, disabled is the native :disabled state.
+ *
+ * Token reference:
+ * - --background-secondary (track fill)    - --background-primary (active pill)
+ * - --background-tertiary (hover/press)    - --text-on-color-light (inactive label)
+ * - --text-primary (active/hover label)    - --border-brand-primary (focus ring)
+ */
 
-/* ── Shared transition ── */
+/* ── Container / track ── */
+
+.bds-segmented-control {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--border-width-lg);
+  padding: var(--border-width-lg);
+  background-color: var(--background-secondary);
+  border-radius: var(--border-radius-md);
+  box-sizing: border-box;
+}
+
+.bds-segmented-control--full-width {
+  display: flex;
+  width: 100%;
+}
+
+/* ── Segment ── */
 
 .bds-segmented-control-item {
+  font-family: var(--font-family-label);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-tight);
+  text-align: center;
+  white-space: nowrap;
+  cursor: pointer;
+  /* backgroundColor (not the `background` shorthand) so base and active set the
+     SAME property — mixing shorthand + non-shorthand triggered React's
+     "conflicting style property" warning when these were inline. See #993. */
+  background-color: transparent;
+  border: none;
+  border-radius: var(--border-radius-sm);
+  /* Inactive label sits on the --background-secondary track, a light-ish neutral
+     surface in BOTH themes. --text-on-color-light is fixed dark in both themes →
+     AA on the track either way. See contrast-pairings.json. */
+  color: var(--text-on-color-light);
+  min-width: 0;
   transition: background-color var(--duration-fast) var(--ease-out),
     color var(--duration-fast) var(--ease-out),
     box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.bds-segmented-control--full-width .bds-segmented-control-item {
+  flex: 1;
+}
+
+/* ── Size ── */
+
+.bds-segmented-control--sm .bds-segmented-control-item {
+  padding: var(--gap-xs) var(--padding-md);
+  font-size: var(--label-sm);
+}
+
+.bds-segmented-control--md .bds-segmented-control-item {
+  padding: var(--gap-sm) var(--padding-lg);
+  font-size: var(--label-md);
+}
+
+.bds-segmented-control--lg .bds-segmented-control-item {
+  padding: var(--gap-md) var(--padding-xl);
+  font-size: var(--label-md);
+}
+
+/* ── Active ── */
+
+.bds-segmented-control-item--active {
+  background-color: var(--background-primary);
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08); /* bds-lint-ignore — subtle elevation for active pill */
 }
 
 /* ── Disabled ── */

--- a/components/ui/SegmentedControl/SegmentedControl.tsx
+++ b/components/ui/SegmentedControl/SegmentedControl.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, type CSSProperties, type KeyboardEvent, useRef } from 'react';
+import { type HTMLAttributes, type KeyboardEvent, useRef } from 'react';
 import { bdsClass } from '../../utils';
 import './SegmentedControl.css';
 
@@ -35,66 +35,6 @@ export interface SegmentedControlProps extends Omit<HTMLAttributes<HTMLDivElemen
   disabled?: boolean;
 }
 
-/* ── Container styles ── */
-
-const containerBase: CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  backgroundColor: 'var(--background-secondary)',
-  borderRadius: 'var(--border-radius-md)',
-  padding: 'var(--border-width-lg)',
-  boxSizing: 'border-box',
-  gap: 'var(--border-width-lg)',
-};
-
-/* ── Size-specific segment styles ── */
-
-const sizeStyles: Record<SegmentedControlSize, CSSProperties> = {
-  sm: {
-    padding: 'var(--gap-xs) var(--padding-md)',
-    fontSize: 'var(--label-sm)',
-  },
-  md: {
-    padding: 'var(--gap-sm) var(--padding-lg)',
-    fontSize: 'var(--label-md)',
-  },
-  lg: {
-    padding: 'var(--gap-md) var(--padding-xl)',
-    fontSize: 'var(--label-md)',
-  },
-};
-
-/* ── Segment base ── */
-
-const segmentBase: CSSProperties = {
-  fontFamily: 'var(--font-family-label)',
-  fontWeight: 'var(--font-weight-semibold)' as unknown as number,
-  lineHeight: 'var(--font-line-height-tight)',
-  textAlign: 'center',
-  whiteSpace: 'nowrap',
-  cursor: 'pointer',
-  // backgroundColor (not the `background` shorthand) so base and active set the
-  // SAME property — mixing shorthand + non-shorthand triggers React's
-  // "conflicting style property" rerender warning. See #993.
-  backgroundColor: 'transparent',
-  border: 'none',
-  borderRadius: 'var(--border-radius-sm)',
-  // Inactive label sits on the --background-secondary track, which is a light-ish
-  // neutral surface in BOTH themes (grayscale-lightest light / grayscale-light dark).
-  // --text-secondary flips to grayscale-light in dark mode and collapses onto the
-  // track (same stop → ~1:1, invisible). --text-on-color-light is fixed dark in both
-  // themes → AA on the track either way. See contrast-pairings.json.
-  color: 'var(--text-on-color-light)',
-  minWidth: 0,
-  transition: 'background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease',
-};
-
-const activeSegmentStyles: CSSProperties = {
-  backgroundColor: 'var(--background-primary)',
-  color: 'var(--text-primary)',
-  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)', // bds-lint-ignore — subtle elevation for active pill
-};
-
 /**
  * SegmentedControl — BDS toggle control for switching between views or modes
  *
@@ -129,12 +69,6 @@ export function SegmentedControl({
   style,
   ...props
 }: SegmentedControlProps) {
-  const containerStyles: CSSProperties = {
-    ...containerBase,
-    ...(fullWidth ? { display: 'flex', width: '100%' } : {}),
-    ...style,
-  };
-
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   // Indices of segments that can receive focus (enabled).
@@ -188,8 +122,13 @@ export function SegmentedControl({
 
   return (
     <div
-      className={bdsClass('bds-segmented-control', className)}
-      style={containerStyles}
+      className={bdsClass(
+        'bds-segmented-control',
+        `bds-segmented-control--${size}`,
+        fullWidth && 'bds-segmented-control--full-width',
+        className,
+      )}
+      style={style}
       role="radiogroup"
       {...props}
       onKeyDown={handleKeyDown}
@@ -198,13 +137,6 @@ export function SegmentedControl({
         const itemValue = item.value ?? item.label;
         const isActive = itemValue === value;
         const isDisabled = disabled || item.disabled;
-
-        const segmentStyles: CSSProperties = {
-          ...segmentBase,
-          ...sizeStyles[size],
-          ...(isActive ? activeSegmentStyles : {}),
-          ...(fullWidth ? { flex: 1 } : {}),
-        };
 
         return (
           <button
@@ -219,9 +151,8 @@ export function SegmentedControl({
             tabIndex={index === tabStopIndex ? 0 : -1}
             className={bdsClass(
               'bds-segmented-control-item',
-              isActive ? 'bds-segmented-control-item--active' : '',
+              isActive && 'bds-segmented-control-item--active',
             )}
-            style={segmentStyles}
             onClick={() => onChange?.(itemValue)}
           >
             {item.label}

--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -48,7 +48,6 @@ const BDS_ROOT = resolve(__dirname, '..');
 // Paths are repo-relative, POSIX separators. Remove an entry once its component
 // is fully migrated to CSS (the gate then guards it against regression).
 const BASELINE = new Set([
-  'components/ui/SegmentedControl/SegmentedControl.tsx',
   'components/ui/Slider/Slider.tsx',
   'components/ui/Stepper/Stepper.tsx',
   'components/ui/Switch/Switch.tsx',

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -67,7 +67,6 @@ function repoRel(file) {
 // introduced this rule (#892, first cleanup batch).
 const INLINE_VAR_BASELINE = new Set([
   'components/ui/TabBar/TabBar.tsx',
-  'components/ui/SegmentedControl/SegmentedControl.tsx',
   'components/ui/Slider/Slider.tsx',
   'components/ui/Stepper/Stepper.tsx',
   'components/ui/PageHeader/PageHeader.tsx',


### PR DESCRIPTION
## Summary
- refactor(segmented-control): migrate inline var() to CSS (#892)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)