### PR TITLE
docs(image): fix 8 dead cross-links on the Image page

### DIFF
--- a/docs-site/content/docs/components/image.mdx
+++ b/docs-site/content/docs/components/image.mdx
@@ -9,12 +9,12 @@ It owns the design-system constraints — shape, fit, and semantics. It is **not
 
 ## Use it for
 
-- Content and editorial images that must hold a fixed shape ([Frame](/docs/components/frame) is the bare aspect-ratio box; Image adds SEO + `<figure>` semantics)
+- Content and editorial images that must hold a fixed shape ([Frame](https://storybook.brikdesigns.com/?path=/story/layouts-frame--playground) is the bare aspect-ratio box; Image adds SEO + `<figure>` semantics)
 - Above-the-fold hero images that need eager, high-priority loading
 - Captioned figures (`<figcaption>`)
 - Responsive images with `srcset` / `sizes`
 
-For avatars use [Avatar](/docs/components/avatar); for illustration scenes use [Marketing Illustration](/docs/components/marketing-illustration); for a raw aspect box with no `<img>` semantics use [Frame](/docs/components/frame).
+For avatars use [Avatar](/docs/components/avatar); for a raw aspect box with no `<img>` semantics use [Frame](https://storybook.brikdesigns.com/?path=/story/layouts-frame--playground).
 
 ## Import
 
@@ -26,14 +26,14 @@ import { Image } from '@brikdesigns/bds';
 
 ### Aspect ratio
 
-`ratio` maps to a slug in the `--aspect-*` token family and wraps the image in a [Frame](/docs/components/frame). The frame reserves layout space before the image loads — the primary defense against cumulative layout shift (CLS).
+`ratio` maps to a slug in the `--aspect-*` token family and wraps the image in a [Frame](https://storybook.brikdesigns.com/?path=/story/layouts-frame--playground). The frame reserves layout space before the image loads — the primary defense against cumulative layout shift (CLS).
 
 ```tsx
 <Image src="/hero.jpg" alt="Team at work" ratio="16-9" />
 <Image src="/portrait.jpg" alt="Dr. Alice Chen" ratio="3-4" />
 ```
 
-Omit `ratio` to render at the image's natural shape. See [Frame](/docs/components/frame) for the full slug vocabulary (`1-1`, `3-2`, `4-3`, `16-9`, `square`, `cinema`, …).
+Omit `ratio` to render at the image's natural shape. See [Frame](https://storybook.brikdesigns.com/?path=/story/layouts-frame--playground) for the full slug vocabulary (`1-1`, `3-2`, `4-3`, `16-9`, `square`, `cinema`, …).
 
 ### Fit
 
@@ -85,7 +85,7 @@ By default Image is `loading="lazy"` + `decoding="async"`. For the above-the-fol
 />
 ```
 
-For automatic candidate generation and format negotiation (WebP/AVIF), let `next/image` or `@astrojs/image` emit the `<img>` and wrap layout concerns with Image's `ratio` at the [Frame](/docs/components/frame) level.
+For automatic candidate generation and format negotiation (WebP/AVIF), let `next/image` or `@astrojs/image` emit the `<img>` and wrap layout concerns with Image's `ratio` at the [Frame](https://storybook.brikdesigns.com/?path=/story/layouts-frame--playground) level.
 
 ## SEO checklist
 
@@ -123,8 +123,6 @@ Plus standard `<figure>` HTML attributes.
 
 ## Related
 
-- [Frame](/docs/components/frame) — the bare aspect-ratio box Image wraps; use it directly for non-`<img>` media
-- [Avatar](/docs/components/avatar) — person identity with initials fallback
-- [Marketing Illustration](/docs/components/marketing-illustration) — composed illustration scenes
-- [Color pairings](/docs/primitives/color-pairings) — for captions and overlays on images
+- [Frame](https://storybook.brikdesigns.com/?path=/story/layouts-frame--playground) — the bare aspect-ratio box Image wraps; use it directly for non-`<img>` media
+- [Avatar](/docs/components/avatar) — person identity with initials fallback- [Color pairings](/docs/primitives/color-pairings) — for captions and overlays on images
 - **[Storybook playground](https://storybook.brikdesigns.com/?path=/docs/components-image--docs)**


### PR DESCRIPTION
## Summary
- docs(image): fix 8 dead cross-links on the Image page

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)