### PR TITLE
refactor(slider): migrate inline var() to CSS (#892)

### DIFF
--- a/components/ui/Slider/Slider.css
+++ b/components/ui/Slider/Slider.css
@@ -12,16 +12,47 @@
  * value ships as a Figma token.
  */
 
-/* ─── Component-scoped override surface ── */
+/* ─── Wrapper (also the component-scoped override surface) ── */
 .bds-slider {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  width: 100%;
   --bds-slider-thumb-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* bds-lint-ignore — lighter than --shadow-sm; promote to Figma */
+}
+
+/* ─── Label row ── */
+.bds-slider__label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bds-slider__label {
+  margin: 0;
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-line-height-snug);
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+.bds-slider__value {
+  font-family: var(--font-family-label);
+  font-size: var(--label-sm);
+  font-weight: var(--font-weight-regular);
+  color: var(--text-secondary);
 }
 
 .bds-slider-input {
   -webkit-appearance: none;
   appearance: none;
+  width: 100%;
+  height: var(--bds-slider-track-height, 6px);
   background: transparent;
   margin: 0;
+  cursor: pointer;
 }
 
 /* Track */
@@ -86,6 +117,8 @@
 
 /* Disabled */
 .bds-slider-input:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
   pointer-events: none;
 }
 

--- a/components/ui/Slider/Slider.tsx
+++ b/components/ui/Slider/Slider.tsx
@@ -57,60 +57,6 @@ const thumbSizes: Record<SliderSize, number> = {
 };
 
 /**
- * Wrapper styles
- *
- * Token reference:
- * - --gap-md = 8px
- */
-const wrapperStyles: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'var(--gap-md)',
-  width: '100%',
-};
-
-/**
- * Label row styles
- *
- * Token reference:
- * - --font-family-label
- * - --label-sm = 14px
- * - --font-weight-semi-bold = 600
- * - --text-primary
- */
-const labelRowStyles: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-};
-
-const labelStyles: CSSProperties = {
-  fontFamily: 'var(--font-family-label)',
-  fontSize: 'var(--label-sm)',
-  fontWeight: 'var(--font-weight-semibold)' as unknown as number,
-  lineHeight: 'var(--font-line-height-snug)',
-  color: 'var(--text-primary)',
-  margin: 0,
-  textTransform: 'capitalize' as const,
-};
-
-/**
- * Value display styles
- *
- * Token reference:
- * - --font-family-label
- * - --label-sm = 14px
- * - --font-weight-regular = 400
- * - --text-secondary
- */
-const valueStyles: CSSProperties = {
-  fontFamily: 'var(--font-family-label)',
-  fontSize: 'var(--label-sm)',
-  fontWeight: 'var(--font-weight-regular)' as unknown as number,
-  color: 'var(--text-secondary)',
-};
-
-/**
  * Slider - BDS range input control
  *
  * A styled range slider with configurable min/max/step, size variants,
@@ -163,28 +109,21 @@ export function Slider({
 
   const percent = max !== min ? ((currentValue - min) / (max - min)) * 100 : 0;
 
-  const inputStyles: CSSProperties = {
-    width: '100%',
-    height: trackHeights[size],
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    opacity: disabled ? 0.5 : 1,
-    // CSS custom properties for the CSS file to consume
-    ...({
-      '--bds-slider-percent': `${percent}%`,
-      '--bds-slider-track-height': `${trackHeights[size]}px`,
-      '--bds-slider-thumb-size': `${thumbSizes[size]}px`,
-    } as React.CSSProperties),
-  };
+  // Runtime bindings the CSS consumes (percent from value; track/thumb from size).
+  // Defining --bds-* custom properties inline is the sanctioned runtime escape
+  // hatch; all static token consumption lives in Slider.css.
+  const inputStyles = {
+    '--bds-slider-percent': `${percent}%`,
+    '--bds-slider-track-height': `${trackHeights[size]}px`,
+    '--bds-slider-thumb-size': `${thumbSizes[size]}px`,
+  } as CSSProperties;
 
   return (
-    <div
-      className={bdsClass('bds-slider', className)}
-      style={{ ...wrapperStyles, ...style }}
-    >
+    <div className={bdsClass('bds-slider', className)} style={style}>
       {(label || showValue) && (
-        <div style={labelRowStyles}>
-          {label && <span style={labelStyles}>{label}</span>}
-          {showValue && <span style={valueStyles}>{currentValue}</span>}
+        <div className="bds-slider__label-row">
+          {label && <span className="bds-slider__label">{label}</span>}
+          {showValue && <span className="bds-slider__value">{currentValue}</span>}
         </div>
       )}
       <input

--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -48,7 +48,6 @@ const BDS_ROOT = resolve(__dirname, '..');
 // Paths are repo-relative, POSIX separators. Remove an entry once its component
 // is fully migrated to CSS (the gate then guards it against regression).
 const BASELINE = new Set([
-  'components/ui/Slider/Slider.tsx',
   'components/ui/Stepper/Stepper.tsx',
   'components/ui/Switch/Switch.tsx',
   'components/ui/PageHeader/PageHeader.tsx',

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -67,7 +67,6 @@ function repoRel(file) {
 // introduced this rule (#892, first cleanup batch).
 const INLINE_VAR_BASELINE = new Set([
   'components/ui/TabBar/TabBar.tsx',
-  'components/ui/Slider/Slider.tsx',
   'components/ui/Stepper/Stepper.tsx',
   'components/ui/PageHeader/PageHeader.tsx',
   'components/ui/Switch/Switch.tsx',


### PR DESCRIPTION
## Summary
- refactor(slider): migrate inline var() to CSS (#892)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)