### PR TITLE
refactor(storybook): story-shape batch 1 — 105 → 71 exports (#1276)

### DIFF
--- a/components/ui/AddableComboList/AddableComboList.mdx
+++ b/components/ui/AddableComboList/AddableComboList.mdx
@@ -10,45 +10,29 @@ import * as Stories from './AddableComboList.stories';
 
 Catalog-backed multi-pick input. Renders a list of suggestions in a typeahead dropdown; allows free-form entries by default, or restrict to catalog values via `strict`. Picked values render as `<Tag>` chips.
 
-## Playground
+> **Note** — Deprecated. Use `<AddableTagList suggestions={...} />` instead (ADR-003); `maxEntries` renames to `maxItems`.
 
-<Canvas of={Stories.Playground} />
+## Default
+
+<Canvas of={Stories.Default} />
 
 ## Variants
 
 ### Pre-populated
 
-Some values already selected. The picker hides them from the dropdown.
-
 <Canvas of={Stories.PrePopulated} />
 
 ### Strict mode
 
-`strict` rejects free-form entries — picks must match a catalog value.
-
 <Canvas of={Stories.StrictMode} />
 
-### With helper text
+### Read mode
 
-`helperText` appears below the input.
+<Canvas of={Stories.ReadMode} />
 
-<Canvas of={Stories.WithHelperText} />
+### Max entries reached
 
-### Disabled
-
-<Canvas of={Stories.Disabled} />
-
-### Max entries hit
-
-`maxEntries` caps the number of picks; the Add button hides at the limit.
-
-<Canvas of={Stories.MaxEntriesHit} />
-
-## Patterns
-
-Three intake fields stacked — services (mixed catalog + custom), payment types (pre-populated), and a strict insurance-network picker.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.MaxEntriesCap} />
 
 ## Props
 

--- a/components/ui/AddableComboList/AddableComboList.stories.tsx
+++ b/components/ui/AddableComboList/AddableComboList.stories.tsx
@@ -80,28 +80,41 @@ const DENTAL_INSURANCE = [
 
 // ── Storybook meta ────────────────────────────────────────────────────────────
 
+/**
+ * @deprecated Use `<AddableTagList suggestions={...} />` instead (ADR-003).
+ * Kept for existing consumers during the migration window — see
+ * AddableTagList.stories.tsx for the canonical replacement.
+ */
 const meta: Meta<typeof AddableComboList> = {
   title: 'Containers/addable-combo-list',
   component: AddableComboList,
-  tags: ['surface-product'],
+  tags: ['surface-product', '!manifest'],
   parameters: { layout: 'centered' },
   argTypes: {
+    values: { control: false, description: 'Current selected values (rendered as Tag chips).' },
+    onChange: { control: false, description: 'Called with the next values on add / remove.' },
+    suggestions: { control: 'object', description: 'Suggestion set filtered by the typed query.' },
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
     label: { control: 'text' },
     addLabel: { control: 'text' },
+    removeLabel: { control: 'text' },
     placeholder: { control: 'text' },
     helperText: { control: 'text' },
     emptyLabel: { control: 'text' },
-    disabled: { control: 'boolean' },
+    disabled: {
+      control: 'boolean',
+      description: 'Read-only chip rendering — see the `ReadMode` story.',
+    },
     strict: { control: 'boolean' },
     maxEntries: { control: 'number' },
+    className: { control: false },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof AddableComboList>;
 
-// ── Controlled wrapper ────────────────────────────────────────────────────────
+// ── Controlled wrapper — hook-driven state machine args can't express (Q4) ────
 
 const Controlled = (args: React.ComponentProps<typeof AddableComboList>) => {
   const [values, setValues] = useState<string[]>(args.values ?? []);
@@ -127,8 +140,7 @@ const Controlled = (args: React.ComponentProps<typeof AddableComboList>) => {
  *
  * @summary Interactive playground for prop tweaking
  */
-export const Playground: Story = {
-  name: 'Default',
+export const Default: Story = {
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -145,10 +157,9 @@ export const Playground: Story = {
  * Pre-populated — dental payment types with some values already selected.
  * Already-selected options are hidden from the dropdown.
  *
- * @summary Pre populated
+ * @summary Starting template with existing selections
  */
 export const PrePopulated: Story = {
-  name: 'Pre-Populated',
   args: {
     label: 'Payment Types Accepted',
     suggestions: DENTAL_PAYMENT_TYPES,
@@ -164,10 +175,9 @@ export const PrePopulated: Story = {
  * Strict mode — insurance providers only.
  * Free-form entries are rejected; only listed providers can be added.
  *
- * @summary Strict mode
+ * @summary Catalog-only picks, no free-form entries
  */
 export const StrictMode: Story = {
-  name: 'Strict Mode',
   args: {
     label: 'Insurance Providers Accepted',
     suggestions: DENTAL_INSURANCE,
@@ -181,32 +191,12 @@ export const StrictMode: Story = {
 };
 
 /**
- * With helper text — shows the optional line beneath the list.
- *
- * @summary With helper text
- */
-export const WithHelperText: Story = {
-  name: 'With Helper Text',
-  args: {
-    label: 'Services Offered',
-    suggestions: DENTAL_SERVICES,
-    values: ['Crowns', 'Teeth Whitening'],
-    placeholder: 'Search or add a service…',
-    addLabel: 'Add Service',
-    helperText: 'Cleaning, implants, orthodontics, cosmetic…',
-    onChange: fn(),
-  },
-  render: (args) => <Controlled {...args} />,
-};
-
-/**
- * Disabled — read-only chip rendering for view-mode sheets.
+ * Read mode (`disabled`) — read-only chip rendering for view-mode sheets.
  * No input or remove controls are rendered.
  *
- * @summary Disabled state
+ * @summary Read-only chip rendering
  */
-export const Disabled: Story = {
-  name: 'Disabled',
+export const ReadMode: Story = {
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -218,12 +208,10 @@ export const Disabled: Story = {
 };
 
 /**
- * MaxEntries hit — values at the cap; input is hidden.
- *
- * @summary Max entries hit
+ * `maxEntries` reached — the input hides once the cap is hit.
+ * @summary List at capacity — input hides
  */
-export const MaxEntriesHit: Story = {
-  name: 'Max Entries Hit',
+export const MaxEntriesCap: Story = {
   args: {
     label: 'Top Services',
     suggestions: DENTAL_SERVICES,
@@ -235,54 +223,14 @@ export const MaxEntriesHit: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
+// ── Interaction tests — play-only, hidden from MCP discovery (Q5) ─────────────
+
 /**
- * Patterns — three real intake fields stacked: services with a controlled
- * vocabulary plus free-form fallback, payment types pre-populated, and
- * a strict insurance picker that rejects free-form entries.
- *
- * @summary Common usage patterns
+ * Selecting an option from the dropdown commits it.
+ * @summary Play-function interaction test
  */
-export const Patterns: Story = {
-  render: () => {
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: 480 }}>
-        <Controlled
-          label="Services Offered"
-          suggestions={DENTAL_SERVICES}
-          values={['Preventive Care / Cleaning', 'Crowns']}
-          placeholder="Search or add a service…"
-          addLabel="Add Service"
-          helperText="Pick from the catalog or add a custom service."
-          onChange={() => {}}
-        />
-        <Controlled
-          label="Payment Types Accepted"
-          suggestions={DENTAL_PAYMENT_TYPES}
-          values={['CareCredit', 'Visa / Mastercard / Discover', 'Cash']}
-          placeholder="Search payment types…"
-          addLabel="Add Payment Type"
-          onChange={() => {}}
-        />
-        <Controlled
-          label="Insurance Networks"
-          suggestions={DENTAL_INSURANCE}
-          values={['Delta Dental', 'Blue Cross Blue Shield']}
-          strict
-          placeholder="Pick from the network list…"
-          addLabel="Add Network"
-          helperText="Strict — only accepted carriers from the catalog."
-          onChange={() => {}}
-        />
-      </div>
-    );
-  },
-};
-
-// ── Interaction stories ───────────────────────────────────────────────────────
-
-/** @summary Select from dropdown */
-export const SelectFromDropdown: Story = {
-  name: 'Interaction — select from dropdown',
+export const InteractionTestSelectFromDropdown: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -311,9 +259,13 @@ export const SelectFromDropdown: Story = {
   },
 };
 
-/** @summary Free form entry */
-export const FreeFormEntry: Story = {
-  name: 'Interaction — free-form entry',
+/**
+ * Typing a value with no matching suggestion and pressing Enter commits it
+ * as a free-form entry.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestFreeFormEntry: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -335,9 +287,12 @@ export const FreeFormEntry: Story = {
   },
 };
 
-/** @summary Keyboard navigation */
-export const KeyboardNavigation: Story = {
-  name: 'Interaction — keyboard navigation',
+/**
+ * Arrow + Enter highlights and commits a suggestion.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestKeyboardNavigation: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -366,9 +321,12 @@ export const KeyboardNavigation: Story = {
   },
 };
 
-/** @summary Escape closes dropdown */
-export const EscapeClosesDropdown: Story = {
-  name: 'Interaction — Escape closes dropdown',
+/**
+ * Escape closes the dropdown without committing.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestEscapeClosesDropdown: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -397,9 +355,12 @@ export const EscapeClosesDropdown: Story = {
   },
 };
 
-/** @summary Backspace removes last tag */
-export const BackspaceRemovesLastTag: Story = {
-  name: 'Interaction — Backspace on empty removes last tag',
+/**
+ * Backspace on an empty input removes the last committed tag.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestBackspaceRemovesLastTag: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -423,9 +384,12 @@ export const BackspaceRemovesLastTag: Story = {
   },
 };
 
-/** @summary Strict rejects free form */
-export const StrictRejectsFreeForm: Story = {
-  name: 'Interaction — strict mode rejects free-form',
+/**
+ * Strict mode rejects a free-form entry that doesn't match a suggestion.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestStrictRejectsFreeForm: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Insurance Providers',
     suggestions: DENTAL_INSURANCE,
@@ -449,9 +413,12 @@ export const StrictRejectsFreeForm: Story = {
   },
 };
 
-/** @summary Duplicate flash */
-export const DuplicateFlash: Story = {
-  name: 'Interaction — duplicate rejected',
+/**
+ * A duplicate (case-insensitive) entry is rejected and never reaches onChange.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestDuplicateRejected: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,

--- a/components/ui/AddableEntryList/AddableEntryList.mdx
+++ b/components/ui/AddableEntryList/AddableEntryList.mdx
@@ -8,47 +8,33 @@ import * as Stories from './AddableEntryList.stories';
 
 <ComponentLinks slug="addable-entry-list" />
 
-User-managed list of `{ primary, description }` entries. The primary field type (`text` or `url`) controls value rendering — text shows raw, URL renders as a link in read mode.
+User-managed list of `{ primary, secondary }` entries. The primary field type (`text` or `url`) controls value rendering — text shows raw, URL renders as a link in read mode. Providing `primarySuggestions` switches the primary field to a combobox.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-All-modes view — read mode and edit mode side by side, with both URL-primary and text-primary configurations.
+### Read mode
 
-<Canvas of={Stories.Variants} />
+`disabled` renders token-backed typography with no inputs or remove controls. Flip `primaryInputType` via Controls to compare the URL-anchor and plain-text renderings.
 
-### Read mode (URL primary)
+<Canvas of={Stories.ReadMode} />
 
-URL primary renders each entry's URL as an anchor in read mode.
+### With suggestions
 
-<Canvas of={Stories.ReadModeUrl} />
+Preserves the reveal-form flow — existing entries render as read-only cards; Add opens a staging form with a combobox-backed primary. `primaryStrict` (Controls) rejects free-form entries.
 
-### Read mode (text primary)
+<Canvas of={Stories.WithSuggestions} />
 
-Text primary shows the value as plain text.
-
-<Canvas of={Stories.ReadModeText} />
-
-### Inline edit (text primary)
-
-Edit mode with inline text inputs for each row.
-
-<Canvas of={Stories.InlineEditText} />
-
-### Empty state
-
-The list renders an empty-state row when no entries exist.
+### Empty
 
 <Canvas of={Stories.Empty} />
 
-## Patterns
+### Max items reached
 
-Catalog-backed services list — primary field tied to an industry catalog with suggestions, free-text fallback, and full edit-flow.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.MaxItemsCap} />
 
 ## Props
 

--- a/components/ui/AddableEntryList/AddableEntryList.stories.tsx
+++ b/components/ui/AddableEntryList/AddableEntryList.stories.tsx
@@ -35,27 +35,6 @@ const DENTAL_SERVICES = [
   'Night Guards / Bruxism',
 ];
 
-// ── Shared helpers ────────────────────────────────────────────────────────────
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div
-    style={{
-      fontFamily: 'var(--font-family-label)',
-      fontSize: 'var(--body-xs)', // bds-lint-ignore
-      textTransform: 'uppercase' as const,
-      letterSpacing: '0.05em',
-      marginBottom: 'var(--gap-md)',
-      color: 'var(--text-muted)',
-    }}
-  >
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
 // ── Storybook meta ────────────────────────────────────────────────────────────
 
 const meta: Meta<typeof AddableEntryList> = {
@@ -64,28 +43,48 @@ const meta: Meta<typeof AddableEntryList> = {
   tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
+    entries: { control: false, description: 'Current list of `{ primary, secondary }` entries.' },
+    onChange: { control: false, description: 'Called with the next entries array on add / edit / remove.' },
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
     primaryInputType: { control: 'select', options: ['text', 'url'] },
     label: { control: 'text' },
     addLabel: { control: 'text' },
+    removeLabel: { control: 'text' },
     primaryPlaceholder: { control: 'text' },
     secondaryPlaceholder: { control: 'text' },
     primaryLabel: { control: 'text' },
     secondaryLabel: { control: 'text' },
     helperText: { control: 'text' },
     emptyLabel: { control: 'text' },
-    disabled: { control: 'boolean' },
+    emptyDescriptionLabel: {
+      control: 'text',
+      description: 'Read-mode fallback shown in place of `secondary` when it is empty.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Read-only rendering — see the `ReadMode` story for the token-backed typography treatment.',
+    },
     allowDuplicates: { control: 'boolean' },
     maxItems: { control: 'number' },
     secondaryRows: { control: 'number' },
-    primaryStrict: { control: 'boolean' },
+    primarySuggestions: {
+      control: 'object',
+      description: 'Suggestion set for the primary field — switches to combobox suggestion mode. See `WithSuggestions`.',
+    },
+    primaryStrict: {
+      control: 'boolean',
+      description: 'Only meaningful with `primarySuggestions` — rejects free-form primary values.',
+    },
+    className: { control: false },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof AddableEntryList>;
 
-// ── Controlled wrapper ────────────────────────────────────────────────────────
+// ── Controlled wrapper — hook-driven state machine args can't express (Q4) ────
+// Every story needs local state to reflect add/edit/remove back into the
+// canvas; the wrapper itself is the irreducible part, not a standalone story.
 
 const Controlled = (args: React.ComponentProps<typeof AddableEntryList>) => {
   const [entries, setEntries] = useState<AddableEntry[]>(args.entries ?? []);
@@ -106,13 +105,14 @@ const Controlled = (args: React.ComponentProps<typeof AddableEntryList>) => {
 // ── Stories ───────────────────────────────────────────────────────────────────
 
 /**
- * Default playground — Competitors. URL primary + notes, inline-editable rows.
- * Each entry renders with its own TextInput + TextArea + Remove button; the
- * Add button appends a new empty row.
+ * Plain inline-edit mode — Competitors. URL primary + notes, each entry
+ * editable in place via TextInput + TextArea + Remove. The Add button
+ * appends a new empty row. Flip `primaryInputType` via Controls to compare
+ * URL vs. plain text.
  *
  * @summary Interactive playground for prop tweaking
  */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     label: 'Competitors',
     primaryInputType: 'url',
@@ -133,13 +133,13 @@ export const Playground: Story = {
 };
 
 /**
- * Read mode — URL primary renders as a clickable anchor; secondary renders
- * with `--body-md`. Titles use `--label-md`. No remove buttons, no Add.
+ * Read mode (`disabled`) — token-backed typography, no inputs, no remove.
+ * `primaryInputType="url"` renders the primary as a clickable anchor; flip
+ * to `text` via Controls to see the plain-text rendering.
  *
- * @summary Read mode url
+ * @summary Read-only rendering — flip primaryInputType for URL vs text
  */
-export const ReadModeUrl: Story = {
-  name: 'Read mode — URL primary',
+export const ReadMode: Story = {
   args: {
     label: 'Competitors',
     primaryInputType: 'url',
@@ -155,63 +155,14 @@ export const ReadModeUrl: Story = {
 };
 
 /**
- * Read mode — text primary (not a link). Primary uses `--label-md`; secondary
- * uses `--body-md`.
+ * Suggestion mode (`primarySuggestions`) — preserves the reveal-form flow:
+ * existing entries render as read-only cards; Add opens a staging form with
+ * a combobox-backed primary. Type "cr" to see "Crowns" appear. Enter commits
+ * and moves focus to the description textarea.
  *
- * @summary Read mode text
+ * @summary Suggestion-backed primary with free-form fallback
  */
-export const ReadModeText: Story = {
-  name: 'Read mode — text primary',
-  args: {
-    label: 'Line Items',
-    primaryInputType: 'text',
-    disabled: true,
-    entries: [
-      { primary: 'Logo design', secondary: 'Primary mark + lockup + responsive variants.' },
-      { primary: 'Brand guidelines', secondary: '12-page PDF including color, typography, and voice.' },
-    ],
-    onChange: fn(),
-  },
-  render: (args) => <Controlled {...args} />,
-};
-
-/**
- * Text primary (inline-editable). Same UX as Playground but with a plain
- * text input instead of a URL input.
- *
- * @summary Inline edit text
- */
-export const InlineEditText: Story = {
-  name: 'Inline edit — text primary',
-  args: {
-    label: 'Line Items',
-    primaryInputType: 'text',
-    primaryLabel: 'Item',
-    secondaryLabel: 'Description',
-    primaryPlaceholder: 'e.g. Logo design',
-    secondaryPlaceholder: 'Optional description',
-    addLabel: 'Add Line Item',
-    removeLabel: 'Remove line item',
-    entries: [
-      { primary: 'Logo design', secondary: '' },
-      { primary: 'Brand guidelines', secondary: '12-page PDF including color, typography, and voice.' },
-    ],
-    onChange: fn(),
-  },
-  render: (args) => <Controlled {...args} />,
-};
-
-/**
- * Primary with suggestions — dental services vocabulary.
- * Type "cr" to see "Crowns" appear. Enter commits and moves focus to description.
- *
- * Suggestion mode preserves the reveal-form flow (existing entries render as
- * read-only cards; Add opens a staging form).
- *
- * @summary Common usage patterns
- */
-export const Patterns: Story = {
-  name: 'Primary With Suggestions',
+export const WithSuggestions: Story = {
   args: {
     label: 'Services',
     primaryLabel: 'Service Name',
@@ -230,31 +181,7 @@ export const Patterns: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
-/**
- * Primary strict — only listed services can be added.
- * Typing a non-matching string shows the strict hint and blocks commit.
- *
- * @summary Primary strict with suggestions
- */
-export const PrimaryStrictWithSuggestions: Story = {
-  name: 'Primary Strict With Suggestions',
-  args: {
-    label: 'Services',
-    primaryLabel: 'Service Name',
-    primaryPlaceholder: 'Search services…',
-    secondaryLabel: 'Description',
-    secondaryPlaceholder: 'Brief description',
-    addLabel: 'Add Service',
-    removeLabel: 'Remove service',
-    primarySuggestions: DENTAL_SERVICES,
-    primaryStrict: true,
-    entries: [],
-    onChange: fn(),
-  },
-  render: (args) => <Controlled {...args} />,
-};
-
-/** @summary Empty state */
+/** @summary Empty starting state before any entries are added */
 export const Empty: Story = {
   args: {
     label: 'Reference Sites',
@@ -272,202 +199,36 @@ export const Empty: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
-/** @summary With empty description label */
-export const WithEmptyDescriptionLabel: Story = {
-  name: 'Empty description fallback (read mode)',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'When `emptyDescriptionLabel` is provided, read-mode entries with no secondary show a muted italic placeholder instead of collapsing to a bare title. ' +
-          'Matches the "title + body with fallback" pattern used by service catalog views.',
-      },
-    },
-  },
+/**
+ * `maxItems` reached — the Add button hides once the cap is hit.
+ * @summary List at capacity — Add button hides
+ */
+export const MaxItemsCap: Story = {
   args: {
-    label: 'Services',
-    disabled: true,
-    emptyDescriptionLabel: 'No description set',
+    label: 'Top Reference Sites',
+    maxItems: 3,
+    addLabel: 'Add Reference',
+    removeLabel: 'Remove reference',
+    helperText: 'Add button hides when the limit is reached.',
     entries: [
-      { primary: 'Cleanings including periodontal care (gum care) and oral cancer screenings', secondary: '' },
-      {
-        primary: 'Cosmetic dentistry',
-        secondary: 'Veneers, whitening, bonding — focused on aesthetic outcomes, not function.',
-      },
+      { primary: 'First reference', secondary: 'First' },
+      { primary: 'Second reference', secondary: 'Second' },
+      { primary: 'Third reference', secondary: 'Third' },
     ],
     onChange: fn(),
   },
   render: (args) => <Controlled {...args} />,
 };
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <div style={{ width: 560 }}>
-      <Stack>
-        <div>
-          <SectionLabel>Modes</SectionLabel>
-          <Stack gap="var(--gap-lg)">
-            <Controlled
-              label="Edit mode — URL primary"
-              primaryInputType="url"
-              primaryLabel="URL"
-              secondaryLabel="Notes"
-              primaryPlaceholder="https://example.com"
-              secondaryPlaceholder="Why this site is a reference"
-              addLabel="Add Reference"
-              removeLabel="Remove reference"
-              entries={[{ primary: 'https://acme.com', secondary: 'Direct competitor' }]}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Read mode — URL primary"
-              primaryInputType="url"
-              disabled
-              entries={[
-                { primary: 'https://acme.com', secondary: 'Direct competitor — stronger brand.' },
-                { primary: 'https://widgets.io', secondary: 'Adjacent market; watch for expansion.' },
-              ]}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Read mode — text primary"
-              disabled
-              entries={[
-                { primary: 'Logo design', secondary: 'Primary mark + lockup' },
-                { primary: 'Brand guidelines', secondary: '12-page PDF' },
-              ]}
-              onChange={() => {}}
-            />
-          </Stack>
-        </div>
-
-        <div>
-          <SectionLabel>Sizes (edit mode)</SectionLabel>
-          <Stack gap="var(--gap-lg)">
-            <Controlled
-              label="Small"
-              size="sm"
-              primaryInputType="url"
-              primaryLabel="URL"
-              secondaryLabel="Notes"
-              addLabel="Add"
-              removeLabel="Remove entry"
-              entries={[{ primary: 'https://acme.com', secondary: 'Direct competitor' }]}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Medium (default)"
-              size="md"
-              primaryInputType="url"
-              primaryLabel="URL"
-              secondaryLabel="Notes"
-              addLabel="Add"
-              removeLabel="Remove entry"
-              entries={[
-                { primary: 'https://acme.com', secondary: 'Direct competitor' },
-                { primary: 'https://widgets.io', secondary: 'Adjacent market' },
-              ]}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Large"
-              size="lg"
-              primaryInputType="url"
-              primaryLabel="URL"
-              secondaryLabel="Notes"
-              addLabel="Add"
-              removeLabel="Remove entry"
-              entries={[{ primary: 'https://acme.com', secondary: 'Direct competitor' }]}
-              onChange={() => {}}
-            />
-          </Stack>
-        </div>
-
-        <div>
-          <SectionLabel>States</SectionLabel>
-          <Stack gap="var(--gap-lg)">
-            <Controlled
-              label="Empty"
-              emptyLabel="No competitors added yet."
-              addLabel="Add Competitor"
-              entries={[]}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="With helper text"
-              helperText="Each row saves in place; Add appends a new entry."
-              primaryInputType="url"
-              primaryLabel="URL"
-              secondaryLabel="Notes"
-              addLabel="Add Competitor"
-              removeLabel="Remove competitor"
-              entries={[{ primary: 'https://acme.com', secondary: 'Direct competitor' }]}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Max 3 entries"
-              maxItems={3}
-              addLabel="Add"
-              removeLabel="Remove entry"
-              helperText="Add button hides when limit is reached."
-              entries={[
-                { primary: 'A', secondary: 'First' },
-                { primary: 'B', secondary: 'Second' },
-                { primary: 'C', secondary: 'Third' },
-              ]}
-              onChange={() => {}}
-            />
-          </Stack>
-        </div>
-
-        <div>
-          <SectionLabel>Suggestion Modes (reveal-form preserved)</SectionLabel>
-          <Stack gap="var(--gap-lg)">
-            <Controlled
-              label="With Suggestions (free-form allowed)"
-              primaryLabel="Service Name"
-              secondaryLabel="Description"
-              primaryPlaceholder="Search or add a service…"
-              secondaryPlaceholder="Brief description"
-              addLabel="Add Service"
-              removeLabel="Remove service"
-              primarySuggestions={DENTAL_SERVICES}
-              entries={[
-                { primary: 'Crowns', secondary: 'Porcelain or ceramic caps to restore damaged teeth.' },
-              ]}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="With Suggestions (strict)"
-              primaryLabel="Service Name"
-              secondaryLabel="Description"
-              primaryPlaceholder="Search services…"
-              secondaryPlaceholder="Brief description"
-              addLabel="Add Service"
-              removeLabel="Remove service"
-              primarySuggestions={DENTAL_SERVICES}
-              primaryStrict
-              entries={[]}
-              onChange={() => {}}
-            />
-          </Stack>
-        </div>
-      </Stack>
-    </div>
-  ),
-};
-
-// ── Interaction stories ───────────────────────────────────────────────────────
+// ── Interaction tests — play-only, hidden from MCP discovery (Q5) ─────────────
 
 /**
  * Plain mode — clicking Add appends an empty row; onChange fires with the
- * appended entry. Typing into a field patches that row via onChange.
- *
- * @summary Add and edit row
+ * appended entry.
+ * @summary Play-function interaction test
  */
-export const AddAndEditRow: Story = {
-  name: 'Interaction — add appends empty row',
+export const InteractionTestAddAppendsRow: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Competitors',
     primaryInputType: 'url',
@@ -494,9 +255,12 @@ export const AddAndEditRow: Story = {
   },
 };
 
-/** @summary Remove an entry */
-export const RemoveAnEntry: Story = {
-  name: 'Interaction — remove an entry (plain mode)',
+/**
+ * Plain mode — removing an entry updates onChange with the remaining rows.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestRemoveEntry: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Competitors',
     primaryInputType: 'url',
@@ -523,11 +287,10 @@ export const RemoveAnEntry: Story = {
 
 /**
  * Read mode — URL primary renders as an anchor pointing to the URL.
- *
- * @summary Read mode url is anchor
+ * @summary Play-function interaction test
  */
-export const ReadModeUrlIsAnchor: Story = {
-  name: 'Interaction — read mode URL primary is an anchor',
+export const InteractionTestReadModeUrlAnchor: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Competitors',
     primaryInputType: 'url',
@@ -546,16 +309,13 @@ export const ReadModeUrlIsAnchor: Story = {
   },
 };
 
-// ── Suggestion mode interactions (preserved) ──────────────────────────────────
-
 /**
- * Keyboard flow — Arrow + Enter in primary commits suggestion and moves focus
- * to the secondary textarea. This is the core two-field keyboard UX for Services.
- *
- * @summary Keyboard flow suggestion
+ * Keyboard flow — Arrow + Enter in primary commits suggestion and moves
+ * focus to the secondary textarea.
+ * @summary Play-function interaction test
  */
-export const KeyboardFlowSuggestion: Story = {
-  name: 'Interaction — suggestion keyboard: Arrow + Enter commits, focuses secondary',
+export const InteractionTestSuggestionKeyboardFlow: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services',
     primaryLabel: 'Service Name',
@@ -597,11 +357,10 @@ export const KeyboardFlowSuggestion: Story = {
 
 /**
  * Strict mode — typing a non-matching string blocks commit.
- *
- * @summary Strict rejects free form
+ * @summary Play-function interaction test
  */
-export const StrictRejectsFreeForm: Story = {
-  name: 'Interaction — strict mode rejects free-form entry',
+export const InteractionTestStrictRejectsFreeForm: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services',
     primaryLabel: 'Service Name',
@@ -631,9 +390,13 @@ export const StrictRejectsFreeForm: Story = {
   },
 };
 
-/** @summary Click select from dropdown */
-export const ClickSelectFromDropdown: Story = {
-  name: 'Interaction — click to select suggestion from dropdown',
+/**
+ * Clicking a suggestion in the dropdown commits it and moves focus to the
+ * secondary textarea.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestClickSelectSuggestion: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services',
     primaryLabel: 'Service Name',
@@ -665,9 +428,12 @@ export const ClickSelectFromDropdown: Story = {
   },
 };
 
-/** @summary Escape closes dropdown */
-export const EscapeClosesDropdown: Story = {
-  name: 'Interaction — Escape closes dropdown, keeps form open',
+/**
+ * Escape closes the dropdown but keeps the staging form open.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestEscapeClosesDropdown: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services',
     primaryLabel: 'Service Name',

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.mdx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.mdx
@@ -10,21 +10,23 @@ import * as Stories from './AddableFieldRowList.stories';
 
 User-managed list of multi-field rows. Render-prop API: consumer supplies the per-row inputs, the list locks the add/remove affordance, grid layout, and empty/max-items behavior. Replaces hand-rolled `display: grid` row tables across the portal.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Empty state and max-items state stacked.
+`AddableFieldRowList` has no semantic-variant axis — the generic `<T>` row shape and render-prop `children` are hook-driven and can't be authored via Controls. Every real usage is a distinct row composition; see [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md).
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 ## Patterns
 
-Three real-world row shapes — phone-system 3-field, holiday hours with cross-field disabling, and competitive frames with three textareas.
+Real row shapes from the portal onboarding survey (ADR-005) — three-field with a Select, cross-field disabling, three-textarea composition, and the empty/max-items cap.
 
-<Canvas of={Stories.Patterns} />
+### Software inventory (3 fields)
+
+<Canvas of={Stories.SoftwareInventory} />
 
 ### Holiday hours (cross-field disabling)
 
@@ -32,11 +34,15 @@ Open / close TextInputs disable when the Closed checkbox is set. Demonstrates th
 
 <Canvas of={Stories.HolidayHours} />
 
-### Competitive frames (3 TextAreas)
+### Competitive frames (3 textareas)
 
 Wider rows that compose three TextAreas — "competitor / gap / copy implication" — used in onboarding strategy sheets.
 
 <Canvas of={Stories.CompetitiveFrames} />
+
+### Max items reached
+
+<Canvas of={Stories.MaxItemsCap} />
 
 ## Props
 

--- a/components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx
+++ b/components/ui/AddableFieldRowList/AddableFieldRowList.stories.tsx
@@ -11,14 +11,35 @@ const meta: Meta<typeof AddableFieldRowList> = {
   component: AddableFieldRowList,
   tags: ['surface-product'],
   parameters: { layout: 'padded' },
+  argTypes: {
+    values: { control: false, description: 'Current list of rows.' },
+    onChange: { control: false, description: 'Called with the next rows on add / update / remove.' },
+    newRow: { control: false, description: 'Factory for a new empty row, called once per "Add" click.' },
+    children: {
+      control: false,
+      description: 'Render-prop for the row field markup — receives `{ row, index, update }`.',
+    },
+    columns: {
+      control: 'text',
+      description: 'CSS `grid-template-columns` for the row fields; the primitive appends an `auto` track for the remove button.',
+    },
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    emptyLabel: { control: 'text' },
+    addLabel: { control: 'text' },
+    removeLabel: { control: 'text' },
+    maxItems: { control: 'number' },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/* ─── Playground: simple two-text-field row ───────────────────
- * Minimal shape — 2 text columns, no Select, no cross-field logic.
- * Used as the "kick the tires" entry point on the docs page.
+/* ─── Default: simple two-text-field row ───────────────────────
+ * Minimal shape — 2 text columns, no Select, no cross-field logic. The
+ * render-prop `children` and generic row shape are hook-driven and can't
+ * be expressed as args (Q4) — every story here wires its own local state.
  */
 
 interface Item {
@@ -26,8 +47,8 @@ interface Item {
   value: string;
 }
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Minimal two-field row — the "kick the tires" entry point */
+export const Default: Story = {
   render: () => {
     const [items, setItems] = useState<Item[]>([
       { label: 'Phone', value: '(615) 555-0100' },
@@ -68,7 +89,7 @@ export const Playground: Story = {
   },
 };
 
-/* ─── Patterns: phone-system-style 3-field row ────────────────
+/* ─── SoftwareInventory: phone-system-style 3-field row ────────
  * Mirrors onboarding-software-sheet.tsx — Name + Purpose + Category Select.
  * The canonical multi-field row pattern across the portal.
  */
@@ -85,9 +106,8 @@ const CATEGORY_OPTIONS = [
   { value: 'other', label: 'Other Tools' },
 ];
 
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Phone System (3 fields)',
+/** @summary Three-field row — text + text + Select */
+export const SoftwareInventory: Story = {
   render: () => {
     const [tools, setTools] = useState<Tool[]>([
       { name: 'HubSpot', purpose: 'CRM and pipeline tracking', category: 'crm' },
@@ -133,7 +153,7 @@ export const Patterns: Story = {
   },
 };
 
-/* ─── Story 2: Holiday hours (cross-field disabling) ──────────
+/* ─── HolidayHours: cross-field disabling ──────────────────────
  * Mirrors onboarding-listing-sheet.tsx — open + close TextInput
  * (disabled when closed) + Closed Checkbox. Demonstrates that the
  * render-prop API supports cross-field interactions naturally.
@@ -145,9 +165,8 @@ interface Holiday {
   closed: boolean;
 }
 
-/** @summary Holiday hours */
+/** @summary Cross-field disabling — Closed checkbox disables open/close */
 export const HolidayHours: Story = {
-  name: 'Holiday hours (cross-field disabling)',
   render: () => {
     const [holidays, setHolidays] = useState<Holiday[]>([
       { open: '09:00', close: '17:00', closed: false },
@@ -196,7 +215,7 @@ export const HolidayHours: Story = {
   },
 };
 
-/* ─── Story 3: Competitive Positioning (3 TextAreas) ──────────
+/* ─── CompetitiveFrames: three TextAreas ────────────────────────
  * Mirrors onboarding-competitors-sheet.tsx — Competitor + Gap +
  * Copy implication. Demonstrates wider rows with TextArea fields
  * and the same 3-column grid working for taller content.
@@ -208,9 +227,8 @@ interface CompetitiveFrame {
   copyImplication: string;
 }
 
-/** @summary Competitive frames */
+/** @summary Three-textarea row for wider composed content */
 export const CompetitiveFrames: Story = {
-  name: 'Competitive Positioning (3 textareas)',
   render: () => {
     const [frames, setFrames] = useState<CompetitiveFrame[]>([
       {
@@ -263,7 +281,7 @@ export const CompetitiveFrames: Story = {
   },
 };
 
-/* ─── Story 4: Empty state + maxItems gating ──────────────────
+/* ─── MaxItemsCap: empty state + maxItems gating ────────────────
  * Demonstrates the empty state and maxItems behavior — Add button
  * disappears once the cap is reached.
  */
@@ -272,9 +290,8 @@ interface SimpleNote {
   text: string;
 }
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  name: 'Empty state + maxItems',
+/** @summary Empty starting state, capped at maxItems */
+export const MaxItemsCap: Story = {
   render: () => {
     const [notes, setNotes] = useState<SimpleNote[]>([]);
 

--- a/components/ui/AddableTagList/AddableTagList.mdx
+++ b/components/ui/AddableTagList/AddableTagList.mdx
@@ -1,0 +1,33 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
+import { ComponentLinks } from '../../../.storybook/blocks/ComponentLinks';
+import * as Stories from './AddableTagList.stories';
+
+<Meta of={Stories} />
+
+# AddableTagList
+
+<ComponentLinks slug="addable-tag-list" />
+
+Reveal-on-click list of removable text tags. Without `suggestions`, it's a plain text input where Enter commits. With `suggestions`, it's a combobox — typing filters the list, and free-form entries are still accepted unless `strict` is set. Replaces `AddableTextList` and `AddableComboList` (ADR-003).
+
+## Default
+
+<Canvas of={Stories.Default} />
+
+## Variants
+
+### With suggestions
+
+<Canvas of={Stories.WithSuggestions} />
+
+### Strict mode
+
+<Canvas of={Stories.StrictMode} />
+
+### Read mode
+
+<Canvas of={Stories.ReadMode} />
+
+## Props
+
+<ArgTypes of={Stories} />

--- a/components/ui/AddableTagList/AddableTagList.stories.tsx
+++ b/components/ui/AddableTagList/AddableTagList.stories.tsx
@@ -52,23 +52,37 @@ const meta: Meta<typeof AddableTagList> = {
   tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
+    values: { control: false, description: 'Current list of tag values.' },
+    onChange: { control: false, description: 'Called with the updated values on add / remove.' },
+    suggestions: {
+      control: 'object',
+      description: 'Optional suggestion set — switches to combobox mode. See `WithSuggestions`.',
+    },
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
     label: { control: 'text' },
     addLabel: { control: 'text' },
+    removeLabel: { control: 'text' },
     placeholder: { control: 'text' },
     helperText: { control: 'text' },
     emptyLabel: { control: 'text' },
-    disabled: { control: 'boolean' },
-    strict: { control: 'boolean' },
+    disabled: {
+      control: 'boolean',
+      description: 'Read-only chip rendering — see the `ReadMode` story.',
+    },
+    strict: {
+      control: 'boolean',
+      description: 'Only meaningful with `suggestions` — rejects free-form entries.',
+    },
     allowDuplicates: { control: 'boolean' },
     maxItems: { control: 'number' },
+    className: { control: false },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof AddableTagList>;
 
-// ── Controlled wrapper ────────────────────────────────────────────────────────
+// ── Controlled wrapper — hook-driven state machine args can't express (Q4) ────
 
 const Controlled = (args: React.ComponentProps<typeof AddableTagList>) => {
   const [values, setValues] = useState<string[]>(args.values ?? []);
@@ -89,8 +103,7 @@ const Controlled = (args: React.ComponentProps<typeof AddableTagList>) => {
 // ── Stories ───────────────────────────────────────────────────────────────────
 
 /** @summary Plain mode — no suggestions, free-form text entry */
-export const Plain: Story = {
-  name: 'Default (plain)',
+export const Default: Story = {
   args: {
     label: 'Anti-messages',
     values: [],
@@ -102,9 +115,12 @@ export const Plain: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
-/** @summary Combobox mode — suggestion-backed, free-form fallback */
+/**
+ * Combobox mode — typing filters `suggestions`; free-form entries still
+ * commit unless `strict` is set.
+ * @summary Suggestion-backed combobox with free-form fallback
+ */
 export const WithSuggestions: Story = {
-  name: 'With Suggestions',
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -117,9 +133,11 @@ export const WithSuggestions: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
-/** @summary Strict mode — only listed suggestions accepted */
+/**
+ * `strict` rejects free-form entries — picks must match a suggestion.
+ * @summary Catalog-only picks, no free-form entries
+ */
 export const StrictMode: Story = {
-  name: 'Strict Mode',
   args: {
     label: 'Insurance Providers',
     suggestions: DENTAL_INSURANCE,
@@ -132,8 +150,11 @@ export const StrictMode: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
-/** @summary Disabled — read-only chip display */
-export const Disabled: Story = {
+/**
+ * Read mode (`disabled`) — read-only chip display, no input or remove.
+ * @summary Read-only chip rendering
+ */
+export const ReadMode: Story = {
   args: {
     label: 'Services Offered',
     suggestions: DENTAL_SERVICES,
@@ -144,49 +165,14 @@ export const Disabled: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
+// ── Interaction tests — play-only, hidden from MCP discovery (Q5) ─────────────
+
 /**
- * Patterns — plain mode alongside suggestion-backed mode.
- * @summary Common usage patterns
+ * Plain mode — typing a value and pressing Enter commits it.
+ * @summary Play-function interaction test
  */
-export const Patterns: Story = {
-  render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: 480 }}>
-      <Controlled
-        label="Anti-messages"
-        values={['No price-first positioning']}
-        placeholder="e.g. No price-first positioning"
-        addLabel="Add"
-        helperText="Things the brand should never say."
-        onChange={() => {}}
-      />
-      <Controlled
-        label="Services Offered"
-        suggestions={DENTAL_SERVICES}
-        values={['Preventive Care / Cleaning', 'Crowns']}
-        placeholder="Search or add a service…"
-        addLabel="Add Service"
-        helperText="Pick from the catalog or add a custom service."
-        onChange={() => {}}
-      />
-      <Controlled
-        label="Insurance Networks"
-        suggestions={DENTAL_INSURANCE}
-        values={['Delta Dental', 'Blue Cross Blue Shield']}
-        strict
-        placeholder="Pick from the network list…"
-        addLabel="Add Network"
-        helperText="Strict — only accepted carriers from the catalog."
-        onChange={() => {}}
-      />
-    </div>
-  ),
-};
-
-// ── Interaction stories ───────────────────────────────────────────────────────
-
-/** @summary Plain mode — Enter commits */
-export const PlainEnterCommits: Story = {
-  name: 'Interaction — plain Enter commits',
+export const InteractionTestPlainEnterCommits: Story = {
+  tags: ['!manifest'],
   args: { label: 'Tags', values: [], addLabel: 'Add', onChange: fn() },
   render: (args) => <Controlled {...args} />,
   play: async ({ canvasElement, args }) => {
@@ -198,9 +184,12 @@ export const PlainEnterCommits: Story = {
   },
 };
 
-/** @summary Combobox — select from dropdown */
-export const SelectFromDropdown: Story = {
-  name: 'Interaction — select from dropdown',
+/**
+ * Combobox mode — selecting an option from the dropdown commits it.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestSelectFromDropdown: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services', suggestions: DENTAL_SERVICES, values: [],
     placeholder: 'Search…', addLabel: 'Add Service', onChange: fn(),
@@ -217,9 +206,12 @@ export const SelectFromDropdown: Story = {
   },
 };
 
-/** @summary Strict rejects free form */
-export const StrictRejectsFreeForm: Story = {
-  name: 'Interaction — strict rejects free-form',
+/**
+ * Strict mode rejects a free-form entry that doesn't match a suggestion.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestStrictRejectsFreeForm: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Insurance', suggestions: DENTAL_INSURANCE, values: [],
     strict: true, placeholder: 'Search…', addLabel: 'Add', onChange: fn(),

--- a/components/ui/AddableTextList/AddableTextList.mdx
+++ b/components/ui/AddableTextList/AddableTextList.mdx
@@ -10,27 +10,31 @@ import * as Stories from './AddableTextList.stories';
 
 User-managed list of plain-text values rendered as `<Tag>` chips. Type, press Enter to add; click the × to remove. For values that need richer structure (title + description), use `AddableEntryList`.
 
-## Playground
+> **Note** — Deprecated. Use `<AddableTagList />` instead (ADR-003).
 
-<Canvas of={Stories.Playground} />
+## Default
+
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Sizes, helper text, disabled, empty, and max-items states.
-
-<Canvas of={Stories.Variants} />
-
-### Empty state
+### Empty
 
 The list renders an inline empty-state message when `values` is empty.
 
 <Canvas of={Stories.Empty} />
 
-## Patterns
+### Read mode
 
-Anti-messages, approved CTAs, and compliance disclaimers — recurring text-list usage in onboarding sheets.
+<Canvas of={Stories.ReadMode} />
 
-<Canvas of={Stories.Patterns} />
+### Max items reached
+
+<Canvas of={Stories.MaxItemsCap} />
+
+### Structured content warning
+
+<Canvas of={Stories.StructuredContentWarning} />
 
 ## Props
 

--- a/components/ui/AddableTextList/AddableTextList.stories.tsx
+++ b/components/ui/AddableTextList/AddableTextList.stories.tsx
@@ -3,45 +3,39 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import { AddableTextList } from './AddableTextList';
 
-const SectionLabel = ({ children }: { children: string }) => (
-  <div
-    style={{
-      fontFamily: 'var(--font-family-label)',
-      fontSize: 'var(--body-xs)', // bds-lint-ignore
-      textTransform: 'uppercase' as const,
-      letterSpacing: '0.05em',
-      marginBottom: 'var(--gap-md)',
-      color: 'var(--text-muted)',
-    }}
-  >
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
+/**
+ * @deprecated Use `<AddableTagList />` instead (ADR-003).
+ * Kept for existing consumers during the migration window — see
+ * AddableTagList.stories.tsx for the canonical replacement.
+ */
 const meta: Meta<typeof AddableTextList> = {
   title: 'Containers/addable-text-list',
   component: AddableTextList,
-  tags: ['surface-product'],
+  tags: ['surface-product', '!manifest'],
   parameters: { layout: 'centered' },
   argTypes: {
+    values: { control: false, description: 'Current list of plain-text values (rendered as Tag chips).' },
+    onChange: { control: false, description: 'Called with the next values on add / remove.' },
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
     label: { control: 'text' },
     addLabel: { control: 'text' },
     placeholder: { control: 'text' },
     helperText: { control: 'text' },
     emptyLabel: { control: 'text' },
-    disabled: { control: 'boolean' },
+    disabled: {
+      control: 'boolean',
+      description: 'Read-only chip rendering — see the `ReadMode` story.',
+    },
     allowDuplicates: { control: 'boolean' },
     maxItems: { control: 'number' },
+    className: { control: false },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof AddableTextList>;
+
+// ── Controlled wrapper — hook-driven state machine args can't express (Q4) ────
 
 const Controlled = (args: React.ComponentProps<typeof AddableTextList>) => {
   const [values, setValues] = useState<string[]>(args.values ?? []);
@@ -59,8 +53,10 @@ const Controlled = (args: React.ComponentProps<typeof AddableTextList>) => {
   );
 };
 
+// ── Stories ───────────────────────────────────────────────────────────────────
+
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     label: 'Services Offered',
     placeholder: 'e.g. Dental cleaning',
@@ -72,7 +68,7 @@ export const Playground: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
-/** @summary Empty state */
+/** @summary Empty starting state before any values are added */
 export const Empty: Story = {
   args: {
     label: 'Back-Office Tools',
@@ -85,9 +81,66 @@ export const Empty: Story = {
   render: (args) => <Controlled {...args} />,
 };
 
-/** @summary Add an entry */
-export const AddAnEntry: Story = {
-  name: 'Interaction — add an entry',
+/**
+ * Read mode (`disabled`) — tags render without a remove control and the
+ * reveal input is hidden.
+ * @summary Read-only chip rendering
+ */
+export const ReadMode: Story = {
+  args: {
+    label: 'Services Offered',
+    disabled: true,
+    values: ['Cleaning', 'Whitening'],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+/**
+ * `maxItems` reached — the Add button hides once the cap is hit.
+ * @summary List at capacity — Add button hides
+ */
+export const MaxItemsCap: Story = {
+  args: {
+    label: 'Compliance-required disclaimers',
+    placeholder: 'Add a disclaimer',
+    maxItems: 3,
+    values: ['Results may vary'],
+    helperText: 'Capped at 3 — Add hides when full.',
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+/**
+ * Do not do this. When values contain title + description pairs (separators
+ * `—`, `:`, newlines), each row collapses into a single unreadable tag. Open
+ * the browser console — the component warns on any value matching the
+ * structured-content pattern and points at `AddableEntryList`. This story
+ * exists to make the wrong choice visible, not to endorse it.
+ *
+ * @summary Anti-pattern — structured content collapses into one tag
+ */
+export const StructuredContentWarning: Story = {
+  args: {
+    label: 'Services (WRONG — use AddableEntryList)',
+    values: [
+      'Molar endodontics — explicitly phased out, do not feature',
+      'Cancellation policy: 24-hour window',
+    ],
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+};
+
+// ── Interaction tests — play-only, hidden from MCP discovery (Q5) ─────────────
+
+/**
+ * Typing a value and clicking Add appends it to the list.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestAddEntry: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Payment Types',
     placeholder: 'e.g. Aetna',
@@ -111,9 +164,12 @@ export const AddAnEntry: Story = {
   },
 };
 
-/** @summary Remove an entry */
-export const RemoveAnEntry: Story = {
-  name: 'Interaction — remove an entry',
+/**
+ * Clicking a tag's remove control updates onChange with the remaining values.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestRemoveEntry: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     values: ['Cleaning', 'Whitening', 'Braces'],
@@ -128,9 +184,12 @@ export const RemoveAnEntry: Story = {
   },
 };
 
-/** @summary Duplicate blocked */
-export const DuplicateBlocked: Story = {
-  name: 'Interaction — duplicates blocked (case-insensitive)',
+/**
+ * A duplicate (case-insensitive) entry is rejected and never reaches onChange.
+ * @summary Play-function interaction test
+ */
+export const InteractionTestDuplicateBlocked: Story = {
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     values: ['Cleaning'],
@@ -144,135 +203,4 @@ export const DuplicateBlocked: Story = {
     await userEvent.type(input, 'cleaning{Enter}');
     await expect(args.onChange).not.toHaveBeenCalled();
   },
-};
-
-/** @summary Anti pattern structured content */
-export const AntiPatternStructuredContent: Story = {
-  name: 'Anti-pattern — structured content in tags',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Do not do this. When values contain title + description pairs (separators `—`, `:`, newlines), each row collapses into a single unreadable tag. ' +
-          'Open the browser console — the component warns on any value matching the structured-content pattern and points at AddableEntryList. ' +
-          'This story exists to make the wrong choice visible, not to endorse it.',
-      },
-    },
-  },
-  args: {
-    label: 'Services (WRONG — use AddableEntryList)',
-    values: [
-      'Molar endodontics — explicitly phased out, do not feature',
-      'Cancellation policy: 24-hour window',
-    ],
-    onChange: fn(),
-  },
-  render: (args) => <Controlled {...args} />,
-};
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => {
-    return (
-      <div style={{ width: 480 }}>
-        <Stack>
-          <Controlled
-            label="Anti-messages"
-            helperText="Phrases the brand will never use. Press Enter to add."
-            placeholder="e.g. price-first positioning"
-            values={[
-              'No price-first positioning',
-              'No corporate-clinic language',
-              'No fear-based messaging',
-            ]}
-            onChange={() => {}}
-          />
-          <Controlled
-            label="Approved CTAs"
-            helperText="Sanctioned button copy across the marketing site."
-            placeholder="e.g. Book a consultation"
-            values={['Book a consultation', 'Schedule a visit', 'Get started']}
-            onChange={() => {}}
-          />
-          <Controlled
-            label="Compliance-required disclaimers"
-            placeholder="Add a disclaimer"
-            maxItems={3}
-            values={['Results may vary']}
-            onChange={() => {}}
-            helperText="Capped at 3 — Add hides when full."
-          />
-        </Stack>
-      </div>
-    );
-  },
-};
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <div style={{ width: 480 }}>
-      <Stack>
-        <div>
-          <SectionLabel>Sizes</SectionLabel>
-          <Stack gap="var(--gap-lg)">
-            <Controlled
-              label="Small"
-              size="sm"
-              placeholder="Enter service"
-              values={['Cleaning']}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Medium (default)"
-              size="md"
-              placeholder="Enter service"
-              values={['Cleaning', 'Whitening']}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Large"
-              size="lg"
-              placeholder="Enter service"
-              values={['Cleaning']}
-              onChange={() => {}}
-            />
-          </Stack>
-        </div>
-
-        <div>
-          <SectionLabel>States</SectionLabel>
-          <Stack gap="var(--gap-lg)">
-            <Controlled
-              label="Empty"
-              emptyLabel="No services added yet."
-              placeholder="Enter service"
-              values={[]}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="With helper text"
-              helperText="Press Enter to add; Escape to cancel."
-              placeholder="Enter service"
-              values={['Cleaning']}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Disabled"
-              disabled
-              values={['Cleaning', 'Whitening']}
-              onChange={() => {}}
-            />
-            <Controlled
-              label="Max 3 items"
-              maxItems={3}
-              values={['A', 'B', 'C']}
-              onChange={() => {}}
-              helperText="Add button hides when limit is reached."
-            />
-          </Stack>
-        </div>
-      </Stack>
-    </div>
-  ),
 };

--- a/components/ui/Board/Board.mdx
+++ b/components/ui/Board/Board.mdx
@@ -10,53 +10,37 @@ import * as Stories from './Board.stories';
 
 Kanban-style board container with columns, headers, and task cards. Composes from `BoardColumn`, `BoardHeader`, and `BoardCard`. Use for assignment views, queue dashboards, and any horizontally-grouped task layout.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-### Single column
+### Density
 
-The simplest shape — one column with a header and cards.
+`BoardCard` renders at `default` or `compact` density — shown side by side since the comparison is the point.
 
-<Canvas of={Stories.SingleColumn} />
-
-### With avatars
-
-Headers can include an avatar for owner attribution.
-
-<Canvas of={Stories.WithAvatars} />
-
-### Empty column
-
-Empty-state messaging when a column has no cards.
-
-<Canvas of={Stories.EmptyColumn} />
-
-### Task cards
-
-Cards support titles, subtitles, tags, and accent colors.
-
-<Canvas of={Stories.TaskCards} />
-
-### Card accent colors
-
-Use accent colors to communicate priority, category, or owner.
-
-<Canvas of={Stories.CardAccentColors} />
+<Canvas of={Stories.Density} />
 
 ## Patterns
 
-Full multi-column board with headers and assigned task cards.
+Composition and hook-driven state that a single args-driven story can't express.
 
-<Canvas of={Stories.Patterns} />
+### With empty column
 
-### Interactive full board
+<Canvas of={Stories.WithEmptyColumn} />
 
-State-driven board where columns and cards respond to user actions.
+### With task cards
 
-<Canvas of={Stories.FullBoardView} />
+Controlled checkbox state on `BoardCard`.
+
+<Canvas of={Stories.WithTaskCards} />
+
+### Full board view
+
+Interactive, token-driven, multi-column board with headers, cards, and live progress.
+
+<Canvas of={Stories.WithFullBoard} />
 
 ## Props
 

--- a/components/ui/Board/Board.stories.tsx
+++ b/components/ui/Board/Board.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect } from 'storybook/test';
 import { Board } from './Board';
 import { BoardColumn } from './BoardColumn';
@@ -53,8 +53,14 @@ const MOCK_HEADERS = [
   },
 ];
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Default — four columns of BoardHeader entries (name + subtitle + progress).
+ * Composition of Board > BoardColumn > BoardHeader, args can't express the
+ * nested-children shape so this is the canonical render-mode sandbox.
+ *
+ * @summary Multi-column board of headers
+ */
+export const Default: Story = {
   render: () => (
     <Board style={{ height: '500px' }}>
       {MOCK_HEADERS.map((col) => (
@@ -73,48 +79,14 @@ export const Playground: Story = {
   ),
 };
 
-/** @summary Single column */
-export const SingleColumn: Story = {
-  render: () => (
-    <Board style={{ height: '400px', maxWidth: '400px' }}>
-      <BoardColumn title="In Progress" count={2}>
-        <BoardHeader name="Cassidy Moore" subtitle="Dental Hygienist" progress={37} />
-        <BoardHeader name="Alex Rivera" subtitle="Receptionist" progress={85} />
-      </BoardColumn>
-    </Board>
-  ),
-};
-
-/** @summary With avatars */
-export const WithAvatars: Story = {
-  render: () => (
-    <Board style={{ height: '400px' }}>
-      <BoardColumn title="Team" count={3}>
-        <BoardHeader
-          name="Cassidy Moore"
-          subtitle="Dental Hygienist"
-          avatarSrc="https://i.pravatar.cc/96?u=cassidy"
-          progress={37}
-        />
-        <BoardHeader
-          name="Jordan Lee"
-          subtitle="Dental Assistant"
-          avatarSrc="https://i.pravatar.cc/96?u=jordan"
-          progress={85}
-        />
-        <BoardHeader
-          name="Riley Kim"
-          subtitle="Receptionist"
-          avatarSrc="https://i.pravatar.cc/96?u=riley"
-          progress={100}
-        />
-      </BoardColumn>
-    </Board>
-  ),
-};
-
-/** @summary Empty column */
-export const EmptyColumn: Story = {
+/**
+ * A column with no children renders its header row only — no placeholder or
+ * empty-state message inside the item area. Verifies columns with zero and
+ * nonzero counts sit correctly side by side.
+ *
+ * @summary Board with an empty column alongside a populated one
+ */
+export const WithEmptyColumn: Story = {
   render: () => (
     <Board style={{ height: '300px' }}>
       <BoardColumn title="Backlog" count={0}>
@@ -169,54 +141,27 @@ function InteractiveCards() {
   );
 }
 
-/** @summary Task cards */
-export const TaskCards: Story = {
+/**
+ * Controlled checkbox state on BoardCard — a hook-driven interaction args
+ * can't express. Toggling a task's completion updates its checked state
+ * and CompletionToggle visual without a page reload.
+ *
+ * @summary Board column with controlled task-card checkboxes
+ */
+export const WithTaskCards: Story = {
   render: () => <InteractiveCards />,
 };
 
-/** @summary Card accent colors */
-export const CardAccentColors: Story = {
-  name: 'Card — Accent Colors',
-  render: () => (
-    <Board style={{ height: '400px' }}>
-      <BoardColumn title="By Department">
-        <BoardCard
-          title="Sterilize instruments"
-          subtitle="Due 9:00 AM"
-          accentColor="var(--background-accent-blue)"
-          tags={<Tag size="sm">Clinical</Tag>}
-          trailingTag={<Badge status="warning" size="sm">Medium</Badge>}
-        />
-        <BoardCard
-          title="Restock PPE supplies"
-          subtitle="Due 10:00 AM"
-          accentColor="var(--background-accent-red)"
-          tags={<Tag size="sm">Front Desk</Tag>}
-          trailingTag={<Badge status="error" size="sm">High</Badge>}
-        />
-        <BoardCard
-          title="Update patient records"
-          subtitle="Due 2:00 PM"
-          accentColor="var(--background-accent-purple)"
-          tags={<Tag size="sm">Admin</Tag>}
-          trailingTag={<Badge status="info" size="sm">Low</Badge>}
-        />
-        <BoardCard
-          title="Equipment maintenance check"
-          subtitle="Due 4:00 PM"
-          accentColor="var(--background-accent-green)"
-          tags={<Tag size="sm">Engineering</Tag>}
-          trailingTag={<Badge status="positive" size="sm">Done</Badge>}
-          checked
-        />
-      </BoardColumn>
-    </Board>
-  ),
-};
-
-/** @summary Card density — default vs compact */
-export const CardDensity: Story = {
-  name: 'Card — Density',
+/**
+ * `density="compact"` drops the title one type step and renders the
+ * subtitle as label-family metadata — for dense, multi-card-per-column
+ * boards. Shown side by side with default density since the comparison
+ * is the entire point and there's no other surface (no Board-level
+ * Control) to see the two together.
+ *
+ * @summary Default vs compact BoardCard density, side by side
+ */
+export const Density: Story = {
   render: () => (
     <Board style={{ height: '440px' }}>
       <BoardColumn title="Default density" count={2}>
@@ -279,82 +224,13 @@ export const CardDensity: Story = {
   },
 };
 
-// ─── Full board (headers + cards) ────────────────────────────────────────────
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Full Board — Headers + Cards',
-  render: () => (
-    <Board style={{ height: '700px' }}>
-      <BoardColumn>
-        <BoardHeader
-          name="Rebecca"
-          subtitle="Maintenance"
-          avatarSrc="https://i.pravatar.cc/96?u=rebecca"
-          progress={37}
-        />
-        <BoardCard
-          title="Check hand sanitizer stations"
-          subtitle="Due today"
-          accentColor="var(--background-brand-primary)"
-          tags={<><Tag size="sm">Engineering</Tag><Tag size="sm">Daily</Tag></>}
-          trailingTag={<Badge status="error" size="sm">Critical</Badge>}
-        />
-        <BoardCard
-          title="Clean countertops"
-          subtitle="Due today"
-          accentColor="var(--background-brand-primary)"
-          tags={<><Tag size="sm">Engineering</Tag><Tag size="sm">Daily</Tag></>}
-          trailingTag={<Badge status="error" size="sm">Critical</Badge>}
-        />
-      </BoardColumn>
-      <BoardColumn>
-        <BoardHeader
-          name="John"
-          subtitle="Maintenance"
-          avatarSrc="https://i.pravatar.cc/96?u=john"
-          progress={20}
-        />
-        <BoardCard
-          title="Empty trash bins and replace liners"
-          subtitle="Due today"
-          accentColor="var(--background-accent-red)"
-          tags={<><Tag size="sm">Cleaning</Tag><Tag size="sm">Daily</Tag></>}
-          trailingTag={<Badge status="warning" size="sm">Medium</Badge>}
-        />
-      </BoardColumn>
-      <BoardColumn>
-        <BoardHeader
-          name="Sarah"
-          subtitle="Clinician"
-          avatarSrc="https://i.pravatar.cc/96?u=sarah"
-          progress={85}
-        />
-        <BoardCard
-          title="Sterilize instruments"
-          subtitle="Due 9:00 AM"
-          accentColor="var(--background-accent-purple)"
-          checked
-          tags={<Tag size="sm">Clinical</Tag>}
-          trailingTag={<Badge status="positive" size="sm">Done</Badge>}
-        />
-        <BoardCard
-          title="Patient room prep"
-          subtitle="Due 10:00 AM"
-          accentColor="var(--background-accent-purple)"
-          tags={<Tag size="sm">Clinical</Tag>}
-        />
-      </BoardColumn>
-    </Board>
-  ),
-};
-
 // ─── Full board view (token-driven — responds to Storybook theme) ────────────
 
 /**
- * Complete board view using only BDS tokens. Switch themes in the
- * Storybook toolbar to see the board adapt. Product-level color
- * overrides (per-user column colors) belong in the consuming app
+ * Complete board view using only BDS tokens — headers, cards, controlled
+ * checkbox state, and a per-column progress calculation together. Switch
+ * themes in the Storybook toolbar to see the board adapt. Product-level
+ * color overrides (per-user column colors) belong in the consuming app
  * (e.g. Renew PMS), not here.
  */
 
@@ -478,8 +354,14 @@ function FullBoardViewExample() {
   );
 }
 
-/** @summary Full board view */
-export const FullBoardView: Story = {
+/**
+ * Multi-column state machine — 4 columns, each with header + cards, checkbox
+ * toggling recomputes that column's progress bar live. The composition and
+ * hook-driven state genuinely can't be expressed as args.
+ *
+ * @summary Full interactive board — headers, cards, and progress
+ */
+export const WithFullBoard: Story = {
   name: 'Full Board View',
   render: () => <FullBoardViewExample />,
 };

--- a/components/ui/CatalogPicker/CatalogPicker.mdx
+++ b/components/ui/CatalogPicker/CatalogPicker.mdx
@@ -10,13 +10,11 @@ import * as Stories from './CatalogPicker.stories';
 
 Industry-aware multi-pick input. Renders a reference catalog as suggestion-backed picks and normalizes every entry with a stable slug plus `source: 'catalog' | 'custom'` attribution.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
-
-<Canvas of={Stories.Variants} />
 
 ### Empty state
 
@@ -39,14 +37,6 @@ Each entry is tagged by origin — catalog picks and custom additions live toget
 Same component, different catalog. The picker is vocabulary-agnostic.
 
 <Canvas of={Stories.DifferentIndustry} />
-
-### Disabled
-
-<Canvas of={Stories.Disabled} />
-
-## Patterns
-
-<Canvas of={Stories.Patterns} />
 
 ## Props
 

--- a/components/ui/CatalogPicker/CatalogPicker.stories.tsx
+++ b/components/ui/CatalogPicker/CatalogPicker.stories.tsx
@@ -63,31 +63,6 @@ const REAL_ESTATE_AMENITIES_CATALOG: readonly CatalogEntry[] = [
   { slug: 'dog-park', displayName: 'Dog Park' },
 ];
 
-// ── Shared layout helpers (per BDS story convention) ─────────────────────────
-
-const Stack = ({
-  children,
-  gap = 'var(--gap-xl)',
-}: {
-  children: React.ReactNode;
-  gap?: string;
-}) => <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>;
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div
-    style={{
-      fontFamily: 'var(--font-family-label)',
-      fontSize: 'var(--label-xs)',
-      textTransform: 'uppercase',
-      letterSpacing: '0.05em',
-      marginBottom: 'var(--gap-md)',
-      color: 'var(--text-muted)',
-    }}
-  >
-    {children}
-  </div>
-);
-
 // ── Storybook meta ───────────────────────────────────────────────────────────
 
 const meta: Meta<typeof CatalogPicker> = {
@@ -96,10 +71,23 @@ const meta: Meta<typeof CatalogPicker> = {
   tags: ['surface-product'],
   parameters: { layout: 'centered' },
   argTypes: {
+    catalog: {
+      control: false,
+      description: 'Reference catalog entries: `{ slug, displayName, aliases? }[]`. Set in code.',
+    },
+    value: {
+      control: false,
+      description: 'Currently picked entries: `{ slug, displayName, description?, source }[]`. Set in code.',
+    },
+    onChange: {
+      control: false,
+      description: 'Called with the next picked list on add/remove.',
+    },
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
     label: { control: 'text' },
     helperText: { control: 'text' },
     addLabel: { control: 'text' },
+    removeLabel: { control: 'text' },
     searchPlaceholder: { control: 'text' },
     descriptionPlaceholder: { control: 'text' },
     emptyLabel: { control: 'text' },
@@ -108,6 +96,10 @@ const meta: Meta<typeof CatalogPicker> = {
     strict: { control: 'boolean' },
     maxItems: { control: 'number' },
     descriptionRows: { control: 'number' },
+    className: {
+      control: false,
+      description: 'Optional className passthrough on the root.',
+    },
   },
 };
 
@@ -141,7 +133,7 @@ const Controlled = (args: React.ComponentProps<typeof CatalogPicker>) => {
  *
  * @summary Interactive playground for prop tweaking
  */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     label: 'Services Offered',
     catalog: DENTAL_SERVICES_CATALOG,
@@ -178,7 +170,7 @@ export const Playground: Story = {
  */
 export const Empty: Story = {
   args: {
-    ...Playground.args,
+    ...Default.args,
     value: [],
   },
   render: (args) => <Controlled {...args} />,
@@ -194,7 +186,7 @@ export const Empty: Story = {
 export const MixedSources: Story = {
   name: 'Mixed Catalog + Custom',
   args: {
-    ...Playground.args,
+    ...Default.args,
     value: [
       {
         slug: 'invisalign',
@@ -224,7 +216,7 @@ export const MixedSources: Story = {
 export const StrictCatalogOnly: Story = {
   name: 'Strict (No Custom)',
   args: {
-    ...Playground.args,
+    ...Default.args,
     label: 'Insurance Plans',
     catalog: [
       { slug: 'in-network-ppo', displayName: 'In-Network PPO' },
@@ -252,7 +244,7 @@ export const StrictCatalogOnly: Story = {
 export const DifferentIndustry: Story = {
   name: 'Real-Estate Amenities',
   args: {
-    ...Playground.args,
+    ...Default.args,
     label: 'Community Amenities',
     catalog: REAL_ESTATE_AMENITIES_CATALOG,
     value: [
@@ -272,89 +264,15 @@ export const DifferentIndustry: Story = {
 };
 
 /**
- * Size variants — tiny, medium, and large controls. Verifies that every
- * tier of the size scale renders coherently. Same catalog + same picks
- * across all three so the visual delta is pure typography/spacing.
- *
- * @summary All variants side by side
- */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Size: sm</SectionLabel>
-        <div style={{ width: 520 }}>
-          <CatalogPicker
-            label="Services Offered"
-            catalog={DENTAL_SERVICES_CATALOG}
-            value={[
-              { slug: 'dental-implants', displayName: 'Dental Implants', source: 'catalog' },
-            ]}
-            onChange={fn()}
-            size="sm"
-            addLabel="Add Service"
-          />
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel>Size: md (default)</SectionLabel>
-        <div style={{ width: 520 }}>
-          <CatalogPicker
-            label="Services Offered"
-            catalog={DENTAL_SERVICES_CATALOG}
-            value={[
-              { slug: 'dental-implants', displayName: 'Dental Implants', source: 'catalog' },
-            ]}
-            onChange={fn()}
-            size="md"
-            addLabel="Add Service"
-          />
-        </div>
-      </div>
-
-      <div>
-        <SectionLabel>Size: lg</SectionLabel>
-        <div style={{ width: 520 }}>
-          <CatalogPicker
-            label="Services Offered"
-            catalog={DENTAL_SERVICES_CATALOG}
-            value={[
-              { slug: 'dental-implants', displayName: 'Dental Implants', source: 'catalog' },
-            ]}
-            onChange={fn()}
-            size="lg"
-            addLabel="Add Service"
-          />
-        </div>
-      </div>
-    </Stack>
-  ),
-};
-
-/**
- * Disabled — read-only render. Remove buttons and the Add button are
- * hidden. Used in the portal when a non-admin views intel sheets.
- *
- * @summary Disabled state
- */
-export const Disabled: Story = {
-  args: {
-    ...Playground.args,
-    disabled: true,
-  },
-  render: (args) => <Controlled {...args} />,
-};
-
-/**
- * Interaction — picks a catalog entry by typing an alias, types a
+ * Interaction test — picks a catalog entry by typing an alias, types a
  * description, commits. Verifies the alias-match path (`source: 'catalog'`)
  * and that the commit clears the form for rapid entry.
  *
  * @summary Alias match commits as catalog
  */
-export const AliasMatchCommitsAsCatalog: Story = {
+export const InteractionTestAliasMatchCommitsAsCatalog: Story = {
   name: 'Alias Match → source=catalog',
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     catalog: DENTAL_SERVICES_CATALOG,
@@ -384,13 +302,14 @@ export const AliasMatchCommitsAsCatalog: Story = {
 };
 
 /**
- * Interaction — types a free-text name that doesn't match any catalog
+ * Interaction test — types a free-text name that doesn't match any catalog
  * entry. Commits as `source: 'custom'` with a derived slug.
  *
  * @summary Free text commits as custom
  */
-export const FreeTextCommitsAsCustom: Story = {
+export const InteractionTestFreeTextCommitsAsCustom: Story = {
   name: 'Free Text → source=custom',
+  tags: ['!manifest'],
   args: {
     label: 'Services Offered',
     catalog: DENTAL_SERVICES_CATALOG,
@@ -416,53 +335,4 @@ export const FreeTextCommitsAsCustom: Story = {
       }),
     ]);
   },
-};
-
-/**
- * Patterns — how the picker reads inside a portal-style intel sheet.
- * Demonstrates the consumer pattern: wrap in a sheet section with a
- * field label outside the component, let the picker own its own dropdown.
- *
- * @summary Common usage patterns
- */
-export const Patterns: Story = {
-  render: () => (
-    <div style={{ width: 520 }}>
-      <Stack>
-        <div>
-          <SectionLabel>Services & Billing</SectionLabel>
-          <CatalogPicker
-            label="Services Offered"
-            helperText="Picks from the industry catalog are tagged automatically. Custom additions are preserved with a derived slug."
-            catalog={DENTAL_SERVICES_CATALOG}
-            value={[
-              {
-                slug: 'dental-implants',
-                displayName: 'Dental Implants',
-                description: 'Permanent tooth replacement with crown or bridge attachment.',
-                source: 'catalog',
-              },
-              {
-                slug: 'invisalign',
-                displayName: 'Invisalign / Clear Aligners',
-                description: 'Diamond-tier certified provider (top 1%).',
-                source: 'catalog',
-              },
-              {
-                slug: 'airflow-polish',
-                displayName: 'AirFlow Polish',
-                description: 'Premium plaque removal using pressurized micro-particles.',
-                source: 'custom',
-              },
-            ]}
-            onChange={fn()}
-            addLabel="Add Service"
-            searchPlaceholder="Search or add a service…"
-            descriptionPlaceholder="What makes this service unique here?"
-            emptyDescriptionLabel="No description set"
-          />
-        </div>
-      </Stack>
-    </div>
-  ),
 };

--- a/components/ui/Meter/Meter.mdx
+++ b/components/ui/Meter/Meter.mdx
@@ -10,49 +10,35 @@ import * as Stories from './Meter.stories';
 
 Bounded-value indicator for completion counters, scores, and capacity displays. Pass `value` and `max`; the `status` prop drives color tokens (`positive`, `warning`, `error`, `neutral`).
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
+### Status
+
 All status colors at standard size.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Pass} />
 
-### Sizes
+<Canvas of={Stories.Fair} />
 
-`size="sm"` and `size="lg"` for compact toolbars or hero metrics.
+<Canvas of={Stories.Fail} />
 
-<Canvas of={Stories.Small} />
+<Canvas of={Stories.Neutral} />
 
-<Canvas of={Stories.Large} />
+### No suffix
 
-### Label position
-
-`labelPosition` controls where the label sits relative to the bar.
-
-<Canvas of={Stories.LabelPositionComparison} />
-
-### Suffix
-
-By default the meter renders `value/max`. Override via `suffix` for percentages or unit labels; pass `suffix={false}` to drop it entirely.
+By default the meter renders `value/max Score`. Pass `valueSuffix=""` for plain `value/max` — the completion-counter pattern.
 
 <Canvas of={Stories.NoSuffix} />
 
-<Canvas of={Stories.CustomSuffix} />
+### Custom fill color
 
-### Custom formatter
+`fillColor` overrides the status-driven color — use for per-category or per-department palettes.
 
-`format` overrides the value-rendering function for unusual displays.
-
-<Canvas of={Stories.CustomFormatter} />
-
-## Patterns
-
-Onboarding completion checklist alongside a system-health dashboard — the recurring multi-meter compositions.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.CustomFillColor} />
 
 ## Props
 

--- a/components/ui/Meter/Meter.stories.tsx
+++ b/components/ui/Meter/Meter.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Meter } from './Meter';
 
 const meta: Meta<typeof Meter> = {
@@ -9,16 +9,6 @@ const meta: Meta<typeof Meter> = {
     layout: 'centered',
   },
   argTypes: {
-    status: {
-      control: 'select',
-      options: ['positive', 'warning', 'error', 'neutral'],
-      description: 'Status variant — drives fill color',
-    },
-    size: {
-      control: 'select',
-      options: ['sm', 'md', 'lg'],
-      description: 'Bar height variant',
-    },
     value: {
       control: { type: 'number', min: 0, max: 100 },
       description: 'Current value',
@@ -27,9 +17,27 @@ const meta: Meta<typeof Meter> = {
       control: { type: 'number', min: 1, max: 100 },
       description: 'Maximum value',
     },
+    status: {
+      control: 'select',
+      options: ['positive', 'warning', 'error', 'neutral'],
+      description: 'Status variant — drives fill color via system tokens',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Bar height: sm=8px, md=12px, lg=16px',
+    },
+    label: {
+      control: 'text',
+      description: 'Label text (e.g. "Pass", "Fair", "Fail")',
+    },
     showValue: {
       control: 'boolean',
       description: 'Show formatted value',
+    },
+    valueFormatter: {
+      control: false,
+      description: 'Custom value formatter function (default renders "value/max"). Set via code, not Controls.',
     },
     labelPosition: {
       control: 'select',
@@ -38,7 +46,7 @@ const meta: Meta<typeof Meter> = {
     },
     valueSuffix: {
       control: 'text',
-      description: 'Suffix after the value (default: " Score"). Pass "" to suppress.',
+      description: 'Suffix after the value (default: " Score"). Pass "" for plain "value/max" (e.g. completion counters).',
     },
     fillColor: {
       control: 'color',
@@ -57,8 +65,10 @@ const meta: Meta<typeof Meter> = {
 export default meta;
 type Story = StoryObj<typeof Meter>;
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/* ─── Default ─────────────────────────────────────────────────── */
+
+/** @summary Interactive score bar — status/label via Controls */
+export const Default: Story = {
   args: {
     value: 4,
     max: 10,
@@ -67,8 +77,9 @@ export const Playground: Story = {
   },
 };
 
-// Status variants
-/** @summary Pass */
+/* ─── Variants — one story per status (Q3 semantic starting points) ─── */
+
+/** @summary Positive status — passing score */
 export const Pass: Story = {
   args: {
     value: 6,
@@ -78,7 +89,7 @@ export const Pass: Story = {
   },
 };
 
-/** @summary Fair */
+/** @summary Warning status — borderline score */
 export const Fair: Story = {
   args: {
     value: 4,
@@ -88,7 +99,7 @@ export const Fair: Story = {
   },
 };
 
-/** @summary Fail */
+/** @summary Error status — failing score */
 export const Fail: Story = {
   args: {
     value: 1,
@@ -98,7 +109,7 @@ export const Fail: Story = {
   },
 };
 
-/** @summary Neutral */
+/** @summary Neutral status — pending or not-yet-scored */
 export const Neutral: Story = {
   args: {
     value: 0,
@@ -108,134 +119,9 @@ export const Neutral: Story = {
   },
 };
 
-// Size variants
-/** @summary Small */
-export const Small: Story = {
-  args: {
-    value: 6,
-    max: 7,
-    status: 'positive',
-    label: 'Pass',
-    size: 'sm',
-  },
-};
+/* ─── Documented usage patterns (Q3 — named in component JSDoc) ─── */
 
-/** @summary Large */
-export const Large: Story = {
-  args: {
-    value: 6,
-    max: 7,
-    status: 'positive',
-    label: 'Pass',
-    size: 'lg',
-  },
-};
-
-// Without value display
-/** @summary No value */
-export const NoValue: Story = {
-  args: {
-    value: 3,
-    max: 10,
-    status: 'warning',
-    label: 'Fair',
-    showValue: false,
-  },
-};
-
-// Custom formatter
-/** @summary Custom formatter */
-export const CustomFormatter: Story = {
-  args: {
-    value: 85,
-    max: 100,
-    status: 'positive',
-    label: 'Pass',
-    valueFormatter: (value: number, max: number) => `${Math.round((value / max) * 100)}%`,
-  },
-};
-
-// Label position variants
-/** @summary Label above */
-export const LabelAbove: Story = {
-  args: {
-    value: 6,
-    max: 7,
-    status: 'positive',
-    label: 'Pass',
-    labelPosition: 'above',
-  },
-};
-
-/** @summary Label below */
-export const LabelBelow: Story = {
-  args: {
-    value: 6,
-    max: 7,
-    status: 'positive',
-    label: 'Pass',
-    labelPosition: 'below',
-  },
-};
-
-// Label position comparison
-/** @summary Label position comparison */
-export const LabelPositionComparison: Story = {
-  render: () => (
-    <div style={{ display: 'flex', gap: 48, width: 600 }}>
-      <div style={{ flex: 1 }}>
-        <p style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-sm)', color: 'var(--text-secondary)', marginBottom: 12 }}>labelPosition=&quot;above&quot;</p>
-        <Meter value={6} max={7} status="positive" label="Pass" labelPosition="above" />
-      </div>
-      <div style={{ flex: 1 }}>
-        <p style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-sm)', color: 'var(--text-secondary)', marginBottom: 12 }}>labelPosition=&quot;below&quot;</p>
-        <Meter value={6} max={7} status="positive" label="Pass" labelPosition="below" />
-      </div>
-    </div>
-  ),
-};
-
-// All statuses side by side
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, width: 300 }}>
-      <Meter value={6} max={7} status="positive" label="Pass" />
-      <Meter value={4} max={10} status="warning" label="Fair" />
-      <Meter value={1} max={5} status="error" label="Fail" />
-      <Meter value={0} max={7} status="neutral" label="Pending" />
-    </div>
-  ),
-};
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--gap-xl)', width: 640 }}>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
-        <div style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-muted)' }}>
-          Onboarding completion
-        </div>
-        <Meter value={3} max={5} status="warning" label="Profile setup" />
-        <Meter value={5} max={5} status="positive" label="Verification" />
-        <Meter value={1} max={4} status="error" label="Billing" />
-        <Meter value={2} max={3} status="warning" label="Team invites" />
-      </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
-        <div style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-muted)' }}>
-          System health
-        </div>
-        <Meter value={98} max={100} status="positive" label="Uptime" valueSuffix="%" />
-        <Meter value={42} max={100} status="warning" label="Storage used" valueSuffix="%" />
-        <Meter value={87} max={100} status="warning" label="API rate limit" valueSuffix="%" />
-        <Meter value={12} max={100} status="positive" label="Error budget" valueSuffix="%" />
-      </div>
-    </div>
-  ),
-};
-
-// Custom suffix
-/** @summary No suffix — plain X/Y for completion counters */
+/** @summary Plain "value/max" with no suffix — completion counters */
 export const NoSuffix: Story = {
   args: {
     value: 4,
@@ -246,19 +132,7 @@ export const NoSuffix: Story = {
   },
 };
 
-/** @summary Custom suffix */
-export const CustomSuffix: Story = {
-  args: {
-    value: 87,
-    max: 100,
-    status: 'positive',
-    label: 'Quiz',
-    valueSuffix: ' pts',
-  },
-};
-
-// Custom fill color (escape hatch)
-/** @summary Custom fill color */
+/** @summary Custom fill color — category/department palette override */
 export const CustomFillColor: Story = {
   args: {
     value: 3,
@@ -267,16 +141,4 @@ export const CustomFillColor: Story = {
     valueSuffix: '',
     fillColor: '#7c5cff',
   },
-};
-
-/** @summary Category-driven fills — multiple custom colors */
-export const CategoryFills: Story = {
-  render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, width: 300 }}>
-      <Meter value={2} max={4} label="Management" valueSuffix="" fillColor="#7c5cff" />
-      <Meter value={5} max={6} label="Operations" valueSuffix="" fillColor="#22c55e" />
-      <Meter value={1} max={9} label="Finance" valueSuffix="" fillColor="#f59e0b" />
-      <Meter value={0} max={3} label="HR" valueSuffix="" fillColor="#06b6d4" />
-    </div>
-  ),
 };

--- a/components/ui/ProgressCircle/ProgressCircle.mdx
+++ b/components/ui/ProgressCircle/ProgressCircle.mdx
@@ -10,47 +10,27 @@ import * as Stories from './ProgressCircle.stories';
 
 Circular progress indicator. Use for compact dashboards, completion meters, and any single-value progress display where a circle reads better than a bar.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-### Sizes
-
-Three diameter presets — `sm` 64px, `md` 96px, `lg` 128px. All snap to the 4-point grid.
-
-<Canvas of={Stories.Sizes} />
-
-### Statuses
+### Status
 
 The `status` prop maps to canonical Brik status tokens — `default` brand fill, `positive`, `warning`, `negative`.
 
-<Canvas of={Stories.Statuses} />
+<Canvas of={Stories.Positive} />
 
-### Matrix
+<Canvas of={Stories.Warning} />
 
-Every `size × status` combination.
-
-<Canvas of={Stories.Matrix} />
+<Canvas of={Stories.Negative} />
 
 ### Custom center
 
-The `showValue` prop accepts a `ReactNode` for arbitrary centered content — pair a percentage with a sub-label, or render a streak counter.
+`showValue` accepts a `ReactNode` for arbitrary centered content — pair a percentage with a sub-label instead of the plain default.
 
 <Canvas of={Stories.CustomCenter} />
-
-### Indeterminate
-
-Set `indeterminate` for continuous spin when progress is unknown. Honors `prefers-reduced-motion`.
-
-<Canvas of={Stories.Indeterminate} />
-
-## Patterns
-
-Animated determinate fill plus a dashboard widget composing the percentage with a sub-label.
-
-<Canvas of={Stories.Patterns} />
 
 ## Props
 

--- a/components/ui/ProgressCircle/ProgressCircle.stories.tsx
+++ b/components/ui/ProgressCircle/ProgressCircle.stories.tsx
@@ -1,33 +1,5 @@
-import React, { useState, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ProgressCircle } from './ProgressCircle';
-
-/* ─── Layout helpers (story-only) ─────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', alignItems: 'center', gap, flexWrap: 'wrap' as const }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Meta ────────────────────────────────────────────── */
 
 const meta: Meta<typeof ProgressCircle> = {
   title: 'Components/progress-circle',
@@ -35,24 +7,46 @@ const meta: Meta<typeof ProgressCircle> = {
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
-    value: { control: { type: 'range', min: 0, max: 100, step: 1 } },
-    size: { control: { type: 'inline-radio' }, options: ['sm', 'md', 'lg'] },
-    status: { control: { type: 'inline-radio' }, options: ['default', 'positive', 'warning', 'negative'] },
-    label: { control: 'text' },
-    showValue: { control: 'boolean' },
-    indeterminate: { control: 'boolean' },
+    value: {
+      control: { type: 'range', min: 0, max: 100, step: 1 },
+      description: 'Progress value from 0 to 100. Ignored when `indeterminate` is true.',
+    },
+    size: {
+      control: { type: 'inline-radio' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Diameter preset — `sm` 64px, `md` 96px, `lg` 128px.',
+    },
+    status: {
+      control: { type: 'inline-radio' },
+      options: ['default', 'positive', 'warning', 'negative'],
+      description: 'Fill color semantic — uses canonical status tokens.',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label for screen readers.',
+    },
+    showValue: {
+      control: false,
+      description: 'Centered slot. Pass `true` to render `${value}%`, a ReactNode for custom content, or omit for none.',
+    },
+    indeterminate: {
+      control: 'boolean',
+      description: 'Animated continuous spin for unknown-duration progress.',
+    },
+    fillColor: {
+      control: 'color',
+      description: 'Override fill stroke color (escape hatch — defaults to status token).',
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof ProgressCircle>;
 
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Default ─────────────────────────────────────────────────── */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Interactive circular progress — value/status via Controls */
+export const Default: Story = {
   args: {
     value: 72,
     size: 'md',
@@ -63,191 +57,60 @@ export const Playground: Story = {
   },
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   2. SIZES — sm / md / lg side by side
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Variants — one story per status (Q3 semantic starting points) ─── */
 
-/** @summary All three diameter presets */
-export const Sizes: Story = {
-  render: () => (
-    <Row>
-      <div>
-        <SectionLabel>sm — 64px</SectionLabel>
-        <ProgressCircle value={50} size="sm" showValue label="Small" />
-      </div>
-      <div>
-        <SectionLabel>md — 96px</SectionLabel>
-        <ProgressCircle value={50} size="md" showValue label="Medium" />
-      </div>
-      <div>
-        <SectionLabel>lg — 128px</SectionLabel>
-        <ProgressCircle value={50} size="lg" showValue label="Large" />
-      </div>
-    </Row>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. STATUSES — default / positive / warning / negative
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Each canonical status token applied as fill */
-export const Statuses: Story = {
-  render: () => (
-    <Row>
-      <div>
-        <SectionLabel>default (brand)</SectionLabel>
-        <ProgressCircle value={72} status="default" showValue label="Default" />
-      </div>
-      <div>
-        <SectionLabel>positive</SectionLabel>
-        <ProgressCircle value={100} status="positive" showValue label="Complete" />
-      </div>
-      <div>
-        <SectionLabel>warning</SectionLabel>
-        <ProgressCircle value={45} status="warning" showValue label="At risk" />
-      </div>
-      <div>
-        <SectionLabel>negative</SectionLabel>
-        <ProgressCircle value={15} status="negative" showValue label="Failing" />
-      </div>
-    </Row>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   4. MATRIX — every size × status combination
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Full size × status matrix */
-export const Matrix: Story = {
-  render: () => {
-    const statuses = ['default', 'positive', 'warning', 'negative'] as const;
-    const sizes = ['sm', 'md', 'lg'] as const;
-    return (
-      <Stack>
-        {statuses.map((status) => (
-          <div key={status}>
-            <SectionLabel>{status}</SectionLabel>
-            <Row>
-              {sizes.map((size) => (
-                <ProgressCircle
-                  key={size}
-                  value={62}
-                  size={size}
-                  status={status}
-                  showValue
-                  label={`${status} ${size}`}
-                />
-              ))}
-            </Row>
-          </div>
-        ))}
-      </Stack>
-    );
+/** @summary Positive status — complete or on-track */
+export const Positive: Story = {
+  args: {
+    value: 100,
+    status: 'positive',
+    showValue: true,
+    label: 'Complete',
   },
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   5. CUSTOM CENTER — arbitrary node content
-   ═══════════════════════════════════════════════════════════════ */
+/** @summary Warning status — at-risk progress */
+export const Warning: Story = {
+  args: {
+    value: 45,
+    status: 'warning',
+    showValue: true,
+    label: 'At risk',
+  },
+};
 
-/** @summary Centered slot accepts any ReactNode for custom labels */
+/** @summary Negative status — failing progress */
+export const Negative: Story = {
+  args: {
+    value: 15,
+    status: 'negative',
+    showValue: true,
+    label: 'Failing',
+  },
+};
+
+/* ─── Documented capability — arbitrary centered content (Q3) ────── */
+
+/**
+ * `showValue` accepts a ReactNode for arbitrary centered content — pair a
+ * percentage with a sub-label instead of the plain `${value}%` default.
+ *
+ * @summary Custom ReactNode content in the centered slot
+ */
 export const CustomCenter: Story = {
-  render: () => (
-    <Row>
-      <ProgressCircle
-        value={70}
-        size="lg"
-        showValue={
-          <div style={{ textAlign: 'center' }}>
-            <div style={{ fontSize: 'var(--heading-md)', fontWeight: 'var(--font-weight-bold)', color: 'var(--text-primary)' }}>
-              70%
-            </div>
-            <div style={{ fontSize: 'var(--body-sm)', color: 'var(--text-secondary)' }}>
-              of 200
-            </div>
-          </div>
-        }
-        label="Tasks complete"
-      />
-      <ProgressCircle
-        value={3}
-        size="lg"
-        showValue={
-          <div style={{ textAlign: 'center' }}>
-            <div style={{ fontSize: 'var(--heading-md)', fontWeight: 'var(--font-weight-bold)', color: 'var(--text-primary)' }}>
-              3
-            </div>
-            <div style={{ fontSize: 'var(--body-sm)', color: 'var(--text-secondary)' }}>
-              of 7 days
-            </div>
-          </div>
-        }
-        label="Streak"
-      />
-    </Row>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   6. INDETERMINATE — animated continuous spin
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Continuous spin for unknown-duration progress */
-export const Indeterminate: Story = {
-  render: () => (
-    <Row>
-      <ProgressCircle value={0} size="sm" indeterminate label="Loading small" />
-      <ProgressCircle value={0} size="md" indeterminate label="Loading medium" />
-      <ProgressCircle value={0} size="lg" indeterminate label="Loading large" />
-    </Row>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   7. PATTERNS — animated determinate fill, dashboard widget
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => {
-    function Animated() {
-      const [progress, setProgress] = useState(0);
-      useEffect(() => {
-        const t = setInterval(() => {
-          setProgress((p) => (p >= 100 ? 0 : p + 1));
-        }, 60);
-        return () => clearInterval(t);
-      }, []);
-      return (
-        <Stack>
-          <div>
-            <SectionLabel>Animated determinate</SectionLabel>
-            <ProgressCircle value={progress} size="lg" showValue label="Loading" />
-          </div>
-          <div>
-            <SectionLabel>Dashboard widget</SectionLabel>
-            <ProgressCircle
-              value={68}
-              size="lg"
-              status="positive"
-              showValue={
-                <div style={{ textAlign: 'center' }}>
-                  <div style={{ fontSize: 'var(--heading-md)', fontWeight: 'var(--font-weight-bold)', color: 'var(--text-primary)' }}>
-                    68%
-                  </div>
-                  <div style={{ fontSize: 'var(--body-sm)', color: 'var(--text-secondary)' }}>
-                    on track
-                  </div>
-                </div>
-              }
-              label="Quarter progress"
-            />
-          </div>
-        </Stack>
-      );
-    }
-    return <Animated />;
+  args: {
+    value: 70,
+    size: 'lg',
+    label: 'Tasks complete',
+    showValue: (
+      <div style={{ textAlign: 'center' }}>
+        <div style={{ fontSize: 'var(--heading-md)', fontWeight: 'var(--font-weight-bold)', color: 'var(--text-primary)' }}>
+          70%
+        </div>
+        <div style={{ fontSize: 'var(--body-sm)', color: 'var(--text-secondary)' }}>
+          of 200
+        </div>
+      </div>
+    ),
   },
 };

--- a/components/ui/ProgressStepper/ProgressStepper.mdx
+++ b/components/ui/ProgressStepper/ProgressStepper.mdx
@@ -10,51 +10,21 @@ import * as Stories from './ProgressStepper.stories';
 
 Multi-step progress indicator. Shows the current position in a wizard, onboarding flow, or checkout sequence. Two variants — labeled `steps` and unlabeled `dots` — plus optional linear-mode constraint.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-### With descriptions
+### Dots
 
-Steps can include descriptions for richer context.
-
-<Canvas of={Stories.WithDescriptions} />
-
-### Step positions
-
-First, middle, and last-step states render distinct connector treatments.
-
-<Canvas of={Stories.FirstStep} />
-
-<Canvas of={Stories.LastStep} />
-
-<Canvas of={Stories.AllComplete} />
-
-### Sizes
-
-`size="sm"` for compact toolbars and constrained layouts.
-
-<Canvas of={Stories.SmallSize} />
-
-### Dots variant
-
-`variant="dots"` swaps the labeled circles for dots — use for mobile carousels and minimal flows.
-
-<Canvas of={Stories.DotsVariant} />
-
-### Linear mode
-
-`linear` constrains navigation to forward-only progression.
-
-<Canvas of={Stories.LinearMode} />
+<Canvas of={Stories.Dots} />
 
 ## Patterns
 
-Interactive multi-step flow with state-driven navigation.
+Component-owned `activeStep` state driving click-to-navigate — the only way to demonstrate real navigation. Toggle `linear` via Controls to compare free navigation against completed-steps-only navigation.
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.WithStepNavigation} />
 
 ## Props
 

--- a/components/ui/ProgressStepper/ProgressStepper.stories.tsx
+++ b/components/ui/ProgressStepper/ProgressStepper.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ProgressStepper, type ProgressStep } from './ProgressStepper';
 
 const meta: Meta<typeof ProgressStepper> = {
@@ -9,16 +9,42 @@ const meta: Meta<typeof ProgressStepper> = {
   parameters: {
     layout: 'padded',
   },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['steps', 'dots'],
+      description: '`steps` (default) — vertical labeled list with numbered circles. `dots` — compact horizontal dot row.',
+    },
+    steps: {
+      control: false,
+      description: 'Step definitions (`label` + optional `description`) — `steps` variant only.',
+    },
+    count: {
+      control: { type: 'number', min: 1 },
+      description: 'Total number of dots — `dots` variant only.',
+    },
+    activeStep: {
+      control: { type: 'number', min: 0 },
+      description: 'Zero-indexed active step',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Size variant',
+    },
+    linear: {
+      control: 'boolean',
+      description: 'When true, only completed steps are clickable — upcoming steps are muted and non-interactive.',
+    },
+    onStepClick: {
+      action: 'stepClicked',
+      description: 'Callback when a step is clicked',
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof ProgressStepper>;
-
-const proposalSteps: ProgressStep[] = [
-  { label: 'Scope of project' },
-  { label: 'Project timeline' },
-  { label: 'Fee summary' },
-];
 
 const onboardingSteps: ProgressStep[] = [
   { label: 'Account setup', description: 'Create your account and set a password' },
@@ -27,175 +53,93 @@ const onboardingSteps: ProgressStep[] = [
   { label: 'Review & confirm', description: 'Review your selections' },
 ];
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
-  args: {
-    steps: proposalSteps,
-    activeStep: 1,
-  },
-};
+/* ─── Default ─────────────────────────────────────────────────── */
 
-/** @summary With descriptions */
-export const WithDescriptions: Story = {
+/** @summary Interactive labeled stepper — steps/activeStep via Controls */
+export const Default: Story = {
   args: {
     steps: onboardingSteps,
     activeStep: 1,
   },
 };
 
-/** @summary First step */
-export const FirstStep: Story = {
-  args: {
-    steps: proposalSteps,
-    activeStep: 0,
-  },
-};
-
-/** @summary Last step */
-export const LastStep: Story = {
-  args: {
-    steps: proposalSteps,
-    activeStep: 2,
-  },
-};
-
-/** @summary All complete */
-export const AllComplete: Story = {
-  args: {
-    steps: proposalSteps,
-    activeStep: 3,
-  },
-};
-
-/** @summary Small size */
-export const SmallSize: Story = {
-  args: {
-    steps: proposalSteps,
-    activeStep: 1,
-    size: 'sm',
-  },
-};
+/* ─── Variants — one story per distinct semantic variant (Q3) ────── */
 
 /**
- * Linear mode prevents skipping ahead. Only completed steps are clickable.
- * The user must advance via a primary CTA (Next button).
- */
-export const LinearMode = () => {
-  const [active, setActive] = useState(1);
-
-  return (
-    <div style={{ display: 'flex', gap: 'var(--space-1000)' }}>{/* bds-lint-ignore — 40px, no gap token */}
-      <ProgressStepper
-        steps={onboardingSteps}
-        activeStep={active}
-        linear
-        onStepClick={setActive}
-        style={{ width: '260px' }}
-      />
-      <div style={{ flex: 1 }}>
-        <h2 style={{ margin: '0 0 var(--gap-md)' }}>{onboardingSteps[active]?.label ?? 'Complete'}</h2>
-        <p style={{ color: 'var(--text-secondary)', margin: '0 0 var(--gap-xs)' }}>
-          {active < onboardingSteps.length
-            ? onboardingSteps[active].description
-            : 'All steps completed!'}
-        </p>
-        <p style={{ color: 'var(--text-muted)', fontSize: 'var(--body-sm)', margin: '0 0 var(--gap-xl)' }}>
-          Try clicking an upcoming step — only completed steps are navigable.
-        </p>
-        <div style={{ display: 'flex', gap: 'var(--gap-md)' }}>
-          <button
-            onClick={() => setActive(Math.max(0, active - 1))}
-            disabled={active === 0}
-          >
-            Previous
-          </button>
-          <button
-            onClick={() => setActive(Math.min(onboardingSteps.length, active + 1))}
-            disabled={active >= onboardingSteps.length}
-            style={{ backgroundColor: 'var(--background-brand-primary)', color: 'var(--text-inverse)', border: 'none', padding: 'var(--padding-tiny) var(--padding-md)', borderRadius: 'var(--border-radius-md)', cursor: 'pointer' }}
-          >
-            Next
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-/**
- * Compact horizontal dot indicator. Use on mobile, in carousels, or as a
- * minimal alternative when label text is redundant with the page heading.
+ * `variant="dots"` swaps the labeled circles for a compact horizontal dot
+ * row — no labels, `role="tablist"` instead of `role="list"`. Use for
+ * mobile carousels and minimal flows.
  *
- * @summary Dots variant
+ * @summary Dots variant — compact horizontal dot row
  */
-export const DotsVariant: Story = {
+export const Dots: Story = {
   args: {
     variant: 'dots',
     count: 5,
     activeStep: 2,
   },
+  argTypes: {
+    steps: { table: { disable: true } },
+  },
 };
 
-/**
- * Dots variant honors the same `linear` mode as the steps variant —
- * only completed dots are clickable.
- */
-export const DotsLinear = () => {
-  const [active, setActive] = useState(2);
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)', alignItems: 'center' }}>
-      <ProgressStepper
-        variant="dots"
-        count={5}
-        activeStep={active}
-        linear
-        onStepClick={setActive}
-      />
-      <p style={{ fontSize: 'var(--body-sm)', color: 'var(--text-muted)', margin: 0 }}>
-        Step {active + 1} of 5 — only completed dots are clickable.
-      </p>
-    </div>
-  );
-};
+/* ─── Irreducible composition (Q4) ────────────────────────────── */
 
 /**
- * @summary Common usage patterns
+ * `onStepClick` + component-owned `activeStep` state — the only way to show
+ * real click-to-navigate behavior. Toggle `linear` via Controls to compare
+ * free navigation against completed-steps-only navigation.
  *
- * Non-linear mode (default) allows free navigation to any step.
+ * @summary Controlled step navigation with Next/Previous
  */
-export const Patterns = () => {
-  const [active, setActive] = useState(0);
+export const WithStepNavigation: Story = {
+  args: {
+    steps: onboardingSteps,
+    linear: true,
+  },
+  argTypes: {
+    activeStep: { table: { disable: true } },
+    variant: { table: { disable: true } },
+    count: { table: { disable: true } },
+  },
+  render: (args) => {
+    const steps = onboardingSteps;
+    const [active, setActive] = useState(0);
 
-  return (
-    <div style={{ display: 'flex', gap: 'var(--space-1000)' }}>{/* bds-lint-ignore — 40px, no gap token */}
-      <ProgressStepper
-        steps={onboardingSteps}
-        activeStep={active}
-        onStepClick={setActive}
-        style={{ width: '260px' }}
-      />
-      <div style={{ flex: 1 }}>
-        <h2 style={{ margin: '0 0 var(--gap-md)' }}>{onboardingSteps[active]?.label ?? 'Complete'}</h2>
-        <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
-          {active < onboardingSteps.length
-            ? onboardingSteps[active].description
-            : 'All steps completed!'}
-        </p>
-        <div style={{ marginTop: 'var(--padding-lg)', display: 'flex', gap: 'var(--gap-md)' }}>
-          <button
-            onClick={() => setActive(Math.max(0, active - 1))}
-            disabled={active === 0}
-          >
-            Previous
-          </button>
-          <button
-            onClick={() => setActive(Math.min(onboardingSteps.length, active + 1))}
-            disabled={active >= onboardingSteps.length}
-          >
-            Next
-          </button>
+    return (
+      <div style={{ display: 'flex', gap: 'var(--space-1000)' }}>{/* bds-lint-ignore — 40px, no gap token */}
+        <ProgressStepper
+          steps={steps}
+          size={args.size}
+          linear={args.linear}
+          activeStep={active}
+          onStepClick={setActive}
+          style={{ width: '260px' }}
+        />
+        <div style={{ flex: 1 }}>
+          <h2 style={{ margin: '0 0 var(--gap-md)' }}>{steps[active]?.label ?? 'Complete'}</h2>
+          <p style={{ color: 'var(--text-secondary)', margin: '0 0 var(--gap-xl)' }}>
+            {active < steps.length
+              ? steps[active].description
+              : 'All steps completed!'}
+          </p>
+          <div style={{ display: 'flex', gap: 'var(--gap-md)' }}>
+            <button
+              onClick={() => setActive(Math.max(0, active - 1))}
+              disabled={active === 0}
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setActive(Math.min(steps.length, active + 1))}
+              disabled={active >= steps.length}
+              style={{ backgroundColor: 'var(--background-brand-primary)', color: 'var(--text-inverse)', border: 'none', padding: 'var(--padding-tiny) var(--padding-md)', borderRadius: 'var(--border-radius-md)', cursor: 'pointer' }}
+            >
+              Next
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  },
 };

--- a/docs-site/content/docs/components/multi-select.mdx
+++ b/docs-site/content/docs/components/multi-select.mdx
@@ -12,7 +12,7 @@ MultiSelect composes [Select](/docs/components/select) + [Tag](/docs/components/
 - Multi-region or multi-tenant scoping
 - Any "pick N from M" choice with a visible-set affordance
 
-For single-pick, use [Select](/docs/components/select). For free-form tag entry where users type new values, use [AddableTagList](https://storybook.brikdesigns.com/?path=/story/containers-addable-tag-list--plain).
+For single-pick, use [Select](/docs/components/select). For free-form tag entry where users type new values, use [AddableTagList](https://storybook.brikdesigns.com/?path=/story/containers-addable-tag-list--default).
 
 ## Import
 
@@ -73,7 +73,7 @@ By default selected-item tags match the dropdown size. Override with `tagSize` f
 ## When *not* to use
 
 - **Don't use MultiSelect for ≤3 options.** Use [Checkbox](/docs/components/checkbox) groups — the choices are visible at all times.
-- **Don't use MultiSelect when users need to enter new tags.** Free-form tag entry belongs in [AddableTagList](https://storybook.brikdesigns.com/?path=/story/containers-addable-tag-list--plain).
+- **Don't use MultiSelect when users need to enter new tags.** Free-form tag entry belongs in [AddableTagList](https://storybook.brikdesigns.com/?path=/story/containers-addable-tag-list--default).
 
 ## Accessibility
 

--- a/scripts/lint-doc-links.js
+++ b/scripts/lint-doc-links.js
@@ -146,6 +146,7 @@ const COMPONENT_LINKS = /<ComponentLinks\b[^>]*\bslug="([^"]+)"/g;
 // issue #1229). Self-cleaning: if a listed slug gains a docs page, the
 // gate fails until it is removed from this set — so the debt can only shrink.
 const COMPONENT_LINKS_WITHOUT_DOCS_PAGE = new Set([
+  'addable-tag-list',
   'animated-icon',
   'block-quote',
   'checklist',


### PR DESCRIPTION
## Summary

Batch 1 of the final grandfathered story-shape sweep (#587 Phase 3 tail). Migrates 10 story files to the ADR-006 two-shape + ADR-010 story-vs-control matrix: banned `Variants`/`Patterns` gallery exports collapsed into `argTypes` Controls, `Playground` renamed to `Default`, Q5 interaction stories renamed `InteractionTest…` + tagged `!manifest`.

**105 → 71 exports** across the batch. Only `.stories.tsx` + `.mdx` touched — component `.tsx`/`.css`/`index.ts` and `meta.title` untouched, so no consumer disruption.

| Component | Before | After | Notes |
|---|---|---|---|
| Meter | 18 | 7 | 4 status stories kept (Q3); size/label/formatter axes → Controls |
| AddableEntryList | 16 | 12 | 7 are `InteractionTest…` Q5; `ReadModeUrl`/`ReadModeText` merged → `ReadMode` |
| AddableComboList | 14 | 12 | 7 Q5; deprecated (ADR-003) → meta tagged `!manifest` |
| ProgressStepper | 10 | 3 | `Default`, `Dots` (distinct ARIA role), `WithStepNavigation` (Q4 hook-driven) |
| CatalogPicker | 10 | 7 | provenance/strict/industry starting templates kept (Q3); 2 Q5 |
| Board | 9 | 5 | 3 irreducible `With…` compositions + `Density` (axis-only-gallery exception, keeps #412 regression play check) |
| AddableTextList | 8 | 8 | deprecated → `!manifest`; `ReadMode`/`MaxItemsCap` extracted from galleries; 3 Q5 |
| AddableTagList | 8 | 7 | `Plain` → `Default`; **`AddableTagList.mdx` created** (was missing); 3 Q5 |
| ProgressCircle | 7 | 5 | `Statuses` gallery split into 3 Q3 stories; `Matrix` (banned two-axis gallery) deleted |
| AddableFieldRowList | 5 | 5 | render-prop primitive, Q4-heavy by design; `argTypes` added (was empty) |

Follow-on fixes caught by the pre-push gate: the `Plain` → `Default` rename changed a story ID linked from `multi-select.mdx` (repointed), and the new `AddableTagList.mdx` joins the #1229 docless-ComponentLinks allowlist until its docs-site page is authored.

**Judgment call for review:** `InteractionTest…` (Q5) stories are not Canvased under `## Patterns` — follows codebase precedent (Switch, CloseButton) where play-only stories stay code-only, over a literal reading of the recipe standard.

## Test plan

- [x] `npm run lint-storybook-recipe` — 91/91 conforming
- [x] `npm run lint-jsdoc` — clean (every story has `@summary` + surface tag)
- [x] `npm run typecheck` — clean
- [x] `npm run typegen:axes:check` — manifest in sync
- [x] `npm run build-storybook` — succeeds
- [x] `npm run lint-doc-links` — all links resolve
- [ ] `npm run chromatic` — **not run**: snapshot quota exhausted (#771). Story renames will reset baselines when quota returns.

Closes #1276

## References

- Parent: #587 (Phase 3) · Lint gate: #569 · ADR-010 · sibling precedent PRs #1085–#1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
