### PR TITLE
fix(card): remove drop shadow from elevated + preset-control (#1146)

### DIFF
--- a/components/ui/Card/Card.css
+++ b/components/ui/Card/Card.css
@@ -27,7 +27,9 @@
 .bds-card--elevated {
   background-color: var(--surface-primary);
   border: none;
-  box-shadow: var(--box-shadow-md);
+  /* Drop shadow removed (brik-bds#1146 / BACKLOG-493) — elevation now reads via
+     the surface-primary fill, not a cast shadow. */
+  box-shadow: var(--box-shadow-none);
 }
 
 /* Borderless — transparent, no border, no shadow. For cards on a colored
@@ -129,7 +131,7 @@
 /* ─── Preset: control ─────────────────────────────────────────── */
 /* Settings/control card layout — replaces the legacy CardControl
  * component. Badge + (title + description) on the left, action on the
- * right. Surface uses primary background + muted border + small shadow
+ * right. Surface uses primary background + muted border (no shadow)
  * regardless of `variant` (variant is ignored for this preset). */
 
 .bds-card--preset-control {
@@ -140,7 +142,9 @@
   background-color: var(--surface-primary);
   border: var(--border-width-md) solid var(--border-muted);
   border-radius: var(--border-radius-lg);
-  box-shadow: var(--shadow-sm);
+  /* Drop shadow removed (brik-bds#1146 / BACKLOG-493) — control cards read flat
+     against the page; the muted border carries the boundary. */
+  box-shadow: var(--box-shadow-none);
   width: 100%;
   box-sizing: border-box;
   flex-wrap: wrap;
@@ -377,11 +381,13 @@
 /* Elevated override for display preset — same specificity rationale as the
  * borderless override above: .bds-card--preset-display redeclares border after
  * .bds-card--elevated in source order, so the ring needs explicit removal here.
- * surface-primary fill + box-shadow-md, no border. */
+ * surface-primary fill, no border, no shadow. */
 .bds-card--preset-display.bds-card--elevated {
   background-color: var(--surface-primary);
   border: none;
-  box-shadow: var(--box-shadow-md);
+  /* Drop shadow removed (brik-bds#1146 / BACKLOG-493) — matches the base
+     --elevated variant, which no longer casts a shadow. */
+  box-shadow: var(--box-shadow-none);
 }
 
 /* Service-line surface tint — a pale wash keyed to a service line, shared by

--- a/components/ui/Card/Card.mdx
+++ b/components/ui/Card/Card.mdx
@@ -20,7 +20,7 @@ Flexible content container. A default flexible content slot (no `preset`), plus 
 
 The `preset` prop selects the shape. Default (no `preset`) gives a flexible `children` slot composable with `CardTitle`, `CardDescription`, and `CardFooter`. Each preset locks the layout in exchange for a typed API.
 
-The default shape also takes a `variant`: `outlined` (default, secondary border), `brand` (primary-color border), `elevated` (drop shadow, no border), and `borderless`.
+The default shape also takes a `variant`: `outlined` (default, secondary border), `brand` (primary-color border), `elevated` (surface fill, no border, no shadow), and `borderless`.
 
 ### Borderless variant
 

--- a/components/ui/Card/Card.tsx
+++ b/components/ui/Card/Card.tsx
@@ -228,7 +228,7 @@ interface CardDisplayPresetProps extends CardBaseProps {
    * card grid sits on a colored surface (service-tier tint) where the
    * default white fill + border ring reads as visual noise.
    *
-   * `elevated` — surface-primary fill + `box-shadow-md`, no border. Use when
+   * `elevated` — surface-primary fill, no border, no shadow. Use when
    * a card grid on a colored surface still needs a contained "card" read but
    * the border ring is unwanted (the restored-fill counterpart to
    * `borderless`).


### PR DESCRIPTION
## Summary
- fix(card): remove drop shadow from elevated + preset-control (#1146)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)