### PR TITLE
feat(blueprints): consolidate bds-features — drop --branded-dark/3col (#1197)

### DIFF
--- a/content-system/blueprints/astro/Features3ColBrandedDark.astro
+++ b/content-system/blueprints/astro/Features3ColBrandedDark.astro
@@ -1,9 +1,14 @@
 ---
 /**
- * features_3col_branded_dark — dark section, 3-column grid of cards
- * filled with per-card brand colors. Each card sets `data-audience` to
- * re-bind `--brand-primary` for that subtree. Drives brikdesigns.com's
- * "Other Service Lines" cross-sell module.
+ * features_3col_branded_dark — Phase D Astro renderer for the `bds-features`
+ * family (brik-bds#1197). Twin of the React `<Features>` primitive. The former
+ * `bp-features-branded-dark` class is retired for the structural `bds-features`
+ * block; `--branded-dark` is banned by ADR-008 §3 (theme + appearance), and the
+ * `3col` count lives in the responsive grid CSS, not the name. The dark surface
+ * is the `--bds-features-bg` default, not a class. Dark section, grid of cards
+ * filled with per-card brand colors — each card sets `data-audience` to re-bind
+ * `--brand-primary` for that subtree. Drives brikdesigns.com's "Other Service
+ * Lines" cross-sell module.
  *
  * Spec: PR #477 (design proposal archived to brik-rag: blueprint-proposal-features-3col-branded-dark).
  *
@@ -24,37 +29,34 @@
  * ## Audience scope binding (consumer responsibility)
  *
  * Each card emits `data-audience={item.audience}`. Inside that subtree,
- * `--brand-primary` and `--background-brand-primary` resolve to the
- * audience's color — but ONLY if the consumer site defines the
- * `[data-audience='X']` cascade rules per
+ * `--brand-primary` and `--background-brand-primary` resolve to the audience's
+ * color — but ONLY if the consumer site defines the `[data-audience='X']`
+ * cascade rules per
  * `docs/theming/client-themes#per-audience-or-service-line-scope-binding`.
  * Without those rules, every card resolves to the global brand color
- * (visually broken — three identical cards).
- *
- * BDS ships the pattern, not the values. brikdesigns.com defines its
- * five service-line bindings (`brand` → yellow, `marketing` → green,
- * `information` → blue, `product` → purple, `service` → orange) in its
- * own globals.css.
+ * (visually broken — three identical cards). BDS ships the pattern, not the
+ * values.
  *
  * ## Renderer parity note
  *
- * Astro renderer uses HTML+CSS+tokens (matches existing blueprint
- * pattern). React renderer composes BDS primitives. Both emit the same
- * `data-audience` attributes so the consumer's cascade works in both
- * contexts.
+ * Astro renderer uses HTML+CSS+tokens (matches the existing blueprint
+ * pattern); React renderer composes BDS primitives (`<Card>`/`<ServiceTag>`).
+ * Both emit the same `data-audience` attributes and `bds-features__*` slots so
+ * the consumer's cascade works in both contexts. The one divergence: the React
+ * path shows a `<ServiceTag>` icon fallback when an image is absent; the Astro
+ * path shows the neutral blank brand block (no React primitive available).
  *
  * CSS custom properties — variation API:
- *   --bds-features-branded-dark-bg          (default: var(--page-inverse))
- *   --bds-features-branded-dark-card-radius (default: var(--border-radius-lg))
- *   --bds-features-branded-dark-gap         (default: var(--gap-lg))
- *   --bds-features-branded-dark-image-pad   (default: var(--padding-xl))
- *   --bds-features-branded-dark-hover-scale (default: 1.02 — set to 1 to disable)
+ *   --bds-features-bg          (default: var(--page-inverse))
+ *   --bds-features-card-radius (default: var(--border-radius-lg))
+ *   --bds-features-gap         (default: var(--gap-lg))
+ *   --bds-features-image-pad   (default: var(--padding-xl))
  *
- * a11y: section uses h2 + aria-labelledby; cards are <ul role="list">
- * of <li>; card title is h3 nested under section h2. Card title uses
- * --font-weight-bold and 18px to clear AA on saturated brand backgrounds
- * (white-on-poppy is 3.78:1 at 14px regular per BDS contrast burndown
- * #40 — bold weight + size promotion gets it into compliant range).
+ * a11y: section uses h2 + aria-labelledby; cards are <ul role="list"> of <li>;
+ * card title is h3 nested under section h2. Card title uses --font-weight-bold
+ * and 18px to clear AA on saturated brand backgrounds (white-on-poppy is
+ * 3.78:1 at 14px regular per BDS contrast burndown #40 — bold weight + size
+ * promotion gets it into compliant range).
  */
 import type { BlueprintProps } from './types';
 
@@ -65,57 +67,57 @@ const titleId = `${section.sectionKey}-title`;
 ---
 
 <section
-  class="bp-features-branded-dark"
+  class="bds-features"
   data-blueprint-key="features_3col_branded_dark"
   aria-labelledby={section.heading ? titleId : undefined}
 >
-  <div class="bp-features-branded-dark__container">
+  <div class="bds-features__container">
     {(section.heading || section.subheading || section.body) && (
-      <header class="bp-features-branded-dark__header">
+      <header class="bds-features__header">
         {section.subheading && (
-          <p class="bp-features-branded-dark__subtitle">{section.subheading}</p>
+          <p class="bds-features__subtitle">{section.subheading}</p>
         )}
         {section.heading && (
-          <h2 id={titleId} class="bp-features-branded-dark__title">
+          <h2 id={titleId} class="bds-features__title">
             {section.heading}
           </h2>
         )}
         {section.body && (
-          <p class="bp-features-branded-dark__lead">{section.body}</p>
+          <p class="bds-features__lead">{section.body}</p>
         )}
       </header>
     )}
 
-    <ul class="bp-features-branded-dark__grid" role="list">
+    <ul class="bds-features__grid" role="list">
       {section.items.map((item) => (
-        <li class="bp-features-branded-dark__item">
+        <li class="bds-features__item">
           <article
-            class="bp-features-branded-dark__card"
+            class="bds-features__card"
             data-audience={item.audience ?? undefined}
           >
-            <a class="bp-features-branded-dark__card-link" href={item.href ?? '#'}>
-              <div class="bp-features-branded-dark__media">
+            <a class="bds-features__card-link" href={item.href ?? '#'}>
+              <div class="bds-features__media">
                 {item.imageUrl ? (
                   <img
                     src={item.imageUrl}
                     alt={item.imageAlt ?? ''}
-                    class="bp-features-branded-dark__image"
+                    class="bds-features__image"
                     loading="lazy"
                     decoding="async"
                   />
                 ) : (
-                  <span class="bp-features-branded-dark__image-fallback" aria-hidden="true" />
+                  <span class="bds-features__image-fallback" aria-hidden="true" />
                 )}
               </div>
 
-              <div class="bp-features-branded-dark__content">
-                <h3 class="bp-features-branded-dark__title">{item.title}</h3>
+              <div class="bds-features__content">
+                <h3 class="bds-features__title">{item.title}</h3>
                 {item.description && (
-                  <p class="bp-features-branded-dark__description">{item.description}</p>
+                  <p class="bds-features__description">{item.description}</p>
                 )}
-                <span class="bp-features-branded-dark__cta">
+                <span class="bds-features__cta">
                   Learn more
-                  <span aria-hidden="true" class="bp-features-branded-dark__cta-arrow">→</span>
+                  <span aria-hidden="true" class="bds-features__cta-arrow">→</span>
                 </span>
               </div>
             </a>
@@ -127,21 +129,21 @@ const titleId = `${section.sectionKey}-title`;
 </section>
 
 <style>
-  .bp-features-branded-dark {
-    background: var(--bds-features-branded-dark-bg, var(--page-inverse));
+  .bds-features {
+    background: var(--bds-features-bg, var(--page-inverse));
     padding-block: clamp(var(--padding-xl), 9vw, var(--padding-huge));
     color: var(--text-on-color-dark);
   }
 
-  .bp-features-branded-dark__container {
-    max-width: 1280px;
+  .bds-features__container {
+    max-width: var(--size-container-xl, 1280px);
     margin-inline: auto;
     padding-inline: var(--padding-lg);
   }
 
   /* ── Section header ─────────────────────────────────────────── */
 
-  .bp-features-branded-dark__header {
+  .bds-features__header {
     text-align: center;
     max-width: 72ch;
     margin-inline: auto;
@@ -151,7 +153,7 @@ const titleId = `${section.sectionKey}-title`;
     gap: var(--gap-md);
   }
 
-  .bp-features-branded-dark__subtitle {
+  .bds-features__subtitle {
     margin: 0;
     font-family: var(--font-family-label);
     font-size: var(--label-lg);
@@ -162,7 +164,7 @@ const titleId = `${section.sectionKey}-title`;
     opacity: 0.85;
   }
 
-  .bp-features-branded-dark__header .bp-features-branded-dark__title {
+  .bds-features__header .bds-features__title {
     margin: 0;
     font-family: var(--font-family-heading);
     font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-xl));
@@ -171,7 +173,7 @@ const titleId = `${section.sectionKey}-title`;
     color: var(--text-on-color-dark);
   }
 
-  .bp-features-branded-dark__lead {
+  .bds-features__lead {
     margin: 0;
     font-family: var(--font-family-body);
     font-size: var(--heading-sm);
@@ -182,37 +184,37 @@ const titleId = `${section.sectionKey}-title`;
 
   /* ── Card grid ──────────────────────────────────────────────── */
 
-  .bp-features-branded-dark__grid {
+  .bds-features__grid {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
     grid-template-columns: 1fr;
-    gap: var(--bds-features-branded-dark-gap, var(--gap-lg));
+    gap: var(--bds-features-gap, var(--gap-lg));
   }
 
   @media (min-width: 768px) {
-    .bp-features-branded-dark__grid {
+    .bds-features__grid {
       grid-template-columns: repeat(2, 1fr);
     }
   }
 
   @media (min-width: 992px) {
-    .bp-features-branded-dark__grid {
+    .bds-features__grid {
       grid-template-columns: repeat(3, 1fr);
     }
   }
 
-  .bp-features-branded-dark__item {
+  .bds-features__item {
     display: flex;
   }
 
   /* ── Card ───────────────────────────────────────────────────── */
 
-  .bp-features-branded-dark__card {
+  .bds-features__card {
     width: 100%;
     background: var(--background-brand-primary);
-    border-radius: var(--bds-features-branded-dark-card-radius, var(--border-radius-lg));
+    border-radius: var(--bds-features-card-radius, var(--border-radius-lg));
     overflow: hidden;
     transform: translateY(0) scale(1);
     transition:
@@ -220,12 +222,12 @@ const titleId = `${section.sectionKey}-title`;
       box-shadow 200ms var(--easing-ease-out);
   }
 
-  .bp-features-branded-dark__card:hover {
-    transform: scale(var(--bds-features-branded-dark-hover-scale, 1.02));
+  .bds-features__card:hover {
+    transform: scale(1.02);
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
   }
 
-  .bp-features-branded-dark__card-link {
+  .bds-features__card-link {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -233,30 +235,30 @@ const titleId = `${section.sectionKey}-title`;
     color: inherit;
   }
 
-  .bp-features-branded-dark__card-link:focus-visible {
+  .bds-features__card-link:focus-visible {
     outline: 3px solid var(--text-on-color-dark);
     outline-offset: -3px;
   }
 
   /* ── Media (top illustration area) ──────────────────────────── */
 
-  .bp-features-branded-dark__media {
+  .bds-features__media {
     aspect-ratio: var(--aspect-1-1);
-    padding: var(--bds-features-branded-dark-image-pad, var(--padding-xl));
+    padding: var(--bds-features-image-pad, var(--padding-xl));
     display: flex;
     align-items: center;
     justify-content: center;
     overflow: hidden;
   }
 
-  .bp-features-branded-dark__image {
+  .bds-features__image {
     max-width: 100%;
     max-height: 100%;
     object-fit: contain;
     display: block;
   }
 
-  .bp-features-branded-dark__image-fallback {
+  .bds-features__image-fallback {
     width: 60%;
     aspect-ratio: var(--aspect-1-1);
     border-radius: 50%;
@@ -266,7 +268,7 @@ const titleId = `${section.sectionKey}-title`;
 
   /* ── Card body ──────────────────────────────────────────────── */
 
-  .bp-features-branded-dark__content {
+  .bds-features__content {
     padding: var(--padding-lg);
     display: flex;
     flex-direction: column;
@@ -276,7 +278,7 @@ const titleId = `${section.sectionKey}-title`;
 
   /* Bold weight + 18px size on title — the AA-clearing posture for
    * white-on-poppy and similar saturated brand backgrounds. */
-  .bp-features-branded-dark__card .bp-features-branded-dark__title {
+  .bds-features__card .bds-features__title {
     margin: 0;
     font-family: var(--font-family-heading);
     font-size: var(--heading-md);
@@ -288,7 +290,7 @@ const titleId = `${section.sectionKey}-title`;
   /* 16px regular description — clears 3:1 at large-text threshold.
    * If consumer atmospheres tighten the contrast budget below this, the
    * fix is on the brand-color side, not here. */
-  .bp-features-branded-dark__description {
+  .bds-features__description {
     margin: 0;
     font-family: var(--font-family-body);
     font-size: var(--heading-sm);
@@ -296,7 +298,7 @@ const titleId = `${section.sectionKey}-title`;
     color: var(--text-on-color-dark);
   }
 
-  .bp-features-branded-dark__cta {
+  .bds-features__cta {
     margin-top: auto;
     display: inline-flex;
     align-items: center;
@@ -308,13 +310,13 @@ const titleId = `${section.sectionKey}-title`;
     line-height: 1.4;
   }
 
-  .bp-features-branded-dark__cta-arrow {
+  .bds-features__cta-arrow {
     display: inline-block;
     transition: transform 200ms var(--easing-ease-out);
   }
 
-  .bp-features-branded-dark__card-link:hover .bp-features-branded-dark__cta-arrow,
-  .bp-features-branded-dark__card-link:focus-visible .bp-features-branded-dark__cta-arrow {
+  .bds-features__card-link:hover .bds-features__cta-arrow,
+  .bds-features__card-link:focus-visible .bds-features__cta-arrow {
     transform: translateX(4px);
   }
 </style>

--- a/content-system/blueprints/react/Features.css
+++ b/content-system/blueprints/react/Features.css
@@ -1,31 +1,33 @@
 /*
- * Features3ColBrandedDark — React renderer styles.
+ * Features — `bds-features` section styles (Phase D, brik-bds#1197).
+ * Consolidates the former bp-features-branded-dark. The `--branded-dark`
+ * class descriptor is gone (ADR-008 §3 — theme + appearance are not names);
+ * the dark surface is now the `--bds-features-bg` default, and the column
+ * count lives here as a responsive grid, never in a class name.
  *
- * Mirrors the Astro twin's visual exactly. Card backgrounds resolve
- * via `--background-brand-primary`, which is re-bound by the consumer
- * site's `[data-audience='X']` cascade rules. BDS ships the pattern;
- * the consumer (brikdesigns.com) ships the audience-specific values.
- *
- * Bold + 18px title, 16px regular description — the AA-clearing
- * posture for white-on-saturated-brand backgrounds (BDS contrast
- * burndown #40).
+ * Bold + 18px card title, 16px regular description — the AA-clearing posture
+ * for white-on-saturated-brand backgrounds (BDS contrast burndown #40). Card
+ * backgrounds resolve via `--background-brand-primary`, re-bound per-card by
+ * the consumer's `[data-audience='X']` cascade. BDS ships the pattern; the
+ * consumer ships the audience-specific values. Tier-4 `--bds-features-*` hooks
+ * let a consumer retheme without forking the block.
  */
 
-.bp-features-branded-dark {
-  background: var(--bds-features-branded-dark-bg, var(--page-inverse));
+.bds-features {
+  background: var(--bds-features-bg, var(--page-inverse));
   padding-block: clamp(var(--padding-xl), 9vw, var(--padding-huge));
   color: var(--text-on-color-dark);
 }
 
-.bp-features-branded-dark__container {
-  max-width: 1280px;
+.bds-features__container {
+  max-width: var(--size-container-xl, 1280px);
   margin-inline: auto;
   padding-inline: var(--padding-lg);
 }
 
 /* ── Section header ────────────────────────────────────────────── */
 
-.bp-features-branded-dark__header {
+.bds-features__header {
   text-align: center;
   max-width: 72ch;
   margin-inline: auto;
@@ -33,7 +35,7 @@
   align-items: center;
 }
 
-.bp-features-branded-dark__subtitle {
+.bds-features__subtitle {
   margin: 0;
   font-family: var(--font-family-label);
   font-size: var(--label-lg);
@@ -44,7 +46,7 @@
   opacity: 0.85;
 }
 
-.bp-features-branded-dark__title {
+.bds-features__header .bds-features__title {
   margin: 0;
   font-family: var(--font-family-heading);
   font-size: clamp(var(--heading-lg), 3.5vw, var(--heading-huge));
@@ -53,7 +55,7 @@
   color: var(--text-on-color-dark);
 }
 
-.bp-features-branded-dark__lead {
+.bds-features__lead {
   margin: 0;
   font-family: var(--font-family-body);
   font-size: var(--heading-sm);
@@ -64,41 +66,41 @@
 
 /* ── Card grid ─────────────────────────────────────────────────── */
 
-.bp-features-branded-dark__grid {
+.bds-features__grid {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--bds-features-branded-dark-gap, var(--gap-lg));
+  gap: var(--bds-features-gap, var(--gap-lg));
 }
 
 @media (min-width: 768px) {
-  .bp-features-branded-dark__grid {
+  .bds-features__grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @media (min-width: 992px) {
-  .bp-features-branded-dark__grid {
+  .bds-features__grid {
     grid-template-columns: repeat(3, 1fr);
   }
 }
 
-.bp-features-branded-dark__item {
+.bds-features__item {
   display: flex;
 }
 
 /* ── Card ──────────────────────────────────────────────────────── */
 
-.bp-features-branded-dark__card {
+.bds-features__card {
   width: 100%;
   /* Override the BDS Card outlined variant — branded cards read as
    * filled panels. Background resolves via --background-brand-primary,
    * re-bound per-card by the consumer's [data-audience='X'] cascade. */
   background: var(--background-brand-primary);
   border: none;
-  border-radius: var(--bds-features-branded-dark-card-radius, var(--border-radius-lg));
+  border-radius: var(--bds-features-card-radius, var(--border-radius-lg));
   overflow: hidden;
   transform: translateY(0) scale(1);
   transition:
@@ -106,12 +108,12 @@
     box-shadow 200ms var(--easing-ease-out);
 }
 
-.bp-features-branded-dark__card:hover {
-  transform: scale(var(--bds-features-branded-dark-hover-scale, 1.02));
+.bds-features__card:hover {
+  transform: scale(1.02);
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
 }
 
-.bp-features-branded-dark__card-link {
+.bds-features__card-link {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -119,30 +121,30 @@
   color: inherit;
 }
 
-.bp-features-branded-dark__card-link:focus-visible {
+.bds-features__card-link:focus-visible {
   outline: 3px solid var(--text-on-color-dark);
   outline-offset: -3px;
 }
 
 /* ── Media (top illustration area) ─────────────────────────────── */
 
-.bp-features-branded-dark__media {
+.bds-features__media {
   aspect-ratio: var(--aspect-1-1);
-  padding: var(--bds-features-branded-dark-image-pad, var(--padding-xl));
+  padding: var(--bds-features-image-pad, var(--padding-xl));
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
 }
 
-.bp-features-branded-dark__image {
+.bds-features__image {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
   display: block;
 }
 
-.bp-features-branded-dark__image-fallback {
+.bds-features__image-fallback {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -151,7 +153,7 @@
   transform-origin: center;
 }
 
-.bp-features-branded-dark__image-fallback--blank {
+.bds-features__image-fallback--blank {
   width: 60%;
   aspect-ratio: var(--aspect-1-1);
   border-radius: 50%;
@@ -162,7 +164,7 @@
 
 /* ── Card body ─────────────────────────────────────────────────── */
 
-.bp-features-branded-dark__content {
+.bds-features__content {
   padding: var(--padding-lg);
   display: flex;
   flex-direction: column;
@@ -171,7 +173,7 @@
 }
 
 /* Bold + 18px — AA-clearing posture for white-on-saturated-brand. */
-.bp-features-branded-dark__title {
+.bds-features__card .bds-features__title {
   margin: 0;
   font-family: var(--font-family-heading);
   font-size: var(--heading-md);
@@ -181,7 +183,7 @@
 }
 
 /* 16px regular — clears 3:1 at the large-text threshold. */
-.bp-features-branded-dark__description {
+.bds-features__description {
   margin: 0;
   font-family: var(--font-family-body);
   font-size: var(--heading-sm);
@@ -189,7 +191,7 @@
   color: var(--text-on-color-dark);
 }
 
-.bp-features-branded-dark__cta {
+.bds-features__cta {
   margin-top: auto;
   display: inline-flex;
   align-items: center;
@@ -201,12 +203,12 @@
   line-height: 1.4;
 }
 
-.bp-features-branded-dark__cta-arrow {
+.bds-features__cta-arrow {
   display: inline-block;
   transition: transform 200ms var(--easing-ease-out);
 }
 
-.bp-features-branded-dark__card-link:hover .bp-features-branded-dark__cta-arrow,
-.bp-features-branded-dark__card-link:focus-visible .bp-features-branded-dark__cta-arrow {
+.bds-features__card-link:hover .bds-features__cta-arrow,
+.bds-features__card-link:focus-visible .bds-features__cta-arrow {
   transform: translateX(4px);
 }

--- a/content-system/blueprints/react/Features.stories.tsx
+++ b/content-system/blueprints/react/Features.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { JSX } from 'react';
+
+import { Features } from './Features';
+
+/* ─── Demo data-audience cascade ────────────────────────────────────
+ *
+ * BDS ships the scope-binding pattern but not audience-specific values
+ * — those live in each consumer's globals.css. Storybook needs the
+ * binding present somewhere so cards visualize in distinct brand
+ * colors. This `<style>` block is a representative example of what a
+ * consumer site would declare for its audience verticals.
+ */
+const audienceCascadeStyles = `
+[data-audience='brand'] {
+  --background-brand-primary: var(--theme-yellow-yellow-light);
+  --brand-primary: var(--theme-yellow-yellow-light);
+  --text-brand-primary: var(--theme-yellow-yellow-dark);
+}
+[data-audience='marketing'] {
+  --background-brand-primary: var(--theme-green-green-light);
+  --brand-primary: var(--theme-green-green-light);
+  --text-brand-primary: var(--theme-green-green-dark);
+}
+[data-audience='information'] {
+  --background-brand-primary: var(--color-blue-light);
+  --text-brand-primary: var(--color-blue-dark);
+}
+[data-audience='product'] {
+  --background-brand-primary: var(--theme-purple-purple-light);
+  --brand-primary: var(--theme-purple-purple-light);
+  --text-brand-primary: var(--theme-purple-purple-dark);
+}
+[data-audience='service'] {
+  --background-brand-primary: var(--theme-orange-orange-light);
+  --brand-primary: var(--theme-orange-orange-light);
+  --text-brand-primary: var(--theme-orange-orange-dark);
+}
+`;
+
+const items = [
+  {
+    title: 'Capability one',
+    description:
+      'A two-line card description that sets the type rhythm without competing with the title.',
+    href: '#',
+    audience: 'brand' as const,
+  },
+  {
+    title: 'Capability two',
+    description:
+      'A two-line card description that sets the type rhythm without competing with the title.',
+    href: '#',
+    audience: 'marketing' as const,
+  },
+  {
+    title: 'Capability three',
+    description:
+      'A two-line card description that sets the type rhythm without competing with the title.',
+    href: '#',
+    audience: 'service' as const,
+  },
+];
+
+const withAudienceCascade = (Story: () => JSX.Element) => (
+  <>
+    <style dangerouslySetInnerHTML={{ __html: audienceCascadeStyles }} />
+    <Story />
+  </>
+);
+
+const meta: Meta<typeof Features> = {
+  title: 'Sections/Blueprints/features',
+  component: Features,
+  tags: ['surface-web', 'surface-shared'],
+  decorators: [withAudienceCascade],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The `bds-features` feature-grid section primitive (brik-bds#1197) — the Phase D consolidation of the features family, retiring the ADR-008-banned `bp-features-branded-dark` (`--dark` = theme, `--branded` = appearance, `3col` = count). Single-member family, so no layout modifier: the block is the responsive grid. The dark surface is the `--bds-features-bg` default, not a class name. Each card emits `data-audience` to re-bind `--background-brand-primary` per the BDS scope-binding pattern; stories include a representative cascade block. Card title uses bold weight + 18px, description 16px regular — the AA-clearing posture for white-on-saturated-brand backgrounds (BDS contrast burndown #40).',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Features>;
+
+/* ─── Stories ──────────────────────────────────────────────────── */
+
+/**
+ * @summary Playground — three audience-distinct cards, the canonical fixture.
+ */
+export const Playground: Story = {
+  args: {
+    sectionKey: 'features-default',
+    title: 'Featured capabilities',
+    body: 'A short section subheading that frames the cards below — typically a cross-sell or capability roll-up.',
+    items,
+  },
+};
+
+/**
+ * @summary Wrapped — four+ cards force the grid to a second row.
+ *
+ * Distinct meaningful state from `Playground`: the row-wrap behavior at the
+ * desktop breakpoint is the layout property worth verifying. Per-card content
+ * variants (missing image, audience accent) are exercised by the leaf `Card`
+ * / `ServiceTag` stories, not duplicated here.
+ */
+export const Wrapped: Story = {
+  args: {
+    sectionKey: 'features-wrapped',
+    title: 'Featured capabilities',
+    body: 'A short section subheading that frames the cards below — typically a cross-sell or capability roll-up.',
+    items: [
+      ...items,
+      {
+        title: 'Capability four',
+        description:
+          'A two-line card description that sets the type rhythm without competing with the title.',
+        href: '#',
+        audience: 'information' as const,
+      },
+    ],
+  },
+};

--- a/content-system/blueprints/react/Features.tsx
+++ b/content-system/blueprints/react/Features.tsx
@@ -1,0 +1,190 @@
+/**
+ * Features — canonical `bds-features` feature-grid section primitive
+ * (Phase D, brik-bds#1197). Consolidates the features blueprint family,
+ * retiring the legacy `bp-features-branded-dark` class — whose
+ * `--branded-dark` descriptor is banned by ADR-008 §3 (`--dark` = theme,
+ * `--branded` = appearance) and whose `3col` count belonged in CSS, never
+ * the class name.
+ *
+ * `features` is a single-member family, so there is NO layout modifier
+ * (ADR-008 §3 — a modifier needs a sibling layout to contrast against): the
+ * block *is* the feature grid. Column count is a responsive CSS concern
+ * (1 → 2 → 3), not a class token. The dark surface is a themeable default
+ * via the `--bds-features-bg` Tier-4 hook (fallback `--page-inverse`), not a
+ * name — the same "surface is a default, not a class" move ADR-008 applied to
+ * `bds-cta`.
+ *
+ * The spine is an optional section header (eyebrow → `h2` → lead) above a
+ * `<ul role="list">` grid of feature cards. Each card is a linked `<Card>`
+ * with a media area (image, a `<ServiceTag>` icon fallback, or a blank brand
+ * block), an `h3` title, an optional description, and a "Learn more" CTA.
+ *
+ * ## Audience scope binding
+ *
+ * Each card emits `data-audience={item.audience}` to re-bind
+ * `--background-brand-primary` for that subtree. BDS ships the pattern, not
+ * the values: the consumer defines the `[data-audience='X']` cascade rules in
+ * its own globals.css. Without them, every card resolves to the global brand
+ * color (three identical cards — a missing-cascade bug on the consumer side,
+ * not a renderer bug). Storybook demonstrates the pattern via a stories-only
+ * cascade block.
+ *
+ * Slots (all pass `scripts/slot-pattern-check.mjs`):
+ *   bds-features, __container, __header, __subtitle, __title, __lead, __grid,
+ *   __item, __card, __card-link, __media, __image, __image-fallback,
+ *   __content, __description, __cta, __cta-arrow
+ *
+ * a11y: section uses `h2` + aria-labelledby; cards are a `<ul role="list">`;
+ * card title is an `h3`. Card title uses `--font-weight-bold` + 18px and the
+ * description 16px regular to clear AA on saturated brand backgrounds (BDS
+ * contrast burndown #40 — full resolution requires brand-color adjustment,
+ * tracked separately).
+ *
+ * @summary Feature grid — optional header above a responsive grid of brand-colored, audience-scoped feature cards on a dark default surface.
+ */
+import { type HTMLAttributes } from 'react';
+
+import { Card, ServiceTag, Stack, type ServiceLine } from '../../../components';
+import { bdsClass } from '../../../components/utils';
+import './Features.css';
+
+/** A single feature card. */
+export interface FeatureItem {
+  /** Card title. Rendered as `h3`. */
+  title: string;
+  /** Optional one-to-two-line card description. */
+  description?: string;
+  /** "Learn more" link target. Defaults to `#`. */
+  href?: string;
+  /** Optional top illustration. Omitted → a `ServiceTag` icon or blank block. */
+  imageUrl?: string;
+  /** Alt text for `imageUrl`. Empty (decorative) when omitted. */
+  imageAlt?: string;
+  /**
+   * Audience slug emitted as `data-audience` for per-card brand-color scope
+   * binding, and used for the `ServiceTag` icon fallback when no `imageUrl`.
+   */
+  audience?: ServiceLine;
+}
+
+export interface FeaturesProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * Stable section identifier. Drives the `aria-labelledby` id and card keys
+   * — keep it stable across renders for a given section.
+   */
+  sectionKey: string;
+  /** Optional section heading. Renders as `<h2>`. */
+  title?: string;
+  /** Optional uppercase eyebrow above the heading. */
+  subtitle?: string;
+  /** Optional lead paragraph under the heading. */
+  body?: string;
+  /** The feature cards. Typically 3; the grid wraps to a second row beyond. */
+  items: FeatureItem[];
+}
+
+export function Features({
+  sectionKey,
+  title,
+  subtitle,
+  body,
+  items,
+  className,
+  ...rest
+}: FeaturesProps) {
+  const titleId = `${sectionKey}-title`;
+  const hasHeader = Boolean(title || subtitle || body);
+
+  return (
+    <section
+      className={bdsClass('bds-features', className)}
+      data-blueprint-key="features_3col_branded_dark"
+      aria-labelledby={title ? titleId : undefined}
+      {...rest}
+    >
+      <div className="bds-features__container">
+        {hasHeader && (
+          <Stack as="header" gap="md" className="bds-features__header">
+            {subtitle && <p className="bds-features__subtitle">{subtitle}</p>}
+            {title && (
+              <h2 id={titleId} className="bds-features__title">
+                {title}
+              </h2>
+            )}
+            {body && <p className="bds-features__lead">{body}</p>}
+          </Stack>
+        )}
+
+        <ul className="bds-features__grid" role="list">
+          {items.map((item, idx) => {
+            const audience = item.audience ?? null;
+            return (
+              <li key={`${sectionKey}-${idx}`} className="bds-features__item">
+                <Card
+                  variant="outlined"
+                  padding="none"
+                  className="bds-features__card"
+                  data-audience={audience ?? undefined}
+                >
+                  <a
+                    className="bds-features__card-link"
+                    href={item.href ?? '#'}
+                  >
+                    <div className="bds-features__media">
+                      {item.imageUrl ? (
+                        <img
+                          src={item.imageUrl}
+                          alt={item.imageAlt ?? ''}
+                          className="bds-features__image"
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      ) : audience ? (
+                        <span
+                          className="bds-features__image-fallback"
+                          aria-hidden="true"
+                        >
+                          <ServiceTag
+                            category={audience}
+                            variant="icon"
+                            size="lg"
+                            serviceName={item.title}
+                          />
+                        </span>
+                      ) : (
+                        <span
+                          className="bds-features__image-fallback bds-features__image-fallback--blank"
+                          aria-hidden="true"
+                        />
+                      )}
+                    </div>
+
+                    <div className="bds-features__content">
+                      <h3 className="bds-features__title">{item.title}</h3>
+                      {item.description && (
+                        <p className="bds-features__description">
+                          {item.description}
+                        </p>
+                      )}
+                      <span className="bds-features__cta">
+                        Learn more
+                        <span
+                          aria-hidden="true"
+                          className="bds-features__cta-arrow"
+                        >
+                          →
+                        </span>
+                      </span>
+                    </div>
+                  </a>
+                </Card>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+export default Features;

--- a/content-system/blueprints/react/Features3ColBrandedDark.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.tsx
@@ -1,163 +1,42 @@
 /**
- * Features3ColBrandedDark — React renderer for the
- * `features_3col_branded_dark` blueprint. Dark section, 3-column grid
- * of cards filled with per-card brand colors via `data-audience`
- * scope binding. Drives brikdesigns.com's "Other Service Lines"
- * cross-sell module on `/services/{slug}` pages.
+ * Features3ColBrandedDark — Phase D adapter (deprecated direct path).
  *
- * Astro twin lives at `../astro/Features3ColBrandedDark.astro` and
- * mirrors the same DOM shape with the same `data-audience` attributes
- * — the consumer site's `[data-audience='X']` cascade rules drive
- * both renderers identically.
+ * After brik-bds#1197 the canonical primitive is `<Features>` (the
+ * `bds-features` feature-grid section block). This file remains as an adapter
+ * so the legacy `features_3col_branded_dark` blueprint key keeps dispatching
+ * through `BlueprintDispatcher` with the same section-data contract that
+ * AI-generated pages expect — it maps `section.*` → `<Features>` props.
  *
- * Contract: BlueprintProps. Per-card data on `section.items[]`; each
- * item carries an `audience` slug that emits `data-audience` on the
- * card, re-binding `--brand-primary` for that subtree.
+ * New consumers should compose `<Features>` directly. This adapter retires
+ * alongside Phase E.
  *
- * ## Audience scope binding
- *
- * BDS ships the pattern, not the audience-specific values. The
- * consumer (brikdesigns.com) defines `[data-audience='brand']`,
- * `[data-audience='marketing']`, etc. in its globals.css with the
- * matching service-line color tokens. Without those rules in place,
- * cards render in the global brand color and the visual collapses to
- * "three identical cards" — not a renderer bug, a missing-cascade bug
- * on the consumer side.
- *
- * Storybook demonstrates the pattern via a stories-only cascade block.
- *
- * CSS custom properties — variation API:
- *   --bds-features-branded-dark-bg          (default: var(--page-inverse))
- *   --bds-features-branded-dark-card-radius (default: var(--border-radius-lg))
- *   --bds-features-branded-dark-gap         (default: var(--gap-lg))
- *   --bds-features-branded-dark-image-pad   (default: var(--padding-xl))
- *   --bds-features-branded-dark-hover-scale (default: 1.02 — set to 1 to disable)
- *
- * a11y: section uses h2 + aria-labelledby; cards are an unordered
- * list with role="list"; card title is h3. Card title uses
- * `--font-weight-bold` and 18px to clear AA on saturated brand
- * backgrounds; description uses 16px regular to clear at the
- * large-text 3:1 threshold (BDS contrast burndown #40 — full
- * resolution requires brand-color adjustment, tracked separately).
- *
- * @summary Dark section, 3-col grid of brand-colored cards (per-audience scope binding).
+ * @deprecated Use `<Features>` directly.
+ * @summary Legacy adapter — maps section data onto `<Features>`.
  */
-import { Card, ServiceTag, Stack, type ServiceLine } from '../../../components';
-
+import type { ServiceLine } from '../../../components';
 import type { BlueprintProps } from '../astro/types';
-import './Features3ColBrandedDark.css';
+import { Features, type FeatureItem } from './Features';
 
 interface Props extends BlueprintProps {}
 
 export function Features3ColBrandedDark({ section }: Props) {
-  const titleId = `${section.sectionKey}-title`;
+  const items: FeatureItem[] = section.items.map((item) => ({
+    title: item.title,
+    description: item.description ?? undefined,
+    href: item.href ?? undefined,
+    imageUrl: item.imageUrl ?? undefined,
+    imageAlt: item.imageAlt ?? undefined,
+    audience: (item.audience ?? undefined) as ServiceLine | undefined,
+  }));
 
   return (
-    <section
-      className="bp-features-branded-dark"
-      data-blueprint-key="features_3col_branded_dark"
-      aria-labelledby={section.heading ? titleId : undefined}
-    >
-      <div className="bp-features-branded-dark__container">
-        {(section.heading || section.subheading || section.body) && (
-          <Stack
-            as="header"
-            gap="md"
-            className="bp-features-branded-dark__header"
-          >
-            {section.subheading && (
-              <p className="bp-features-branded-dark__subtitle">
-                {section.subheading}
-              </p>
-            )}
-            {section.heading && (
-              <h2
-                id={titleId}
-                className="bp-features-branded-dark__title"
-              >
-                {section.heading}
-              </h2>
-            )}
-            {section.body && (
-              <p className="bp-features-branded-dark__lead">{section.body}</p>
-            )}
-          </Stack>
-        )}
-
-        <ul className="bp-features-branded-dark__grid" role="list">
-          {section.items.map((item, idx) => {
-            const audience = item.audience ?? null;
-            return (
-              <li
-                key={`${section.sectionKey}-${idx}`}
-                className="bp-features-branded-dark__item"
-              >
-                <Card
-                  variant="outlined"
-                  padding="none"
-                  className="bp-features-branded-dark__card"
-                  data-audience={audience ?? undefined}
-                >
-                  <a
-                    className="bp-features-branded-dark__card-link"
-                    href={item.href ?? '#'}
-                  >
-                    <div className="bp-features-branded-dark__media">
-                      {item.imageUrl ? (
-                        <img
-                          src={item.imageUrl}
-                          alt={item.imageAlt ?? ''}
-                          className="bp-features-branded-dark__image"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      ) : audience ? (
-                        <span
-                          className="bp-features-branded-dark__image-fallback"
-                          aria-hidden="true"
-                        >
-                          <ServiceTag
-                            category={audience as ServiceLine}
-                            variant="icon"
-                            size="lg"
-                            serviceName={item.title}
-                          />
-                        </span>
-                      ) : (
-                        <span
-                          className="bp-features-branded-dark__image-fallback bp-features-branded-dark__image-fallback--blank"
-                          aria-hidden="true"
-                        />
-                      )}
-                    </div>
-
-                    <div className="bp-features-branded-dark__content">
-                      <h3 className="bp-features-branded-dark__title">
-                        {item.title}
-                      </h3>
-                      {item.description && (
-                        <p className="bp-features-branded-dark__description">
-                          {item.description}
-                        </p>
-                      )}
-                      <span className="bp-features-branded-dark__cta">
-                        Learn more
-                        <span
-                          aria-hidden="true"
-                          className="bp-features-branded-dark__cta-arrow"
-                        >
-                          →
-                        </span>
-                      </span>
-                    </div>
-                  </a>
-                </Card>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-    </section>
+    <Features
+      sectionKey={section.sectionKey}
+      title={section.heading ?? undefined}
+      subtitle={section.subheading ?? undefined}
+      body={section.body ?? undefined}
+      items={items}
+    />
   );
 }
 

--- a/content-system/blueprints/react/index.ts
+++ b/content-system/blueprints/react/index.ts
@@ -79,6 +79,16 @@ export type { HeroProps, HeroLayout } from './Hero';
 export { About } from './About';
 export type { AboutProps, AboutTestimonial } from './About';
 
+// `<Features>` — the `bds-features` feature-grid section primitive
+// (post-brik-bds#1197 consolidation). Props-based: an optional header above a
+// responsive grid of brand-colored, audience-scoped feature cards on a dark
+// default surface. Replaces the ADR-008-banned `bp-features-branded-dark`
+// (`--dark` = theme, `--branded` = appearance, `3col` = count). New consumers
+// compose this directly; the `features_3col_branded_dark` key dispatches
+// through the adapter below.
+export { Features } from './Features';
+export type { FeaturesProps, FeatureItem } from './Features';
+
 // Legacy section-data adapters — preserve `BlueprintDispatcher` +
 // AI-render path compatibility. Internally compose `<CardGrid>` +
 // `<Card preset="display">`. Direct consumers should reach for those


### PR DESCRIPTION
## Summary
- feat(blueprints): consolidate bds-features — drop --branded-dark/3col (#1197)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)