### PR TITLE
refactor(board-column): migrate inline var() to CSS (#892)

### DIFF
--- a/components/ui/Board/Board.css
+++ b/components/ui/Board/Board.css
@@ -71,6 +71,12 @@
   flex-shrink: 0;
 }
 
+.bds-board-column__title-group {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-xs);
+}
+
 .bds-board-column__title {
   font-family: var(--font-family-label);
   font-size: var(--label-sm);

--- a/components/ui/Board/BoardColumn.tsx
+++ b/components/ui/Board/BoardColumn.tsx
@@ -41,7 +41,7 @@ export function BoardColumn({
     >
       {(title || headerAction) && (
         <div className="bds-board-column__header">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-xs)' }}>
+          <div className="bds-board-column__title-group">
             {title && <h3 className="bds-board-column__title">{title}</h3>}
             {count !== undefined && (
               <span className="bds-board-column__count">{count}</span>

--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -48,7 +48,6 @@ const BDS_ROOT = resolve(__dirname, '..');
 // Paths are repo-relative, POSIX separators. Remove an entry once its component
 // is fully migrated to CSS (the gate then guards it against regression).
 const BASELINE = new Set([
-  'components/ui/Board/BoardColumn.tsx',
 ]);
 
 // A line that DEFINES a `--bds-*` custom property (runtime binding) — allowed.

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -67,7 +67,6 @@ function repoRel(file) {
 // introduced this rule (#892, first cleanup batch).
 const INLINE_VAR_BASELINE = new Set([
   'components/ui/TabBar/TabBar.tsx',
-  'components/ui/Board/BoardColumn.tsx',
 ]);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- refactor(board-column): migrate inline var() to CSS (#892)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)