### PR TITLE
fix(subnav): tokenize hardcoded header/nav/footer padding

### DIFF
--- a/components/ui/SubNavigation/SubNavigation.css
+++ b/components/ui/SubNavigation/SubNavigation.css
@@ -14,7 +14,7 @@
 /* ─── Header ─────────────────────────────────────────────────── */
 
 .bds-subnav__header {
-  padding: 24px 16px 16px; /* bds-lint-ignore — Figma sub-nav header spec */
+  padding: var(--padding-lg) var(--padding-md) var(--padding-md);
   border-bottom: var(--border-width-md) solid var(--border-secondary);
 }
 
@@ -22,7 +22,7 @@
 
 .bds-subnav__nav {
   flex: 1;
-  padding: 16px 8px; /* bds-lint-ignore — Figma sub-nav padding */
+  padding: var(--padding-md) var(--padding-tiny);
   display: flex;
   flex-direction: column;
   gap: var(--gap-xs);
@@ -31,7 +31,7 @@
 /* ─── Footer ─────────────────────────────────────────────────── */
 
 .bds-subnav__footer {
-  padding: 16px; /* bds-lint-ignore — Figma sub-nav footer spec */
+  padding: var(--padding-md);
   border-top: var(--border-width-md) solid var(--border-secondary);
 }
 }


### PR DESCRIPTION
## What

Tokenizes the three hardcoded padding declarations in `.bds-subnav__*`, removing the `bds-lint-ignore` escapes. Part of the #1146 polish batch (the SubNavigation-padding slice, rehomed from portal #1830); resolves the standalone duplicate #1147.

| Element | Before | After |
|---|---|---|
| `.bds-subnav__header` | `24px 16px 16px` | `var(--padding-lg) var(--padding-md) var(--padding-md)` |
| `.bds-subnav__nav` | `16px 8px` | `var(--padding-md) var(--padding-tiny)` |
| `.bds-subnav__footer` | `16px` | `var(--padding-md)` |

## Why it's a visual no-op

At the default spacing mode (no `[data-mode-spacing]`), the tokens resolve to exactly the prior px via `dist/tokens.css`:

- `--padding-lg` → `--space-600` → **24px**
- `--padding-md` → `--space-400` → **16px**
- `--padding-tiny` → `--space-200` → **8px**

Identical to the old hardcoded values. The change adds `[data-mode-spacing]` (compact/comfortable/spacious) scaling that the hardcoded px previously blocked — the intent of the space-mode work (#828).

## Verification

- `typecheck` ✓ · `lint-inline-var` clean ✓ · `lint-tokens` 0 errors ✓ · `canonical-check` 0 violations ✓
- `SubNavigation` unit tests 2/2 ✓
- Storybook build clean (514 stories); Chromatic pixel-diff **quota-blocked** (#771) — same wall #892 shipped through. Gated on the deterministic no-op proof above + the suite instead.

Closes #1147
Part of #1146