### PR TITLE
fix(devbar): keep review feedback popover on-screen (#1233)

### DIFF
--- a/.storybook/public/brik-feedback-widget.js
+++ b/.storybook/public/brik-feedback-widget.js
@@ -205,6 +205,10 @@
       box-shadow: 0 8px 40px rgba(0,0,0,0.25);
       padding: 20px;
       width: 320px;
+      max-width: calc(100vw - 24px);
+      max-height: calc(100vh - 24px);
+      overflow-y: auto;
+      box-sizing: border-box;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
     }
     .bfb-form h3 {
@@ -615,6 +619,30 @@
   // ── Comment form ────────────────────────────────────────────────────────
   let formEl = null;
 
+  // Collision-aware placement. Anchors the popover to the pin (viewport coords),
+  // preferring right-of / below the anchor, flipping to the left / above side
+  // when it would overflow, and clamping within the viewport as a final guard so
+  // the popover — and its Submit button — is never rendered off-screen.
+  function positionForm(el, anchorX, anchorY) {
+    const gap = 16;    // space between the pin and the popover
+    const margin = 12; // min gap from the viewport edge
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const { width: w, height: h } = el.getBoundingClientRect();
+
+    let left = anchorX + gap;
+    if (left + w > vw - margin) left = anchorX - gap - w; // flip to the left
+    if (left < margin) left = Math.max(margin, vw - w - margin);
+
+    let top = anchorY + gap;
+    if (top + h > vh - margin) top = anchorY - gap - h;   // flip above
+    if (top < margin) top = Math.max(margin, vh - h - margin);
+
+    el.style.left = Math.round(left) + 'px';
+    el.style.top = Math.round(top) + 'px';
+    el.style.visibility = '';
+  }
+
   function showForm(pinX, pinY, screenX, screenY) {
     removeForm();
 
@@ -624,23 +652,9 @@
 
     formEl = document.createElement('div');
     formEl.className = 'bfb-form';
-
-    // Position form near click but keep on screen
-    const formWidth = 320;
-    const formHeight = 280;
-    let left = screenX + 20;
-    let top = screenY - 20;
-
-    if (left + formWidth > window.innerWidth - 20) {
-      left = screenX - formWidth - 20;
-    }
-    if (top + formHeight > window.innerHeight - 20) {
-      top = window.innerHeight - formHeight - 20;
-    }
-    if (top < 20) top = 20;
-
-    formEl.style.left = left + 'px';
-    formEl.style.top = top + 'px';
+    // Hidden until measured — positionForm() places it collision-aware after
+    // the content is in the DOM (its height varies with context/tags).
+    formEl.style.visibility = 'hidden';
 
     // Build context display
     const ctx = currentSectionContext || {};
@@ -739,6 +753,9 @@
     });
 
     document.body.appendChild(formEl);
+
+    // Place collision-aware now that the popover is measurable.
+    positionForm(formEl, screenX, screenY);
 
     // Focus the right field
     if (!authorName) {

--- a/components/ui/BrikDevBar/widgets/feedback-widget.js
+++ b/components/ui/BrikDevBar/widgets/feedback-widget.js
@@ -205,6 +205,10 @@
       box-shadow: 0 8px 40px rgba(0,0,0,0.25);
       padding: 20px;
       width: 320px;
+      max-width: calc(100vw - 24px);
+      max-height: calc(100vh - 24px);
+      overflow-y: auto;
+      box-sizing: border-box;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
     }
     .bfb-form h3 {
@@ -615,6 +619,30 @@
   // ── Comment form ────────────────────────────────────────────────────────
   let formEl = null;
 
+  // Collision-aware placement. Anchors the popover to the pin (viewport coords),
+  // preferring right-of / below the anchor, flipping to the left / above side
+  // when it would overflow, and clamping within the viewport as a final guard so
+  // the popover — and its Submit button — is never rendered off-screen.
+  function positionForm(el, anchorX, anchorY) {
+    const gap = 16;    // space between the pin and the popover
+    const margin = 12; // min gap from the viewport edge
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const { width: w, height: h } = el.getBoundingClientRect();
+
+    let left = anchorX + gap;
+    if (left + w > vw - margin) left = anchorX - gap - w; // flip to the left
+    if (left < margin) left = Math.max(margin, vw - w - margin);
+
+    let top = anchorY + gap;
+    if (top + h > vh - margin) top = anchorY - gap - h;   // flip above
+    if (top < margin) top = Math.max(margin, vh - h - margin);
+
+    el.style.left = Math.round(left) + 'px';
+    el.style.top = Math.round(top) + 'px';
+    el.style.visibility = '';
+  }
+
   function showForm(pinX, pinY, screenX, screenY) {
     removeForm();
 
@@ -624,23 +652,9 @@
 
     formEl = document.createElement('div');
     formEl.className = 'bfb-form';
-
-    // Position form near click but keep on screen
-    const formWidth = 320;
-    const formHeight = 280;
-    let left = screenX + 20;
-    let top = screenY - 20;
-
-    if (left + formWidth > window.innerWidth - 20) {
-      left = screenX - formWidth - 20;
-    }
-    if (top + formHeight > window.innerHeight - 20) {
-      top = window.innerHeight - formHeight - 20;
-    }
-    if (top < 20) top = 20;
-
-    formEl.style.left = left + 'px';
-    formEl.style.top = top + 'px';
+    // Hidden until measured — positionForm() places it collision-aware after
+    // the content is in the DOM (its height varies with context/tags).
+    formEl.style.visibility = 'hidden';
 
     // Build context display
     const ctx = currentSectionContext || {};
@@ -739,6 +753,9 @@
     });
 
     document.body.appendChild(formEl);
+
+    // Place collision-aware now that the popover is measurable.
+    positionForm(formEl, screenX, screenY);
 
     // Focus the right field
     if (!authorName) {


### PR DESCRIPTION
## What

The pin-drop comment popover could render partly off-screen — hiding the Submit button — because placement used a hardcoded 280px height guess and only flipped horizontally.

Replaces the eager placement with a collision-aware `positionForm()`:
- measures the rendered popover (height varies with context + revision tags)
- prefers right-of / below the pin, flips to the left / above side on overflow
- clamps within the viewport as a final guard
- adds `max-width` / `max-height` + `overflow-y` so the popover never exceeds the viewport (internal scroll on very short screens)

## Verification

Driven with Playwright against a mockup harness at **1000×700**, **375×667** (mobile), and **800×360** (short): the popover stays fully on-screen at every edge, corner, and centre; on the short viewport it caps at `100vh − 24px` and scrolls internally so Submit stays reachable.

## Notes

- Canonical widget only. Consumers (portal, renew-pms, brikdesigns, brik-llm cache) re-sync via `scripts/sync-devbar-widgets.sh` after merge (brikdesigns/brik-llm#1341 gate).
- One of the brikdesigns/brik-bds#1232 UX-pass sub-issues.

Closes #1233