### PR TITLE
docs(color): document the scope-stable --*-accent role

### DIFF
--- a/docs-site/content/docs/primitives/color.mdx
+++ b/docs-site/content/docs/primitives/color.mdx
@@ -129,6 +129,30 @@ Canonical Figma tokens for positive, negative, and warning states. Background va
   columns={4}
 />
 
+## Accent
+
+The **scope-stable accent** — one brand highlight that stays fixed regardless of `[data-audience]` scope (brik fills it from `tan`; each Brand Kit fills its own). Use it for audience-independent affordances such as an active carousel dot or an eyebrow rule.
+
+It is distinct from two neighbours it is easy to confuse:
+
+- **`--*-brand-primary`** re-tints per audience scope (Vale: land → gold, healthcare → olive). The accent must *not* shift, so it is its own role — not a brand-tier token.
+- **The per-color status accents** (`--background-accent-blue`, `--text-accent-green`, …) encode state/category, not the brand highlight.
+
+<ColorGrid
+  colors={[
+    { name: 'page-accent', cssVar: '--page-accent' },
+    { name: 'surface-accent', cssVar: '--surface-accent' },
+    { name: 'background-accent', cssVar: '--background-accent' },
+    { name: 'text-accent', cssVar: '--text-accent', isText: true },
+    { name: 'border-accent', cssVar: '--border-accent' },
+  ]}
+  columns={4}
+/>
+
+<Callout type="info">
+  Brand Kits fill `--*-accent` per client (brik → `tan`, Vale Partners → gold). Because the audience scopes re-bind only the brand-primary tier, the accent stays constant across every `[data-audience]` — that scope-stability is the whole point of the role.
+</Callout>
+
 ## Presence
 
 Online/offline indicator tokens used by Avatar and Dot components.


### PR DESCRIPTION
## What

Adds a `## Accent` section to [primitives/color](docs-site/content/docs/primitives/color.mdx) documenting the standalone `--*-accent` role shipped in BDS 0.129.0 (#1263).

Frames it as the **scope-stable brand highlight**, distinct from:
- `--*-brand-primary` — re-tints per `[data-audience]` scope (must not, for a fixed accent)
- the per-color status accents (`--background-accent-blue`, …) — encode state, not brand

Reuses the existing `ColorGrid` + `Callout` grammar; frontmatter unchanged; heading depth `##` per the Fumadocs content standard.

Completes **#798 AC3** — AC1 (token in dist) + AC2 (Vale adoption, `vale-partners#56`) already shipped. `Closes #798`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)