### PR TITLE
chore(release): v0.129.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brikdesigns/bds",
-  "version": "0.128.0",
+  "version": "0.129.0",
   "description": "Brik Design System — React components, Figma-synced tokens, and Content System (BCS) vocabulary",
   "private": false,
   "main": "dist/lib-entry.cjs",


### PR DESCRIPTION
## Release v0.129.0

Batched release of the #821 Brand Kit reconciliation cluster — all token changes on `main` since v0.128.0.

| PR | Change |
|---|---|
| #1260 | Stage Foundations backstop for 24 non-service semantics |
| #1263 | Resync Brik Brand Kit color set — backstopped prune + grayscale AA re-map; adds the standalone `--*-accent` family (→ `tan`) |
| #1264 | Reference `tan.lightest` for `--*-brand-secondary` light values |

**Bump:** minor (0.128.0 → 0.129.0) — new token names `--{text,surface,background,border,page}-accent` + value changes in `dist/tokens.css`.

**After merge:** tag `v0.129.0` from `main` tip to trigger the [`Release` workflow](.github/workflows/release.yml) (publishes to GitHub Packages + creates the GitHub Release).

**Unblocks:** #798 AC2 — `web/vale-partners` can then bump to `^0.129.0` and adopt `--background-accent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)