### PR TITLE
feat(content-system): add serviceLine as canonical alias for audience

### DIFF
--- a/components/ui/Breadcrumb/Breadcrumb.css
+++ b/components/ui/Breadcrumb/Breadcrumb.css
@@ -61,34 +61,34 @@
  * --text-service-X-muted (forbidden by BDS naming canon: scoped
  * tokens carry context modifiers only, not hierarchy). */
 
-[data-audience='brand'] .bds-breadcrumb {
+:is([data-audience='brand'], [data-service-line='brand']) .bds-breadcrumb {
   --text-secondary: var(--text-service-brand-on-light);
   --text-muted: var(--text-service-brand-on-light);
 }
 
-[data-audience='marketing'] .bds-breadcrumb {
+:is([data-audience='marketing'], [data-service-line='marketing']) .bds-breadcrumb {
   --text-secondary: var(--text-service-marketing-on-light);
   --text-muted: var(--text-service-marketing-on-light);
 }
 
-[data-audience='information'] .bds-breadcrumb {
+:is([data-audience='information'], [data-service-line='information']) .bds-breadcrumb {
   --text-secondary: var(--text-service-information-on-light);
   --text-muted: var(--text-service-information-on-light);
 }
 
-[data-audience='product'] .bds-breadcrumb {
+:is([data-audience='product'], [data-service-line='product']) .bds-breadcrumb {
   --text-secondary: var(--text-service-product-on-light);
   --text-muted: var(--text-service-product-on-light);
 }
 
-[data-audience='back-office'] .bds-breadcrumb {
+:is([data-audience='back-office'], [data-service-line='back-office']) .bds-breadcrumb {
   --text-secondary: var(--text-service-back-office-on-light);
   --text-muted: var(--text-service-back-office-on-light);
 }
 
 /* @deprecated alias of [data-audience='back-office'] — remove with the
    `service` ServiceLine member in a future major. */
-[data-audience='service'] .bds-breadcrumb {
+:is([data-audience='service'], [data-service-line='service']) .bds-breadcrumb {
   --text-secondary: var(--text-service-back-office-on-light);
   --text-muted: var(--text-service-back-office-on-light);
 }
@@ -104,33 +104,33 @@
  * HeroSplitImageCardOverlay flips the headline/link cascade — so the current crumb
  * clears AA on the dark band (6.89–9.06:1) WITHOUT inverting the light-tint pages.
  * A bare [data-audience] flip regressed /services/brand to 1:1 (0.122.2). */
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='brand'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='brand'], [data-service-line='brand']) .bds-breadcrumb {
   --text-secondary: var(--text-service-brand-on-dark);
   --text-muted: var(--text-service-brand-on-dark);
 }
 
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='marketing'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='marketing'], [data-service-line='marketing']) .bds-breadcrumb {
   --text-secondary: var(--text-service-marketing-on-dark);
   --text-muted: var(--text-service-marketing-on-dark);
 }
 
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='information'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='information'], [data-service-line='information']) .bds-breadcrumb {
   --text-secondary: var(--text-service-information-on-dark);
   --text-muted: var(--text-service-information-on-dark);
 }
 
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='product'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='product'], [data-service-line='product']) .bds-breadcrumb {
   --text-secondary: var(--text-service-product-on-dark);
   --text-muted: var(--text-service-product-on-dark);
 }
 
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='back-office'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='back-office'], [data-service-line='back-office']) .bds-breadcrumb {
   --text-secondary: var(--text-service-back-office-on-dark);
   --text-muted: var(--text-service-back-office-on-dark);
 }
 
 /* @deprecated alias of [data-audience='back-office'] — see above. */
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='service'] .bds-breadcrumb {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='service'], [data-service-line='service']) .bds-breadcrumb {
   --text-secondary: var(--text-service-back-office-on-dark);
   --text-muted: var(--text-service-back-office-on-dark);
 }

--- a/components/ui/Breadcrumb/Breadcrumb.mdx
+++ b/components/ui/Breadcrumb/Breadcrumb.mdx
@@ -31,19 +31,20 @@ Real-world usage: page headers and settings navigation.
 
 <Canvas of={Stories.Patterns} />
 
-## Audience cascade
+## Service-line cascade
 
-When a breadcrumb sits inside a `[data-audience='X']` subtree, the
+When a breadcrumb sits inside a `[data-service-line='X']` subtree, the
 current page label and separators rebind canonical `--text-secondary`
 and `--text-muted` to the matching `--text-service-{name}` value
 (`brand`, `marketing`, `information`, `product`, and `service` → back-office).
 
 The component itself stays scope-blind — only the cascade block in
-`Breadcrumb.css` knows about audiences. Consumers set `data-audience`
+`Breadcrumb.css` knows about service lines. Consumers set `data-service-line`
 on any ancestor (page wrapper, hero card, sidebar column) and the
-breadcrumb inside picks up the hue.
+breadcrumb inside picks up the hue. The legacy `data-audience` attribute
+still resolves during the deprecation window (#788).
 
-<Canvas of={Stories.AudienceCascade} />
+<Canvas of={Stories.ServiceLineCascade} />
 
 ## Props
 

--- a/components/ui/Breadcrumb/Breadcrumb.stories.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.stories.tsx
@@ -192,16 +192,17 @@ export const Patterns: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   4. AUDIENCE CASCADE — service-line tinting via [data-audience]
+   4. SERVICE-LINE CASCADE — tinting via [data-service-line]
    ═══════════════════════════════════════════════════════════════ */
 
 // The breadcrumb stays scope-blind — __current reads --text-secondary
 // and __separator reads --text-muted as always. When the breadcrumb
-// sits inside a [data-audience='X'] subtree, Breadcrumb.css rebinds
+// sits inside a [data-service-line='X'] subtree, Breadcrumb.css rebinds
 // those two canonical tokens to --text-service-{name} so the current
-// page label + separators pick up the audience hue. The 'service'
-// audience maps to the back-office token set per the #563 rename.
-const AUDIENCES = [
+// page label + separators pick up the service-line hue. The 'service'
+// slug maps to the back-office token set per the #563 rename.
+// (The deprecated `[data-audience='X']` attribute still resolves — #788.)
+const SERVICE_LINES = [
   { id: 'brand', label: 'Brand (yellow)' },
   { id: 'marketing', label: 'Marketing (green)' },
   { id: 'information', label: 'Information (blue)' },
@@ -210,13 +211,13 @@ const AUDIENCES = [
   { id: 'service', label: 'Service — @deprecated alias of back-office (orange)' },
 ] as const;
 
-/** @summary Service-line tinting via [data-audience] cascade */
-export const AudienceCascade: Story = {
+/** @summary Service-line tinting via [data-service-line] cascade */
+export const ServiceLineCascade: Story = {
   render: () => (
     <Stack>
-      {AUDIENCES.map(({ id, label }) => (
-        <div key={id} data-audience={id}>
-          <SectionLabel>{`[data-audience='${id}'] — ${label}`}</SectionLabel>
+      {SERVICE_LINES.map(({ id, label }) => (
+        <div key={id} data-service-line={id}>
+          <SectionLabel>{`[data-service-line='${id}'] — ${label}`}</SectionLabel>
           <Breadcrumb
             items={[
               { label: 'Home', href: '#' },

--- a/content-system/blueprints/astro/types.ts
+++ b/content-system/blueprints/astro/types.ts
@@ -155,14 +155,20 @@ export interface BlueprintSection {
     readonly category?: 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
     readonly hasOptions?: boolean;
     /**
-     * Audience slug for `data-audience` scope binding. Re-binds canonical
-     * brand tokens (`--brand-primary`, `--background-brand-primary`,
+     * Service-line slug for `data-service-line` scope binding. Re-binds
+     * canonical brand tokens (`--brand-primary`, `--background-brand-primary`,
      * `--text-brand-primary`, `--border-brand-primary`) within the rendered
      * card so each card can carry its own service-line color. Used by
      * `features_3col_branded_dark`. The consumer site MUST define the
-     * `[data-audience='X'] { … }` cascade rules per the BDS scope-binding
+     * `[data-service-line='X'] { … }` cascade rules per the BDS scope-binding
      * docs (`docs/theming/client-themes`); BDS ships the pattern, not the
-     * audience-specific values.
+     * service-line-specific values.
+     */
+    readonly serviceLine?: 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
+    /**
+     * @deprecated Use `serviceLine`. Retained as a working alias — blueprints
+     * read `serviceLine ?? audience` and emit both `data-service-line` and
+     * `data-audience`. Removed with the `audience` API in a future major (#788).
      */
     readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
     /** Alt text for `imageUrl`. Defaults to empty (decorative) when omitted. */
@@ -184,17 +190,23 @@ export interface BlueprintSection {
     readonly href?: string;
   }>;
   /**
-   * Audience slug for `data-audience` scope binding at the SECTION
-   * level (cf. `items[].audience`, which scopes per-card). Re-binds
+   * Service-line slug for `data-service-line` scope binding at the SECTION
+   * level (cf. `items[].serviceLine`, which scopes per-card). Re-binds
    * canonical brand tokens within the rendered section so the hero,
    * background, and accents pick up the service-line color palette.
    * Used by `hero_split_image_card_overlay`. Consumer site MUST define
-   * the `[data-audience='X'] { … }` cascade rules — BDS ships the
-   * pattern, not the audience-specific values.
+   * the `[data-service-line='X'] { … }` cascade rules — BDS ships the
+   * pattern, not the service-line-specific values.
    *
    * Additive, optional — blueprints that don't read this are unaffected.
    *
    * `back-office` is canonical; `service` is a @deprecated alias (see #797).
+   */
+  readonly serviceLine?: 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
+  /**
+   * @deprecated Use `serviceLine`. Retained as a working alias — blueprints
+   * read `serviceLine ?? audience` and emit both `data-service-line` and
+   * `data-audience`. Removed with the `audience` API in a future major (#788).
    */
   readonly audience?: 'brand' | 'marketing' | 'information' | 'product' | 'back-office' | 'service';
   /**
@@ -204,14 +216,14 @@ export interface BlueprintSection {
    * **Precedence (brik-bds#546):**
    *   1. If `iconUrl` is set, render a raw `<img>` (this slot's legacy
    *      contract — still respected for non-category eyebrows).
-   *   2. Otherwise, if `audience` is set, the blueprint renders a canonical
-   *      `<ServiceTag category={audience} variant="icon">` for the eyebrow
-   *      — the design-system path. Theme-aware, no consumer-side URL
-   *      computation needed.
+   *   2. Otherwise, if `serviceLine` (or the deprecated `audience`) is set, the
+   *      blueprint renders a canonical `<ServiceTag category={serviceLine}
+   *      variant="icon">` for the eyebrow — the design-system path. Theme-aware,
+   *      no consumer-side URL computation needed.
    *   3. Otherwise no eyebrow renders.
    *
    * Most service-detail pages can stop passing `iconUrl` entirely once
-   * `audience` is set. Keep `iconUrl` for cases where the visual is NOT a
+   * `serviceLine` is set. Keep `iconUrl` for cases where the visual is NOT a
    * category indicator (e.g., a holiday campaign hero with a snowflake).
    *
    * Pair with `iconAlt` for an informational alt; default empty (decorative).

--- a/content-system/blueprints/react/Features.stories.tsx
+++ b/content-system/blueprints/react/Features.stories.tsx
@@ -3,7 +3,7 @@ import type { JSX } from 'react';
 
 import { Features } from './Features';
 
-/* ─── Demo data-audience cascade ────────────────────────────────────
+/* ─── Demo data-service-line cascade ────────────────────────────────────
  *
  * BDS ships the scope-binding pattern but not audience-specific values
  * — those live in each consumer's globals.css. Storybook needs the
@@ -11,27 +11,27 @@ import { Features } from './Features';
  * colors. This `<style>` block is a representative example of what a
  * consumer site would declare for its audience verticals.
  */
-const audienceCascadeStyles = `
-[data-audience='brand'] {
+const serviceLineCascadeStyles = `
+[data-service-line='brand'] {
   --background-brand-primary: var(--theme-yellow-yellow-light);
   --brand-primary: var(--theme-yellow-yellow-light);
   --text-brand-primary: var(--theme-yellow-yellow-dark);
 }
-[data-audience='marketing'] {
+[data-service-line='marketing'] {
   --background-brand-primary: var(--theme-green-green-light);
   --brand-primary: var(--theme-green-green-light);
   --text-brand-primary: var(--theme-green-green-dark);
 }
-[data-audience='information'] {
+[data-service-line='information'] {
   --background-brand-primary: var(--color-blue-light);
   --text-brand-primary: var(--color-blue-dark);
 }
-[data-audience='product'] {
+[data-service-line='product'] {
   --background-brand-primary: var(--theme-purple-purple-light);
   --brand-primary: var(--theme-purple-purple-light);
   --text-brand-primary: var(--theme-purple-purple-dark);
 }
-[data-audience='service'] {
+[data-service-line='service'] {
   --background-brand-primary: var(--theme-orange-orange-light);
   --brand-primary: var(--theme-orange-orange-light);
   --text-brand-primary: var(--theme-orange-orange-dark);
@@ -44,27 +44,27 @@ const items = [
     description:
       'A two-line card description that sets the type rhythm without competing with the title.',
     href: '#',
-    audience: 'brand' as const,
+    serviceLine: 'brand' as const,
   },
   {
     title: 'Capability two',
     description:
       'A two-line card description that sets the type rhythm without competing with the title.',
     href: '#',
-    audience: 'marketing' as const,
+    serviceLine: 'marketing' as const,
   },
   {
     title: 'Capability three',
     description:
       'A two-line card description that sets the type rhythm without competing with the title.',
     href: '#',
-    audience: 'service' as const,
+    serviceLine: 'service' as const,
   },
 ];
 
 const withAudienceCascade = (Story: () => JSX.Element) => (
   <>
-    <style dangerouslySetInnerHTML={{ __html: audienceCascadeStyles }} />
+    <style dangerouslySetInnerHTML={{ __html: serviceLineCascadeStyles }} />
     <Story />
   </>
 );
@@ -79,7 +79,7 @@ const meta: Meta<typeof Features> = {
     docs: {
       description: {
         component:
-          'The `bds-features` feature-grid section primitive (brik-bds#1197) — the Phase D consolidation of the features family, retiring the ADR-008-banned `bp-features-branded-dark` (`--dark` = theme, `--branded` = appearance, `3col` = count). Single-member family, so no layout modifier: the block is the responsive grid. The dark surface is the `--bds-features-bg` default, not a class name. Each card emits `data-audience` to re-bind `--background-brand-primary` per the BDS scope-binding pattern; stories include a representative cascade block. Card title uses bold weight + 18px, description 16px regular — the AA-clearing posture for white-on-saturated-brand backgrounds (BDS contrast burndown #40).',
+          'The `bds-features` feature-grid section primitive (brik-bds#1197) — the Phase D consolidation of the features family, retiring the ADR-008-banned `bp-features-branded-dark` (`--dark` = theme, `--branded` = appearance, `3col` = count). Single-member family, so no layout modifier: the block is the responsive grid. The dark surface is the `--bds-features-bg` default, not a class name. Each card emits `data-service-line` to re-bind `--background-brand-primary` per the BDS scope-binding pattern; stories include a representative cascade block. Card title uses bold weight + 18px, description 16px regular — the AA-clearing posture for white-on-saturated-brand backgrounds (BDS contrast burndown #40).',
       },
     },
   },
@@ -122,7 +122,7 @@ export const Wrapped: Story = {
         description:
           'A two-line card description that sets the type rhythm without competing with the title.',
         href: '#',
-        audience: 'information' as const,
+        serviceLine: 'information' as const,
       },
     ],
   },

--- a/content-system/blueprints/react/Features.tsx
+++ b/content-system/blueprints/react/Features.tsx
@@ -61,8 +61,14 @@ export interface FeatureItem {
   /** Alt text for `imageUrl`. Empty (decorative) when omitted. */
   imageAlt?: string;
   /**
-   * Audience slug emitted as `data-audience` for per-card brand-color scope
-   * binding, and used for the `ServiceTag` icon fallback when no `imageUrl`.
+   * Service-line slug emitted as `data-service-line` for per-card brand-color
+   * scope binding, and used for the `ServiceTag` icon fallback when no `imageUrl`.
+   */
+  serviceLine?: ServiceLine;
+  /**
+   * @deprecated Use `serviceLine`. Working alias — resolved as
+   * `serviceLine ?? audience`; the card emits both `data-service-line` and
+   * `data-audience` during the deprecation window (#788).
    */
   audience?: ServiceLine;
 }
@@ -117,14 +123,16 @@ export function Features({
 
         <ul className="bds-features__grid" role="list">
           {items.map((item, idx) => {
-            const audience = item.audience ?? null;
+            // `serviceLine` is canonical; `audience` is the deprecated alias (#788).
+            const serviceLine = item.serviceLine ?? item.audience ?? null;
             return (
               <li key={`${sectionKey}-${idx}`} className="bds-features__item">
                 <Card
                   variant="outlined"
                   padding="none"
                   className="bds-features__card"
-                  data-audience={audience ?? undefined}
+                  data-service-line={serviceLine ?? undefined}
+                  data-audience={serviceLine ?? undefined}
                 >
                   <a
                     className="bds-features__card-link"
@@ -139,13 +147,13 @@ export function Features({
                           loading="lazy"
                           decoding="async"
                         />
-                      ) : audience ? (
+                      ) : serviceLine ? (
                         <span
                           className="bds-features__image-fallback"
                           aria-hidden="true"
                         >
                           <ServiceTag
-                            category={audience}
+                            category={serviceLine}
                             variant="icon"
                             size="lg"
                             serviceName={item.title}

--- a/content-system/blueprints/react/Features3ColBrandedDark.stories.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.stories.tsx
@@ -4,7 +4,7 @@ import { Features3ColBrandedDark } from './Features3ColBrandedDark';
 import type { BlueprintProps } from '../astro/types';
 import { baseTheme, baseClientFacts } from './_fixtures';
 
-/* ─── Demo data-audience cascade ────────────────────────────────────
+/* ─── Demo data-service-line cascade ────────────────────────────────────
  *
  * BDS ships the scope-binding pattern but not audience-specific values
  * — those live in each consumer's globals.css. Storybook needs the
@@ -14,29 +14,29 @@ import { baseTheme, baseClientFacts } from './_fixtures';
  *
  * Per the cascade rules (`docs/theming/client-themes`), we re-bind
  * `--background-brand-primary` and the related brand-* tokens inside
- * the `[data-audience='X']` subtree. Components stay scope-blind.
+ * the `[data-service-line='X']` subtree. Components stay scope-blind.
  */
-const audienceCascadeStyles = `
-[data-audience='brand'] {
+const serviceLineCascadeStyles = `
+[data-service-line='brand'] {
   --background-brand-primary: var(--theme-yellow-yellow-light);
   --brand-primary: var(--theme-yellow-yellow-light);
   --text-brand-primary: var(--theme-yellow-yellow-dark);
 }
-[data-audience='marketing'] {
+[data-service-line='marketing'] {
   --background-brand-primary: var(--theme-green-green-light);
   --brand-primary: var(--theme-green-green-light);
   --text-brand-primary: var(--theme-green-green-dark);
 }
-[data-audience='information'] {
+[data-service-line='information'] {
   --background-brand-primary: var(--color-blue-light);
   --text-brand-primary: var(--color-blue-dark);
 }
-[data-audience='product'] {
+[data-service-line='product'] {
   --background-brand-primary: var(--theme-purple-purple-light);
   --brand-primary: var(--theme-purple-purple-light);
   --text-brand-primary: var(--theme-purple-purple-dark);
 }
-[data-audience='service'] {
+[data-service-line='service'] {
   --background-brand-primary: var(--theme-orange-orange-light);
   --brand-primary: var(--theme-orange-orange-light);
   --text-brand-primary: var(--theme-orange-orange-dark);
@@ -73,19 +73,19 @@ const featuresSection: BlueprintProps['section'] = {
       title: 'Capability one',
       description: 'A two-line card description that sets the type rhythm without competing with the title.',
       href: '#',
-      audience: 'brand',
+      serviceLine: 'brand',
     },
     {
       title: 'Capability two',
       description: 'A two-line card description that sets the type rhythm without competing with the title.',
       href: '#',
-      audience: 'marketing',
+      serviceLine: 'marketing',
     },
     {
       title: 'Capability three',
       description: 'A two-line card description that sets the type rhythm without competing with the title.',
       href: '#',
-      audience: 'service',
+      serviceLine: 'service',
     },
   ],
 };
@@ -100,7 +100,7 @@ const baseProps: BlueprintProps = {
 
 const withAudienceCascade = (Story: () => JSX.Element) => (
   <>
-    <style dangerouslySetInnerHTML={{ __html: audienceCascadeStyles }} />
+    <style dangerouslySetInnerHTML={{ __html: serviceLineCascadeStyles }} />
     <Story />
   </>
 );
@@ -117,7 +117,7 @@ const meta: Meta<typeof Features3ColBrandedDark> = {
     docs: {
       description: {
         component:
-          'Dark section with a 3-column grid of brand-colored cards. Each card emits `data-audience` to re-bind `--background-brand-primary` for that subtree per the BDS scope-binding pattern (`docs/theming/client-themes`). Stories include a representative cascade block showing how a consumer site would declare per-audience bindings. Card title uses bold weight + 18px, description 16px regular — the AA-clearing posture for white-on-saturated-brand backgrounds (BDS contrast burndown #40).',
+          'Dark section with a 3-column grid of brand-colored cards. Each card emits `data-service-line` to re-bind `--background-brand-primary` for that subtree per the BDS scope-binding pattern (`docs/theming/client-themes`). Stories include a representative cascade block showing how a consumer site would declare per-audience bindings. Card title uses bold weight + 18px, description 16px regular — the AA-clearing posture for white-on-saturated-brand backgrounds (BDS contrast burndown #40).',
       },
     },
   },
@@ -156,7 +156,7 @@ export const Wrapped: Story = {
           title: 'Capability four',
           description: 'A two-line card description that sets the type rhythm without competing with the title.',
           href: '#',
-          audience: 'information',
+          serviceLine: 'information',
         },
       ],
     },

--- a/content-system/blueprints/react/Features3ColBrandedDark.tsx
+++ b/content-system/blueprints/react/Features3ColBrandedDark.tsx
@@ -26,7 +26,9 @@ export function Features3ColBrandedDark({ section }: Props) {
     href: item.href ?? undefined,
     imageUrl: item.imageUrl ?? undefined,
     imageAlt: item.imageAlt ?? undefined,
-    audience: (item.audience ?? undefined) as ServiceLine | undefined,
+    // `serviceLine` canonical; `audience` deprecated alias (#788). Pass both
+    // through so `Features` can resolve `serviceLine ?? audience`.
+    serviceLine: (item.serviceLine ?? item.audience ?? undefined) as ServiceLine | undefined,
   }));
 
   return (

--- a/content-system/blueprints/react/Hero.css
+++ b/content-system/blueprints/react/Hero.css
@@ -169,7 +169,7 @@
  * rename. Both bind the orange back-office tokens (`service-back-office`,
  * renamed from the bug-named `service-service` in #563). API-level rename
  * `data-audience` → `data-service-line` is a separate cross-repo follow-up. */
-.bds-hero--with-pricing-card[data-audience='brand'] {
+.bds-hero--with-pricing-card:is([data-audience='brand'], [data-service-line='brand']) {
   background: var(--surface-service-brand-inverse);
   --bds-hero-headline-color: var(--text-service-brand-on-light);
   --bds-hero-eyebrow-color: var(--text-service-brand-on-light);
@@ -179,7 +179,7 @@
   --text-on-color-light: var(--color-grayscale-white);
 }
 
-.bds-hero--with-pricing-card[data-audience='marketing'] {
+.bds-hero--with-pricing-card:is([data-audience='marketing'], [data-service-line='marketing']) {
   background: var(--surface-service-marketing-inverse);
   --bds-hero-headline-color: var(--text-service-marketing-on-light);
   --bds-hero-eyebrow-color: var(--text-service-marketing-on-light);
@@ -189,7 +189,7 @@
   --text-on-color-light: var(--color-grayscale-white);
 }
 
-.bds-hero--with-pricing-card[data-audience='information'] {
+.bds-hero--with-pricing-card:is([data-audience='information'], [data-service-line='information']) {
   background: var(--surface-service-information-inverse);
   --bds-hero-headline-color: var(--text-service-information-on-light);
   --bds-hero-eyebrow-color: var(--text-service-information-on-light);
@@ -199,7 +199,7 @@
   --text-on-color-light: var(--color-grayscale-white);
 }
 
-.bds-hero--with-pricing-card[data-audience='product'] {
+.bds-hero--with-pricing-card:is([data-audience='product'], [data-service-line='product']) {
   background: var(--surface-service-product-inverse);
   --bds-hero-headline-color: var(--text-service-product-on-light);
   --bds-hero-eyebrow-color: var(--text-service-product-on-light);
@@ -209,8 +209,8 @@
   --text-on-color-light: var(--color-grayscale-white);
 }
 
-.bds-hero--with-pricing-card[data-audience='back-office'],
-.bds-hero--with-pricing-card[data-audience='service'] {
+.bds-hero--with-pricing-card:is([data-audience='back-office'], [data-service-line='back-office']),
+.bds-hero--with-pricing-card:is([data-audience='service'], [data-service-line='service']) {
   background: var(--surface-service-back-office-inverse);
   --bds-hero-headline-color: var(--text-service-back-office-on-light);
   --bds-hero-eyebrow-color: var(--text-service-back-office-on-light);
@@ -226,14 +226,14 @@
  * can't sustain white text (2.87–4.36:1); darker ones can. Override
  * --text-inverse per luminance group so all five lines pass AA in dark mode.
  * Uses mode-invariant --text-on-color-light (black) / --text-on-color-dark (white). */
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='brand'],
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='marketing'] {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='brand'], [data-service-line='brand']),
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='marketing'], [data-service-line='marketing']) {
   --text-inverse: var(--text-on-color-light); /* black on yellow/green-darker: 4.82–7.33:1 */
 }
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='information'],
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='product'],
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='back-office'],
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='service'] {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='information'], [data-service-line='information']),
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='product'], [data-service-line='product']),
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='back-office'], [data-service-line='back-office']),
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='service'], [data-service-line='service']) {
   --text-inverse: var(--text-on-color-dark);  /* white on blue/purple/orange-darker: 5.48–9.48:1 */
 }
 
@@ -245,32 +245,32 @@
  * (6.89–9.06:1) via contrast-gate (brik-bds#1017). The inner inverse <Button>
  * is unaffected: its label/fill ride --text-inverse / --background-inverse
  * (surface-service-{line}-dark), handled above. */
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='brand'] {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='brand'], [data-service-line='brand']) {
   --bds-hero-headline-color: var(--text-service-brand-on-dark);
   --bds-hero-eyebrow-color: var(--text-service-brand-on-dark);
   --bds-hero-lead-color: var(--text-service-brand-on-dark);
   --text-brand-primary: var(--text-service-brand-on-dark);
 }
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='marketing'] {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='marketing'], [data-service-line='marketing']) {
   --bds-hero-headline-color: var(--text-service-marketing-on-dark);
   --bds-hero-eyebrow-color: var(--text-service-marketing-on-dark);
   --bds-hero-lead-color: var(--text-service-marketing-on-dark);
   --text-brand-primary: var(--text-service-marketing-on-dark);
 }
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='information'] {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='information'], [data-service-line='information']) {
   --bds-hero-headline-color: var(--text-service-information-on-dark);
   --bds-hero-eyebrow-color: var(--text-service-information-on-dark);
   --bds-hero-lead-color: var(--text-service-information-on-dark);
   --text-brand-primary: var(--text-service-information-on-dark);
 }
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='product'] {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='product'], [data-service-line='product']) {
   --bds-hero-headline-color: var(--text-service-product-on-dark);
   --bds-hero-eyebrow-color: var(--text-service-product-on-dark);
   --bds-hero-lead-color: var(--text-service-product-on-dark);
   --text-brand-primary: var(--text-service-product-on-dark);
 }
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='back-office'],
-:root[data-theme="dark"] .bds-hero--with-pricing-card[data-audience='service'] {
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='back-office'], [data-service-line='back-office']),
+:root[data-theme="dark"] .bds-hero--with-pricing-card:is([data-audience='service'], [data-service-line='service']) {
   --bds-hero-headline-color: var(--text-service-back-office-on-dark);
   --bds-hero-eyebrow-color: var(--text-service-back-office-on-dark);
   --bds-hero-lead-color: var(--text-service-back-office-on-dark);

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -4,7 +4,7 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 import { HeroSplitImageCardOverlay } from './HeroSplitImageCardOverlay';
 import type { BlueprintProps } from '../astro/types';
 
-/* ─── Demo data-audience cascade ────────────────────────────────────
+/* ─── Demo data-service-line cascade ────────────────────────────────────
  *
  * BDS ships the scope-binding pattern; consumer sites declare the
  * audience-specific values. This <style> block mirrors what
@@ -12,24 +12,24 @@ import type { BlueprintProps } from '../astro/types';
  * the canonical "Information" hero renders against the same blue
  * tint as the live site.
  */
-const audienceCascadeStyles = `
-[data-audience='brand'] {
+const serviceLineCascadeStyles = `
+[data-service-line='brand'] {
   --page-brand-primary: var(--theme-yellow-yellow-light);
   --text-brand-primary: var(--theme-yellow-yellow-dark);
 }
-[data-audience='marketing'] {
+[data-service-line='marketing'] {
   --page-brand-primary: var(--theme-green-green-light);
   --text-brand-primary: var(--theme-green-green-dark);
 }
-[data-audience='information'] {
+[data-service-line='information'] {
   --page-brand-primary: var(--color-blue-light);
   --text-brand-primary: var(--color-blue-dark);
 }
-[data-audience='product'] {
+[data-service-line='product'] {
   --page-brand-primary: var(--theme-purple-purple-light);
   --text-brand-primary: var(--theme-purple-purple-dark);
 }
-[data-audience='service'] {
+[data-service-line='service'] {
   --page-brand-primary: var(--theme-orange-orange-light);
   --text-brand-primary: var(--theme-orange-orange-dark);
 }
@@ -76,7 +76,7 @@ const interiorHeroSection: BlueprintProps['section'] = {
     { label: 'Category', href: '#' },
     { label: 'Service detail' },
   ],
-  audience: 'information',
+  serviceLine: 'information',
   priceCard: {
     imageUrl: 'https://placehold.co/600x600/eaf1fb/1f3d70?text=Deliverable',
     imageAlt: '',
@@ -105,7 +105,7 @@ const baseProps: BlueprintProps = {
 
 const withAudienceCascade = (Story: () => JSX.Element) => (
   <>
-    <style dangerouslySetInnerHTML={{ __html: audienceCascadeStyles }} />
+    <style dangerouslySetInnerHTML={{ __html: serviceLineCascadeStyles }} />
     <Story />
   </>
 );
@@ -122,7 +122,7 @@ const meta: Meta<typeof HeroSplitImageCardOverlay> = {
     docs: {
       description: {
         component:
-          'Interior-page hero blueprint. 58/42 split: left column carries the page trail (breadcrumb, eyebrow, h1, optional body, single dark CTA) on a soft audience-tinted background; right column shows a white image card with optional price overlay. Drives `/services/{cat}/{slug}` style pages — the failure zone where agents previously improvised layouts because no canonical block covered the shape. Audience tinting is a `data-audience` cascade: BDS ships the pattern, consumer sites declare the per-audience color values. The Playground fixture mirrors `brikdesigns.com/service/layout-design`.',
+          'Interior-page hero blueprint. 58/42 split: left column carries the page trail (breadcrumb, eyebrow, h1, optional body, single dark CTA) on a soft audience-tinted background; right column shows a white image card with optional price overlay. Drives `/services/{cat}/{slug}` style pages — the failure zone where agents previously improvised layouts because no canonical block covered the shape. Service-line tinting is a `data-service-line` cascade: BDS ships the pattern, consumer sites declare the per-audience color values. The Playground fixture mirrors `brikdesigns.com/service/layout-design`.',
       },
     },
   },
@@ -164,9 +164,9 @@ export const LandscapePhotography: Story = {
 
 /**
  * @summary Service-tag opt-out — `showServiceTag={false}` suppresses the
- * eyebrow icon/ServiceTag slot while `audience` still drives the
- * `data-audience` color theming (note the tint is unchanged from Playground).
- * For support-plan heroes that want the audience tint without a service-line
+ * eyebrow icon/ServiceTag slot while `serviceLine` still drives the
+ * `data-service-line` color theming (note the tint is unchanged from Playground).
+ * For support-plan heroes that want the service-line tint without a service-line
  * badge — brikdesigns.com #452.
  */
 export const NoServiceTag: Story = {

--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.tsx
@@ -71,7 +71,9 @@ export function HeroSplitImageCardOverlay({
   icon,
   onPriceCtaClick,
 }: Props) {
-  const { breadcrumb = [], audience, iconUrl, iconAlt, priceCard } = section;
+  const { breadcrumb = [], serviceLine, audience, iconUrl, iconAlt, priceCard } = section;
+  // `serviceLine` is canonical; `audience` is the deprecated alias (#788).
+  const resolvedServiceLine = serviceLine ?? audience;
 
   const breadcrumbNode =
     breadcrumb.length > 0 ? (
@@ -108,10 +110,10 @@ export function HeroSplitImageCardOverlay({
               decoding="async"
             />
           )
-        : audience
+        : resolvedServiceLine
           ? (
               <ServiceTag
-                category={audience}
+                category={resolvedServiceLine}
                 variant="icon"
                 size="lg"
                 className="bds-hero__icon"
@@ -200,7 +202,8 @@ export function HeroSplitImageCardOverlay({
       breadcrumb={breadcrumbNode}
       eyebrow={eyebrowNode}
       media={media}
-      data-audience={audience}
+      data-service-line={resolvedServiceLine}
+      data-audience={resolvedServiceLine}
       data-blueprint-key="hero_split_image_card_overlay"
     />
   );


### PR DESCRIPTION
## Summary
- feat(content-system): add serviceLine as canonical alias for audience

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)

---

### Verification — headless Playwright (Chromatic quota exhausted, #771)
Because #788 is a color-cascade attribute rename, a missed `[data-audience]` selector would silently drop a service-line tint. Rather than ship blind, I drove **Playwright/Chromium** against the built `dist` CSS and asserted the painted result across **all 6 service lines** and **both attributes**:

**Breadcrumb** (`__current` color, 12 selectors):
| line | `data-service-line` | `data-audience` | result |
|---|---|---|---|
| brand | rgb(99,71,22) | rgb(99,71,22) | ✅ match, ≠ control |
| marketing | rgb(42,85,66) | rgb(42,85,66) | ✅ |
| information | rgb(49,73,82) | rgb(49,73,82) | ✅ |
| product | rgb(43,36,64) | rgb(43,36,64) | ✅ |
| back-office | rgb(63,16,0) | rgb(63,16,0) | ✅ |
| service (→back-office) | rgb(63,16,0) | rgb(63,16,0) | ✅ |

**Hero pricing-card** (`background`, 18 selectors) — ✅ all 6 match across both attributes in **light AND dark** mode.

Control (no attribute) differs from every tinted case, confirming the selectors actually fire and **no `[data-audience]` selector was missed** in the `:is()` sweep.

- ✅ `typecheck` · `lint-tokens` (0 err) · `lint-inline-var` · `lint-jsdoc` · `lint-storybook-recipe` · blueprint-naming · Tier-4 · ADR-008 slots — clean
- ✅ `build:lib` — `serviceLine` in built `dist` types; `data-service-line` compiled into `dist/styles.css`
- ✅ Backward-compatible: existing `audience` / `data-audience` consumers unaffected (both emitted, both matched by CSS)

**Not in this PR:** consumer migration (audience → serviceLine) + eventual `audience` removal (separate major). renew-pms migration blocked by its code freeze.