### PR TITLE
chore(release): @brikdesigns/bds 0.122.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.122.1",
+  "version": "0.122.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.122.1",
+      "version": "0.122.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.122.1",
+  "version": "0.122.2",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/lib-entry.cjs",


### PR DESCRIPTION
Release 0.122.2. Ships the breadcrumb dark-mode audience-cascade fix (#1188, closes #1187) — current crumb clears AA on the dark service band (6.89–9.06:1). Version bump only; tag `v0.122.2` after merge triggers the Release workflow.