### PR TITLE
refactor(switch): migrate inline var() to CSS (#892)

### DIFF
--- a/components/ui/Switch/Switch.css
+++ b/components/ui/Switch/Switch.css
@@ -44,9 +44,20 @@
   position: relative;
   display: inline-block;
   border-radius: var(--border-radius-pill);
+  /* default variant carries state on the track: neutral off, brand on */
+  background-color: var(--border-muted); /* bds-lint-ignore token-family — no semantic switch-track-inactive token; neutral track rail */
   transition: background-color var(--duration-normal) var(--ease-out);
   flex-shrink: 0;
   cursor: inherit;
+}
+
+.bds-switch__input:checked ~ .bds-switch__track {
+  background-color: var(--background-brand-primary);
+}
+
+/* accent-knob keeps the track neutral in both states — state moves to the knob */
+.bds-switch--accent-knob .bds-switch__input:checked ~ .bds-switch__track {
+  background-color: var(--border-muted); /* bds-lint-ignore token-family — accent-knob track stays neutral */
 }
 
 /* ─── Knob ───────────────────────────────────────────────────── */
@@ -57,5 +68,14 @@
   border-radius: 50%;
   transition: transform var(--duration-normal) var(--ease-out);
   box-shadow: var(--shadow-sm);
+}
+
+/* accent-knob variant carries state on the knob: muted off, brand on */
+.bds-switch--accent-knob .bds-switch__knob {
+  background-color: var(--text-secondary); /* bds-lint-ignore token-family — muted-gray knob fill; no semantic switch-knob-off token */
+}
+
+.bds-switch--accent-knob .bds-switch__input:checked ~ .bds-switch__track .bds-switch__knob {
+  background-color: var(--background-brand-primary);
 }
 }

--- a/components/ui/Switch/Switch.tsx
+++ b/components/ui/Switch/Switch.tsx
@@ -76,32 +76,20 @@ export function Switch({
   const s = sizes[size];
   const isAccentKnob = variant === 'accent-knob';
 
-  // Runtime-calculated track dimensions.
-  // default: track carries state (brand-fill on / neutral off).
-  // accent-knob: track stays neutral in both states; the knob carries state.
+  // Size-dependent, Figma-driven dimensions stay inline (runtime-calculated).
+  // State colors (track brand/neutral, accent-knob fill) live in Switch.css,
+  // driven by :checked + the .bds-switch--accent-knob modifier.
   const trackStyle: CSSProperties = {
-    width: `${s.trackW}px`, // bds-lint-ignore — Figma-driven switch dimensions
-    height: `${s.trackH}px`, // bds-lint-ignore
-    backgroundColor:
-      isAccentKnob || !isChecked
-        ? 'var(--border-muted)' // bds-lint-ignore — no semantic switch-track-inactive token
-        : 'var(--background-brand-primary)',
+    width: `${s.trackW}px`,
+    height: `${s.trackH}px`,
   };
 
-  // Runtime-calculated knob dimensions + position. For accent-knob the knob
-  // carries state (brand-fill on / muted-gray off); default leaves the fill to
-  // Switch.css (--surface-primary).
   const knobStyle: CSSProperties = {
-    top: `${s.pad}px`, // bds-lint-ignore
-    left: `${s.pad}px`, // bds-lint-ignore
-    width: `${s.knob}px`, // bds-lint-ignore
-    height: `${s.knob}px`, // bds-lint-ignore
+    top: `${s.pad}px`,
+    left: `${s.pad}px`,
+    width: `${s.knob}px`,
+    height: `${s.knob}px`,
     transform: isChecked ? `translateX(${s.travel}px)` : 'translateX(0)',
-    ...(isAccentKnob && {
-      backgroundColor: isChecked
-        ? 'var(--background-brand-primary)'
-        : 'var(--text-secondary)',
-    }),
   };
 
   return (

--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -48,7 +48,6 @@ const BDS_ROOT = resolve(__dirname, '..');
 // Paths are repo-relative, POSIX separators. Remove an entry once its component
 // is fully migrated to CSS (the gate then guards it against regression).
 const BASELINE = new Set([
-  'components/ui/Switch/Switch.tsx',
   'components/ui/PageHeader/PageHeader.tsx',
   'components/ui/ProgressStepper/ProgressStepper.tsx',
   'components/ui/Board/BoardColumn.tsx',

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -68,7 +68,6 @@ function repoRel(file) {
 const INLINE_VAR_BASELINE = new Set([
   'components/ui/TabBar/TabBar.tsx',
   'components/ui/PageHeader/PageHeader.tsx',
-  'components/ui/Switch/Switch.tsx',
   'components/ui/ProgressStepper/ProgressStepper.tsx',
   'components/ui/Board/BoardColumn.tsx',
 ]);


### PR DESCRIPTION
## Summary
- refactor(switch): migrate inline var() to CSS (#892)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)