### PR TITLE
fix(breadcrumb): flip audience cascade to on-dark in dark mode (#1187)

### DIFF
--- a/components/ui/Breadcrumb/Breadcrumb.css
+++ b/components/ui/Breadcrumb/Breadcrumb.css
@@ -92,4 +92,45 @@
   --text-secondary: var(--text-service-back-office-on-light);
   --text-muted: var(--text-service-back-office-on-light);
 }
+
+/* ─── Dark mode: flip the audience cascade to the on-dark companions ──────
+ * In dark mode the [data-audience] band surface flips to the {hue}-darkest
+ * companion, so the *-on-light tokens the cascade above binds (a dark hue)
+ * collapse onto it — the current crumb, which rides --text-secondary, renders
+ * the SAME colour as the band and vanishes (1:1; brikdesigns#688). The link is
+ * unaffected: it rides --text-brand-primary, flipped by HeroSplitImageCardOverlay's
+ * own dark audience cascade. Rebind --text-secondary / --text-muted to the
+ * *-on-dark companion so the current crumb clears AA on the dark band (6.89–9.06:1,
+ * the same pairings the hero uses), staying recessive via the regular weight above.
+ * Mirrors Hero.css's dark audience cascade. */
+:root[data-theme="dark"] [data-audience='brand'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-brand-on-dark);
+  --text-muted: var(--text-service-brand-on-dark);
+}
+
+:root[data-theme="dark"] [data-audience='marketing'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-marketing-on-dark);
+  --text-muted: var(--text-service-marketing-on-dark);
+}
+
+:root[data-theme="dark"] [data-audience='information'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-information-on-dark);
+  --text-muted: var(--text-service-information-on-dark);
+}
+
+:root[data-theme="dark"] [data-audience='product'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-product-on-dark);
+  --text-muted: var(--text-service-product-on-dark);
+}
+
+:root[data-theme="dark"] [data-audience='back-office'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-back-office-on-dark);
+  --text-muted: var(--text-service-back-office-on-dark);
+}
+
+/* @deprecated alias of [data-audience='back-office'] — see above. */
+:root[data-theme="dark"] [data-audience='service'] .bds-breadcrumb {
+  --text-secondary: var(--text-service-back-office-on-dark);
+  --text-muted: var(--text-service-back-office-on-dark);
+}
 }


### PR DESCRIPTION
## Why

`Breadcrumb.css`'s `[data-audience]` cascade (#781) rebinds `--text-secondary`/`--text-muted` → `--text-service-{hue}-on-light` with **no dark-mode variant**. In dark mode the band surface flips to the `{hue}` inverse companion, so the current crumb (which rides `--text-secondary`) renders a dark hue on that dark band → **1:1, invisible**. The link is unaffected — it rides `--text-brand-primary`, flipped by the hero's own dark audience cascade.

Surfaced as a serious axe failure on the brikdesigns#688 dark service heroes (`.bds-breadcrumb__current` `#634716` on `#634716`). #835 fixed the light-mode weight hierarchy but never analyzed dark mode.

## What

Add a `:root[data-theme="dark"] [data-audience='{hue}'] .bds-breadcrumb` cascade rebinding `--text-secondary`/`--text-muted` → the `*-on-dark` companions (all five hues + the `service` alias), mirroring `Hero.css`. The current crumb now matches the link colour on the dark band, staying recessive via the existing regular-weight rule — the "same colour, distinguish by weight" intent, now correct in both themes.

Uses only contract-validated pairings (`contrast-pairings.json` #26–34: `--text-service-{hue}-on-dark` on `--surface-service-{hue}-inverse`, AA).

## Verification

- `npm run contrast-gate` ✅ · `lint-tokens` (0 errors) ✅ · `canonical-class-check` (0 violations) ✅
- Rendered the built `dist/styles.css` in isolation, dark theme, per audience — current crumb clears AA on the dark band:

| audience | current-crumb AA |
|---|---|
| brand | 7.30:1 |
| marketing | 7.69:1 |
| information | 6.89:1 |
| product | 7.53:1 |
| back-office | 9.06:1 |

Light mode unchanged (cascade untouched).

## Follow-ups (not in this PR)

- [ ] `npm run chromatic` before merge (component CSS change — per repo CLAUDE.md).
- [ ] After release, bump `@brikdesigns/bds` in brikdesigns and **remove** the consumer workaround in `globals.css` (`:root[data-theme="dark"] .bds-hero--with-pricing-card .bds-breadcrumb__current { color: var(--text-brand-primary) }`), landed in brikdesigns#688.

Closes #1187
