### PR TITLE
refactor(storybook): story-shape batch 2 — 41 → 35 exports (#1277)

### DIFF
--- a/components/ui/Breadcrumb/Breadcrumb.mdx
+++ b/components/ui/Breadcrumb/Breadcrumb.mdx
@@ -8,30 +8,21 @@ import * as Stories from './Breadcrumb.stories';
 
 <ComponentLinks slug="breadcrumb" />
 
-Navigation breadcrumb trail showing the current page location within a hierarchy. Supports slash and chevron separators.
+Navigation breadcrumb trail showing the current page location within a hierarchy. Toggle `separator` (`slash` / `chevron`) via Controls on Default.
 
 Pass `linkComponent` (e.g. `next/link`) so linked crumbs route client-side instead of triggering a full-page reload. See [framework guides → client-side routing](/docs/getting-started/framework-guides).
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Separator styles, nesting depths, and dark background usage.
+### With link component
 
-- **`slash`** — `/` default separator
-- **`chevron`** — `>` alternative visual style
-
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.WithLinkComponent} />
 
 ## Patterns
-
-Real-world usage: page headers and settings navigation.
-
-<Canvas of={Stories.Patterns} />
-
-## Service-line cascade
 
 When a breadcrumb sits inside a `[data-service-line='X']` subtree, the
 current page label and separators rebind canonical `--text-secondary`
@@ -49,4 +40,3 @@ still resolves during the deprecation window (#788).
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/Breadcrumb/Breadcrumb.stories.tsx
+++ b/components/ui/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Breadcrumb } from './Breadcrumb';
 import { type BdsLinkComponent } from '../NavItem';
@@ -11,25 +10,6 @@ const MockLink: BdsLinkComponent = ({ href, children, ...props }) => (
   </a>
 );
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof Breadcrumb> = {
@@ -38,7 +18,16 @@ const meta: Meta<typeof Breadcrumb> = {
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
-    separator: { control: 'select', options: ['slash', 'chevron'] },
+    items: {
+      control: 'object',
+      description:
+        'Crumb trail in order. The last item renders as plain text with `aria-current="page"`; earlier items render as `<a>` when `href` is set.',
+    },
+    separator: {
+      control: 'select',
+      options: ['slash', 'chevron'],
+      description: 'Visual separator between crumbs. Default `slash` (`/`); `chevron` renders `›`.',
+    },
     linkComponent: {
       description:
         'Render each linked crumb with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. See ADR-012.',
@@ -51,11 +40,11 @@ export default meta;
 type Story = StoryObj<typeof Breadcrumb>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   1. DEFAULT — args-driven sandbox. Controls work.
    ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     items: [
       { label: 'Home', href: '#' },
@@ -65,6 +54,10 @@ export const Playground: Story = {
     separator: 'slash',
   },
 };
+
+/* ═══════════════════════════════════════════════════════════════
+   2. VARIANTS — Q3 semantic starting points
+   ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Linked crumbs routed through an injected link component for client-side routing */
 export const WithLinkComponent: Story = {
@@ -79,120 +72,8 @@ export const WithLinkComponent: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Separator styles, depths, single item
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Slash separator (default)</SectionLabel>
-        <Breadcrumb
-          items={[
-            { label: 'Home', href: '#' },
-            { label: 'Products', href: '#' },
-            { label: 'Design System' },
-          ]}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Chevron separator</SectionLabel>
-        <Breadcrumb
-          separator="chevron"
-          items={[
-            { label: 'Home', href: '#' },
-            { label: 'Products', href: '#' },
-            { label: 'Design System' },
-          ]}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Deep nesting</SectionLabel>
-        <Breadcrumb
-          items={[
-            { label: 'Home', href: '#' },
-            { label: 'Products', href: '#' },
-            { label: 'Design System', href: '#' },
-            { label: 'Components', href: '#' },
-            { label: 'Breadcrumb' },
-          ]}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Single item</SectionLabel>
-        <Breadcrumb items={[{ label: 'Dashboard' }]} />
-      </div>
-
-      <div>
-        <SectionLabel>On dark background</SectionLabel>
-        <div style={{ backgroundColor: 'var(--background-brand-primary)', padding: 'var(--padding-xl)', borderRadius: 'var(--border-radius-md)' }}>
-          <Breadcrumb
-            items={[
-              { label: 'Show All', href: '#' },
-              { label: 'Product', href: '#' },
-              { label: 'Design System' },
-            ]}
-          />
-        </div>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world compositions
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Stack gap="var(--gap-huge)">
-      {/* Page header breadcrumb */}
-      <div>
-        <SectionLabel>Page header context</SectionLabel>
-        <div style={{
-          padding: 'var(--padding-xl)',
-          borderBottom: 'var(--border-width-md) solid var(--border-secondary)',
-        }}>
-          <Breadcrumb
-            separator="chevron"
-            items={[
-              { label: 'Admin', href: '#' },
-              { label: 'Companies', href: '#' },
-              { label: 'Acme Corp' },
-            ]}
-          />
-          <h1 style={{
-            fontFamily: 'var(--font-family-heading)',
-            fontSize: 'var(--heading-lg)',
-            marginTop: 'var(--gap-lg)',
-          }}>
-            Acme Corp
-          </h1>
-        </div>
-      </div>
-
-      {/* Settings path */}
-      <div>
-        <SectionLabel>Settings navigation</SectionLabel>
-        <Breadcrumb
-          items={[
-            { label: 'Settings', href: '#' },
-            { label: 'Integrations', href: '#' },
-            { label: 'Webflow API' },
-          ]}
-        />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   4. SERVICE-LINE CASCADE — tinting via [data-service-line]
+   3. PATTERNS — Q4 irreducible: driven by an ancestor DOM attribute
+      ([data-service-line]), not a component prop. Args can't express it.
    ═══════════════════════════════════════════════════════════════ */
 
 // The breadcrumb stays scope-blind — __current reads --text-secondary
@@ -214,10 +95,21 @@ const SERVICE_LINES = [
 /** @summary Service-line tinting via [data-service-line] cascade */
 export const ServiceLineCascade: Story = {
   render: () => (
-    <Stack>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)' }}>
       {SERVICE_LINES.map(({ id, label }) => (
         <div key={id} data-service-line={id}>
-          <SectionLabel>{`[data-service-line='${id}'] — ${label}`}</SectionLabel>
+          <p
+            style={{
+              fontFamily: 'var(--font-family-label)',
+              fontSize: 'var(--body-xs)', // bds-lint-ignore
+              textTransform: 'uppercase' as const,
+              letterSpacing: '0.05em',
+              marginBottom: 'var(--gap-md)',
+              color: 'var(--text-muted)',
+            }}
+          >
+            {`[data-service-line='${id}'] — ${label}`}
+          </p>
           <Breadcrumb
             items={[
               { label: 'Home', href: '#' },
@@ -227,6 +119,6 @@ export const ServiceLineCascade: Story = {
           />
         </div>
       ))}
-    </Stack>
+    </div>
   ),
 };

--- a/components/ui/Dialog/Dialog.mdx
+++ b/components/ui/Dialog/Dialog.mdx
@@ -10,24 +10,16 @@ import * as Stories from './Dialog.stories';
 
 Focused confirmation overlay for user decisions. Simpler than `Modal` — intended for confirm/cancel flows.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
-
-Default, destructive, and custom content modes.
-
-<Canvas of={Stories.Variants} />
 
 - **`default`** — Standard confirmation with primary action
 - **`destructive`** — Red action button for irreversible operations
 
-## Patterns
-
-Save-before-leaving and delete confirmation flows.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.Destructive} />
 
 ## Props
 

--- a/components/ui/Dialog/Dialog.stories.tsx
+++ b/components/ui/Dialog/Dialog.stories.tsx
@@ -9,41 +9,50 @@ const meta: Meta<typeof Dialog> = {
   tags: ['!manifest', 'surface-shared'], // deprecated — hide from MCP discovery (use Modal preset="confirm")
   parameters: { layout: 'centered' },
   argTypes: {
-    variant: { control: 'select', options: ['default', 'destructive'] },
     title: { control: 'text' },
     description: { control: 'text' },
     confirmLabel: { control: 'text' },
     cancelLabel: { control: 'text' },
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive'],
+      description: '`destructive` is the starting template for delete-type confirmations.',
+    },
+    closeOnBackdrop: { control: 'boolean' },
+    isOpen: { table: { disable: true } },
+    onClose: { table: { disable: true } },
+    onConfirm: { table: { disable: true } },
+    children: { table: { disable: true } },
   },
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Dialog>;
 
-/* ─── Layout helpers ─────────────────────────────────────────── */
+/* ═══════════════════════════════════════════════════════════════
+   DEFAULT — args-driven sandbox. `isOpen` has no uncontrolled mode,
+   so the trigger + useState wiring is irreducible to args alone
+   (ADR-010 Q4). `render` reads `args`, so title / description /
+   confirmLabel / cancelLabel / variant / closeOnBackdrop stay live
+   via Controls.
+   ═══════════════════════════════════════════════════════════════ */
 
-const SectionLabel = ({ children }: { children: string }) => (
-  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-    {children}
-  </span>
-);
-
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%' }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-lg)', flexWrap: 'wrap' }}>
-    {children}
-  </div>
-);
-
-/* ─── Playground ─────────────────────────────────────────────── */
-
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Deprecated — use `<Modal preset="confirm">`. Kept as a controlled
+ * overlay for existing consumers migrating off it.
+ *
+ * @summary Confirm dialog (deprecated — use Modal preset="confirm")
+ */
+export const Default: Story = {
+  args: {
+    isOpen: false,
+    onClose: () => {},
+    title: 'Confirm action',
+    description: 'Are you sure you want to proceed? This action cannot be undone.',
+    variant: 'default',
+    confirmLabel: 'Confirm',
+    cancelLabel: 'Cancel',
+  },
   render: (args) => {
     const [open, setOpen] = useState(false);
     return (
@@ -58,132 +67,41 @@ export const Playground: Story = {
       </>
     );
   },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   DESTRUCTIVE — Q3 starting template (ADR-010's own canonical
+   example: "variant: 'destructive' for a delete CTA").
+   ═══════════════════════════════════════════════════════════════ */
+
+/**
+ * `variant="destructive"` switches the confirm button to the destructive
+ * treatment — the starting template for delete-style confirmations.
+ *
+ * @summary Destructive variant — delete-style confirm action
+ */
+export const Destructive: Story = {
   args: {
     isOpen: false,
     onClose: () => {},
-    title: 'Confirm action',
-    description: 'Are you sure you want to proceed? This action cannot be undone.',
-    variant: 'default',
-    confirmLabel: 'Confirm',
-    cancelLabel: 'Cancel',
+    variant: 'destructive',
+    title: 'Delete item?',
+    description: 'This will permanently remove the item. You cannot undo this action.',
+    confirmLabel: 'Delete',
+    cancelLabel: 'Keep',
   },
-};
-
-/* ─── Variants ───────────────────────────────────────────────── */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => {
-    const [openId, setOpenId] = useState<string | null>(null);
-    const open = (id: string) => setOpenId(id);
-    const close = () => setOpenId(null);
-
+  render: (args) => {
+    const [open, setOpen] = useState(false);
     return (
-      <Stack>
-        <SectionLabel>Default variant</SectionLabel>
-        <Row>
-          <div>
-            <Button onClick={() => open('default')}>Open dialog</Button>
-            <Dialog
-              isOpen={openId === 'default'}
-              onClose={close}
-              title="Confirm action"
-              description="Are you sure you want to proceed? This action cannot be undone."
-              onConfirm={close}
-            />
-          </div>
-        </Row>
-
-        <SectionLabel>Destructive variant</SectionLabel>
-        <Row>
-          <div>
-            <Button variant="secondary" onClick={() => open('destructive')}>Delete item</Button>
-            <Dialog
-              isOpen={openId === 'destructive'}
-              onClose={close}
-              title="Delete item?"
-              description="This will permanently remove the item. You cannot undo this action."
-              variant="destructive"
-              confirmLabel="Delete"
-              cancelLabel="Keep"
-              onConfirm={close}
-            />
-          </div>
-        </Row>
-
-        <SectionLabel>Custom content (replaces description)</SectionLabel>
-        <Row>
-          <div>
-            <Button onClick={() => open('custom')}>Open custom dialog</Button>
-            <Dialog
-              isOpen={openId === 'custom'}
-              onClose={close}
-              title="Update preferences"
-              confirmLabel="Save"
-              onConfirm={close}
-            >
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
-                <p style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)', color: 'var(--text-secondary)', margin: 0 }}>
-                  Choose how you would like to receive notifications.
-                </p>
-                <label style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)' }}>
-                  <input type="checkbox" defaultChecked /> Email notifications
-                </label>
-                <label style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)' }}>
-                  <input type="checkbox" /> SMS notifications
-                </label>
-              </div>
-            </Dialog>
-          </div>
-        </Row>
-      </Stack>
-    );
-  },
-};
-
-/* ─── Patterns ───────────────────────────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => {
-    const [openId, setOpenId] = useState<string | null>(null);
-    const open = (id: string) => setOpenId(id);
-    const close = () => setOpenId(null);
-
-    return (
-      <Stack>
-        <SectionLabel>Save changes before leaving</SectionLabel>
-        <Row>
-          <div>
-            <Button onClick={() => open('save')}>Leave page</Button>
-            <Dialog
-              isOpen={openId === 'save'}
-              onClose={close}
-              title="Unsaved changes"
-              description="You have unsaved changes. Do you want to save before leaving?"
-              confirmLabel="Save & leave"
-              cancelLabel="Discard"
-              onConfirm={close}
-            />
-          </div>
-        </Row>
-
-        <SectionLabel>Delete confirmation</SectionLabel>
-        <Row>
-          <div>
-            <Button variant="secondary" onClick={() => open('delete')}>Delete company</Button>
-            <Dialog
-              isOpen={openId === 'delete'}
-              onClose={close}
-              title="Delete company?"
-              description="This will permanently remove the company and all associated data. This action cannot be undone."
-              variant="destructive"
-              confirmLabel="Delete"
-              onConfirm={close}
-            />
-          </div>
-        </Row>
-      </Stack>
+      <>
+        <Button variant="secondary" onClick={() => setOpen(true)}>Delete item</Button>
+        <Dialog
+          {...args}
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          onConfirm={() => setOpen(false)}
+        />
+      </>
     );
   },
 };

--- a/components/ui/Footer/Footer.mdx
+++ b/components/ui/Footer/Footer.mdx
@@ -8,30 +8,50 @@ import * as Stories from './Footer.stories';
 
 <ComponentLinks slug="footer" />
 
-Site-wide footer with logo, navigation columns, social links, and copyright. Supports default and brand color variants.
+Site-wide footer with logo, navigation columns, social links, and copyright. Toggle `variant` (`default` / `brand` / `inverse`) via Controls on Default.
 
 Pass `linkComponent` (e.g. `next/link`) so column and bottom-bar links route client-side instead of triggering a full-page reload. See [framework guides → client-side routing](/docs/getting-started/framework-guides).
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Default, brand, social links, and minimal configurations.
+### Default
 
-- **`default`** — primary background with border-top
-- **`brand`** — brand-colored background with inverse text
+<Canvas of={Stories.Default} />
 
-<Canvas of={Stories.Variants} />
+### Constrained
 
-## Patterns
+Constrain inner content to a `--content-width-*` while the background stays full-bleed.
 
-Real-world usage: full marketing site footer with services, resources, legal columns, and social links.
+<Canvas of={Stories.Constrained} />
 
-<Canvas of={Stories.Patterns} />
+### With link component
+
+<Canvas of={Stories.WithLinkComponent} />
+
+### External links
+
+External column links (`external: true`) open in a new tab with `rel="noopener noreferrer"` and bypass the router `linkComponent`.
+
+<Canvas of={Stories.ExternalLinks} />
+
+### Marketing composition
+
+Full marketing-site shape: newsletter (`aboveTop`), contact block (`brandExtra`), badged service columns, bottom links, and social icons.
+
+<Canvas of={Stories.Marketing} />
 
 ## Props
 
 <ArgTypes of={Stories} />
 
+## CSS Override API
+
+| Variable | Default | Use |
+| --- | --- | --- |
+| `--bds-footer-surface` | `var(--surface-inverse)` | Background for `variant="inverse"`. Override on an ancestor (e.g. `:root`) to pin the inverse footer to a fixed color across light + dark themes. |
+
+<Canvas of={Stories.SurfaceOverride} />

--- a/components/ui/Footer/Footer.stories.tsx
+++ b/components/ui/Footer/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { CSSProperties } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
 import { Footer } from './Footer';
@@ -10,25 +10,6 @@ const MockLink: BdsLinkComponent = ({ href, children, ...props }) => (
   <a href={href} data-link-component="mock" {...props}>
     {children}
   </a>
-);
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
 );
 
 /* ─── Shared Data ─────────────────────────────────────────────── */
@@ -71,15 +52,6 @@ const LogoPlaceholder = () => (
   </div>
 );
 
-const socialLinks = (
-  <>
-    <a href="#" style={{ color: 'inherit', textDecoration: 'none', fontSize: 'var(--body-md)' }}>FB</a>
-    <a href="#" style={{ color: 'inherit', textDecoration: 'none', fontSize: 'var(--body-md)' }}>IG</a>
-    <a href="#" style={{ color: 'inherit', textDecoration: 'none', fontSize: 'var(--body-md)' }}>LI</a>
-    <a href="#" style={{ color: 'inherit', textDecoration: 'none', fontSize: 'var(--body-md)' }}>X</a>
-  </>
-);
-
 /* ─── Meta ────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof Footer> = {
@@ -88,16 +60,45 @@ const meta: Meta<typeof Footer> = {
   tags: ['surface-web'],
   parameters: { layout: 'fullscreen' },
   argTypes: {
-    variant: { control: 'select', options: ['default', 'brand', 'inverse'] },
+    logo: { control: false, description: 'Logo element rendered in the top-left brand area.' },
+    tagline: { control: 'text', description: 'Optional tagline or description below the logo.' },
+    brandExtra: {
+      control: false,
+      description:
+        'Optional content rendered inside the logo area, below the tagline — typically a contact block (phone / email / address).',
+    },
+    columns: { control: false, description: 'Link columns — each a `{ heading, links }` group.' },
+    columnHeadingLevel: {
+      control: 'select',
+      options: ['h2', 'h3', 'h4', 'h5', 'h6'],
+      description:
+        'Render level for column headings. Default `h4` so a page whose last in-page heading is h2/h3 keeps `heading-order` intact.',
+    },
+    copyright: { control: 'text' },
+    bottomLinks: {
+      control: false,
+      description: 'Inline links next to the copyright, separated by a bullet — typically Terms / Privacy.',
+    },
+    socialLinks: {
+      control: false,
+      description: 'Right-aligned content in the bottom bar — typically social icons or a small tagline.',
+    },
+    aboveTop: {
+      control: false,
+      description:
+        'Content rendered above the standard top section, full-width — typical use: newsletter signup, announcement banner, secondary CTA.',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'brand', 'inverse'],
+      description:
+        'Background surface. Pure color/text swap — no semantic or ARIA difference between values. `inverse` meets WCAG AA on `body-sm`.',
+    },
     containerMaxWidth: {
       control: 'select',
       options: [undefined, 'narrow', 'default', 'wide', 'xl'],
       description:
         'Constrain inner content to a `--content-width-*` while the background stays full-bleed. Omit for full-width.',
-    },
-    columnHeadingLevel: {
-      control: 'select',
-      options: ['h2', 'h3', 'h4', 'h5', 'h6'],
     },
     linkComponent: {
       description:
@@ -111,19 +112,23 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   1. DEFAULT — args-driven sandbox. Controls work.
    ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     logo: <LogoPlaceholder />,
     tagline: 'Building better digital experiences for small businesses.',
     columns: sampleColumns,
-    copyright: '\u00A9 2026 Brik Designs. All rights reserved.',
+    copyright: '© 2026 Brik Designs. All rights reserved.',
     variant: 'default',
   },
 };
+
+/* ═══════════════════════════════════════════════════════════════
+   2. VARIANTS — Q3 semantic starting points
+   ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Inner content constrained to a content width while the background spans full-bleed */
 export const Constrained: Story = {
@@ -142,7 +147,7 @@ export const WithLinkComponent: Story = {
   args: {
     logo: <LogoPlaceholder />,
     columns: sampleColumns,
-    copyright: '\u00A9 2026 Brik Designs. All rights reserved.',
+    copyright: '© 2026 Brik Designs. All rights reserved.',
     bottomLinks: [
       { label: 'Terms', href: '/terms' },
       { label: 'Privacy', href: '/privacy' },
@@ -182,82 +187,7 @@ export const ExternalLinks: Story = {
   },
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Default, brand, with social, minimal
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Default</SectionLabel>
-        <Footer
-          logo={<LogoPlaceholder />}
-          tagline="Building better digital experiences for small businesses."
-          columns={sampleColumns}
-          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Brand</SectionLabel>
-        <Footer
-          logo={<LogoPlaceholder />}
-          tagline="Building better digital experiences for small businesses."
-          columns={sampleColumns}
-          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
-          variant="brand"
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Inverse (dark surface \u2014 meets WCAG AA on body-sm)</SectionLabel>
-        <Footer
-          logo={<LogoPlaceholder />}
-          tagline="Building better digital experiences for small businesses."
-          columns={sampleColumns}
-          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
-          variant="inverse"
-        />
-      </div>
-
-      <div style={{ '--bds-footer-surface': 'var(--color-grayscale-darkest)' } as React.CSSProperties}>
-        <SectionLabel>
-          Inverse + `--bds-footer-surface` override (pinned to grayscale-darkest across themes)
-        </SectionLabel>
-        <Footer
-          logo={<LogoPlaceholder />}
-          tagline="Building better digital experiences for small businesses."
-          columns={sampleColumns}
-          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
-          variant="inverse"
-        />
-      </div>
-
-      <div>
-        <SectionLabel>With social links</SectionLabel>
-        <Footer
-          logo={<LogoPlaceholder />}
-          columns={sampleColumns}
-          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
-          socialLinks={socialLinks}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Minimal (copyright only)</SectionLabel>
-        <Footer copyright={'\u00A9 2026 Brik Designs. All rights reserved.'} />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Full marketing page footer
-   ═══════════════════════════════════════════════════════════════ */
-
-/* \u2500\u2500\u2500 Marketing-pattern helpers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 */
+/* ─── Marketing-pattern helpers ──────────────────────────────── */
 
 const NewsletterSection = () => (
   <div style={{
@@ -304,7 +234,7 @@ const NewsletterSection = () => (
 const ContactBlock = () => (
   <>
     <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)', fontSize: 'var(--body-sm)' }}>
-      <span style={{ opacity: 0.6 }}>{'\u260E'}</span>
+      <span style={{ opacity: 0.6 }}>{'☎'}</span>
       <span>(555) 123-4567</span>
     </div>
     <a
@@ -318,7 +248,7 @@ const ContactBlock = () => (
         textDecoration: 'none',
       }}
     >
-      <span style={{ opacity: 0.6 }}>{'\u2709'}</span>
+      <span style={{ opacity: 0.6 }}>{'✉'}</span>
       <span>hello@example.com</span>
     </a>
   </>
@@ -337,89 +267,65 @@ const ServiceDot = ({ color }: { color: string }) => (
   />
 );
 
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Minimal marketing footer (legacy shape \u2014 no marketing slots)</SectionLabel>
-        <Footer
-          logo={<LogoPlaceholder />}
-          tagline="Modern websites and digital systems for growing businesses."
-          columns={[
-            {
-              heading: 'Services',
-              links: [
-                { label: 'Web Design', href: '#' },
-                { label: 'Development', href: '#' },
-                { label: 'SEO', href: '#' },
-                { label: 'Consulting', href: '#' },
-              ],
-            },
-            {
-              heading: 'Resources',
-              links: [
-                { label: 'Blog', href: '#' },
-                { label: 'Case Studies', href: '#' },
-                { label: 'Documentation', href: '#' },
-              ],
-            },
-            {
-              heading: 'Legal',
-              links: [
-                { label: 'Privacy Policy', href: '#' },
-                { label: 'Terms of Service', href: '#' },
-              ],
-            },
-          ]}
-          copyright={'\u00A9 2026 Brik Designs LLC. All rights reserved.'}
-          socialLinks={socialLinks}
-        />
-      </div>
+/** @summary Full marketing-site footer — newsletter, contact block, badged service columns, bottom links, and social */
+export const Marketing: Story = {
+  args: {
+    aboveTop: <NewsletterSection />,
+    logo: <LogoPlaceholder />,
+    tagline: "We're a digital marketing and design agency.",
+    brandExtra: <ContactBlock />,
+    columns: [
+      {
+        heading: 'Services',
+        links: [
+          { label: 'Brand Design', href: '#', adornment: <ServiceDot color="var(--surface-service-brand)" /> },
+          { label: 'Marketing Design', href: '#', adornment: <ServiceDot color="var(--surface-service-marketing)" /> },
+          { label: 'Information Design', href: '#', adornment: <ServiceDot color="var(--surface-service-information)" /> },
+          { label: 'Product Design', href: '#', adornment: <ServiceDot color="var(--surface-service-product)" /> },
+          { label: 'Back Office Design', href: '#', adornment: <ServiceDot color="var(--surface-service-back-office)" /> },
+        ],
+      },
+      {
+        heading: 'About',
+        links: [
+          { label: 'Who We Are', href: '#' },
+          { label: 'What We Do', href: '#' },
+          { label: 'Customer Stories', href: '#' },
+        ],
+      },
+      {
+        heading: 'Follow Us',
+        links: [
+          { label: 'LinkedIn', href: '#' },
+          { label: 'Instagram', href: '#' },
+          { label: 'Facebook', href: '#' },
+        ],
+      },
+    ],
+    copyright: '© 2026 Brik Designs. All rights reserved.',
+    bottomLinks: [
+      { label: 'Terms', href: '#' },
+      { label: 'Privacy policy', href: '#' },
+    ],
+    socialLinks: <span>Made with {'❤️'} in Palm Beach, FL</span>,
+  },
+};
 
-      <div>
-        <SectionLabel>Full marketing footer \u2014 newsletter + contact + badged columns + bottom links</SectionLabel>
-        <Footer
-          aboveTop={<NewsletterSection />}
-          logo={<LogoPlaceholder />}
-          tagline="We're a digital marketing and design agency."
-          brandExtra={<ContactBlock />}
-          columns={[
-            {
-              heading: 'Services',
-              links: [
-                { label: 'Brand Design', href: '#', adornment: <ServiceDot color="var(--surface-service-brand)" /> },
-                { label: 'Marketing Design', href: '#', adornment: <ServiceDot color="var(--surface-service-marketing)" /> },
-                { label: 'Information Design', href: '#', adornment: <ServiceDot color="var(--surface-service-information)" /> },
-                { label: 'Product Design', href: '#', adornment: <ServiceDot color="var(--surface-service-product)" /> },
-                { label: 'Back Office Design', href: '#', adornment: <ServiceDot color="var(--surface-service-back-office)" /> },
-              ],
-            },
-            {
-              heading: 'About',
-              links: [
-                { label: 'Who We Are', href: '#' },
-                { label: 'What We Do', href: '#' },
-                { label: 'Customer Stories', href: '#' },
-              ],
-            },
-            {
-              heading: 'Follow Us',
-              links: [
-                { label: 'LinkedIn', href: '#' },
-                { label: 'Instagram', href: '#' },
-                { label: 'Facebook', href: '#' },
-              ],
-            },
-          ]}
-          copyright={'\u00A9 2026 Brik Designs. All rights reserved.'}
-          bottomLinks={[
-            { label: 'Terms', href: '#' },
-            { label: 'Privacy policy', href: '#' },
-          ]}
-          socialLinks={<span>Made with {'\u2764\uFE0F'} in Palm Beach, FL</span>}
-        />
-      </div>
-    </Stack>
-  ),
+/* ═══════════════════════════════════════════════════════════════
+   3. CSS OVERRIDE API — `--bds-footer-surface` demo
+   ═══════════════════════════════════════════════════════════════ */
+
+/** @summary `--bds-footer-surface` pinned via inline style override so the inverse variant holds a fixed color across light + dark themes */
+export const SurfaceOverride: Story = {
+  args: {
+    logo: <LogoPlaceholder />,
+    tagline: 'Building better digital experiences for small businesses.',
+    columns: sampleColumns,
+    copyright: '© 2026 Brik Designs. All rights reserved.',
+    variant: 'inverse',
+    style: {
+      // bds-lint-ignore — component-scoped CSS variable override, not a design token
+      ['--bds-footer-surface' as string]: 'var(--color-grayscale-darkest)',
+    } as CSSProperties,
+  },
 };

--- a/components/ui/Modal/Modal.mdx
+++ b/components/ui/Modal/Modal.mdx
@@ -10,33 +10,29 @@ import * as Stories from './Modal.stories';
 
 Portal-rendered dialog overlay with backdrop, escape key, and scroll lock. Use for focused tasks, confirmations, and forms.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
+
+Size (`sm` · `md` · `lg` · `xl` · `full`), `closeOnBackdrop`, `closeOnEscape`, and `showCloseButton` are all Controls on the canvas above.
 
 ## Variants
 
-Size variants, scrolling content, and no close button.
-
-<Canvas of={Stories.Variants} />
-
-- **`sm`** — Compact, simple messages
-- **`md`** — Default, standard dialogs
-- **`lg`** — Extended, complex content
-- **`xl`** — Extra large, data-heavy views
-- **`full`** — Full screen
-
 ### Confirm preset
 
-`preset="confirm"` collapses the legacy `Dialog` shape into Modal as a compact `alertdialog` with auto-rendered Cancel/Confirm buttons. Use `confirmVariant="destructive"` for delete-type actions.
+`preset="confirm"` collapses the legacy `Dialog` shape into Modal as a compact `alertdialog` with an auto-rendered Cancel/Confirm footer.
 
-<Canvas of={Stories.ConfirmPreset} />
+<Canvas of={Stories.Confirm} />
+
+### Destructive confirm
+
+`confirmVariant="destructive"` — the starting template for delete-type confirmations.
+
+<Canvas of={Stories.ConfirmDestructive} />
 
 ## Patterns
 
-Confirm delete and form in modal.
-
-<Canvas of={Stories.Patterns} />
+Composition the matrix can't express as args.
 
 ### Two-column form (xl)
 

--- a/components/ui/Modal/Modal.stories.tsx
+++ b/components/ui/Modal/Modal.stories.tsx
@@ -1,8 +1,11 @@
-import type { Meta } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
 import { useState } from 'react';
-import { Modal } from './Modal';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { Modal, type ModalProps } from './Modal';
 import { Button } from '../Button';
+
+/** Narrows `ModalProps` to the confirm-preset branch for the render callbacks below. */
+type ModalConfirmArgs = Extract<ModalProps, { preset: 'confirm' }>;
 
 const meta: Meta<typeof Modal> = {
   title: 'Components/modal',
@@ -10,61 +13,85 @@ const meta: Meta<typeof Modal> = {
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   argTypes: {
-    size: { control: 'select', options: ['sm', 'md', 'lg', 'xl', 'full'] },
+    title: { control: 'text' },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'xl', 'full'],
+      description: 'Default-shape only. `xl` unlocks multi-column body layouts (see TwoColumnForm).',
+    },
     closeOnBackdrop: { control: 'boolean' },
     closeOnEscape: { control: 'boolean' },
-    showCloseButton: { control: 'boolean' },
+    showCloseButton: {
+      control: 'boolean',
+      description: 'Default-shape only — hides the header X (footer / Escape remain the dismissal surface).',
+    },
+    description: { control: 'text', description: 'Confirm-preset only — body copy under the title.' },
+    confirmLabel: { control: 'text', description: 'Confirm-preset only.' },
+    cancelLabel: { control: 'text', description: 'Confirm-preset only.' },
+    confirmVariant: {
+      control: 'select',
+      options: ['primary', 'destructive'],
+      description: 'Confirm-preset only — `destructive` is the starting template for delete-type actions.',
+    },
+    confirmDisabled: { control: 'boolean', description: 'Confirm-preset only.' },
+    confirmLoading: { control: 'boolean', description: 'Confirm-preset only.' },
+    preset: { table: { disable: true } },
+    isOpen: { table: { disable: true } },
+    onClose: { table: { disable: true } },
+    onConfirm: { table: { disable: true } },
+    children: { table: { disable: true } },
+    footer: { table: { disable: true } },
+    'aria-label': { table: { disable: true } },
   },
 };
 
 export default meta;
+type Story = StoryObj<typeof Modal>;
 
-/* ─── Layout helpers ─────────────────────────────────────────── */
+/* ═══════════════════════════════════════════════════════════════
+   DEFAULT — args-driven sandbox. `isOpen` has no uncontrolled mode,
+   so the trigger + useState wiring is irreducible to args alone
+   (ADR-010 Q4). `render` reads `args`, so size / closeOnBackdrop /
+   closeOnEscape / showCloseButton stay live via Controls.
+   ═══════════════════════════════════════════════════════════════ */
 
-const SectionLabel = ({ children }: { children: string }) => (
-  <span style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-sm)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-    {children}
-  </span>
-);
-
-const Stack = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-xl)', width: '100%' }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-lg)', flexWrap: 'wrap' }}>
-    {children}
-  </div>
-);
-
-/* ─── Playground ─────────────────────────────────────────────── */
-
-export const Playground = {
-  render: () => {
+/**
+ * Default modal shape — header title, body, and footer actions. Toggle
+ * size, closeOnBackdrop, closeOnEscape, and showCloseButton via Controls.
+ *
+ * @summary Default modal — header, body, and footer actions
+ */
+export const Default: Story = {
+  args: {
+    isOpen: false,
+    onClose: () => {},
+    title: 'Title goes here',
+    size: 'md',
+    closeOnBackdrop: true,
+    closeOnEscape: true,
+    showCloseButton: true,
+    children: <p>Description goes here</p>,
+  },
+  render: (args) => {
     const [isOpen, setIsOpen] = useState(false);
     return (
       <>
         <Button onClick={() => setIsOpen(true)}>Open modal</Button>
         <Modal
+          {...args}
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
-          title="Title goes here"
-          size="md"
           footer={
             <>
               <Button variant="ghost" onClick={() => setIsOpen(false)}>Cancel</Button>
               <Button variant="primary" onClick={() => setIsOpen(false)}>Save</Button>
             </>
           }
-        >
-          <p>Description goes here</p>
-        </Modal>
+        />
       </>
     );
   },
-  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const trigger = canvas.getByRole('button', { name: 'Open modal' });
 
@@ -85,190 +112,93 @@ export const Playground = {
   },
 };
 
-/* ─── Variants ───────────────────────────────────────────────── */
-
-export const Variants = () => {
-    const [openId, setOpenId] = useState<string | null>(null);
-    const open = (id: string) => setOpenId(id);
-    const close = () => setOpenId(null);
-
-    return (
-      <Stack>
-        <SectionLabel>Size: sm / md / lg</SectionLabel>
-        <Row>
-          {(['sm', 'md', 'lg'] as const).map((size) => (
-            <div key={size}>
-              <Button onClick={() => open(size)}>Open {size}</Button>
-              <Modal
-                isOpen={openId === size}
-                onClose={close}
-                title={`${size.toUpperCase()} modal`}
-                size={size}
-                footer={<Button variant="primary" onClick={close}>Done</Button>}
-              >
-                <p>This is a {size} modal.</p>
-              </Modal>
-            </div>
-          ))}
-        </Row>
-
-        <SectionLabel>Scrolling content</SectionLabel>
-        <Row>
-          <div>
-            <Button onClick={() => open('scroll')}>Open scrolling modal</Button>
-            <Modal
-              isOpen={openId === 'scroll'}
-              onClose={close}
-              title="Long content"
-              footer={
-                <>
-                  <Button variant="ghost" onClick={close}>Cancel</Button>
-                  <Button variant="primary" onClick={close}>Done</Button>
-                </>
-              }
-            >
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
-                {Array.from({ length: 20 }, (_, i) => (
-                  <p key={i}>Paragraph {i + 1}. The modal body scrolls when content exceeds max height.</p>
-                ))}
-              </div>
-            </Modal>
-          </div>
-        </Row>
-
-        <SectionLabel>No close button</SectionLabel>
-        <Row>
-          <div>
-            <Button onClick={() => open('noclose')}>Open modal</Button>
-            <Modal
-              isOpen={openId === 'noclose'}
-              onClose={close}
-              title="No close button"
-              showCloseButton={false}
-              footer={<Button variant="primary" onClick={close}>Close</Button>}
-            >
-              <p>This modal has no header close button. Use the footer or press Escape.</p>
-            </Modal>
-          </div>
-        </Row>
-      </Stack>
-    );
-};
-
-/* ─── Confirm preset ─────────────────────────────────────────── */
+/* ═══════════════════════════════════════════════════════════════
+   CONFIRM PRESET — two Q3 starting templates (ADR-010): the base
+   confirm shape, and the destructive variant named in the matrix's
+   own canonical example ("variant: 'destructive' for a delete CTA").
+   ═══════════════════════════════════════════════════════════════ */
 
 /**
- * `preset="confirm"` — compact alertdialog with auto-rendered confirm/cancel
- * footer. Replaces the legacy `Dialog` component (per ADR-004).
+ * `preset="confirm"` — compact alertdialog with an auto-rendered
+ * confirm/cancel footer. Replaces the legacy `Dialog` component
+ * (ADR-004). The starting template for confirmation flows.
  *
- * Use `confirmVariant="destructive"` for delete-type actions; the confirm
- * button switches to the danger color while keeping the same shape.
+ * @summary preset="confirm" — auto-rendered confirm/cancel footer
  */
-export const ConfirmPreset = () => {
-    const [openId, setOpenId] = useState<string | null>(null);
-    const open = (id: string) => setOpenId(id);
-    const close = () => setOpenId(null);
-
+export const Confirm: Story = {
+  args: {
+    isOpen: false,
+    onClose: () => {},
+    preset: 'confirm',
+    title: 'Save changes?',
+    description: 'Your edits will be applied to the live record.',
+    confirmLabel: 'Save',
+    confirmVariant: 'primary',
+  },
+  argTypes: {
+    size: { table: { disable: true } },
+    closeOnBackdrop: { table: { disable: true } },
+    closeOnEscape: { table: { disable: true } },
+    showCloseButton: { table: { disable: true } },
+  },
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
     return (
-      <Stack>
-        <SectionLabel>Default confirm</SectionLabel>
-        <Row>
-          <div>
-            <Button onClick={() => open('default')}>Confirm action</Button>
-            <Modal
-              isOpen={openId === 'default'}
-              onClose={close}
-              preset="confirm"
-              title="Save changes?"
-              description="Your edits will be applied to the live record."
-              confirmLabel="Save"
-              onConfirm={close}
-            />
-          </div>
-        </Row>
-
-        <SectionLabel>Destructive confirm</SectionLabel>
-        <Row>
-          <div>
-            <Button variant="destructive" onClick={() => open('destructive')}>Delete item</Button>
-            <Modal
-              isOpen={openId === 'destructive'}
-              onClose={close}
-              preset="confirm"
-              title="Delete this item?"
-              description="This action cannot be undone."
-              confirmLabel="Delete"
-              confirmVariant="destructive"
-              onConfirm={close}
-            />
-          </div>
-        </Row>
-      </Stack>
+      <>
+        <Button onClick={() => setIsOpen(true)}>Confirm action</Button>
+        <Modal
+          {...(args as ModalConfirmArgs)}
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          onConfirm={() => setIsOpen(false)}
+        />
+      </>
     );
+  },
 };
 
-/* ─── Patterns ───────────────────────────────────────────────── */
-
-export const Patterns = () => {
-    const [openId, setOpenId] = useState<string | null>(null);
-    const open = (id: string) => setOpenId(id);
-    const close = () => setOpenId(null);
-
+/**
+ * `confirmVariant="destructive"` — switches the confirm button to the
+ * destructive treatment while keeping the compact alertdialog shape. The
+ * starting template for delete-type confirmations.
+ *
+ * @summary confirmVariant="destructive" — delete-style confirm action
+ */
+export const ConfirmDestructive: Story = {
+  args: {
+    isOpen: false,
+    onClose: () => {},
+    preset: 'confirm',
+    title: 'Delete this item?',
+    description: 'This action cannot be undone.',
+    confirmLabel: 'Delete',
+    confirmVariant: 'destructive',
+  },
+  argTypes: {
+    size: { table: { disable: true } },
+    closeOnBackdrop: { table: { disable: true } },
+    closeOnEscape: { table: { disable: true } },
+    showCloseButton: { table: { disable: true } },
+  },
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
     return (
-      <Stack>
-        <SectionLabel>Confirm delete</SectionLabel>
-        <Row>
-          <div>
-            <Button onClick={() => open('delete')}>Confirm action</Button>
-            <Modal
-              isOpen={openId === 'delete'}
-              onClose={close}
-              title="Confirm delete"
-              footer={
-                <>
-                  <Button variant="ghost" onClick={close}>Cancel</Button>
-                  <Button variant="primary" onClick={close}>Delete</Button>
-                </>
-              }
-            >
-              <p>Are you sure you want to delete this item? This action cannot be undone.</p>
-            </Modal>
-          </div>
-        </Row>
-
-        <SectionLabel>Form in modal</SectionLabel>
-        <Row>
-          <div>
-            <Button onClick={() => open('form')}>Open form</Button>
-            <Modal
-              isOpen={openId === 'form'}
-              onClose={close}
-              title="Contact form"
-              footer={
-                <>
-                  <Button variant="ghost" onClick={close}>Cancel</Button>
-                  <Button variant="primary" onClick={close}>Submit</Button>
-                </>
-              }
-            >
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-sm)' }}>
-                  <label style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-md)' }}>Name</label>
-                  <input type="text" placeholder="Your name" style={{ padding: 'var(--padding-md)', border: 'var(--border-width-md) solid var(--border-input)', borderRadius: 'var(--border-radius-50)', fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)' }} />
-                </div>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-sm)' }}>
-                  <label style={{ fontFamily: 'var(--font-family-label)', fontSize: 'var(--label-md)' }}>Email</label>
-                  <input type="email" placeholder="your@email.com" style={{ padding: 'var(--padding-md)', border: 'var(--border-width-md) solid var(--border-input)', borderRadius: 'var(--border-radius-50)', fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)' }} />
-                </div>
-              </div>
-            </Modal>
-          </div>
-        </Row>
-      </Stack>
+      <>
+        <Button variant="destructive" onClick={() => setIsOpen(true)}>Delete item</Button>
+        <Modal
+          {...(args as ModalConfirmArgs)}
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          onConfirm={() => setIsOpen(false)}
+        />
+      </>
     );
+  },
 };
 
-/* ─── Two-column form (xl) ───────────────────────────────────── */
+/* ═══════════════════════════════════════════════════════════════
+   TWO-COLUMN FORM — irreducible composition (ADR-010 Q4).
+   ═══════════════════════════════════════════════════════════════ */
 
 const fieldInput = {
   padding: 'var(--padding-md)',
@@ -288,18 +218,20 @@ const Field = ({ label: text, children }: { label: string; children: React.React
 );
 
 /**
- * @summary xl modal hosting a two-column showcase panel + lead form.
+ * `xl` modal hosting a two-column showcase panel + lead form. Reachable as
+ * a Control on `Default`, but that only widens an empty body — this story
+ * exists because the production composition it unlocks (a showcase panel
+ * beside a multi-field form; the brikdesigns lead-capture modal, #599) is
+ * irreducible to a prop toggle (ADR-010 Q4): the side-by-side layout needs
+ * `xl`'s width to read as two columns rather than wrap. The panel mirrors
+ * the in-app `LeadModalLayout` (surface-primary card, border-muted edge,
+ * stacked label → value → price · frequency); email and phone share a row
+ * to keep the form compact.
  *
- * The `xl` size is reachable as a Control on `Playground`, but that only
- * widens an empty body. This story exists because the production composition
- * it unlocks — a showcase panel beside a multi-field form (brikdesigns
- * lead-capture modal, #599) — is irreducible to a prop toggle (ADR-010 Q4):
- * the side-by-side layout needs `xl`'s width to read as two columns rather
- * than wrap. The panel mirrors the in-app `LeadModalLayout` (surface-primary
- * card, border-muted edge, stacked label → value → price · frequency); email
- * and phone share a row to keep the form compact.
+ * @summary xl modal — two-column showcase panel + lead-capture form
  */
-export const TwoColumnForm = () => {
+export const TwoColumnForm: Story = {
+  render: () => {
     const [isOpen, setIsOpen] = useState(false);
     return (
       <>
@@ -365,21 +297,21 @@ export const TwoColumnForm = () => {
         </Modal>
       </>
     );
-};
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Get started' }));
 
-TwoColumnForm.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
-  const canvas = within(canvasElement);
-  await userEvent.click(canvas.getByRole('button', { name: 'Get started' }));
+    // Modal portals to document.body — query the dialog there (#599 gotcha).
+    const dialog = within(document.body).getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAccessibleName('Get started');
 
-  // Modal portals to document.body — query the dialog there (#599 gotcha).
-  const dialog = within(document.body).getByRole('dialog');
-  await expect(dialog).toBeVisible();
-  await expect(dialog).toHaveAccessibleName('Get started');
+    // Both columns render: the showcase panel (left) + the form (right).
+    await expect(within(dialog).getByText('Interested in')).toBeVisible();
+    await expect(within(dialog).getByLabelText('Email')).toBeVisible();
+    await expect(within(dialog).getByLabelText('Phone')).toBeVisible();
 
-  // Both columns render: the showcase panel (left) + the form (right).
-  await expect(within(dialog).getByText('Interested in')).toBeVisible();
-  await expect(within(dialog).getByLabelText('Email')).toBeVisible();
-  await expect(within(dialog).getByLabelText('Phone')).toBeVisible();
-
-  await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+  },
 };

--- a/components/ui/NavBar/NavBar.mdx
+++ b/components/ui/NavBar/NavBar.mdx
@@ -10,23 +10,23 @@ import * as Stories from './NavBar.stories';
 
 Top-level navigation bar with logo, links, and action buttons. Supports sticky positioning for scroll-persistent navigation.
 
-Pass `linkComponent` (e.g. `next/link`) so nav links route client-side instead of triggering a full-page reload. See [framework guides → client-side routing](/docs/getting-started/framework-guides).
+## Default
 
-## Playground
+Toggle `sticky`, edit `links`, or swap the `actions` slot in Controls to explore layouts (links-only, multiple actions, minimal logo + action).
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Full nav, links only, multiple actions, and minimal configurations.
+### Default
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
-## Patterns
+### With Link Component
 
-Real-world usage: sticky nav bar with scrollable page content.
+Pass `linkComponent` (e.g. `next/link`) so nav links route client-side instead of triggering a full-page reload. See [framework guides → client-side routing](/docs/getting-started/framework-guides).
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.WithLinkComponent} />
 
 ## Props
 

--- a/components/ui/NavBar/NavBar.stories.tsx
+++ b/components/ui/NavBar/NavBar.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { NavBar } from './NavBar';
 import { Button } from '../Button';
@@ -10,25 +9,6 @@ const MockLink: BdsLinkComponent = ({ href, children, ...props }) => (
   <a href={href} data-link-component="mock" {...props}>
     {children}
   </a>
-);
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
 );
 
 /* ─── Shared Data ─────────────────────────────────────────────── */
@@ -60,6 +40,22 @@ const meta: Meta<typeof NavBar> = {
   tags: ['surface-web'],
   parameters: { layout: 'fullscreen' },
   argTypes: {
+    logo: {
+      control: false,
+      description: 'Logo element (image, SVG, or text) rendered at the left edge.',
+    },
+    links: {
+      control: 'object',
+      description: 'Navigation links. Each entry sets `active` for the current page.',
+    },
+    actions: {
+      control: false,
+      description: 'Right-side actions slot (buttons, dropdowns). ReactNode.',
+    },
+    sticky: {
+      control: 'boolean',
+      description: 'Pins the nav bar to the viewport top while scrolling.',
+    },
     linkComponent: {
       description:
         'Render each nav link with a router-aware component (Next.js `Link`, Remix `Link`) for client-side routing instead of the default `<a>`. See ADR-012.',
@@ -72,11 +68,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox. Toggle `sticky`, edit `links`, or
+   swap the `actions` slot in Controls to explore layouts.
    ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     logo: <LogoPlaceholder />,
     links: sampleLinks,
@@ -92,75 +89,4 @@ export const WithLinkComponent: Story = {
     actions: <Button size="sm">Get Started</Button>,
     linkComponent: MockLink,
   },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Links only, multiple actions, minimal, sticky
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Full nav bar</SectionLabel>
-        <NavBar
-          logo={<LogoPlaceholder />}
-          links={sampleLinks}
-          actions={<Button size="sm">Get Started</Button>}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Links only</SectionLabel>
-        <NavBar logo={<LogoPlaceholder />} links={sampleLinks} />
-      </div>
-
-      <div>
-        <SectionLabel>Multiple actions</SectionLabel>
-        <NavBar
-          logo={<LogoPlaceholder />}
-          links={sampleLinks.slice(0, 3)}
-          actions={
-            <div style={{ display: 'flex', gap: 'var(--gap-md)', alignItems: 'center' }}>
-              <Button variant="ghost" size="sm">Log In</Button>
-              <Button size="sm">Sign Up</Button>
-            </div>
-          }
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Minimal (logo + action)</SectionLabel>
-        <NavBar logo={<LogoPlaceholder />} actions={<Button size="sm">Contact</Button>} />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Sticky nav with scrollable content
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <div>
-      <NavBar
-        logo={<LogoPlaceholder />}
-        links={sampleLinks}
-        actions={<Button size="sm">Get Started</Button>}
-        sticky
-      />
-      <div style={{
-        height: 2000,
-        padding: 'var(--padding-xl)',
-        fontFamily: 'var(--font-family-body)',
-        fontSize: 'var(--body-md)',
-        color: 'var(--text-secondary)',
-      }}>
-        <p>Scroll down to see the sticky navbar behavior.</p>
-      </div>
-    </div>
-  ),
 };

--- a/components/ui/PageHeader/PageHeader.mdx
+++ b/components/ui/PageHeader/PageHeader.mdx
@@ -10,44 +10,29 @@ import * as Stories from './PageHeader.stories';
 
 Composable page-level header that brings together BDS components: `Breadcrumb`, `Button`, and `TabBar`. No background by default — inherits from parent context; the opt-in `sticky` prop adds an opaque surface so it can pin on scroll.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-All slot combinations: title only, subtitle, breadcrumbs, actions, tabs, metadata, and full composition.
-
-- **`badge`** — `ServiceTag variant="icon"` icon badge left of title (service pages)
-- **`breadcrumbs`** — `Breadcrumb` navigation trail above title
-- **`actions`** — `Button` action buttons aligned right
-- **`metadata`** — built-in key-value grid with border-top
-- **`tabs`** — `TabBar` tab navigation below the title block
-
-<Canvas of={Stories.Variants} />
-
-## Patterns
-
-Real-world usage: company detail pages and analytics dashboards.
-
-<Canvas of={Stories.Patterns} />
-
-## Read / edit mode
-
-`PageHeader` is bimodal — symmetric with [`Sheet`](?path=/docs/containers-sheet--docs). When `mode` is set and no explicit `actions` slot is provided, the header auto-renders mode-appropriate actions:
-
-- **`mode="read"`** with `onEdit` → `[Edit]` (primary, pen icon)
-- **`mode="edit"`** with `onSave` / `onCancel` → `[Cancel] [Save]` `ButtonGroup`
-
-Explicit `actions` always overrides mode-driven auto-actions (mirrors `Sheet`'s `footer` override). When `mode` is unset, behavior is unchanged — no breaking change.
+`PageHeader` is bimodal — symmetric with [`Sheet`](?path=/docs/containers-sheet--docs). When `mode` is set and no explicit `actions` slot is provided, the header auto-renders mode-appropriate actions. Explicit `actions` always overrides mode-driven auto-actions (mirrors `Sheet`'s `footer` override). When `mode` is unset, behavior is unchanged — no breaking change.
 
 The canonical URL pattern for bimodal pages is `/{table}/[slug]` (read) and `/{table}/[slug]/edit` (edit) — see [Read-Mode Page](?path=/docs/containers-read-mode-page--docs).
 
+### Read mode
+
+`mode="read"` with `onEdit` → `[Edit]` (primary, pen icon).
+
 <Canvas of={Stories.ReadMode} />
+
+### Edit mode
+
+`mode="edit"` with `onSave` / `onCancel` → `[Cancel] [Save]` `ButtonGroup`. Toggle `saveLoading` / `saveDisabled` via Controls.
 
 <Canvas of={Stories.EditMode} />
 
-## Structured actions
+### Structured actions
 
 `actions` accepts any `ReactNode`, but a bare flex row lets each surface pick its own ordering and mix button sizes. `PageHeaderActions` fixes the hierarchy once:
 
@@ -72,7 +57,9 @@ Slots accept rendered elements — a raw `<Button>` or a consumer wrapper (`<Del
 
 <Canvas of={Stories.StructuredActions} />
 
-## Sticky
+## Patterns
+
+### Sticky
 
 Set `sticky` to pin the header to the top of its scroll container as the body scrolls. It renders an opaque `--surface-primary` background (so content passes cleanly beneath) and stacks above page content but below `NavBar` and overlays. Non-sticky remains the default — existing consumers are unaffected. The header sticks within the nearest scrolling ancestor, so that container — not the window — must own the scroll.
 
@@ -82,3 +69,15 @@ Set `sticky` to pin the header to the top of its scroll container as the body sc
 
 <ArgTypes of={Stories} />
 
+## CSS Override API
+
+Four component-scoped CSS variables on `.bds-page-header` tune the internal rhythm without forking the component. Override at any cascade level (theme file, `globals.css`, `style` prop). Defaults preserve the lean 0.57.0 shape.
+
+| Variable | Default | Controls |
+| --- | --- | --- |
+| `--page-header-section-gap` | `--gap-xl` (24px) | Gap between root sections (inner / metadata / tabs) |
+| `--page-header-content-gap` | `--gap-sm` (6px) | Gap between the title-row and the subtitle |
+| `--page-header-actions-gap` | `--gap-sm` (6px) | Gap between the content column (title + subtitle) and the actions column |
+| `--page-header-padding-bottom` | `0` | Bottom padding below the header |
+
+<Canvas of={Stories.TunableSpacing} />

--- a/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/components/ui/PageHeader/PageHeader.stories.tsx
@@ -1,41 +1,12 @@
-import React, { useState } from 'react';
+import type { CSSProperties } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
 import { PageHeader } from './PageHeader';
 import { PageHeaderActions } from './PageHeaderActions';
 import { Breadcrumb } from '../Breadcrumb';
-import { TabBar, type TabItem } from '../TabBar';
-import { Button, type ButtonSize } from '../Button';
+import { TabBar } from '../TabBar';
+import { Button } from '../Button';
 import { ServiceTag } from '../ServiceTag';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Helpers ─────────────────────────────────────────────────── */
-
-function useInteractiveTabs(labels: string[]): TabItem[] {
-  const [activeIndex, setActiveIndex] = useState(0);
-  return labels.map((label, i) => ({
-    label,
-    active: i === activeIndex,
-    onClick: () => setActiveIndex(i),
-  }));
-}
 
 const sampleBreadcrumbs = [
   { label: 'Show All', href: '#' },
@@ -53,10 +24,65 @@ const meta: Meta<typeof PageHeader> = {
   argTypes: {
     title: { control: 'text' },
     subtitle: { control: 'text' },
+    badge: {
+      control: false,
+      description: 'Badge displayed left of the title, e.g. `<ServiceTag variant="icon">`.',
+    },
+    breadcrumbs: {
+      control: false,
+      description: 'Breadcrumb element (typically a `Breadcrumb` component) rendered above the title row.',
+    },
+    actions: {
+      control: false,
+      description:
+        'Right-aligned action element(s) (primary Button, dropdown menu, etc.). Overrides any mode-driven auto-actions when set.',
+    },
+    tabs: {
+      control: false,
+      description: 'Optional `TabBar` (or equivalent) rendered at the bottom of the header — page-level navigation.',
+    },
+    metadata: {
+      control: false,
+      description: 'Key/value pairs rendered below the title row (e.g. Owner, Status, Updated).',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Title scale. Default `lg`.',
+    },
     sticky: {
       control: 'boolean',
-      description: 'Pin the header to the top of its scroll container on scroll. Renders an opaque surface so content scrolls beneath it. Default `false`.',
+      description:
+        'Pin the header to the top of its scroll container on scroll. Renders an opaque surface so content scrolls beneath it. Default `false`.',
     },
+    mode: {
+      control: 'select',
+      options: ['read', 'edit'],
+      description: 'Bimodal page state — drives auto-rendered actions. See the Read mode / Edit mode variants.',
+    },
+    onEdit: {
+      control: false,
+      description: 'Navigation handler in read mode. Wires the auto-rendered `[Edit]` button.',
+    },
+    onSave: {
+      control: false,
+      description: 'Submit handler in edit mode. Wires the auto-rendered `[Save]` button.',
+    },
+    onCancel: {
+      control: false,
+      description: 'Discard handler in edit mode. Wires the auto-rendered `[Cancel]` button.',
+    },
+    saveLoading: {
+      control: 'boolean',
+      description: 'Show loading state on the auto-rendered `[Save]` button.',
+    },
+    saveDisabled: {
+      control: 'boolean',
+      description: 'Disable the auto-rendered `[Save]` button (e.g. while the form is invalid).',
+    },
+    editLabel: { control: 'text', description: 'Label for the auto-rendered `[Edit]` button. Default `"Edit"`.' },
+    saveLabel: { control: 'text', description: 'Label for the auto-rendered `[Save]` button. Default `"Save"`.' },
+    cancelLabel: { control: 'text', description: 'Label for the auto-rendered `[Cancel]` button. Default `"Cancel"`.' },
   },
 };
 
@@ -64,14 +90,15 @@ export default meta;
 type Story = StoryObj<typeof PageHeader>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   1. DEFAULT — args-driven sandbox. Controls work.
    ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     title: 'My Account',
     subtitle: 'Manage your membership plan.',
+    badge: <ServiceTag category="brand" variant="icon" serviceName="Brand Identity Bundle" size="lg" />,
     breadcrumbs: <Breadcrumb items={sampleBreadcrumbs} />,
     actions: (
       <>
@@ -79,182 +106,16 @@ export const Playground: Story = {
         <Button variant="secondary">Secondary Button</Button>
       </>
     ),
+    metadata: [
+      { label: 'Category', value: 'Brand' },
+      { label: 'Billing', value: 'One-time' },
+      { label: 'Stripe Product', value: 'brand-design' },
+    ],
   },
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Different slot combinations
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => {
-    const tabs = useInteractiveTabs(['Active', 'Latest', 'Product', 'Design System', 'Marketing']);
-    const filterTabs = useInteractiveTabs(['All', 'Active', 'Archived']);
-
-    return (
-      <Stack gap="var(--gap-huge)">
-        <div>
-          <SectionLabel>Title only</SectionLabel>
-          <PageHeader title="Dashboard" />
-        </div>
-
-        <div>
-          <SectionLabel>Title + subtitle</SectionLabel>
-          <PageHeader title="Team Members" subtitle="Manage your team and their permissions." />
-        </div>
-
-        <div>
-          <SectionLabel>With breadcrumbs</SectionLabel>
-          <PageHeader
-            title="Design System"
-            subtitle="Components, tokens, and documentation."
-            breadcrumbs={
-              <Breadcrumb items={[
-                { label: 'Home', href: '#' },
-                { label: 'Products', href: '#' },
-                { label: 'Design System' },
-              ]} />
-            }
-          />
-        </div>
-
-        <div>
-          <SectionLabel>With actions</SectionLabel>
-          <PageHeader
-            title="Settings"
-            subtitle="Configure your account preferences."
-            actions={
-              <>
-                <Button variant="primary">Save Changes</Button>
-                <Button variant="secondary">Cancel</Button>
-              </>
-            }
-          />
-        </div>
-
-        <div>
-          <SectionLabel>With tabs</SectionLabel>
-          <PageHeader
-            title="Projects"
-            subtitle="Browse and manage all projects."
-            tabs={<TabBar variant="tab" items={filterTabs} />}
-          />
-        </div>
-
-        <div>
-          <SectionLabel>With badge + metadata</SectionLabel>
-          <PageHeader
-            title="Brand Design"
-            subtitle="Service details and billing info."
-            badge={<ServiceTag category="brand" variant="icon" serviceName="Brand Identity Bundle" size="lg" />}
-            breadcrumbs={<Breadcrumb items={sampleBreadcrumbs} />}
-            actions={
-              <>
-                <Button variant="primary" size="sm">Primary Button</Button>
-                <Button variant="secondary" size="sm">Secondary Button</Button>
-              </>
-            }
-            metadata={[
-              { label: 'Category', value: 'Brand' },
-              { label: 'Billing', value: 'One-time' },
-              { label: 'Stripe Product', value: 'brand-design' },
-            ]}
-          />
-        </div>
-
-        <div>
-          <SectionLabel>Full composition</SectionLabel>
-          <PageHeader
-            title="My Account"
-            subtitle="Manage your membership plan."
-            breadcrumbs={<Breadcrumb items={sampleBreadcrumbs} />}
-            actions={
-              <>
-                <Button variant="primary">Primary Button</Button>
-                <Button variant="secondary">Secondary Button</Button>
-              </>
-            }
-            tabs={<TabBar variant="tab" items={tabs} />}
-          />
-        </div>
-      </Stack>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world compositions
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => {
-    const reportTabs = useInteractiveTabs(['Overview', 'Revenue', 'Engagement', 'Retention']);
-
-    return (
-      <Stack gap="var(--gap-huge)">
-        {/* Service detail page */}
-        <div>
-          <SectionLabel>Service detail page</SectionLabel>
-          <PageHeader
-            title="Website Design"
-            subtitle="Custom web development and design service."
-            badge={<ServiceTag category="marketing" variant="icon" serviceName="Custom Standard Web Development and Design" size="lg" />}
-            breadcrumbs={
-              <Breadcrumb items={[
-                { label: 'Admin', href: '#' },
-                { label: 'Services', href: '#' },
-                { label: 'Website Design' },
-              ]} />
-            }
-            actions={<Button variant="primary" size="sm">Edit Service</Button>}
-            metadata={[
-              { label: 'Category', value: 'Marketing' },
-              { label: 'Billing', value: 'Monthly' },
-              { label: 'Status', value: 'Active' },
-            ]}
-          />
-        </div>
-
-        {/* Company detail page */}
-        <div>
-          <SectionLabel>Company detail page</SectionLabel>
-          <PageHeader
-            title="Acme Corp"
-            subtitle="Enterprise client since 2024"
-            breadcrumbs={
-              <Breadcrumb items={[
-                { label: 'Admin', href: '#' },
-                { label: 'Companies', href: '#' },
-                { label: 'Acme Corp' },
-              ]} />
-            }
-            actions={<Button variant="primary" size="sm">Edit Company</Button>}
-            metadata={[
-              { label: 'Status', value: 'Active' },
-              { label: 'Plan', value: 'Enterprise' },
-              { label: 'MRR', value: '$12,400' },
-            ]}
-          />
-        </div>
-
-        {/* Analytics dashboard */}
-        <div>
-          <SectionLabel>Analytics dashboard</SectionLabel>
-          <PageHeader
-            title="Analytics"
-            subtitle="Monitor key performance metrics."
-            tabs={<TabBar variant="tab" items={reportTabs} />}
-          />
-        </div>
-      </Stack>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   4. READ / EDIT MODE — bimodal page state, symmetric with Sheet
+   2. VARIANTS — Q3 semantic starting points
    ═══════════════════════════════════════════════════════════════ */
 
 /**
@@ -262,201 +123,86 @@ export const Patterns: Story = {
  * slot. The `actions` prop, when supplied, always overrides mode-driven
  * actions — mirrors `Sheet`'s `footer` override.
  *
- * @summary Read mode
+ * @summary Read mode — auto-renders [Edit]
  */
 export const ReadMode: Story = {
-  render: () => (
-    <PageHeader
-      title="Brand Identity Bundle"
-      subtitle="Marketing · Active · Updated 2 days ago"
-      breadcrumbs={
-        <Breadcrumb items={[
-          { label: 'Settings', href: '#' },
-          { label: 'Services', href: '#' },
-          { label: 'Brand Identity Bundle' },
-        ]} />
-      }
-      mode="read"
-      onEdit={() => alert('Navigate to /settings/services/brand-identity-bundle/edit')}
-    />
-  ),
+  args: {
+    title: 'Brand Identity Bundle',
+    subtitle: 'Marketing · Active · Updated 2 days ago',
+    breadcrumbs: (
+      <Breadcrumb items={[
+        { label: 'Settings', href: '#' },
+        { label: 'Services', href: '#' },
+        { label: 'Brand Identity Bundle' },
+      ]} />
+    ),
+    mode: 'read',
+    onEdit: fn(),
+  },
 };
 
 /**
  * Edit mode auto-renders `[Cancel] [Save]` ButtonGroup in the `actions`
- * slot. Pass `saveLoading` while the save promise is in flight and
- * `saveDisabled` when the form is invalid.
+ * slot. Toggle `saveLoading` / `saveDisabled` via Controls to see the
+ * auto-rendered `[Save]` button's loading / disabled state.
  *
- * @summary Edit mode
+ * @summary Edit mode — auto-renders [Cancel] [Save]
  */
 export const EditMode: Story = {
-  render: () => {
-    const [saving, setSaving] = useState(false);
-    const handleSave = () => {
-      setSaving(true);
-      setTimeout(() => setSaving(false), 900);
-    };
-    return (
-      <PageHeader
-        title="Edit Brand Identity Bundle"
-        subtitle="Update the service catalog entry."
-        breadcrumbs={
-          <Breadcrumb items={[
-            { label: 'Settings', href: '#' },
-            { label: 'Services', href: '#' },
-            { label: 'Brand Identity Bundle', href: '#' },
-            { label: 'Edit' },
-          ]} />
-        }
-        mode="edit"
-        onSave={handleSave}
-        onCancel={() => alert('Return to /settings/services/brand-identity-bundle')}
-        saveLoading={saving}
-      />
-    );
+  args: {
+    title: 'Edit Brand Identity Bundle',
+    subtitle: 'Update the service catalog entry.',
+    breadcrumbs: (
+      <Breadcrumb items={[
+        { label: 'Settings', href: '#' },
+        { label: 'Services', href: '#' },
+        { label: 'Brand Identity Bundle', href: '#' },
+        { label: 'Edit' },
+      ]} />
+    ),
+    mode: 'edit',
+    onSave: fn(),
+    onCancel: fn(),
   },
 };
-
-/* ═══════════════════════════════════════════════════════════════
-   5. STRUCTURED ACTIONS — PageHeaderActions hierarchy
-   ═══════════════════════════════════════════════════════════════ */
 
 /**
  * `PageHeaderActions` replaces the hand-composed flex div consumers used to
  * pass into `actions`. It fixes the hierarchy — `destructive` (far left) ·
  * `secondary` · `primary` (far right) — and injects a single shared `size`
  * (default `md`) into every slotted button, so a group can't render
- * mismatched sizes side by side (BACKLOG-638). Shown here at `sm` / `md` /
- * `lg`; each row stays internally size-consistent regardless of what the
- * individual buttons declare.
+ * mismatched sizes side by side (BACKLOG-638).
  *
- * @summary Structured action hierarchy at sm / md / lg
+ * @summary Structured destructive / secondary / primary action hierarchy
  */
 export const StructuredActions: Story = {
-  render: () => {
-    const sizes: ButtonSize[] = ['sm', 'md', 'lg'];
-    return (
-      <Stack gap="var(--gap-huge)">
-        {sizes.map((size) => (
-          <div key={size}>
-            <SectionLabel>{`Hierarchy — size="${size}"`}</SectionLabel>
-            <PageHeader
-              title="Acme Corp"
-              subtitle="Enterprise client since 2024"
-              breadcrumbs={
-                <Breadcrumb items={[
-                  { label: 'Admin', href: '#' },
-                  { label: 'Companies', href: '#' },
-                  { label: 'Acme Corp' },
-                ]} />
-              }
-              actions={
-                <PageHeaderActions
-                  size={size}
-                  destructive={<Button variant="destructive">Delete</Button>}
-                  secondary={<Button variant="outline">Edit</Button>}
-                  primary={<Button variant="primary">New Proposal</Button>}
-                />
-              }
-              metadata={[
-                { label: 'Status', value: 'Active' },
-                { label: 'Plan', value: 'Enterprise' },
-              ]}
-            />
-          </div>
-        ))}
-
-        <div>
-          <SectionLabel>Primary only</SectionLabel>
-          <PageHeader
-            title="Website Design"
-            subtitle="Custom web development and design service."
-            actions={<PageHeaderActions primary={<Button variant="primary">Edit Service</Button>} />}
-          />
-        </div>
-
-        <div>
-          <SectionLabel>Secondary + primary (no destructive)</SectionLabel>
-          <PageHeader
-            title="Analytics"
-            subtitle="Monitor key performance metrics."
-            actions={
-              <PageHeaderActions
-                secondary={<Button variant="outline">Export</Button>}
-                primary={<Button variant="primary">Share</Button>}
-              />
-            }
-          />
-        </div>
-      </Stack>
-    );
+  args: {
+    title: 'Acme Corp',
+    subtitle: 'Enterprise client since 2024',
+    breadcrumbs: (
+      <Breadcrumb items={[
+        { label: 'Admin', href: '#' },
+        { label: 'Companies', href: '#' },
+        { label: 'Acme Corp' },
+      ]} />
+    ),
+    actions: (
+      <PageHeaderActions
+        destructive={<Button variant="destructive">Delete</Button>}
+        secondary={<Button variant="outline">Edit</Button>}
+        primary={<Button variant="primary">New Proposal</Button>}
+      />
+    ),
+    metadata: [
+      { label: 'Status', value: 'Active' },
+      { label: 'Plan', value: 'Enterprise' },
+    ],
   },
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   6. TUNABLE SPACING — component-scoped CSS variables
-   ═══════════════════════════════════════════════════════════════ */
-
-/**
- * @summary Demonstrates the four CSS variables that tune internal rhythm —
- * defaults vs a roomier override (matching renew-pms's tuning).
- */
-export const TunableSpacing: Story = {
-  render: () => {
-    return (
-      <Stack gap="var(--gap-huge)">
-        {/* Defaults */}
-        <div>
-          <SectionLabel>Defaults — gap-sm content gap, no default divider (padding-bottom 0)</SectionLabel>
-          <PageHeader
-            title="Default Header"
-            subtitle="Title↔subtitle gap = gap-sm. No default divider — a header with no tabs ends flush (padding-bottom 0)."
-            actions={<Button variant="primary" size="sm">Action</Button>}
-          />
-        </div>
-
-        {/* Tuned for clinical density (renew-pms) */}
-        <div>
-          <SectionLabel>Tuned — wider content gap + restored bottom padding</SectionLabel>
-          <PageHeader
-            title="Tuned Header"
-            subtitle="Content gap widened to padding-sm; padding-bottom restored to padding-lg (e.g. when a consumer adds a manual divider)."
-            actions={<Button variant="primary" size="sm">Action</Button>}
-            style={{
-              // bds-lint-ignore — component-scoped CSS variables, not design tokens
-              ['--page-header-content-gap' as string]: 'var(--padding-sm)',
-              ['--page-header-padding-bottom' as string]: 'var(--padding-lg)',
-            }}
-          />
-        </div>
-
-        {/* Even roomier — shows the full knob set */}
-        <div>
-          <SectionLabel>Roomy — all four knobs at the higher end</SectionLabel>
-          <PageHeader
-            title="Roomy Header"
-            subtitle="Each gap stepped up one tier — useful for marketing-shaped pages with breathing room."
-            tabs={<TabBar variant="tab" items={[
-              { label: 'Overview', active: true, onClick: () => {} },
-              { label: 'Settings', active: false, onClick: () => {} },
-            ]} />}
-            actions={<Button variant="primary" size="sm">Action</Button>}
-            style={{
-              // bds-lint-ignore — component-scoped CSS variables, not design tokens
-              ['--page-header-section-gap' as string]: 'var(--gap-xl)',
-              ['--page-header-content-gap' as string]: 'var(--gap-md)',
-              ['--page-header-actions-gap' as string]: 'var(--gap-md)',
-              ['--page-header-padding-bottom' as string]: 'var(--padding-md)',
-            }}
-          />
-        </div>
-      </Stack>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   Sticky — pins to the top of a scroll container on scroll
+   3. PATTERNS — Q4 irreducible: needs a scrollable ancestor container,
+      not just a prop value, to demonstrate `sticky`.
    ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Sticky header pinned to the top of a scroll container */
@@ -477,15 +223,47 @@ export const Sticky: Story = {
         actions={<Button variant="primary" size="sm">Action</Button>}
       />
       <div style={{ padding: 'var(--padding-lg)' }}>
-        <Stack gap="var(--gap-md)">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
           {Array.from({ length: 12 }).map((_, i) => (
             <p key={i}>
               Row {i + 1} — body content scrolls beneath the pinned header, which keeps
               its opaque surface so nothing shows through.
             </p>
           ))}
-        </Stack>
+        </div>
       </div>
     </div>
   ),
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   4. CSS OVERRIDE API — tunable spacing demo
+   ═══════════════════════════════════════════════════════════════ */
+
+/**
+ * Demonstrates the four CSS variables that tune internal rhythm — every
+ * knob stepped up one tier from its default. Useful for marketing-shaped
+ * pages that want more breathing room than the lean default rhythm.
+ *
+ * @summary Component-scoped CSS variables that tune internal rhythm
+ */
+export const TunableSpacing: Story = {
+  args: {
+    title: 'Roomy Header',
+    subtitle: 'Each gap stepped up one tier — useful for marketing-shaped pages with breathing room.',
+    tabs: (
+      <TabBar variant="tab" items={[
+        { label: 'Overview', active: true, onClick: () => {} },
+        { label: 'Settings', active: false, onClick: () => {} },
+      ]} />
+    ),
+    actions: <Button variant="primary" size="sm">Action</Button>,
+    style: {
+      // bds-lint-ignore — component-scoped CSS variables, not design tokens
+      ['--page-header-section-gap' as string]: 'var(--gap-xl)',
+      ['--page-header-content-gap' as string]: 'var(--gap-md)',
+      ['--page-header-actions-gap' as string]: 'var(--gap-md)',
+      ['--page-header-padding-bottom' as string]: 'var(--padding-md)',
+    } as CSSProperties,
+  },
 };

--- a/components/ui/Pagination/Pagination.mdx
+++ b/components/ui/Pagination/Pagination.mdx
@@ -10,21 +10,21 @@ import * as Stories from './Pagination.stories';
 
 Page navigation controls with previous/next arrows, page numbers, and ellipsis for large page counts. Supports left, center, and right alignment.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Alignment positions (left, center, right), few pages, and single page.
+Pagination has no semantic-variant axis — alignment (`position`), page count, and sibling count are all exposed via Controls on the canvas above.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 ## Patterns
 
-Real-world usage: table pagination with result count.
+Real-world usage: table pagination paired with a derived "Showing X–Y of Z results" label.
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.WithResultCount} />
 
 ## Props
 

--- a/components/ui/Pagination/Pagination.stories.tsx
+++ b/components/ui/Pagination/Pagination.stories.tsx
@@ -1,26 +1,6 @@
-import React from 'react';
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Pagination } from './Pagination';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
 
 /* ─── Meta ────────────────────────────────────────────── */
 
@@ -30,18 +10,26 @@ const meta = {
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
-    position: {
-      control: 'select',
-      options: ['left', 'center', 'right'],
-    },
     currentPage: {
       control: { type: 'number', min: 1, max: 100 },
+      description: 'Current active page (1-indexed).',
     },
     totalPages: {
       control: { type: 'number', min: 1, max: 100 },
+      description: 'Total number of pages. Fewer than `siblingCount * 2 + 5` renders with no ellipsis.',
+    },
+    position: {
+      control: 'select',
+      options: ['left', 'center', 'right'],
+      description: 'Alignment of the pagination controls.',
+    },
+    onChange: {
+      control: false,
+      description: 'Callback fired with the new page number when a page or arrow control is clicked.',
     },
     siblingCount: {
       control: { type: 'number', min: 0, max: 3 },
+      description: 'Number of sibling pages to show around the current page.',
     },
   },
 } satisfies Meta<typeof Pagination>;
@@ -50,11 +38,13 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox. `render` wraps the controlled
+   `currentPage`/`onChange` pair in local state (Q4 — Controls alone
+   can't drive click-through paging), so clicking pages/arrows works.
    ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   render: (args) => {
     const [page, setPage] = useState(args.currentPage);
     return <Pagination {...args} currentPage={page} onChange={setPage} />;
@@ -68,54 +58,12 @@ export const Playground: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Positions, few pages, single page
+   WITH RESULT COUNT — Q4 irreducible: the "Showing X–Y of Z"
+   label is derived from controlled page state that args can't express
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  args: { currentPage: 5, totalPages: 20, onChange: () => {} },
-  render: () => {
-    function PaginationVariants() {
-      const [left, setLeft] = useState(5);
-      const [center, setCenter] = useState(10);
-      const [right, setRight] = useState(15);
-      const [few, setFew] = useState(3);
-
-      return (
-        <Stack>
-          <div>
-            <SectionLabel>Left aligned</SectionLabel>
-            <Pagination currentPage={left} totalPages={20} position="left" onChange={setLeft} />
-          </div>
-          <div>
-            <SectionLabel>Center aligned</SectionLabel>
-            <Pagination currentPage={center} totalPages={20} position="center" onChange={setCenter} />
-          </div>
-          <div>
-            <SectionLabel>Right aligned</SectionLabel>
-            <Pagination currentPage={right} totalPages={20} position="right" onChange={setRight} />
-          </div>
-          <div>
-            <SectionLabel>Few pages (no ellipsis)</SectionLabel>
-            <Pagination currentPage={few} totalPages={5} position="center" onChange={setFew} />
-          </div>
-          <div>
-            <SectionLabel>Single page</SectionLabel>
-            <Pagination currentPage={1} totalPages={1} position="center" onChange={() => {}} />
-          </div>
-        </Stack>
-      );
-    }
-    return <PaginationVariants />;
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Table pagination
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
+/** @summary Paired with a derived "Showing X–Y of Z results" label */
+export const WithResultCount: Story = {
   args: { currentPage: 1, totalPages: 12, onChange: () => {} },
   render: () => {
     function TablePagination() {
@@ -125,7 +73,6 @@ export const Patterns: Story = {
 
       return (
         <div>
-          <SectionLabel>Table pagination</SectionLabel>
           <div style={{
             fontFamily: 'var(--font-family-body)',
             fontSize: 'var(--body-sm)',

--- a/components/ui/Popover/Popover.mdx
+++ b/components/ui/Popover/Popover.mdx
@@ -10,21 +10,19 @@ import * as Stories from './Popover.stories';
 
 Floating content panel anchored to a trigger element. Supports click or hover triggering, four placements, and controlled/uncontrolled modes.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
+
+Trigger mode (`click`, `hover`) is a Control on the canvas above.
 
 ## Variants
 
-Placements (`top`, `bottom`, `left`, `right`) and trigger modes (`click`, `hover`).
+### Placements
 
-<Canvas of={Stories.Variants} />
+All four placements (`top`, `bottom`, `left`, `right`) side by side — the comparison is the point.
 
-## Patterns
-
-Real-world usage: notification settings popover with form controls.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.Placements} />
 
 ## Props
 

--- a/components/ui/Popover/Popover.stories.tsx
+++ b/components/ui/Popover/Popover.stories.tsx
@@ -3,26 +3,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Popover } from './Popover';
 import { Button } from '../Button';
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
+/* ─── Layout helper (story-only) ──────────────────────────────── */
 
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-const Row = ({ children, gap = 'var(--gap-lg)' }: { children: React.ReactNode; gap?: string }) => (
+const Row = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
   <div style={{ display: 'flex', flexWrap: 'wrap', gap, alignItems: 'flex-start' }}>{children}</div>
 );
 
@@ -61,6 +44,8 @@ const meta: Meta<typeof Popover> = {
     ),
   ],
   argTypes: {
+    content: { control: false, description: 'Popover panel content.' },
+    children: { control: false, description: 'The trigger element.' },
     placement: {
       control: 'select',
       options: ['top', 'bottom', 'left', 'right'],
@@ -69,6 +54,8 @@ const meta: Meta<typeof Popover> = {
       control: 'select',
       options: ['click', 'hover'],
     },
+    isOpen: { table: { disable: true } },
+    onOpenChange: { table: { disable: true } },
   },
 } satisfies Meta<typeof Popover>;
 
@@ -76,11 +63,18 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox. Popover manages its own open
+   state internally when `isOpen` is left unset, so args alone
+   drive the trigger interaction — no render/hook wiring needed.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Click the trigger to reveal the panel. Switch `placement` and `trigger`
+ * via Controls.
+ *
+ * @summary Floating content panel anchored to a trigger
+ */
+export const Default: Story = {
   args: {
     content: sampleContent,
     placement: 'bottom',
@@ -90,84 +84,32 @@ export const Playground: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Placements, trigger modes
+   PLACEMENTS — narrow axis-only-gallery exception (ADR-006): side
+   by side is the entire point, and the Controls panel can only
+   show one placement at a time. Mirrors the sibling Tooltip file.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
+/**
+ * All four placements around the trigger. Side-by-side is the point —
+ * the Controls panel can only show one placement at a time.
+ *
+ * @summary All four placements side by side
+ */
+export const Placements: Story = {
   render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Placements</SectionLabel>
-        <Row gap="var(--gap-xl)">
-          <Popover content={sampleContent} placement="top">
-            <Button variant="outline" size="sm">Top</Button>
-          </Popover>
-          <Popover content={sampleContent} placement="bottom">
-            <Button variant="outline" size="sm">Bottom</Button>
-          </Popover>
-          <Popover content={sampleContent} placement="left">
-            <Button variant="outline" size="sm">Left</Button>
-          </Popover>
-          <Popover content={sampleContent} placement="right">
-            <Button variant="outline" size="sm">Right</Button>
-          </Popover>
-        </Row>
-      </div>
-
-      <div>
-        <SectionLabel>Trigger modes</SectionLabel>
-        <Row>
-          <Popover content={sampleContent} trigger="click">
-            <Button variant="outline" size="sm">Click trigger</Button>
-          </Popover>
-          <Popover content={sampleContent} trigger="hover">
-            <Button variant="ghost" size="sm">Hover trigger</Button>
-          </Popover>
-        </Row>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Rich content popover
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Notification settings</SectionLabel>
-        <Popover
-          placement="bottom"
-          content={
-            <div style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 'var(--gap-md)',
-              fontFamily: 'var(--font-family-body)',
-              minWidth: 240,
-            }}>
-              <div style={{ fontSize: 'var(--label-md)', fontWeight: 'var(--font-weight-semibold)' as unknown as number, color: 'var(--text-primary)' }}>
-                Notification settings
-              </div>
-              <label style={{ fontSize: 'var(--body-sm)', color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)' }}>
-                <input type="checkbox" defaultChecked /> Push notifications
-              </label>
-              <label style={{ fontSize: 'var(--body-sm)', color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)' }}>
-                <input type="checkbox" /> Email digest
-              </label>
-              <label style={{ fontSize: 'var(--body-sm)', color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)' }}>
-                <input type="checkbox" defaultChecked /> Sound alerts
-              </label>
-            </div>
-          }
-        >
-          <Button>Settings</Button>
-        </Popover>
-      </div>
-    </Stack>
+    <Row>
+      <Popover content={sampleContent} placement="top">
+        <Button variant="outline" size="sm">Top</Button>
+      </Popover>
+      <Popover content={sampleContent} placement="bottom">
+        <Button variant="outline" size="sm">Bottom</Button>
+      </Popover>
+      <Popover content={sampleContent} placement="left">
+        <Button variant="outline" size="sm">Left</Button>
+      </Popover>
+      <Popover content={sampleContent} placement="right">
+        <Button variant="outline" size="sm">Right</Button>
+      </Popover>
+    </Row>
   ),
 };

--- a/components/ui/Sheet/ReadModeSheet.mdx
+++ b/components/ui/Sheet/ReadModeSheet.mdx
@@ -20,7 +20,7 @@ This pattern composes four primitives:
 
 ## Canonical composition
 
-<Canvas of={SheetSectionStories.Patterns} />
+<Canvas of={SheetSectionStories.Default} />
 
 The three `SheetSection`s in the example above demonstrate:
 

--- a/components/ui/SheetSection/SheetSection.mdx
+++ b/components/ui/SheetSection/SheetSection.mdx
@@ -10,21 +10,15 @@ import * as Stories from './SheetSection.stories';
 
 The named wrapper for a block of content inside a `<Sheet>` body. Pairs an uppercase section heading with its content and locks the vertical rhythm between sections.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Heading-only, heading + description, description-only (sheet lead), and empty shells.
+SheetSection has no semantic-variant axis — heading-only, heading + description, description-only (sheet lead), and empty shells are all presence/absence of `heading` and `description`, exposed via Controls on the canvas above. See [ADR-010 §components without a variant axis](../../../docs/adrs/ADR-010-storybook-axes-of-information.md) for the framework.
 
-<Canvas of={Stories.Variants} />
-
-## Patterns
-
-The canonical "Brand Identity" sheet layout — lead description followed by named sections.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.Default} />
 
 ## Props
 

--- a/components/ui/SheetSection/SheetSection.stories.tsx
+++ b/components/ui/SheetSection/SheetSection.stories.tsx
@@ -7,9 +7,15 @@ const meta: Meta<typeof SheetSection> = {
   tags: ['surface-product'],
   parameters: { layout: 'padded' },
   argTypes: {
-    heading: { control: 'text' },
-    description: { control: 'text' },
-    spacing: { control: 'select', options: ['md', 'lg'] },
+    heading: { control: 'text', description: 'Omit for intro / description-only sections.' },
+    headingLevel: {
+      control: 'select',
+      options: ['h2', 'h3', 'h4'],
+      description: 'Render level for the heading element. Defaults to `h3` to keep the Sheet’s own `<h2>` title as the outline root.',
+    },
+    description: { control: 'text', description: 'Optional lead paragraph rendered under the heading.' },
+    spacing: { control: 'select', options: ['md', 'lg'], description: 'Vertical rhythm between this section and the next.' },
+    children: { control: false, description: 'Section content — Field, FieldGrid, Card, CardList, Table, TagGroup, BulletList, etc.' },
   },
 };
 
@@ -31,10 +37,22 @@ const Frame = ({ children }: { children: React.ReactNode }) => (
   </div>
 );
 
-/* ─── 1. Playground ──────────────────────────────────────────── */
+/* ═══════════════════════════════════════════════════════════════
+   DEFAULT — SheetSection has no semantic-variant axis (ADR-010
+   §components without a variant axis): heading-only, heading +
+   description, description-only (lead), and empty shells are all
+   presence/absence of the same two optional props, not distinct
+   ARIA roles or contextual semantics. All variation is Controls.
+   ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/**
+ * Toggle `heading`, `description`, `headingLevel`, and `spacing` via
+ * Controls — clear `heading` for a description-only lead section, or
+ * clear `description` for a heading-only section.
+ *
+ * @summary Named block wrapper for content inside a Sheet body
+ */
+export const Default: Story = {
   args: {
     heading: 'Color Primitives',
     description: undefined,
@@ -44,70 +62,6 @@ export const Playground: Story = {
     <Frame>
       <SheetSection {...args}>
         <p style={bodyText}>Section content renders here.</p>
-      </SheetSection>
-    </Frame>
-  ),
-};
-
-/* ─── 2. Variants ────────────────────────────────────────────── */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Frame>
-      <SheetSection heading="Positioning">
-        <p style={bodyText}>A heading with content, no description.</p>
-      </SheetSection>
-
-      <SheetSection
-        heading="Brand Identity"
-        description="Birdwell & Mutlak Dentistry presents a bold, editorial identity anchored in a warm gold palette paired with neutral grays."
-      >
-        <p style={bodyText}>A heading with both description and content.</p>
-      </SheetSection>
-
-      <SheetSection description="An intro paragraph with no heading — use for sheet-level lead copy.">
-        <p style={bodyText}>Sections without a heading skip the uppercase label entirely.</p>
-      </SheetSection>
-
-      <SheetSection heading="Standalone heading" />
-    </Frame>
-  ),
-};
-
-/* ─── 3. Patterns ────────────────────────────────────────────── */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => (
-    <Frame>
-      <SheetSection description="This sheet documents the foundational brand identity, typography, and mode preferences.">
-        {null}
-      </SheetSection>
-
-      <SheetSection heading="Color Primitives">
-        <div style={{ display: 'flex', gap: 'var(--gap-lg)' }}>
-          {['#c49a2f', '#b0b0b0', '#ffffff', '#000000'].map((hex) => (
-            <div
-              key={hex}
-              style={{
-                width: 40,
-                height: 40,
-                background: hex,
-                borderRadius: 'var(--border-radius-circle)',
-                border: '1px solid var(--border-secondary)',
-              }}
-            />
-          ))}
-        </div>
-      </SheetSection>
-
-      <SheetSection heading="Typography">
-        <p style={bodyText}>Typography table renders here.</p>
-      </SheetSection>
-
-      <SheetSection heading="Mode Recommendations">
-        <p style={bodyText}>Mode recommendations render here.</p>
       </SheetSection>
     </Frame>
   ),

--- a/components/ui/TabBar/TabBar.mdx
+++ b/components/ui/TabBar/TabBar.mdx
@@ -8,28 +8,40 @@ import * as Stories from './TabBar.stories';
 
 <ComponentLinks slug="tab-bar" />
 
-Horizontal tab navigation with four style variants: text, text-underline, tab (bordered bar), and box (filled). Supports on-color backgrounds and disabled tabs.
+Horizontal tab navigation with four style variants: text, text-underline, tab (bordered bar), and box (filled). Supports on-color backgrounds and disabled tabs via Controls.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
-
-All four variants, on-color backgrounds, disabled tabs, and compact tab bars.
 
 - **`text`** — plain labels with brand color for active tab; no indicator
 - **`text-underline`** — `text` color behavior + per-tab brand-color underline below the active tab. Use for app-level page headers that want both the brand-active text emphasis and an underline indicator
 - **`tab`** — bottom-border bar with neutral-color active text and a brand-color underline that sits over the bar's baseline border
 - **`box`** — filled background for active, bordered for inactive
 
-<Canvas of={Stories.Variants} />
+### Text
+
+<Canvas of={Stories.Text} />
+
+### Text underline
+
+<Canvas of={Stories.TextUnderline} />
+
+### Tab
+
+<Canvas of={Stories.Tab} />
+
+### Box
+
+<Canvas of={Stories.Box} />
 
 ## Patterns
 
-Real-world usage: settings page navigation and content filter tabs.
+Real-world usage: settings page navigation where clicking a tab switches the active tab and its content.
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.WithControlledTabs} />
 
 ## Props
 

--- a/components/ui/TabBar/TabBar.stories.tsx
+++ b/components/ui/TabBar/TabBar.stories.tsx
@@ -1,60 +1,7 @@
-import React from 'react';
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, within, fn } from 'storybook/test';
 import { TabBar } from './TabBar';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ─── Shared Data ─────────────────────────────────────────────── */
-
-const tabLabels = ['Active', 'Latest', 'Product', 'Design System', 'Marketing', 'Other'];
-const fewLabels = ['All', 'Active', 'Archived'];
-
-/** Interactive wrapper — clicking a tab makes it active */
-function InteractiveTabBar({
-  variant,
-  onColor,
-  labels = tabLabels,
-  disabledIndices = [],
-}: {
-  variant?: 'text' | 'text-underline' | 'tab' | 'box';
-  onColor?: boolean;
-  labels?: string[];
-  disabledIndices?: number[];
-}) {
-  const [activeIndex, setActiveIndex] = useState(0);
-
-  return (
-    <TabBar
-      variant={variant}
-      onColor={onColor}
-      items={labels.map((label, i) => ({
-        label,
-        active: i === activeIndex,
-        disabled: disabledIndices.includes(i),
-        onClick: () => setActiveIndex(i),
-      }))}
-    />
-  );
-}
 
 /* ─── Meta ────────────────────────────────────────────────────── */
 
@@ -64,8 +11,24 @@ const meta: Meta<typeof TabBar> = {
   tags: ['surface-shared'],
   parameters: { layout: 'padded' },
   argTypes: {
-    variant: { control: 'select', options: ['text', 'text-underline', 'tab', 'box'] },
-    onColor: { control: 'boolean' },
+    items: {
+      control: false,
+      description:
+        'Tab items — each renders as a `button[role="tab"]`. Set `active`, `disabled`, `onClick`, ' +
+        'and optionally `dot` (boolean or `DotStatus`) for an attention-cue indicator.',
+    },
+    variant: {
+      control: 'select',
+      options: ['text', 'text-underline', 'tab', 'box'],
+      description:
+        '`text` (default) = plain labels, no indicator. `text-underline` = text + brand-color underline ' +
+        'below the active tab. `tab` = bottom-border bar with brand-color underline. `box` = filled ' +
+        'background for active, bordered for inactive.',
+    },
+    onColor: {
+      control: 'boolean',
+      description: 'On-color mode — switches text/border to on-color-dark tokens for brand/dark backgrounds.',
+    },
   },
 };
 
@@ -73,148 +36,89 @@ export default meta;
 type Story = StoryObj<typeof TabBar>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox
    ═══════════════════════════════════════════════════════════════ */
 
-const tabClickHandler = fn();
-
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     variant: 'tab',
     items: [
-      { label: 'Overview', active: true, onClick: tabClickHandler },
-      { label: 'Billing', dot: true, onClick: tabClickHandler },
-      { label: 'Security', onClick: tabClickHandler },
+      { label: 'Overview', active: true },
+      { label: 'Billing', dot: true },
+      { label: 'Security' },
     ],
   },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const tabs = canvas.getAllByRole('tab');
+};
 
-    await expect(tabs).toHaveLength(3);
-    await expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+/* ═══════════════════════════════════════════════════════════════
+   VARIANTS — one story per style (Q3 semantic starting points)
+   ═══════════════════════════════════════════════════════════════ */
 
-    // Click second tab
-    await userEvent.click(tabs[1]);
-    await expect(tabClickHandler).toHaveBeenCalled();
+/** @summary Plain labels with brand color for the active tab; no indicator */
+export const Text: Story = {
+  args: {
+    variant: 'text',
+    items: [
+      { label: 'All', active: true },
+      { label: 'Active' },
+      { label: 'Archived' },
+    ],
+  },
+};
+
+/** @summary Text color behavior plus a brand-color underline below the active tab */
+export const TextUnderline: Story = {
+  args: {
+    variant: 'text-underline',
+    items: [
+      { label: 'All', active: true },
+      { label: 'Active' },
+      { label: 'Archived' },
+    ],
+  },
+};
+
+/** @summary Bottom-border bar with a brand-color underline over the baseline */
+export const Tab: Story = {
+  args: {
+    variant: 'tab',
+    items: [
+      { label: 'Overview', active: true },
+      { label: 'Billing', dot: true },
+      { label: 'Feedback', dot: 'warning' },
+      { label: 'Security' },
+    ],
+  },
+};
+
+/** @summary Filled background for the active tab, bordered for inactive */
+export const Box: Story = {
+  args: {
+    variant: 'box',
+    items: [
+      { label: 'All', active: true },
+      { label: 'Active' },
+      { label: 'Draft' },
+      { label: 'Archived' },
+    ],
   },
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — All variants, on-color, disabled, few tabs
+   WITH CONTROLLED TABS — Q4 irreducible: clicking a tab updates
+   which tab is active, which args alone can't express
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      {/* All four variants */}
-      <div>
-        <SectionLabel>Text</SectionLabel>
-        <InteractiveTabBar variant="text" />
-      </div>
-
-      <div>
-        <SectionLabel>Text — underline</SectionLabel>
-        <InteractiveTabBar variant="text-underline" />
-      </div>
-
-      <div>
-        <SectionLabel>Tab</SectionLabel>
-        <InteractiveTabBar variant="tab" />
-      </div>
-
-      <div>
-        <SectionLabel>Box</SectionLabel>
-        <InteractiveTabBar variant="box" />
-      </div>
-
-      {/* On color */}
-      <div style={{
-        backgroundColor: 'var(--background-brand-primary)',
-        padding: 'var(--padding-xl)',
-        borderRadius: 'var(--border-radius-md)',
-      }}>
-        <SectionLabel>Text — on color</SectionLabel>
-        <InteractiveTabBar variant="text" onColor />
-      </div>
-
-      <div style={{
-        backgroundColor: 'var(--background-brand-primary)',
-        padding: 'var(--padding-xl)',
-        borderRadius: 'var(--border-radius-md)',
-      }}>
-        <SectionLabel>Text underline — on color</SectionLabel>
-        <InteractiveTabBar variant="text-underline" onColor />
-      </div>
-
-      <div style={{
-        backgroundColor: 'var(--background-brand-primary)',
-        padding: 'var(--padding-xl)',
-        borderRadius: 'var(--border-radius-md)',
-      }}>
-        <SectionLabel>Tab — on color</SectionLabel>
-        <InteractiveTabBar variant="tab" onColor />
-      </div>
-
-      {/* Indicator dot — attention cue on a tab */}
-      <div>
-        <SectionLabel>Indicator dot — "Billing" needs attention</SectionLabel>
-        <TabBar
-          variant="tab"
-          items={[
-            { label: 'Overview', active: true },
-            { label: 'Billing', dot: true },
-            { label: 'Reporting', dot: true },
-            { label: 'Security' },
-          ]}
-        />
-      </div>
-
-      {/* Status dot — color the cue by DotStatus */}
-      <div>
-        <SectionLabel>Status dot — "Feedback" has open items (warning)</SectionLabel>
-        <TabBar
-          variant="tab"
-          items={[
-            { label: 'Overview', active: true },
-            { label: 'Feedback', dot: 'warning' },
-            { label: 'Files', dot: 'positive' },
-            { label: 'Activity' },
-          ]}
-        />
-      </div>
-
-      {/* Disabled tabs */}
-      <div>
-        <SectionLabel>Disabled — "Marketing" and "Other"</SectionLabel>
-        <InteractiveTabBar variant="tab" disabledIndices={[4, 5]} />
-      </div>
-
-      {/* Few tabs */}
-      <div>
-        <SectionLabel>Few tabs</SectionLabel>
-        <InteractiveTabBar variant="text" labels={fewLabels} />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Page header with tab navigation
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
+/** @summary Clicking a tab updates the active tab and its content */
+export const WithControlledTabs: Story = {
   render: () => {
     function SettingsPage() {
       const [activeIndex, setActiveIndex] = useState(0);
-      const tabs = ['General', 'Billing', 'Team', 'Integrations', 'Security'];
+      const tabs = ['General', 'Billing', 'Team', 'Security'];
 
       return (
         <div>
-          <SectionLabel>Settings page navigation</SectionLabel>
           <div style={{ borderBottom: 'var(--border-width-md) solid var(--border-secondary)' }}>
             <TabBar
               variant="tab"
@@ -237,30 +141,35 @@ export const Patterns: Story = {
       );
     }
 
-    function FilterTabs() {
-      const [activeIndex, setActiveIndex] = useState(0);
-      const filters = ['All', 'Active', 'Draft', 'Archived'];
+    return <SettingsPage />;
+  },
+};
 
-      return (
-        <div>
-          <SectionLabel>Content filter</SectionLabel>
-          <TabBar
-            variant="box"
-            items={filters.map((label, i) => ({
-              label,
-              active: i === activeIndex,
-              onClick: () => setActiveIndex(i),
-            }))}
-          />
-        </div>
-      );
-    }
+/* ═══════════════════════════════════════════════════════════════
+   INTERACTION TEST — Q5 play-only, hidden from MCP discovery
+   ═══════════════════════════════════════════════════════════════ */
 
-    return (
-      <Stack>
-        <SettingsPage />
-        <FilterTabs />
-      </Stack>
-    );
+const tabClickHandler = fn();
+
+/** @summary Verifies clicking a tab fires its onClick handler */
+export const InteractionTest: Story = {
+  tags: ['!manifest'],
+  args: {
+    variant: 'tab',
+    items: [
+      { label: 'Overview', active: true, onClick: tabClickHandler },
+      { label: 'Billing', onClick: tabClickHandler },
+      { label: 'Security', onClick: tabClickHandler },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tabs = canvas.getAllByRole('tab');
+
+    await expect(tabs).toHaveLength(3);
+    await expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.click(tabs[1]);
+    await expect(tabClickHandler).toHaveBeenCalled();
   },
 };


### PR DESCRIPTION
## Summary

Batch 2 of the final grandfathered story-shape sweep (#587 Phase 3 tail; batch 1 was #1284). Migrates 10 story files to the ADR-006 two-shape + ADR-010 story-vs-control matrix: banned `Variants`/`Patterns` gallery exports collapsed into `argTypes` Controls, `Playground` renamed to `Default`.

**41 → 35 exports.** Only `.stories.tsx` + `.mdx` touched — component `.tsx`/`.css`/`index.ts` and `meta.title` untouched, so no consumer disruption.

| Component | Before | After | Notes |
|---|---|---|---|
| PageHeader | 6 | 6 | Galleries folded into a kitchen-sink `Default`; `TunableSpacing` now documented under a `## CSS Override API` MDX section |
| Footer | 6 | 6 | `variant` gallery → Control; `Marketing` (Q3) + `SurfaceOverride` (CSS var) added; new `containerMaxWidth` prop covered |
| Modal | 5 | 4 | **CSF2 arrow-fn exports converted to CSF3**; `ConfirmPreset` split into `Confirm` + `ConfirmDestructive` (Q3); discriminated-union args typed via `Extract<>` |
| Breadcrumb | 5 | 3 | `separator` → Control; `ServiceLineCascade` kept (Q4 — driven by ancestor `[data-service-line]`) |
| NavBar | 4 | 2 | Slot-presence gallery + contrived sticky-scroll demo → Controls |
| TabBar | 3 | 7 | Net growth is correct: banned mega-gallery split into 4 real `variant` stories (Q3) + `WithControlledTabs` (Q4) + play-only `InteractionTest` |
| SheetSection | 3 | 1 | No variant axis — pure optional-string props → Controls (Field #652 precedent) |
| Popover | 3 | 2 | `Placements` kept (axis-only-gallery exception, mirrors Tooltip); trigger modes → Controls |
| Pagination | 3 | 2 | `position`/page-count → Controls; `WithResultCount` kept (Q4 derived label) |
| Dialog | 5 | 2 | Deprecated (stays `!manifest`); `Destructive` kept (Q3); pattern re-skins dropped |

Collateral fix: `Sheet/ReadModeSheet.mdx` Canvased the removed `SheetSection.Patterns` story — repointed to `Default` (only stale reference repo-wide).

## Test plan

- [x] `npm run lint-storybook-recipe` — 91/91 conforming
- [x] `npm run lint-jsdoc` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run typegen:axes:check` — manifest in sync
- [x] `npm run build-storybook` — succeeds
- [x] `npm run lint-doc-links` — all links resolve (docs-site pages link autodocs `--overview` IDs keyed off untouched `meta.title`)
- [ ] `npm run chromatic` — **not run**: snapshot quota exhausted (#771); story renames will reset baselines when quota returns

Closes #1277

## References

- Parent: #587 (Phase 3) · Batch 1: #1284 · Lint gate: #569 · ADR-010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
