### PR TITLE
feat(footer): add containerMaxWidth content-width constraint prop (#698)

### DIFF
--- a/components/ui/Footer/Footer.css
+++ b/components/ui/Footer/Footer.css
@@ -58,6 +58,28 @@
   background-color: var(--bds-footer-surface, var(--surface-inverse));
 }
 
+/* ─── Content-width constraint ────────────────────────────────────
+   Center the footer's inner content at a canonical `--content-width-*`
+   while the background stays full-bleed. The `max()` keeps the existing
+   `--padding-lg` gutter at narrow viewports and switches to auto-centering
+   once the viewport exceeds the target width. Vertical padding from the
+   `.bds-footer` shorthand is untouched — only `padding-inline` is overridden. */
+.bds-footer--constrain-narrow {
+  padding-inline: max(var(--padding-lg), calc((100% - var(--content-width-narrow)) / 2));
+}
+
+.bds-footer--constrain-default {
+  padding-inline: max(var(--padding-lg), calc((100% - var(--content-width-default)) / 2));
+}
+
+.bds-footer--constrain-wide {
+  padding-inline: max(var(--padding-lg), calc((100% - var(--content-width-wide)) / 2));
+}
+
+.bds-footer--constrain-xl {
+  padding-inline: max(var(--padding-lg), calc((100% - var(--content-width-xl)) / 2));
+}
+
 /* ─── Top section: logo + columns ─────────────────────────────── */
 
 .bds-footer__top {

--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -89,6 +89,12 @@ const meta: Meta<typeof Footer> = {
   parameters: { layout: 'fullscreen' },
   argTypes: {
     variant: { control: 'select', options: ['default', 'brand', 'inverse'] },
+    containerMaxWidth: {
+      control: 'select',
+      options: [undefined, 'narrow', 'default', 'wide', 'xl'],
+      description:
+        'Constrain inner content to a `--content-width-*` while the background stays full-bleed. Omit for full-width.',
+    },
     columnHeadingLevel: {
       control: 'select',
       options: ['h2', 'h3', 'h4', 'h5', 'h6'],
@@ -116,6 +122,18 @@ export const Playground: Story = {
     columns: sampleColumns,
     copyright: '\u00A9 2026 Brik Designs. All rights reserved.',
     variant: 'default',
+  },
+};
+
+/** @summary Inner content constrained to a content width while the background spans full-bleed */
+export const Constrained: Story = {
+  args: {
+    logo: <LogoPlaceholder />,
+    tagline: 'Building better digital experiences for small businesses.',
+    columns: sampleColumns,
+    copyright: '© 2026 Brik Designs. All rights reserved.',
+    variant: 'default',
+    containerMaxWidth: 'xl',
   },
 };
 

--- a/components/ui/Footer/Footer.tsx
+++ b/components/ui/Footer/Footer.tsx
@@ -90,12 +90,27 @@ export interface FooterProps extends HTMLAttributes<HTMLElement> {
    * ADR-012.
    */
   linkComponent?: BdsLinkComponent;
+  /**
+   * Constrain the footer's inner content to a canonical content width while
+   * the background stays full-bleed. Backed by the `--content-width-*` token
+   * family (see design.brikdesigns.com/docs/primitives/size) — content centers
+   * with a `--padding-lg` gutter fallback at narrow viewports. Omit for the
+   * default full-width behavior.
+   */
+  containerMaxWidth?: FooterContainerWidth;
 }
 
 /**
  * Footer variant
  */
 export type FooterVariant = 'default' | 'brand' | 'inverse';
+
+/**
+ * Footer content-width constraint. Maps to the `--content-width-*` token
+ * family. `full` is intentionally omitted — it is equivalent to the default
+ * unconstrained footer.
+ */
+export type FooterContainerWidth = 'narrow' | 'default' | 'wide' | 'xl';
 
 /**
  * Renders a footer link with the injected `linkComponent` (client-side routing)
@@ -193,6 +208,7 @@ export function Footer({
   socialLinks,
   aboveTop,
   variant = 'default',
+  containerMaxWidth,
   linkComponent,
   className = '',
   style,
@@ -206,7 +222,12 @@ export function Footer({
 
   return (
     <footer
-      className={bdsClass('bds-footer', `bds-footer--${variant}`, className)}
+      className={bdsClass(
+        'bds-footer',
+        `bds-footer--${variant}`,
+        containerMaxWidth && `bds-footer--constrain-${containerMaxWidth}`,
+        className,
+      )}
       style={style}
       {...props}
     >


### PR DESCRIPTION
## Summary
- feat(footer): add containerMaxWidth content-width constraint prop (#698)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)