### PR TITLE
fix(subnav): fixed 80px header bar via --size-1800 (#1146)

### DIFF
--- a/components/ui/SubNavigation/SubNavigation.css
+++ b/components/ui/SubNavigation/SubNavigation.css
@@ -14,7 +14,15 @@
 /* ─── Header ─────────────────────────────────────────────────── */
 
 .bds-subnav__header {
-  padding: var(--padding-lg) var(--padding-md) var(--padding-md);
+  /* Fixed 80px header bar (brik-bds#1146 / BACKLOG-485). Content is vertically
+     centered within the bar; horizontal padding is retained, vertical padding
+     is governed by the fixed height. box-sizing keeps the border-bottom inside
+     the 80px. */
+  height: var(--size-1800);
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  padding: 0 var(--padding-md);
   border-bottom: var(--border-width-md) solid var(--border-secondary);
 }
 


### PR DESCRIPTION
## Summary
- fix(subnav): fixed 80px header bar via --size-1800 (#1146)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)