### PR TITLE
chore(release): @brikdesigns/bds 0.122.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.122.2",
+  "version": "0.122.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.122.2",
+      "version": "0.122.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.122.2",
+  "version": "0.122.3",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/lib-entry.cjs",


### PR DESCRIPTION
Release 0.122.3. Scopes the breadcrumb dark on-dark flip to the pricing-card band (#1190), fixing the /services/brand service-line regression from 0.122.2 (#1188). Tag `v0.122.3` after merge triggers the Release workflow.