### PR TITLE
feat(filter-bar): collapse controls into Filters popover on narrow own width (#641)

### DIFF
--- a/components/ui/FilterBar/FilterBar.css
+++ b/components/ui/FilterBar/FilterBar.css
@@ -30,4 +30,17 @@
   flex-wrap: wrap;
   align-items: center;
 }
+
+/* ─── Collapsed controls (narrow own-width → Filters popover, ADR-019) ── */
+
+.bds-filter-bar__collapse {
+  margin-left: auto;
+}
+
+.bds-filter-bar__collapse-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-sm);
+  min-width: 200px;
+}
 }

--- a/components/ui/FilterBar/FilterBar.stories.tsx
+++ b/components/ui/FilterBar/FilterBar.stories.tsx
@@ -159,3 +159,73 @@ export const Default: Story = {
     );
   },
 };
+
+/* ═══════════════════════════════════════════════════════════════
+   COLLAPSED — narrow own-width. Below ~600px of its OWN width (via
+   ResizeObserver, ADR-019) the controls collapse into a `Filters (N)`
+   popover so they never wrap. The 420px container forces the collapse;
+   the component reacts to its own box, not the viewport. `activeFilterCount`
+   drives the count on the trigger.
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Narrow own-width collapses controls into a Filters popover */
+export const Collapsed: Story = {
+  args: {
+    title: 'Engagements',
+    label: 'engagements',
+    clearLabel: 'Clear filters',
+    activeStatus: 'brand',
+    onClear: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 420, minHeight: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => {
+    const [industry, setIndustry] = useState<string | undefined>('saas');
+    const [activeOnly, setActiveOnly] = useState(true);
+
+    const filteredRows = useMemo(
+      () =>
+        rows.filter((r) => {
+          if (industry && r.industry !== industry) return false;
+          if (activeOnly && r.status !== 'active') return false;
+          return true;
+        }),
+      [industry, activeOnly],
+    );
+
+    const activeFilterCount = (industry ? 1 : 0) + (activeOnly ? 1 : 0);
+
+    const handleClear = () => {
+      setIndustry(undefined);
+      setActiveOnly(false);
+      args.onClear?.();
+    };
+
+    return (
+      <FilterBar
+        {...args}
+        total={rows.length}
+        filtered={filteredRows.length}
+        activeFilterCount={activeFilterCount}
+        onClear={handleClear}
+      >
+        <FilterButton
+          label="Industry"
+          options={industryOptions}
+          value={industry}
+          onChange={setIndustry}
+        />
+        <FilterToggle
+          label="Active only"
+          active={activeOnly}
+          onToggle={() => setActiveOnly((prev) => !prev)}
+        />
+      </FilterBar>
+    );
+  },
+};

--- a/components/ui/FilterBar/FilterBar.tsx
+++ b/components/ui/FilterBar/FilterBar.tsx
@@ -1,8 +1,19 @@
 import type { HTMLAttributes, ReactNode } from 'react';
 import { Button } from '../Button';
 import { Counter, type CounterStatus } from '../Counter';
+import { Popover } from '../Popover';
+import { useElementWidth } from '../shared';
 import { bdsClass } from '../../utils';
 import './FilterBar.css';
+
+/**
+ * Own-width threshold below which the filter controls collapse into a
+ * "Filters" popover (ADR-019). Chosen so a title + counter + ~3 controls +
+ * clear still fit inline above it; below it they would wrap awkwardly. This is
+ * the component's *own* width (via ResizeObserver), not the viewport, so the
+ * bar collapses the same in a sidebar as full-bleed.
+ */
+const COLLAPSE_BELOW_PX = 600;
 
 export interface FilterBarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /** Total count before filtering */
@@ -21,6 +32,13 @@ export interface FilterBarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'ti
   clearLabel?: string;
   /** FilterButton / FilterToggle children rendered on the right */
   children: ReactNode;
+  /**
+   * Number of currently-active filters. When the bar collapses on narrow
+   * widths (see ADR-019), the trigger reads `Filters (N)` so active state is
+   * visible without opening the popover. Omit (or `0`) for a plain `Filters`
+   * trigger — the counter still reflects the filtered result count.
+   */
+  activeFilterCount?: number;
 }
 
 /**
@@ -31,6 +49,10 @@ export interface FilterBarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'ti
  * The counter shows the current filtered count. When `filtered < total` the
  * counter switches to `activeStatus` (default `brand`) and, if `onClear` is
  * provided, a ghost "Clear filters" button appears after the filter controls.
+ *
+ * On narrow *own* widths (below ~600px, via ResizeObserver — ADR-019) the
+ * filter controls collapse into a `Filters` popover so they never wrap
+ * awkwardly; pass `activeFilterCount` to surface `Filters (N)` when collapsed.
  *
  * @example
  * ```tsx
@@ -58,6 +80,7 @@ export function FilterBar({
   onClear,
   clearLabel = 'Clear filters',
   children,
+  activeFilterCount,
   className,
   style,
   ...props
@@ -67,8 +90,30 @@ export function FilterBar({
     (props['aria-label'] as string | undefined) ??
     (typeof title === 'string' ? `${title} filter bar` : `${label} filter bar`);
 
+  const [ref, width] = useElementWidth<HTMLDivElement>();
+  const collapsed = width !== null && width < COLLAPSE_BELOW_PX;
+
+  // Rendered in exactly one place at a time (inline OR inside the popover), so
+  // the interactive filter controls are never duplicated in the DOM.
+  const controls = (
+    <>
+      {children}
+      {onClear && isFiltered && (
+        <Button variant="ghost" size="md" onClick={onClear}>
+          {clearLabel}
+        </Button>
+      )}
+    </>
+  );
+
+  const triggerLabel =
+    activeFilterCount && activeFilterCount > 0
+      ? `Filters (${activeFilterCount})`
+      : 'Filters';
+
   return (
     <div
+      ref={ref}
       className={bdsClass('bds-filter-bar', className)}
       style={style}
       aria-label={ariaLabel}
@@ -81,14 +126,21 @@ export function FilterBar({
         size="sm"
       />
 
-      <div className="bds-filter-bar__controls">
-        {children}
-        {onClear && isFiltered && (
-          <Button variant="ghost" size="md" onClick={onClear}>
-            {clearLabel}
-          </Button>
-        )}
-      </div>
+      {collapsed ? (
+        <div className="bds-filter-bar__collapse">
+          <Popover
+            content={
+              <div className="bds-filter-bar__collapse-panel">{controls}</div>
+            }
+          >
+            <Button variant="secondary" size="md">
+              {triggerLabel}
+            </Button>
+          </Popover>
+        </div>
+      ) : (
+        <div className="bds-filter-bar__controls">{controls}</div>
+      )}
     </div>
   );
 }

--- a/components/ui/shared/index.ts
+++ b/components/ui/shared/index.ts
@@ -4,3 +4,4 @@
 // The barrel export satisfies the component-completeness pre-commit check.
 export { useSuggestionFilter } from './useSuggestionFilter';
 export type { UseSuggestionFilterOptions, UseSuggestionFilterReturn } from './useSuggestionFilter';
+export { useElementWidth } from './useElementWidth';

--- a/components/ui/shared/useElementWidth.ts
+++ b/components/ui/shared/useElementWidth.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState, type RefObject } from 'react';
+
+/**
+ * Track an element's own inline (content-box) width via `ResizeObserver`.
+ *
+ * The mechanism behind own-width-responsive primitives (ADR-019): a component
+ * collapses on *its own* width, not the viewport, so it behaves the same in a
+ * sidebar, a card, or full-bleed. Prefer this over a viewport media query for
+ * any BDS primitive whose layout should react to the space it is given.
+ *
+ * SSR-safe: `width` is `null` until the first observation (and where
+ * `ResizeObserver` is unavailable), so callers render their expanded/default
+ * layout on the first paint and collapse only once a real measurement lands.
+ *
+ * @returns `[ref, width]` — attach `ref` to the element to measure; `width` is
+ * the observed inline width in px, or `null` before the first measurement.
+ */
+export function useElementWidth<T extends HTMLElement = HTMLElement>(): [
+  RefObject<T>,
+  number | null,
+] {
+  const ref = useRef<T>(null);
+  const [width, setWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        // contentBoxSize is the spec path; fall back to contentRect for older engines.
+        const inlineSize =
+          entry.contentBoxSize?.[0]?.inlineSize ?? entry.contentRect.width;
+        setWidth(inlineSize);
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, width];
+}

--- a/docs/adrs/ADR-019-own-width-responsive-primitives.md
+++ b/docs/adrs/ADR-019-own-width-responsive-primitives.md
@@ -1,0 +1,43 @@
+# ADR-019 — Responsive primitives collapse on their own width, not the viewport
+
+**Status:** Accepted (2026-07-14)
+**Date:** 2026-07-14
+**Supersedes:** —
+**Superseded by:** —
+**Owner:** Nick Stanerson
+**Related:** #641 (FilterBar responsive collapse — first application), ADR-010 (Storybook axes — the viewport toolbar global these stories exercise), ADR-004 (component-bloat guardrails — this is a behavior on an existing component, not a new one)
+
+## Context
+
+`FilterBar` (and future list/table-header primitives) render a horizontal row of controls. At narrow widths the controls wrap awkwardly or overflow. #641 asked for a responsive collapse into a "Filters" popover.
+
+The obvious lever is a **viewport media query** (`@media (max-width: 768px)`). But BDS primitives are placed in wildly different containers — full-bleed page bodies, cards, sidebars, table toolbars. A viewport query collapses a bar that is 400px wide inside a 1440px viewport *only when the whole window shrinks*, which is wrong: the bar should collapse based on the space **it** has, regardless of window size.
+
+Two mechanisms respond to a component's own width:
+
+1. **CSS container queries** (`container-type: inline-size` + `@container`). Elegant and JS-free, but they can only toggle *visibility/layout* of elements already in the DOM. Collapsing filter controls into a popover means the controls must live in a different DOM location (the popover panel) when collapsed. A pure container-query approach forces rendering the controls **twice** — once inline, once in the panel — toggled by `display`. For BDS's **controlled, interactive** filter controls (`FilterButton`/`FilterToggle`), that means duplicate interactive elements, duplicate a11y labels, and two focus targets for one logical control.
+
+2. **`ResizeObserver` measuring the element's own inline width**, driving a conditional render. The controls exist in exactly one place at a time. Single instance, clean a11y.
+
+BDS uses zero container queries today, so either path is a first-of-kind pattern worth recording.
+
+## Decision
+
+**Responsive BDS primitives collapse on their own width, measured with `ResizeObserver`, not on the viewport.** The shared hook `components/ui/shared/useElementWidth.ts` is the canonical mechanism:
+
+- It returns `[ref, width]`; `width` is `null` until the first observation (SSR-safe and available-guarded), so components render their **expanded/default** layout on first paint and collapse only once a real measurement lands — no hydration mismatch, no collapse flash toward the wrong state.
+- Collapse thresholds are **own-width px constants co-located with the component** (e.g. `FilterBar`'s `COLLAPSE_BELOW_PX = 600`), commented with their rationale — not viewport breakpoints. They are the width at which *that component's* content stops fitting, which is a component concern, not a global one.
+- When the collapsed and expanded layouts place children in different DOM locations (inline row vs. popover panel), the children are authored **once** as a fragment and rendered into exactly one branch — never duplicated across both and toggled by CSS.
+
+**Why not CSS container queries:** the duplicate-interactive-control problem above. Container queries remain the right tool for *pure visibility/layout* responses where no element moves in the tree; this ADR does not forbid them for that case. It only settles that **own-width, not viewport, is the axis**, and that **ResizeObserver + single-instance conditional render is the pattern when elements relocate on collapse.**
+
+## Consequences
+
+- **Correct in any container.** A `FilterBar` collapses the same in a 420px sidebar as in a shrunk window — behavior tracks the box it is given.
+- **One reusable hook.** `useElementWidth` is internal (not part of the public package surface; exported only from the `shared` barrel) and reused by every future own-width-responsive primitive. No per-component ResizeObserver boilerplate.
+- **A small JS cost.** One observer per responsive instance. Acceptable for the a11y and single-instance correctness it buys.
+- **First paint is the expanded layout.** Components that are *always* narrow briefly show the expanded layout before the first measurement collapses them. Mitigated by the observer firing on mount; if a future component needs zero-flash it can accept an initial `collapsed` hint prop, but the default is expanded-then-measure.
+
+## First application
+
+`FilterBar` (#641): below 600px of its own width the title + counter stay inline and the filter controls (+ clear) move into a `Filters (N)` popover. `activeFilterCount` surfaces the active count on the collapsed trigger. Verified in Storybook via a width-constrained `Collapsed` story.


### PR DESCRIPTION
## Summary
- feat(filter-bar): collapse controls into Filters popover on narrow own width (#641)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)