### PR TITLE
fix(breadcrumb): scope dark on-dark flip to pricing-card band

### DIFF
--- a/components/ui/Breadcrumb/Breadcrumb.css
+++ b/components/ui/Breadcrumb/Breadcrumb.css
@@ -93,43 +93,44 @@
   --text-muted: var(--text-service-back-office-on-light);
 }
 
-/* ─── Dark mode: flip the audience cascade to the on-dark companions ──────
- * In dark mode the [data-audience] band surface flips to the {hue}-darkest
- * companion, so the *-on-light tokens the cascade above binds (a dark hue)
- * collapse onto it — the current crumb, which rides --text-secondary, renders
- * the SAME colour as the band and vanishes (1:1; brikdesigns#688). The link is
- * unaffected: it rides --text-brand-primary, flipped by HeroSplitImageCardOverlay's
- * own dark audience cascade. Rebind --text-secondary / --text-muted to the
- * *-on-dark companion so the current crumb clears AA on the dark band (6.89–9.06:1,
- * the same pairings the hero uses), staying recessive via the regular weight above.
- * Mirrors Hero.css's dark audience cascade. */
-:root[data-theme="dark"] [data-audience='brand'] .bds-breadcrumb {
+/* ─── Dark mode: flip the on-dark companions ONLY on the inverse pricing-card band ──
+ * The [data-audience] cascade above binds the *-on-light tokens (a dark hue),
+ * which is correct wherever the breadcrumb sits on a fixed-light service tint
+ * (`.service-surface` — e.g. the service-LINE hero, brikdesigns /services/brand).
+ * But inside `.bds-hero--with-pricing-card` the surface flips to the {hue} inverse
+ * (dark) companion in dark mode, so those on-light tokens collapse onto it — the
+ * current crumb, which rides --text-secondary, vanishes (1:1; brikdesigns#688).
+ * Scope the on-dark flip to that pricing-card band ONLY — the exact scope where
+ * HeroSplitImageCardOverlay flips the headline/link cascade — so the current crumb
+ * clears AA on the dark band (6.89–9.06:1) WITHOUT inverting the light-tint pages.
+ * A bare [data-audience] flip regressed /services/brand to 1:1 (0.122.2). */
+:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='brand'] .bds-breadcrumb {
   --text-secondary: var(--text-service-brand-on-dark);
   --text-muted: var(--text-service-brand-on-dark);
 }
 
-:root[data-theme="dark"] [data-audience='marketing'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='marketing'] .bds-breadcrumb {
   --text-secondary: var(--text-service-marketing-on-dark);
   --text-muted: var(--text-service-marketing-on-dark);
 }
 
-:root[data-theme="dark"] [data-audience='information'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='information'] .bds-breadcrumb {
   --text-secondary: var(--text-service-information-on-dark);
   --text-muted: var(--text-service-information-on-dark);
 }
 
-:root[data-theme="dark"] [data-audience='product'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='product'] .bds-breadcrumb {
   --text-secondary: var(--text-service-product-on-dark);
   --text-muted: var(--text-service-product-on-dark);
 }
 
-:root[data-theme="dark"] [data-audience='back-office'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='back-office'] .bds-breadcrumb {
   --text-secondary: var(--text-service-back-office-on-dark);
   --text-muted: var(--text-service-back-office-on-dark);
 }
 
 /* @deprecated alias of [data-audience='back-office'] — see above. */
-:root[data-theme="dark"] [data-audience='service'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='service'] .bds-breadcrumb {
   --text-secondary: var(--text-service-back-office-on-dark);
   --text-muted: var(--text-service-back-office-on-dark);
 }


### PR DESCRIPTION
0.122.2 (#1188) flipped the breadcrumb audience cascade to `*-on-dark` for **all** `[data-audience]` breadcrumbs in dark mode. That regressed the service-LINE hero (brikdesigns `/services/brand`), where the breadcrumb sits on a **fixed-light** `.service-surface` tint — on-dark (light) text collapsed to 1:1. Caught by brikdesigns axe on PR #689 (not merged; no shipped impact).

Scope the flip to `.bds-hero--with-pricing-card[data-audience]` — the exact context where HeroSplitImageCardOverlay flips its headline/link cascade, and the only place the band goes dark.

Verified both archetypes on the built `styles.css`:
- pricing-card dark band: current crumb **7.30:1** (on-dark) ✓
- service tint (line hero): current crumb **5.87:1** (stays on-light) ✓

Fixes the /services/brand regression from #1188 (#1187).