### PR TITLE
Add CI workflow gate for the bundled service-icon registry

### DIFF
--- a/.github/workflows/service-icons-check.yml
+++ b/.github/workflows/service-icons-check.yml
@@ -1,0 +1,54 @@
+name: Service Icon Registry Check
+
+# Ensures components/ui/ServiceTag/service-icons.generated.ts stays in sync with
+# the source marks in components/ui/ServiceTag/icons/*/*.svg. Fails the build if
+# a source glyph was added, removed, or edited without regenerating the committed
+# registry (`npm run gen:service-icons`) — so a service glyph can't silently go
+# missing or stale in the bundled offline set, and the no-404 guarantee (#1242)
+# stays true.
+#
+# Why this is a CI gate (not just the husky pre-commit mirror):
+#   - Cloud-agent commits bypass local hooks entirely.
+#   - PRs from fresh clones may not have husky installed.
+#   - The offline-glyph guarantee is only as good as the committed registry.
+#
+# Source: scripts/gen-service-icons.mjs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'components/ui/ServiceTag/icons/**/*.svg'
+      - 'components/ui/ServiceTag/service-icons.generated.ts'
+      - 'scripts/gen-service-icons.mjs'
+  push:
+    branches:
+      - main
+    paths:
+      - 'components/ui/ServiceTag/icons/**/*.svg'
+      - 'components/ui/ServiceTag/service-icons.generated.ts'
+      - 'scripts/gen-service-icons.mjs'
+
+concurrency:
+  group: service-icons-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  service-icons-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check bundled service-icon registry is in sync
+        run: npm run gen:service-icons:check

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -135,10 +135,9 @@ fi
 # ── Service-icon registry drift (#1242) ──
 # Keeps components/ui/ServiceTag/service-icons.generated.ts in sync with the
 # source glyphs so the bundled offline set (and the no-404 guarantee) can't go
-# stale. Local mirror of `npm run gen:service-icons:check`.
-# NOTE: this lives in husky (not a CI workflow like logo-registry-check.yml)
-# only until the gh token regains the `workflow` scope needed to push
-# .github/workflows/* — tracked in #1243. Restore the CI gate there.
+# stale. Fast local mirror of the authoritative CI gate
+# (.github/workflows/service-icons-check.yml, #1243) — defense in depth for
+# commits made outside CI.
 STAGED_SERVICE_ICONS=$(git diff --cached --name-only --diff-filter=ACMD -- 'components/ui/ServiceTag/icons/**/*.svg' 'components/ui/ServiceTag/service-icons.generated.ts' 'scripts/gen-service-icons.mjs')
 if [ -n "$STAGED_SERVICE_ICONS" ]; then
   echo "Checking bundled service-icon registry is in sync (#1242)..."


### PR DESCRIPTION
Restores the CI gate deferred from #1244 (the #1242 PR) — at the time the gh token lacked the `workflow` scope, so `.github/workflows/*` couldn't be pushed. Scope is now granted.

## What
- `.github/workflows/service-icons-check.yml` — mirrors `logo-registry-check.yml`; runs `npm run gen:service-icons:check` when a source glyph, the generated registry, or the generator changes. Fails if the committed `service-icons.generated.ts` is stale.
- Husky pre-commit comment updated: it's now the fast local mirror of this authoritative CI gate (defense in depth for out-of-CI commits).

## Why CI, not just husky
Cloud-agent commits and fresh clones bypass husky; the offline-glyph / no-404 guarantee (#1242) is only as good as the committed registry.

Verified locally: `gen:service-icons:check` exits 1 on drift, 0 when in sync.

Closes #1243