### PR TITLE
feat(empty-state): add composed media slot + md action button (#1146)

### DIFF
--- a/components/ui/EmptyState/EmptyState.css
+++ b/components/ui/EmptyState/EmptyState.css
@@ -17,6 +17,21 @@
   min-height: 240px; /* bds-lint-ignore — design constraint */
 }
 
+/* ─── Media (optional illustration above the text) ───────────── */
+
+.bds-empty-state__media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+}
+
+/* Keep composed media (e.g. an <Image>) from overflowing the container. */
+.bds-empty-state__media :where(img, svg) {
+  max-width: 100%;
+  height: auto;
+}
+
 /* ─── Text wrapper ───────────────────────────────────────────── */
 
 .bds-empty-state__text {

--- a/components/ui/EmptyState/EmptyState.mdx
+++ b/components/ui/EmptyState/EmptyState.mdx
@@ -16,7 +16,11 @@ Placeholder for screens with no data. Use when a list, table, or page has no con
 
 ## Variants
 
-The component varies on whether a primary action is present, how much content the title and description carry, and whether the children slot replaces the button. Each axis is its own story.
+The component varies on whether a primary action is present, whether a composed `media` illustration is shown, how much content the title and description carry, and whether the children slot replaces the button. Each axis is its own story.
+
+### With media
+
+<Canvas of={Stories.WithMedia} />
 
 ### With action
 

--- a/components/ui/EmptyState/EmptyState.stories.tsx
+++ b/components/ui/EmptyState/EmptyState.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { EmptyState } from './EmptyState';
+import { Image } from '../Image';
 
 const meta: Meta<typeof EmptyState> = {
   title: 'Components/empty-state',
@@ -49,6 +50,23 @@ export const NoAction: Story = {
 export const TitleOnly: Story = {
   args: {
     title: 'No data available',
+  },
+};
+
+/** @summary With media — a composed `<Image>` illustration above the text, plus an `md` action */
+export const WithMedia: Story = {
+  args: {
+    media: (
+      <Image
+        src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNDAgMTYwIj48cmVjdCB3aWR0aD0iMjQwIiBoZWlnaHQ9IjE2MCIgZmlsbD0iI2RmZTNlOCIvPjwvc3ZnPg=="
+        alt=""
+        ratio="3-2"
+        width={240}
+      />
+    ),
+    title: 'No projects yet',
+    description: 'Create your first project to get started.',
+    buttonProps: { children: 'Create Project' },
   },
 };
 

--- a/components/ui/EmptyState/EmptyState.tsx
+++ b/components/ui/EmptyState/EmptyState.tsx
@@ -12,7 +12,14 @@ export interface EmptyStateProps extends Omit<HTMLAttributes<HTMLDivElement>, 't
   title: string;
   /** Optional description below the title */
   description?: string;
-  /** Optional button props — renders a primary Button when provided */
+  /**
+   * Optional illustration/media rendered above the text. Compose a BDS
+   * primitive — canonically an `<Image ratio="…" src="…" />` (or, once the
+   * illustration kit ships runtime assets, an illustration node). Omit to
+   * hide; presence is the show/hide control.
+   */
+  media?: ReactNode;
+  /** Optional button props — renders a primary `md` Button when provided */
   buttonProps?: {
     children: ReactNode;
     onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -26,14 +33,17 @@ export interface EmptyStateProps extends Omit<HTMLAttributes<HTMLDivElement>, 't
 /**
  * EmptyState — feedback component for empty content areas
  *
- * Displays a centered title, optional description, and optional
- * action button within a bordered surface container.
+ * Displays an optional centered illustration/media, a title, an optional
+ * description, and an optional `md` action button within a bordered surface
+ * container. The `media` slot is composed (canonically an `<Image>`); its
+ * presence is the show/hide control.
  *
- * @summary Empty/zero-state messaging with optional action
+ * @summary Empty/zero-state messaging with optional media + action
  */
 export function EmptyState({
   title,
   description,
+  media,
   buttonProps,
   children,
   className,
@@ -42,12 +52,13 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <div className={bdsClass('bds-empty-state', className)} style={style} {...props}>
+      {media && <div className="bds-empty-state__media">{media}</div>}
       <div className="bds-empty-state__text">
         <h2 className="bds-empty-state__title">{title}</h2>
         {description && <p className="bds-empty-state__description">{description}</p>}
       </div>
       {buttonProps && !children && (
-        <Button variant="primary" size="sm" {...buttonProps} />
+        <Button variant="primary" size="md" {...buttonProps} />
       )}
       {children}
     </div>


### PR DESCRIPTION
## Summary
- feat(empty-state): add composed media slot + md action button (#1146)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)