### PR TITLE
fix(devfeedback): derive page from URL slug on no-selection path (#890)

### DIFF
--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.test.ts
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { detectPageSlug } from './DevFeedbackWidget';
+
+/**
+ * Unit coverage for the no-selection page fallback (brik-bds#890).
+ *
+ * Runs in the `components` (node) project, so there is no ambient DOM — we stub
+ * `window` / `document` per case. This mirrors the inspector's `detectPage()`
+ * contract: the URL pathname slug is canonical; `document.title` is only the
+ * root-path fallback.
+ */
+describe('detectPageSlug', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const stub = (pathname: string, title = 'Brik Client Portal') => {
+    vi.stubGlobal('window', { location: { pathname } });
+    vi.stubGlobal('document', { title });
+  };
+
+  it('returns the route slug on a non-root path, not document.title', () => {
+    stub('/admin', 'Brik Client Portal');
+    expect(detectPageSlug()).toBe('admin');
+  });
+
+  it('strips leading and trailing slashes and preserves nested slugs', () => {
+    stub('/settings/services/', 'Brik Client Portal');
+    expect(detectPageSlug()).toBe('settings/services');
+  });
+
+  it('falls back to document.title on the root path (empty slug)', () => {
+    stub('/', 'Brik Client Portal');
+    expect(detectPageSlug()).toBe('Brik Client Portal');
+  });
+
+  it('returns undefined when both the slug and title are empty', () => {
+    stub('/', '   ');
+    expect(detectPageSlug()).toBeUndefined();
+  });
+
+  it('returns undefined in a non-browser (SSR) environment', () => {
+    // No window/document stubbed — both are undefined in node.
+    expect(detectPageSlug()).toBeUndefined();
+  });
+});

--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
@@ -131,12 +131,39 @@ export interface DevFeedbackWidgetProps {
   // Element context for the submission (feedback-contract 0.2.0). The widget is
   // a pure submission form — element selection lives in the inspector (ADR-007),
   // which emits `brik:inspect:report`. A host wires that event to these props.
-  /** Human page name (feedback-contract 0.2.0). Defaults to `document.title` when unset. */
+  /**
+   * Human page name (feedback-contract 0.2.0). When unset, derived from the
+   * URL pathname slug — `document.title` is only the last-resort fallback for
+   * the root path (brik-bds#890). Product apps share one templated `<title>`
+   * across routes, so the slug is what a triager needs.
+   */
   page?: string;
   /** Section label the picked element sits in (e.g. "hero"). From the inspector when wired. */
   section?: string;
   /** BDS component block class of the picked element (e.g. "bds-button"). From the inspector when wired. */
   component?: string;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+/**
+ * Page identity for the no-selection submission path. Mirrors `detectPage()`
+ * in `BrikDevBar/widgets/inspect-widget.js` (the inspector/selection path,
+ * brik-bds#885): the URL pathname slug is canonical and preferred, because
+ * product apps (portal, renew-pms) share one templated `<title>` across every
+ * route — so `document.title` is non-discriminating there (brik-bds#890 /
+ * brik-llm#979). `document.title` is kept only as a fallback for the root path,
+ * where the slug is empty.
+ */
+export function detectPageSlug(): string | undefined {
+  if (typeof window !== 'undefined' && window.location.pathname) {
+    const slug = window.location.pathname.replace(/^\/+|\/+$/g, '');
+    if (slug) return slug;
+  }
+  if (typeof document !== 'undefined') {
+    const title = document.title?.trim();
+    if (title) return title;
+  }
+  return undefined;
 }
 
 // ── Component ───────────────────────────────────────────────────────────
@@ -337,9 +364,7 @@ export function DevFeedbackWidget({
           // Element context (feedback-contract 0.2.0). Page name is always
           // known; section/component arrive as props when a host wires the
           // inspector's brik:inspect:report event (ADR-007).
-          page:
-            page ??
-            (typeof document !== 'undefined' ? document.title || undefined : undefined),
+          page: page ?? detectPageSlug(),
           section,
           component,
           // Optional screenshot (feedback-contract 0.7.0, brik-client-portal#1912).


### PR DESCRIPTION
## Summary
- fix(devfeedback): derive page from URL slug on no-selection path (#890)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)