### PR TITLE
feat(DevFeedbackWidget): forward componentTitle + domPath to /api/feedback

### DIFF
--- a/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
+++ b/components/ui/DevFeedbackWidget/DevFeedbackWidget.tsx
@@ -142,6 +142,10 @@ export interface DevFeedbackWidgetProps {
   section?: string;
   /** BDS component block class of the picked element (e.g. "bds-button"). From the inspector when wired. */
   component?: string;
+  /** Nearest BDS section title of the picked element (e.g. "Integrations"). From the inspector when wired (brik-client-portal#1760). */
+  componentTitle?: string;
+  /** Stable structural DOM path to the picked element. From the inspector when wired (brik-client-portal#1760). */
+  domPath?: string;
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -180,6 +184,8 @@ export function DevFeedbackWidget({
   page,
   section,
   component,
+  componentTitle,
+  domPath,
 }: DevFeedbackWidgetProps = {}) {
   const [open, setOpen] = useState(false);
   const [type, setType] = useState<string>('bug');
@@ -367,6 +373,12 @@ export function DevFeedbackWidget({
           page: page ?? detectPageSlug(),
           section,
           component,
+          // Element-identity fields (brik-client-portal#1760): the nearest BDS
+          // section title + a stable structural DOM path, so a ticket on a
+          // repeated-label field uniquely identifies the element. Wired from the
+          // inspector's brik:inspect:report event alongside section/component.
+          component_title: componentTitle,
+          dom_path: domPath,
           // Optional screenshot (feedback-contract 0.7.0, brik-client-portal#1912).
           // Downscaled + JPEG-compressed data URL; omitted when none attached.
           screenshot_base64: screenshot ?? undefined,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.123.1",
+  "version": "0.124.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/lib-entry.cjs",


### PR DESCRIPTION
## Summary
- feat(DevFeedbackWidget): forward componentTitle + domPath to /api/feedback

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)