### PR TITLE
fix(page-header): drop redundant metadata top padding (0.127.1)

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -107,8 +107,13 @@
   display: flex;
   gap: var(--gap-sm);
   align-items: flex-start;
-  padding-top: var(--padding-xl);
   width: 100%;
+  /* No extra top padding: the root `--page-header-section-gap` (--gap-xl)
+     already separates the metadata section from the title row, symmetric with
+     the gap below it to the tabs. The old `padding-top: var(--padding-xl)` was
+     spacing that accompanied the internal divider removed in brik-bds#400 —
+     leaving it double-stacked the gap, which only showed when the `metadata`
+     slot was populated (headers without metadata looked fine). */
 }
 
 .bds-page-header__metadata-item {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.127.0",
+  "version": "0.127.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brikdesigns/bds",
-      "version": "0.127.0",
+      "version": "0.127.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@iconify-json/ph": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.127.0",
+  "version": "0.127.1",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/lib-entry.cjs",


### PR DESCRIPTION
## Summary
- fix(page-header): drop redundant metadata top padding (0.127.1)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)