### PR TITLE
feat(subnav): add bordered prop to toggle the right divider (#1146)

### DIFF
--- a/components/ui/SubNavigation/SubNavigation.css
+++ b/components/ui/SubNavigation/SubNavigation.css
@@ -11,6 +11,12 @@
   overflow-y: auto;
 }
 
+/* Opt out of the panel/content divider (bordered={false}). Right border only —
+   the header/footer dividers are unaffected. */
+.bds-subnav[data-bordered="false"] {
+  border-right: none;
+}
+
 /* ─── Header ─────────────────────────────────────────────────── */
 
 .bds-subnav__header {

--- a/components/ui/SubNavigation/SubNavigation.mdx
+++ b/components/ui/SubNavigation/SubNavigation.mdx
@@ -22,6 +22,12 @@ Toggle `showHeader`, `showFooter`, or override `width` in the Controls panel.
 
 <Canvas of={Stories.Default} />
 
+### No border
+
+Set `bordered={false}` when the app shell supplies its own panel/content separation. Only the right divider is removed — the header/footer dividers stay.
+
+<Canvas of={Stories.NoBorder} />
+
 ## Patterns
 
 ### Two-column shell

--- a/components/ui/SubNavigation/SubNavigation.stories.tsx
+++ b/components/ui/SubNavigation/SubNavigation.stories.tsx
@@ -102,6 +102,10 @@ const meta = {
       description: 'Accessible label for the nav landmark.',
       control: 'text',
     },
+    bordered: {
+      description: 'Draw the right-side panel/content divider. Default `true`; set `false` when the shell supplies its own separation.',
+      control: 'boolean',
+    },
     linkComponent: {
       description: 'Render each nav item with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. See ADR-012.',
       control: false,
@@ -130,6 +134,15 @@ export const Default: Story = {
     items: itemsWithIcons,
     showHeader: false,
     showFooter: false,
+  },
+};
+
+/** @summary No right border (`bordered={false}`) — for shells that supply their own panel/content separation */
+export const NoBorder: Story = {
+  args: {
+    items: itemsWithIcons,
+    bordered: false,
+    showHeader: true,
   },
 };
 

--- a/components/ui/SubNavigation/SubNavigation.tsx
+++ b/components/ui/SubNavigation/SubNavigation.tsx
@@ -19,6 +19,13 @@ export interface SubNavigationProps {
   footer?: ReactNode;
   /** Custom width (default: 194px). */
   width?: string;
+  /**
+   * Draw the right-side border (the divider between the sub-nav panel and the
+   * content column). Default `true`. Set `false` for shells that supply their
+   * own separation (e.g. a content-side border or a background step). Only the
+   * right border is affected — the header/footer dividers are unchanged.
+   */
+  bordered?: boolean;
   /** Accessible label for the nav landmark. Required when multiple navs are on the page. */
   ariaLabel?: string;
   /**
@@ -43,10 +50,16 @@ export function SubNavigation({
   footer,
   width = '194px',
   ariaLabel = 'Section navigation',
+  bordered = true,
   linkComponent,
 }: SubNavigationProps) {
   return (
-    <aside className="bds-subnav" style={{ width }} aria-label={ariaLabel}>
+    <aside
+      className="bds-subnav"
+      style={{ width }}
+      aria-label={ariaLabel}
+      data-bordered={bordered ? undefined : 'false'}
+    >
       {header && <div className="bds-subnav__header">{header}</div>}
 
       <nav className="bds-subnav__nav">


### PR DESCRIPTION
## Summary
- feat(subnav): add `bordered` prop to toggle the right divider (#1146)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)