### PR TITLE
feat(page-header): add opt-in sticky variant

### DIFF
--- a/components/ui/PageHeader/PageHeader.css
+++ b/components/ui/PageHeader/PageHeader.css
@@ -32,6 +32,18 @@
   width: 100%;
 }
 
+/* ─── Sticky ─────────────────────────────────────────────────
+   Opt-in via the `sticky` prop. Pins to the top of the nearest scroll
+   container; the opaque surface keeps body content from showing through.
+   z-index sits above page content but below NavBar (100) and overlays
+   (Sheet 900 / Modal 1000). */
+.bds-page-header--sticky {
+  position: sticky;
+  top: 0;
+  z-index: 20; /* bds-lint-ignore — raw stacking value, matches NavBar/Sheet/Modal convention */
+  background-color: var(--surface-primary);
+}
+
 /* ─── Content (title + subtitle) ─────────────────────────────── */
 
 .bds-page-header__content {

--- a/components/ui/PageHeader/PageHeader.mdx
+++ b/components/ui/PageHeader/PageHeader.mdx
@@ -8,7 +8,7 @@ import * as Stories from './PageHeader.stories';
 
 <ComponentLinks slug="page-header" />
 
-Composable page-level header that brings together BDS components: `Breadcrumb`, `Button`, and `TabBar`. No background — inherits from parent context.
+Composable page-level header that brings together BDS components: `Breadcrumb`, `Button`, and `TabBar`. No background by default — inherits from parent context; the opt-in `sticky` prop adds an opaque surface so it can pin on scroll.
 
 ## Playground
 
@@ -71,6 +71,12 @@ Slots accept rendered elements — a raw `<Button>` or a consumer wrapper (`<Del
 ```
 
 <Canvas of={Stories.StructuredActions} />
+
+## Sticky
+
+Set `sticky` to pin the header to the top of its scroll container as the body scrolls. It renders an opaque `--surface-primary` background (so content passes cleanly beneath) and stacks above page content but below `NavBar` and overlays. Non-sticky remains the default — existing consumers are unaffected. The header sticks within the nearest scrolling ancestor, so that container — not the window — must own the scroll.
+
+<Canvas of={Stories.Sticky} />
 
 ## Props
 

--- a/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/components/ui/PageHeader/PageHeader.stories.tsx
@@ -53,6 +53,10 @@ const meta: Meta<typeof PageHeader> = {
   argTypes: {
     title: { control: 'text' },
     subtitle: { control: 'text' },
+    sticky: {
+      control: 'boolean',
+      description: 'Pin the header to the top of its scroll container on scroll. Renders an opaque surface so content scrolls beneath it. Default `false`.',
+    },
   },
 };
 
@@ -449,4 +453,39 @@ export const TunableSpacing: Story = {
       </Stack>
     );
   },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   Sticky — pins to the top of a scroll container on scroll
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary Sticky header pinned to the top of a scroll container */
+export const Sticky: Story = {
+  render: () => (
+    <div
+      style={{
+        height: 320,
+        overflowY: 'auto',
+        border: '1px solid var(--border-muted)',
+        background: 'var(--surface-primary)',
+      }}
+    >
+      <PageHeader
+        title="Project detail"
+        subtitle="Scroll this container — the header stays pinned to the top."
+        sticky
+        actions={<Button variant="primary" size="sm">Action</Button>}
+      />
+      <div style={{ padding: 'var(--padding-lg)' }}>
+        <Stack gap="var(--gap-md)">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <p key={i}>
+              Row {i + 1} — body content scrolls beneath the pinned header, which keeps
+              its opaque surface so nothing shows through.
+            </p>
+          ))}
+        </Stack>
+      </div>
+    </div>
+  ),
 };

--- a/components/ui/PageHeader/PageHeader.tsx
+++ b/components/ui/PageHeader/PageHeader.tsx
@@ -47,6 +47,14 @@ export interface PageHeaderProps extends HTMLAttributes<HTMLDivElement> {
   /** Title scale. Default: 'lg' */
   size?: 'sm' | 'md' | 'lg';
   /**
+   * Pin the header to the top of its scroll container on scroll
+   * (`position: sticky`). Renders an opaque `--surface-primary` background so
+   * body content scrolls cleanly beneath it. Default `false` — non-sticky
+   * consumers are unaffected. The header sticks within the nearest scrolling
+   * ancestor; ensure that container, not the window, owns the scroll.
+   */
+  sticky?: boolean;
+  /**
    * Bimodal page state. Drives auto-rendered `actions` when no explicit
    * `actions` slot is provided. See {@link PageHeaderMode}.
    */
@@ -102,6 +110,7 @@ export function PageHeader({
   tabs,
   metadata,
   size = 'lg',
+  sticky = false,
   mode,
   onEdit,
   onSave,
@@ -153,7 +162,12 @@ export function PageHeader({
 
   return (
     <div
-      className={bdsClass('bds-page-header', size !== 'lg' && `bds-page-header--${size}`, className)}
+      className={bdsClass(
+        'bds-page-header',
+        size !== 'lg' && `bds-page-header--${size}`,
+        sticky && 'bds-page-header--sticky',
+        className,
+      )}
       style={style}
       data-mode={mode}
       {...props}


### PR DESCRIPTION
## Summary
- feat(page-header): add opt-in sticky variant

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)

---

### Verification
- ✅ `typecheck` · `lint-tokens` (0 err) · `lint-inline-var` · `lint-jsdoc` · `lint-storybook-recipe` · ADR-008 slots — clean
- ✅ `build:lib` — `sticky` present in built `dist` type declarations
- ✅ Storybook published to Chromatic — [view build](https://www.chromatic.com/build?appId=69b8918cac3056b39424d5d3&number=888)
- ⚠️ **Visual diffs did NOT run — Chromatic snapshot quota exhausted (#771).** Published for review; automated regression is quota-blocked, not passed. New CSS: one `--sticky` modifier (position/z-index/surface); the `Sticky` story demonstrates pin-on-scroll.