### PR TITLE
chore(tooling): retire inline-var baseline, enforce repo-wide (#892)

### DIFF
--- a/scripts/lint-inline-var.mjs
+++ b/scripts/lint-inline-var.mjs
@@ -17,17 +17,16 @@
  *               the sanctioned Component-tier pattern in token-anatomy.mdx):
  *                 style={{ '--bds-slider-percent': `${pct}%` }}
  *
- * ── Baseline ────────────────────────────────────────────────────────────────
+ * ── Enforcement ──────────────────────────────────────────────────────────────
  *
- * Existing offenders are listed in BASELINE and do not fail the gate — they're
- * burned down in per-component follow-up PRs (#892). A file NOT in the baseline
- * that introduces a consuming inline var() fails the build. As each component is
- * cleaned, delete its entry from BASELINE so it can never regress.
+ * The #892 burn-down is complete: every component is clean, so the gate enforces
+ * repo-wide — any consuming inline var() in component TSX fails the build.
+ * (History: offenders were once grandfathered in a BASELINE set and removed
+ * per-component as they migrated to CSS; the set emptied when #892 closed.)
  *
  * ── Exit codes ───────────────────────────────────────────────────────────────
- *   0  Clean — no un-baselined inline token consumption
- *   1  Violations found (new offender, or a baselined file that's now clean —
- *      remove it from BASELINE)
+ *   0  Clean — no inline token consumption
+ *   1  Violations found
  *   2  Bad invocation
  *
  * ── CLI ──────────────────────────────────────────────────────────────────────
@@ -43,12 +42,6 @@ import { execSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BDS_ROOT = resolve(__dirname, '..');
-
-// ── Baseline — known offenders, burned down per-component in #892 ────────────
-// Paths are repo-relative, POSIX separators. Remove an entry once its component
-// is fully migrated to CSS (the gate then guards it against regression).
-const BASELINE = new Set([
-]);
 
 // A line that DEFINES a `--bds-*` custom property (runtime binding) — allowed.
 const BDS_DEFINE_RE = /['"]--bds-[\w-]+['"]\s*:/;
@@ -78,8 +71,6 @@ function relPosix(abs) {
 
 function scanFile(filePath) {
   const rel = relPosix(filePath);
-  if (BASELINE.has(rel)) return { violations: [], baselinedButClean: false, rel };
-
   const lines = readFileSync(filePath, 'utf8').split('\n');
   const violations = [];
   for (let i = 0; i < lines.length; i++) {
@@ -91,39 +82,22 @@ function scanFile(filePath) {
   return { violations, rel };
 }
 
-// A baselined file that is now clean should be removed from the baseline.
-function baselinedFileStillDirty(rel) {
-  const abs = resolve(BDS_ROOT, rel);
-  if (!existsSync(abs)) return false;
-  const lines = readFileSync(abs, 'utf8').split('\n');
-  return lines.some((l) => VAR_CONSUME_RE.test(l) && !BDS_DEFINE_RE.test(l));
-}
-
 const GUIDANCE =
   'Move the token into the component CSS (BEM under `bds-`, keyed on state via ' +
   'class / [data-*] / [aria-*]); inline style objects must not consume tokens. ' +
   'Defining a `--bds-*` custom property inline (runtime binding) is allowed. ' +
   'See .claude/standards/component-build.md and brik-bds#892.';
 
-function render(allViolations, staleBaseline, scanned) {
-  const out = [];
-  if (allViolations.length === 0 && staleBaseline.length === 0) {
-    return `lint-inline-var: clean — ${scanned} TSX file(s) scanned, 0 un-baselined inline token consumers\n`;
+function render(allViolations, scanned) {
+  if (allViolations.length === 0) {
+    return `lint-inline-var: clean — ${scanned} TSX file(s) scanned, 0 inline token consumers\n`;
   }
-  if (allViolations.length > 0) {
-    out.push(`lint-inline-var: ${allViolations.length} inline token consumer(s) outside the baseline`);
-    out.push('');
-    for (const v of allViolations) {
-      out.push(`  ${v.file}:${v.line}  ${v.text}`);
-    }
-    out.push('');
-    out.push(`  ↳ ${GUIDANCE}`);
+  const out = [`lint-inline-var: ${allViolations.length} inline token consumer(s) in component TSX`, ''];
+  for (const v of allViolations) {
+    out.push(`  ${v.file}:${v.line}  ${v.text}`);
   }
-  if (staleBaseline.length > 0) {
-    out.push('');
-    out.push(`lint-inline-var: ${staleBaseline.length} baseline entr(y/ies) now clean — remove from BASELINE in scripts/lint-inline-var.mjs:`);
-    for (const rel of staleBaseline) out.push(`  ${rel}`);
-  }
+  out.push('');
+  out.push(`  ↳ ${GUIDANCE}`);
   return out.join('\n') + '\n';
 }
 
@@ -157,13 +131,8 @@ function main() {
     allViolations.push(...scanFile(file).violations);
   }
 
-  // Only surface stale-baseline hints on a full scan (not --staged).
-  const staleBaseline = args.includes('--staged')
-    ? []
-    : [...BASELINE].filter((rel) => !baselinedFileStillDirty(rel));
-
-  process.stdout.write(render(allViolations, staleBaseline, files.length));
-  process.exit(allViolations.length > 0 || staleBaseline.length > 0 ? 1 : 0);
+  process.stdout.write(render(allViolations, files.length));
+  process.exit(allViolations.length > 0 ? 1 : 0);
 }
 
 main();

--- a/scripts/lint-tokens.js
+++ b/scripts/lint-tokens.js
@@ -14,10 +14,9 @@
  *      docs/TOKEN-PR-CHECKLIST.md for the property↔family table.
  *   6. Raw inline var(--…) in component TSX — styles belong in the component's
  *      .css file (BEM under bds-), never a CSSProperties object. See the
- *      component-build standard §"Styles live in CSS". Files in
- *      INLINE_VAR_BASELINE are grandfathered to warnings (ratchet); clean
- *      files error. Escape hatch: `bds-lint-ignore` for runtime-calculated
- *      values that genuinely cannot live in CSS.
+ *      component-build standard §"Styles live in CSS". Errors repo-wide (the
+ *      #892 burn-down is complete). Escape hatch: `bds-lint-ignore` for
+ *      runtime-calculated values that genuinely cannot live in CSS.
  *
  * Usage:
  *   node scripts/lint-tokens.js              # full report (errors + warnings)
@@ -48,26 +47,6 @@ const BLUEPRINTS_DIR = path.join(__dirname, '..', 'content-system', 'blueprints'
 function repoRel(file) {
   return path.relative(REPO_ROOT, file).split(path.sep).join('/');
 }
-
-// ---------------------------------------------------------------------------
-// Rule 6 baseline (inline-var ratchet) — brik-bds#892
-// ---------------------------------------------------------------------------
-// Component TSX files with KNOWN pre-existing inline var(--…) style objects.
-// These are grandfathered to `warning` so the repo-wide CI run (release.yml +
-// pr-checklist.sh both call `--errors-only`) stays green while the 157-violation
-// backlog is migrated to CSS over a series of per-component PRs.
-//
-// RATCHET: any component TSX NOT on this list errors on the first inline var().
-// New components therefore can never introduce inline-var debt. As each file is
-// migrated to .css (CSSProperties → bds- BEM classes), delete its entry here.
-// When the set is empty, delete it and the conditional in checkInlineVarTsx —
-// the rule then errors repo-wide for every component.
-//
-// AddressInput is intentionally absent: it was migrated in the same PR that
-// introduced this rule (#892, first cleanup batch).
-const INLINE_VAR_BASELINE = new Set([
-  'components/ui/TabBar/TabBar.tsx',
-]);
 
 // ---------------------------------------------------------------------------
 // Tier 4 fallback-literal baseline (ratchet) — brik-bds#1043 / ADR-014
@@ -935,9 +914,8 @@ function checkTokenFamilyPairing(line, lineNum, file, isComponent) {
  * as bds- BEM classes. A raw `var(--…)` string in a .tsx is the fingerprint of
  * an inline style object, so this rule flags every such reference.
  *
- * Severity is ratcheted via INLINE_VAR_BASELINE: files with known pre-existing
- * debt warn (so repo-wide --errors-only CI stays green during migration); every
- * other component file errors, so no NEW inline-var debt can land.
+ * Every consuming inline var() in a component .tsx is an error — the #892
+ * burn-down is complete, so there is no longer a grandfathered baseline.
  *
  * Only runs for component .tsx (callers exclude .stories.tsx / .test.tsx, where
  * inline style is allowed for layout helpers). Skips comment lines and any line
@@ -953,7 +931,7 @@ function checkInlineVarTsx(line, lineNum, file) {
   }
   if (line.includes('bds-lint-ignore')) return violations;
 
-  const severity = INLINE_VAR_BASELINE.has(repoRel(file)) ? 'warning' : 'error';
+  const severity = 'error';
 
   const regex = /var\((--[\w-]+)/g;
   let match;


### PR DESCRIPTION
## Summary
- chore(tooling): retire inline-var baseline, enforce repo-wide (#892)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)