### PR TITLE
refactor(progress-stepper): migrate inline var() to CSS (#892)

### DIFF
--- a/components/ui/ProgressStepper/ProgressStepper.css
+++ b/components/ui/ProgressStepper/ProgressStepper.css
@@ -25,6 +25,9 @@
   align-items: center;
 }
 
+.bds-progress-stepper--variant-dots.bds-progress-stepper--sm { gap: var(--gap-sm); }
+.bds-progress-stepper--variant-dots.bds-progress-stepper--md { gap: var(--gap-md); }
+
 /* ─── Step row ───────────────────────────────────────────────── */
 
 .bds-progress-stepper__step-row {

--- a/components/ui/ProgressStepper/ProgressStepper.tsx
+++ b/components/ui/ProgressStepper/ProgressStepper.tsx
@@ -51,10 +51,11 @@ const CIRCLE_SIZE: Record<ProgressStepperSize, number> = {
   md: 32,
 };
 
-// bds-lint-ignore — Figma-driven dot sizes for the 'dots' variant
-const DOTS_CONFIG: Record<ProgressStepperSize, { dotSize: number; activeDotWidth: number; gap: string }> = {
-  sm: { dotSize: 6, activeDotWidth: 18, gap: 'var(--gap-sm)' },
-  md: { dotSize: 8, activeDotWidth: 24, gap: 'var(--gap-md)' },
+// bds-lint-ignore — Figma-driven dot sizes for the 'dots' variant.
+// Container gap is size-scoped in ProgressStepper.css (variant-dots + --{size}).
+const DOTS_CONFIG: Record<ProgressStepperSize, { dotSize: number; activeDotWidth: number }> = {
+  sm: { dotSize: 6, activeDotWidth: 18 },
+  md: { dotSize: 8, activeDotWidth: 24 },
 };
 
 function getStepStatus(index: number, activeStep: number): StepStatus {
@@ -248,9 +249,10 @@ function DotsRender({
       className={bdsClass(
         'bds-progress-stepper',
         'bds-progress-stepper--variant-dots',
+        `bds-progress-stepper--${size}`,
         className,
       )}
-      style={{ gap: config.gap, ...style }}
+      style={style}
       role="tablist"
       aria-label="Progress"
       {...props}

--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -48,7 +48,6 @@ const BDS_ROOT = resolve(__dirname, '..');
 // Paths are repo-relative, POSIX separators. Remove an entry once its component
 // is fully migrated to CSS (the gate then guards it against regression).
 const BASELINE = new Set([
-  'components/ui/ProgressStepper/ProgressStepper.tsx',
   'components/ui/Board/BoardColumn.tsx',
 ]);
 

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -67,7 +67,6 @@ function repoRel(file) {
 // introduced this rule (#892, first cleanup batch).
 const INLINE_VAR_BASELINE = new Set([
   'components/ui/TabBar/TabBar.tsx',
-  'components/ui/ProgressStepper/ProgressStepper.tsx',
   'components/ui/Board/BoardColumn.tsx',
 ]);
 


### PR DESCRIPTION
## Summary
- refactor(progress-stepper): migrate inline var() to CSS (#892)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)