### PR TITLE
feat(filter-button,select): add explicit "All" / clear affordance

### DIFF
--- a/components/ui/FilterButton/FilterButton.css
+++ b/components/ui/FilterButton/FilterButton.css
@@ -112,6 +112,13 @@
   background-color: var(--background-secondary);
 }
 
+/* "All" / clear entry — separated from concrete options by a hairline. */
+.bds-filter-button__option--all {
+  margin-bottom: var(--gap-tiny);
+  border-bottom: 1px solid var(--border-muted);
+  border-radius: 0;
+}
+
 /* ─── Icon wrapper ────────────────────────────────────── */
 
 .bds-filter-button__icon {

--- a/components/ui/FilterButton/FilterButton.mdx
+++ b/components/ui/FilterButton/FilterButton.mdx
@@ -24,6 +24,12 @@ FilterButton has no semantic-variant axis — all variation (size, label, active
 - **`md`** — 40px height, 16px body (default)
 - **`lg`** — 48px height, 18px body
 
+### "All" clear entry
+
+Set `allLabel` to render an explicit clear entry atop the dropdown that resets the selection to `undefined` — shown as selected while no option is active. Without it, clearing is only possible by re-clicking the active option.
+
+<Canvas of={Stories.WithAllOption} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/FilterButton/FilterButton.stories.tsx
+++ b/components/ui/FilterButton/FilterButton.stories.tsx
@@ -45,6 +45,10 @@ const meta: Meta<typeof FilterButton> = {
       control: 'boolean',
       description: 'Locks the trigger, blocks dropdown open, applies muted styling.',
     },
+    allLabel: {
+      control: 'text',
+      description: 'When set, renders an explicit clear entry (e.g. "All") atop the dropdown that resets the selection to `undefined`. Shown selected while no option is active.',
+    },
     onChange: {
       action: 'changed',
       description: 'Called with the new id when a selection is made, or `undefined` when the user clicks the active option to clear.',
@@ -74,6 +78,30 @@ export const Default: Story = {
   },
   render: (args) => {
     const [value, setValue] = useState<string | undefined>(undefined);
+    return (
+      <FilterButton
+        {...args}
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          args.onChange?.(v);
+        }}
+      />
+    );
+  },
+};
+
+/** @summary With an explicit "All" clear entry atop the dropdown */
+export const WithAllOption: Story = {
+  args: {
+    label: 'Category',
+    options: categoryOptions,
+    allLabel: 'All categories',
+    size: 'md',
+    onChange: fn(),
+  },
+  render: (args) => {
+    const [value, setValue] = useState<string | undefined>('marketing');
     return (
       <FilterButton
         {...args}

--- a/components/ui/FilterButton/FilterButton.tsx
+++ b/components/ui/FilterButton/FilterButton.tsx
@@ -40,6 +40,13 @@ export interface FilterButtonProps extends Omit<HTMLAttributes<HTMLDivElement>, 
   value?: string;
   /** Callback when selection changes (undefined = cleared) */
   onChange?: (value: string | undefined) => void;
+  /**
+   * When set, renders an explicit "clear" entry at the top of the dropdown
+   * (e.g. `"All"`) that resets the selection to `undefined`. Shown as selected
+   * while no option is active. Omit to keep the current clear-on-reclick-only
+   * behavior.
+   */
+  allLabel?: string;
   /** Size of the trigger button (default: 'md') */
   size?: FilterButtonSize;
   /** Disabled — locks the trigger, blocks dropdown open, applies muted styling. */
@@ -76,6 +83,7 @@ export function FilterButton({
   options,
   value,
   onChange,
+  allLabel,
   size = 'md',
   disabled = false,
   className = '',
@@ -137,6 +145,11 @@ export function FilterButton({
     setIsOpen(false);
   };
 
+  const handleClear = () => {
+    onChange?.(undefined);
+    setIsOpen(false);
+  };
+
   return (
     <div
       ref={wrapperRef}
@@ -163,6 +176,21 @@ export function FilterButton({
 
       {isOpen && (
         <div ref={dropdownRef} className="bds-filter-button__dropdown" role="listbox">
+          {allLabel && (
+            <button
+              type="button"
+              className={bdsClass(
+                'bds-filter-button__option',
+                'bds-filter-button__option--all',
+                !value && 'bds-filter-button__option--selected',
+              )}
+              role="option"
+              aria-selected={!value}
+              onClick={handleClear}
+            >
+              <span>{allLabel}</span>
+            </button>
+          )}
           {options.map((option) => (
             <button
               key={option.id}

--- a/components/ui/Select/Select.mdx
+++ b/components/ui/Select/Select.mdx
@@ -32,6 +32,12 @@ States exposed via Controls:
 - **Error** — red border + ring (set `error` Control)
 - **Disabled** — 50% opacity, non-interactive
 
+### "All" / no-filter entry
+
+Set `allOption` for a selectable empty-value entry (e.g. "All service lines") — a real, non-greyed choice, unlike the `placeholder` prompt. The two are mutually exclusive; `allOption` wins if both are set. Use it for filter selects where "show everything" is an explicit option.
+
+<Canvas of={Stories.WithAllOption} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/components/ui/Select/Select.stories.tsx
+++ b/components/ui/Select/Select.stories.tsx
@@ -32,6 +32,10 @@ const meta: Meta<typeof Select> = {
       control: 'text',
       description: 'Empty-value option text shown when no selection has been made.',
     },
+    allOption: {
+      control: 'text',
+      description: 'Renders a selectable "no filter" entry (e.g. "All") with an empty value — a real, non-greyed choice, unlike `placeholder`. Mutually exclusive with `placeholder`.',
+    },
     helperText: {
       control: 'text',
       description: 'Hint text under the select. Hidden when `error` is present.',
@@ -90,6 +94,29 @@ export const Default: Story = {
     await expect(select).toBeVisible();
     await userEvent.selectOptions(select, 'second');
     await expect(select).toHaveValue('second');
+    await expect(args.onChange).toHaveBeenCalled();
+  },
+};
+
+/** @summary With a selectable "All" (no-filter) entry instead of a placeholder */
+export const WithAllOption: Story = {
+  args: {
+    label: 'Service line',
+    allOption: 'All service lines',
+    size: 'md',
+    fullWidth: true,
+    options: flatOptions,
+    onChange: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole('combobox');
+
+    // The "All" entry is a real, selectable empty-value option.
+    await userEvent.selectOptions(select, 'first');
+    await expect(select).toHaveValue('first');
+    await userEvent.selectOptions(select, 'All service lines');
+    await expect(select).toHaveValue('');
     await expect(args.onChange).toHaveBeenCalled();
   },
 };

--- a/components/ui/Select/Select.tsx
+++ b/components/ui/Select/Select.tsx
@@ -22,6 +22,13 @@ export interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement
   options: (SelectOption | SelectOptionGroup)[];
   /** Empty-value option text shown when no selection has been made. Renders as a placeholder-styled first option. */
   placeholder?: string;
+  /**
+   * Renders a selectable "no filter" entry (e.g. `"All"`) as the first option
+   * with an empty value — distinct from `placeholder` in that it is a real,
+   * non-greyed choice, not a pre-selection prompt. Mutually exclusive with
+   * `placeholder`; when both are set, `allOption` wins. Use for filter selects.
+   */
+  allOption?: string;
   /** Controlled selection. Pair with `onChange` — uncontrolled callers use `defaultValue`. */
   value?: string;
   /** Initial selection for uncontrolled use. */
@@ -58,6 +65,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     {
       options,
       placeholder,
+      allOption,
       value,
       defaultValue,
       disabled = false,
@@ -79,12 +87,14 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const inputId = id || (label ? generatedId : undefined);
     const hasError = Boolean(error);
 
+    // `allOption` is a real (non-greyed) choice, so it never triggers
+    // placeholder styling even though it shares the empty value.
     const [isPlaceholder, setIsPlaceholder] = useState(
-      !value && !defaultValue && Boolean(placeholder)
+      !value && !defaultValue && Boolean(placeholder) && !allOption
     );
 
     const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-      setIsPlaceholder(e.target.value === '');
+      setIsPlaceholder(e.target.value === '' && Boolean(placeholder) && !allOption);
       onChange?.(e);
     };
 
@@ -130,7 +140,11 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             }
             {...props}
           >
-            {placeholder && <option value="">{placeholder}</option>}
+            {allOption ? (
+              <option value="">{allOption}</option>
+            ) : (
+              placeholder && <option value="">{placeholder}</option>
+            )}
             {options.map((opt) =>
               isOptionGroup(opt) ? (
                 <optgroup key={opt.label} label={opt.label}>


### PR DESCRIPTION
## Summary
- feat(filter-button,select): add explicit "All" / clear affordance

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)

---

### Verification
- ✅ `typecheck` · `lint-tokens` (0 err) · `lint-inline-var` · `lint-jsdoc` · `lint-storybook-recipe` · ADR-008 slots — clean
- ✅ `build:lib` — `allLabel` / `allOption` present in built `dist` type declarations
- ✅ Select `WithAllOption` play test asserts empty-value selection round-trips
- ✅ Storybook published to Chromatic (build #887) — [view](https://www.chromatic.com/build?appId=69b8918cac3056b39424d5d3&number=887)
- ⚠️ **Visual diffs did NOT run — Chromatic snapshot quota exhausted (#771).** Published for review; automated regression is quota-blocked, not passed. New DOM: one dropdown entry (FilterButton) + one `<option>` (Select), both reusing existing option styling.