### PR TITLE
refactor(stepper): migrate inline var() to CSS (#892)

### DIFF
--- a/components/ui/Stepper/Stepper.css
+++ b/components/ui/Stepper/Stepper.css
@@ -9,6 +9,35 @@
   box-sizing: border-box;
 }
 
+/* ─── Size ────────────────────────────────────────────── */
+
+.bds-stepper--sm { gap: var(--gap-sm); }
+.bds-stepper--md { gap: var(--gap-md); }
+.bds-stepper--lg { gap: var(--gap-md); }
+
+.bds-stepper--sm .bds-stepper__button {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--border-radius-sm);
+  font-size: 10px;
+}
+.bds-stepper--md .bds-stepper__button {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--border-radius-md);
+  font-size: 12px;
+}
+.bds-stepper--lg .bds-stepper__button {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--border-radius-md);
+  font-size: 14px;
+}
+
+.bds-stepper--sm .bds-stepper__value { font-size: var(--label-sm); min-width: 28px; }
+.bds-stepper--md .bds-stepper__value { font-size: var(--label-md); min-width: 36px; }
+.bds-stepper--lg .bds-stepper__value { font-size: var(--label-lg); min-width: 44px; }
+
 /* ─── Buttons ─────────────────────────────────────────── */
 
 .bds-stepper__button {

--- a/components/ui/Stepper/Stepper.tsx
+++ b/components/ui/Stepper/Stepper.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type HTMLAttributes } from 'react';
+import { type HTMLAttributes } from 'react';
 import { Icon } from '@iconify/react';
 import { Minus, Plus } from '../../icons';
 import { bdsClass } from '../../utils';
@@ -23,36 +23,6 @@ export interface StepperProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onCh
   disabled?: boolean;
 }
 
-const sizeConfig: Record<StepperSize, {
-  buttonSize: number;
-  iconSize: number;
-  fontSize: string;
-  gap: string;
-  borderRadius: string;
-}> = {
-  sm: {
-    buttonSize: 28,
-    iconSize: 10,
-    fontSize: 'var(--label-sm)',
-    gap: 'var(--gap-sm)',
-    borderRadius: 'var(--border-radius-sm)',
-  },
-  md: {
-    buttonSize: 36,
-    iconSize: 12,
-    fontSize: 'var(--label-md)',
-    gap: 'var(--gap-md)',
-    borderRadius: 'var(--border-radius-md)',
-  },
-  lg: {
-    buttonSize: 44,
-    iconSize: 14,
-    fontSize: 'var(--label-lg)',
-    gap: 'var(--gap-md)',
-    borderRadius: 'var(--border-radius-md)',
-  },
-};
-
 /**
  * Stepper — numeric input with increment/decrement buttons.
  *
@@ -74,8 +44,6 @@ export function Stepper({
   style,
   ...props
 }: StepperProps) {
-  const config = sizeConfig[size];
-
   const canDecrement = !disabled && value - step >= min;
   const canIncrement = !disabled && value + step <= max;
 
@@ -87,23 +55,10 @@ export function Stepper({
     if (canIncrement) onChange(value + step);
   };
 
-  // Runtime-calculated dimensions per size — must stay inline
-  const buttonStyle = (): CSSProperties => ({
-    width: config.buttonSize,
-    height: config.buttonSize,
-    borderRadius: config.borderRadius,
-    fontSize: config.iconSize,
-  });
-
-  const valueStyle: CSSProperties = {
-    fontSize: config.fontSize,
-    minWidth: config.buttonSize,
-  };
-
   return (
     <div
-      className={bdsClass('bds-stepper', className)}
-      style={{ gap: config.gap, ...style }}
+      className={bdsClass('bds-stepper', `bds-stepper--${size}`, className)}
+      style={style}
       role="group"
       aria-label="Stepper"
       {...props}
@@ -113,14 +68,12 @@ export function Stepper({
         onClick={handleDecrement}
         disabled={!canDecrement}
         className={bdsClass('bds-stepper__button', !canDecrement && 'bds-stepper__button--disabled')}
-        style={buttonStyle()}
         aria-label="Decrease"
       >
         <Icon icon={Minus} />
       </button>
       <span
         className={bdsClass('bds-stepper__value', disabled && 'bds-stepper__value--disabled')}
-        style={valueStyle}
         aria-live="polite"
       >
         {value}
@@ -130,7 +83,6 @@ export function Stepper({
         onClick={handleIncrement}
         disabled={!canIncrement}
         className={bdsClass('bds-stepper__button', !canIncrement && 'bds-stepper__button--disabled')}
-        style={buttonStyle()}
         aria-label="Increase"
       >
         <Icon icon={Plus} />

--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -48,7 +48,6 @@ const BDS_ROOT = resolve(__dirname, '..');
 // Paths are repo-relative, POSIX separators. Remove an entry once its component
 // is fully migrated to CSS (the gate then guards it against regression).
 const BASELINE = new Set([
-  'components/ui/Stepper/Stepper.tsx',
   'components/ui/Switch/Switch.tsx',
   'components/ui/PageHeader/PageHeader.tsx',
   'components/ui/ProgressStepper/ProgressStepper.tsx',

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -67,7 +67,6 @@ function repoRel(file) {
 // introduced this rule (#892, first cleanup batch).
 const INLINE_VAR_BASELINE = new Set([
   'components/ui/TabBar/TabBar.tsx',
-  'components/ui/Stepper/Stepper.tsx',
   'components/ui/PageHeader/PageHeader.tsx',
   'components/ui/Switch/Switch.tsx',
   'components/ui/ProgressStepper/ProgressStepper.tsx',


### PR DESCRIPTION
## Summary
- refactor(stepper): migrate inline var() to CSS (#892)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)