### PR TITLE
Story-shape batch 4 — empties the banned-export set (9 files)

### DIFF
--- a/components/ui/Avatar/Avatar.mdx
+++ b/components/ui/Avatar/Avatar.mdx
@@ -10,15 +10,15 @@ import * as Stories from './Avatar.stories';
 
 User profile images with automatic fallback to initials. Supports multiple sizes and optional status indicators for presence states.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Sizes, content types (initials vs image), and status indicators.
+Initials-only fallback vs photo-backed avatar — the two content-type starting points. Size, status, and color are Controls on both.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Initials} />
 
 - **`sm`** — 32px, compact lists and inline mentions
 - **`md`** — 40px, default for cards and comments
@@ -27,11 +27,10 @@ Sizes, content types (initials vs image), and status indicators.
 
 ## Patterns
 
-Real-world compositions: user lists and stacked avatar groups.
+Overlapping avatar stack — a composition whose negative-margin/border overlap can't be expressed by a single Avatar's args.
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.AvatarGroup} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/Avatar/Avatar.stories.tsx
+++ b/components/ui/Avatar/Avatar.stories.tsx
@@ -11,46 +11,38 @@ const meta: Meta<typeof Avatar> = {
     layout: 'centered',
   },
   argTypes: {
+    name: {
+      control: 'text',
+      description: 'Name used to generate initials when no image loads.',
+    },
+    src: {
+      control: 'text',
+      description: 'Image source URL. Falls back to initials when omitted or on load error.',
+    },
+    alt: {
+      control: 'text',
+      description: 'Alt text for the image.',
+    },
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg', 'xl'],
+      description: 'Size token. Default `md`.',
     },
     status: {
       control: 'select',
       options: [undefined, 'online', 'offline', 'busy', 'away'],
+      description: 'Presence status dot. Omit for none.',
     },
     color: {
       control: 'select',
       options: [undefined, 'green', 'purple', 'blue', 'orange', 'yellow', 'red'],
+      description: 'Accent color for the initials fallback. No effect when an image loads.',
     },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Avatar>;
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-lg)', flexWrap: 'wrap', alignItems: 'center' }}>{children}</div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
 
 /* ─── Character headshots (The Office) ────────────────────────── */
 
@@ -59,16 +51,15 @@ const headshots = {
   dwight:  'https://randomuser.me/api/portraits/men/44.jpg',
   jim:     'https://randomuser.me/api/portraits/men/75.jpg',
   pam:     'https://randomuser.me/api/portraits/women/68.jpg',
-  creed:   'https://randomuser.me/api/portraits/men/85.jpg',
-  oscar:   'https://randomuser.me/api/portraits/men/52.jpg',
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox, photo-backed avatar. Size,
+   status, and color are Controls (ADR-010 Q2).
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Interactive Avatar — photo-backed, size/status/color via Controls */
+export const Default: Story = {
   args: {
     name: 'Michael Scott',
     src: headshots.michael,
@@ -77,125 +68,44 @@ export const Playground: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Sizes, content types, statuses
+   INITIALS — Q3 starting template: initials-only fallback, no
+   image source. A distinct content-type an agent reaches for
+   directly (e.g. a contact with no photo on file).
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Sizes (initials)</SectionLabel>
-        <Row>
-          <Avatar name="Michael Scott" size="sm" />
-          <Avatar name="Dwight Schrute" size="md" />
-          <Avatar name="Jim Halpert" size="lg" />
-          <Avatar name="Pam Beesly" size="xl" />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>Colors (initials)</SectionLabel>
-        <Row>
-          <Avatar name="Green Ivy" color="green" size="lg" />
-          <Avatar name="Purple Rain" color="purple" size="lg" />
-          <Avatar name="Blue Sky" color="blue" size="lg" />
-          <Avatar name="Orange Peel" color="orange" size="lg" />
-          <Avatar name="Yellow Sun" color="yellow" size="lg" />
-          <Avatar name="Red Rose" color="red" size="lg" />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>With image</SectionLabel>
-        <Row>
-          <Avatar src={headshots.michael} alt="Michael Scott" name="Michael Scott" size="sm" />
-          <Avatar src={headshots.dwight} alt="Dwight Schrute" name="Dwight Schrute" size="md" />
-          <Avatar src={headshots.jim} alt="Jim Halpert" name="Jim Halpert" size="lg" />
-          <Avatar src={headshots.pam} alt="Pam Beesly" name="Pam Beesly" size="xl" />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>Status indicators</SectionLabel>
-        <Row>
-          <Avatar src={headshots.michael} alt="Michael Scott" name="Michael Scott" status="online" />
-          <Avatar src={headshots.dwight} alt="Dwight Schrute" name="Dwight Schrute" status="offline" />
-          <Avatar src={headshots.jim} alt="Jim Halpert" name="Jim Halpert" status="busy" />
-          <Avatar src={headshots.pam} alt="Pam Beesly" name="Pam Beesly" status="away" />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>Image + status (large)</SectionLabel>
-        <Row>
-          <Avatar src={headshots.creed} alt="Creed Bratton" name="Creed Bratton" status="online" size="lg" />
-          <Avatar src={headshots.oscar} alt="Oscar Martinez" name="Oscar Martinez" status="busy" size="lg" />
-          <Avatar src={headshots.michael} alt="Michael Scott" name="Michael Scott" status="away" size="lg" />
-        </Row>
-      </div>
-    </Stack>
-  ),
+/** @summary Initials-only fallback — no image source */
+export const Initials: Story = {
+  args: {
+    name: 'Dwight Schrute',
+    size: 'lg',
+  },
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world usage
+   AVATARGROUP — Q4 irreducible composition: overlapping avatar
+   stack. Negative-margin + border overlap across multiple
+   instances can't be expressed by a single Avatar's args.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Patterns',
+/** @summary Overlapping stacked-avatar group composition */
+export const AvatarGroup: Story = {
   render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>User list</SectionLabel>
-        <Stack gap="var(--gap-md)">
-          {([
-            { name: 'Michael Scott', src: headshots.michael, status: 'online' as const },
-            { name: 'Dwight Schrute', src: headshots.dwight, status: 'online' as const },
-            { name: 'Jim Halpert', src: headshots.jim, status: 'away' as const },
-            { name: 'Pam Beesly', src: headshots.pam, status: 'online' as const },
-            { name: 'Creed Bratton', src: headshots.creed, status: 'offline' as const },
-            { name: 'Oscar Martinez', src: headshots.oscar, status: 'busy' as const },
-          ]).map((user) => (
-            <div key={user.name} style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-sm)' }}>
-              <Avatar name={user.name} src={user.src} status={user.status} />
-              <div>
-                <div style={{
-                  fontFamily: 'var(--font-family-label)',
-                  fontSize: 'var(--label-md)', // bds-lint-ignore
-                  fontWeight: 'var(--font-weight-semibold)',
-                }}>
-                  {user.name}
-                </div>
-                <div style={{
-                  fontFamily: 'var(--font-family-body)',
-                  fontSize: 'var(--body-sm)', // bds-lint-ignore
-                  color: 'var(--text-secondary)',
-                }}>
-                  {user.status.charAt(0).toUpperCase() + user.status.slice(1)}
-                </div>
-              </div>
-            </div>
-          ))}
-        </Stack>
-      </div>
-      <div>
-        <SectionLabel>Avatar group (stacked)</SectionLabel>
-        <div style={{ display: 'flex', marginLeft: 'var(--padding-sm)' }}>
-          {([
-            { name: 'Michael Scott', src: headshots.michael },
-            { name: 'Dwight Schrute', src: headshots.dwight },
-            { name: 'Jim Halpert', src: headshots.jim },
-            { name: 'Pam Beesly', src: headshots.pam },
-            { name: '+2', src: undefined },
-          ]).map((user) => (
-            <Avatar
-              key={user.name}
-              name={user.name}
-              src={user.src}
-              size="md"
-              style={{ marginLeft: '-12px', border: '2px solid var(--background-input)' }}
-            />
-          ))}
-        </div>
-      </div>
-    </Stack>
+    <div style={{ display: 'flex', marginLeft: 'var(--padding-sm)' }}>
+      {([
+        { name: 'Michael Scott', src: headshots.michael },
+        { name: 'Dwight Schrute', src: headshots.dwight },
+        { name: 'Jim Halpert', src: headshots.jim },
+        { name: 'Pam Beesly', src: headshots.pam },
+        { name: '+2', src: undefined },
+      ]).map((user) => (
+        <Avatar
+          key={user.name}
+          name={user.name}
+          src={user.src}
+          size="md"
+          style={{ marginLeft: '-12px', border: '2px solid var(--background-input)' }}
+        />
+      ))}
+    </div>
   ),
 };

--- a/components/ui/Chip/Chip.mdx
+++ b/components/ui/Chip/Chip.mdx
@@ -10,26 +10,20 @@ import * as Stories from './Chip.stories';
 
 Compact interactive pill for filtering, selection, and removable tokens. Use for filter dropdown triggers, active-filter chips, and multi-select state.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Single hierarchy axis — primary / secondary. Size and state combinations below.
+Single hierarchy axis — primary / secondary. Pure color axis with no semantic difference between values, so it's a Control on the Default sandbox above, alongside size, dropdown/remove affordances, and disabled state.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 - **`secondary`** (default) — Neutral filter chip. The everyday filter pill.
 - **`primary`** — Emphasized chip. Active/selected filter, current state.
 
 Chip is **interactive only** — appearance (`solid` / `outline`) was removed in v0.66 because it duplicated the hierarchy axis for an interactive component. Read-only fill variations live on [Badge](badge.mdx) and [Tag](tag.mdx).
-
-## Patterns
-
-Real-world compositions for filtering and selection.
-
-<Canvas of={Stories.Patterns} />
 
 ## Props
 
@@ -51,4 +45,3 @@ Component-scoped CSS variables exposed on `.bds-chip`. Set on a wrapping element
   --chip-pressed-overlay: rgba(0, 0, 0, 0.14);
 }
 ```
-

--- a/components/ui/Chip/Chip.stories.tsx
+++ b/components/ui/Chip/Chip.stories.tsx
@@ -12,117 +12,64 @@ const meta: Meta<typeof Chip> = {
     layout: 'centered',
   },
   argTypes: {
+    label: {
+      control: 'text',
+      description: 'Chip label text.',
+    },
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
+      description: 'Size token. Default `md`.',
     },
     variant: {
       control: 'select',
       options: ['primary', 'secondary'],
+      description:
+        'Hierarchy — `secondary` (default, neutral) or `primary` (emphasized/selected). ' +
+        'Pure color axis, no semantic difference between values.',
     },
-    showDropdown: { control: 'boolean' },
-    disabled: { control: 'boolean' },
+    icon: {
+      control: false,
+      description: 'Optional leading icon element.',
+    },
+    avatar: {
+      control: false,
+      description: 'Optional avatar element rendered before the label.',
+    },
+    showDropdown: {
+      control: 'boolean',
+      description: 'Show trailing dropdown caret.',
+    },
+    onRemove: {
+      action: 'removed',
+      description: 'Removable chip — pass a handler to show the trailing remove button.',
+    },
+    onChipClick: {
+      action: 'clicked',
+      description: 'Click handler for the chip body.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disabled state — blocks click/remove and mutes appearance.',
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Chip>;
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-lg)', flexWrap: 'wrap', alignItems: 'center' }}>{children}</div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox. Hierarchy (variant), size,
+   dropdown/remove affordances, and disabled state are pure
+   axes with no semantic difference between values — Controls
+   (ADR-010 Q2), not standalone stories.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Interactive Chip — hierarchy, size, affordances via Controls */
+export const Default: Story = {
   args: {
     label: 'Chip',
     icon: <Icon icon="ph:funnel" />,
     showDropdown: true,
   },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — All combinations in one view
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Variants</SectionLabel>
-        <Row>
-          <Chip label="Secondary" variant="secondary" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Primary" variant="primary" icon={<Icon icon="ph:funnel" />} showDropdown />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>Sizes</SectionLabel>
-        <Row>
-          <Chip label="Small" size="sm" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Medium" size="md" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Large" size="lg" icon={<Icon icon="ph:funnel" />} showDropdown />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>States</SectionLabel>
-        <Row>
-          <Chip label="Default" icon={<Icon icon="ph:funnel" />} showDropdown />
-          <Chip label="Removable" icon={<Icon icon="ph:tag" />} onRemove={() => {}} />
-          <Chip label="Disabled" icon={<Icon icon="ph:funnel" />} showDropdown disabled />
-        </Row>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world usage
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Patterns',
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Active filters</SectionLabel>
-        <Row>
-          <Chip label="Status: Active" variant="primary" onRemove={() => {}} />
-          <Chip label="Category: Design" onRemove={() => {}} />
-          <Chip label="Date: This week" onRemove={() => {}} />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>Filter dropdown</SectionLabel>
-        <Row>
-          <Chip label="All statuses" icon={<Icon icon="ph:funnel" />} showDropdown onChipClick={() => {}} />
-          <Chip label="Category" icon={<Icon icon="ph:funnel" />} showDropdown onChipClick={() => {}} />
-        </Row>
-      </div>
-    </Stack>
-  ),
 };

--- a/components/ui/Counter/Counter.mdx
+++ b/components/ui/Counter/Counter.mdx
@@ -10,15 +10,15 @@ import * as Stories from './Counter.stories';
 
 Numeric count indicator with status colors. Pill-shaped badge for notification counts, item quantities, and step indicators.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-All statuses across all sizes, plus max overflow behavior.
+Status and size are pure color/dimension axes with no semantic difference between values — both are Controls on the Default sandbox above, not standalone stories.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 - **`success`** -- Completed items, positive counts.
 - **`error`** -- Error counts, alerts.
@@ -27,13 +27,6 @@ All statuses across all sizes, plus max overflow behavior.
 - **`progress`** -- In-progress items.
 - **`brand`** -- General counts, notifications.
 
-## Patterns
-
-Real-world notification count compositions.
-
-<Canvas of={Stories.Patterns} />
-
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/Counter/Counter.stories.tsx
+++ b/components/ui/Counter/Counter.stories.tsx
@@ -13,17 +13,21 @@ const meta: Meta<typeof Counter> = {
   argTypes: {
     count: {
       control: { type: 'number', min: 0, max: 999 },
+      description: 'Numeric count to display.',
     },
     status: {
       control: 'select',
       options: ['success', 'error', 'warning', 'neutral', 'progress', 'brand'],
+      description: 'Status color — pure color axis, no semantic difference between values.',
     },
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
+      description: 'Size token. Default `sm`.',
     },
     max: {
       control: { type: 'number', min: 1, max: 999 },
+      description: 'Max count — displays `{max}+` when `count` exceeds it.',
     },
   },
 };
@@ -31,101 +35,17 @@ const meta: Meta<typeof Counter> = {
 export default meta;
 type Story = StoryObj<typeof Counter>;
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-md)', flexWrap: 'wrap', alignItems: 'center' }}>{children}</div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox. Status, size, and max overflow
+   are pure color/dimension axes with no semantic difference
+   between values — Controls (ADR-010 Q2), not standalone stories.
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+/** @summary Interactive Counter — status, size, max via Controls */
+export const Default: Story = {
   args: {
     count: 5,
     status: 'success',
     size: 'sm',
   },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — All statuses × all sizes + max overflow
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => {
-    const statuses = ['success', 'error', 'warning', 'neutral', 'progress', 'brand'] as const;
-    const sizes = ['sm', 'md', 'lg'] as const;
-    return (
-      <Stack>
-        {sizes.map((size) => (
-          <div key={size}>
-            <SectionLabel>{size}</SectionLabel>
-            <Row>
-              {statuses.map((status) => (
-                <Counter key={`${size}-${status}`} count={1} status={status} size={size} />
-              ))}
-            </Row>
-          </div>
-        ))}
-        <div>
-          <SectionLabel>Max overflow</SectionLabel>
-          <Row>
-            <Counter count={5} max={99} status="error" size="md" />
-            <Counter count={99} max={99} status="error" size="md" />
-            <Counter count={150} max={99} status="error" size="md" />
-          </Row>
-        </div>
-      </Stack>
-    );
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world usage
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Patterns',
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Notification counts</SectionLabel>
-        <Stack gap="var(--gap-md)">
-          {[
-            { label: 'Inbox', count: 12, status: 'brand' as const },
-            { label: 'Errors', count: 3, status: 'error' as const },
-            { label: 'Pending', count: 7, status: 'warning' as const },
-            { label: 'Complete', count: 42, status: 'success' as const },
-          ].map(({ label, count, status }) => (
-            <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-md)' }}>
-              <Counter count={count} status={status} />
-              <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)' }}>{label}</span>
-            </div>
-          ))}
-        </Stack>
-      </div>
-    </Stack>
-  ),
 };

--- a/components/ui/Divider/Divider.mdx
+++ b/components/ui/Divider/Divider.mdx
@@ -10,28 +10,21 @@ import * as Stories from './Divider.stories';
 
 Visual separator for content sections. Supports horizontal and vertical orientations with configurable spacing.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Orientations and spacing options.
+Horizontal or vertical orientation with four spacing tokens, available via Controls.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 - **`none`** -- 0px. Tight separators, table rows.
 - **`sm`** -- 12px. Compact spacing.
 - **`md`** -- 16px. Default breathing room.
 - **`lg`** -- 24px. Section-level separation.
 
-## Patterns
-
-Real-world usage: content sections and toolbar separators.
-
-<Canvas of={Stories.Patterns} />
-
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/Divider/Divider.stories.tsx
+++ b/components/ui/Divider/Divider.stories.tsx
@@ -18,31 +18,13 @@ const meta: Meta<typeof Divider> = {
     spacing: {
       control: 'select',
       options: ['none', 'sm', 'md', 'lg'],
+      description: '`none` 0px, `sm` 12px, `md` 16px, `lg` 24px margin.',
     },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Divider>;
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
 
 const bodyText: React.CSSProperties = {
   fontFamily: 'var(--font-family-body)',
@@ -51,12 +33,10 @@ const bodyText: React.CSSProperties = {
   margin: 0,
 };
 
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Default ─────────────────────────────────────────────────── */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     orientation: 'horizontal',
     spacing: 'none',
@@ -70,73 +50,4 @@ export const Playground: Story = {
       </div>
     ),
   ],
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Orientations and spacings
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Horizontal spacings</SectionLabel>
-        <div style={{ width: '400px', ...bodyText, color: 'var(--text-secondary)', fontSize: 'var(--body-sm)' }}>
-          <p style={{ margin: 0 }}>spacing="none"</p>
-          <Divider spacing="none" />
-          <p style={{ margin: 0 }}>spacing="sm"</p>
-          <Divider spacing="sm" />
-          <p style={{ margin: 0 }}>spacing="md"</p>
-          <Divider spacing="md" />
-          <p style={{ margin: 0 }}>spacing="lg"</p>
-          <Divider spacing="lg" />
-          <p style={{ margin: 0 }}>End</p>
-        </div>
-      </div>
-      <div>
-        <SectionLabel>Vertical</SectionLabel>
-        <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          height: '48px',
-          ...bodyText,
-        }}>
-          <span>Left</span>
-          <Divider orientation="vertical" spacing="md" />
-          <span>Right</span>
-        </div>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world usage
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Patterns',
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Content section separator</SectionLabel>
-        <div style={{ width: '400px' }}>
-          <p style={bodyText}>First paragraph of content goes here. This section introduces the topic.</p>
-          <Divider spacing="lg" />
-          <p style={bodyText}>Second section with related content. The divider provides visual separation.</p>
-        </div>
-      </div>
-      <div>
-        <SectionLabel>Toolbar separator</SectionLabel>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--gap-md)', height: '32px' }}>
-          <span style={bodyText}>Edit</span>
-          <span style={bodyText}>Copy</span>
-          <Divider orientation="vertical" spacing="sm" />
-          <span style={bodyText}>Delete</span>
-        </div>
-      </div>
-    </Stack>
-  ),
 };

--- a/components/ui/Dot/Dot.mdx
+++ b/components/ui/Dot/Dot.mdx
@@ -10,15 +10,15 @@ import * as Stories from './Dot.stories';
 
 Small status indicator circles that communicate state through color. Available in six status variants and three sizes.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-All statuses and sizes in one view.
+Six status colors and three sizes, available via Controls.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 - **`default`** -- Brand primary. General-purpose indicator.
 - **`positive`** -- Green. Online, success, operational.
@@ -27,13 +27,6 @@ All statuses and sizes in one view.
 - **`info`** -- Blue. Informational, in-progress.
 - **`neutral`** -- Gray. Inactive, disabled.
 
-## Patterns
-
-Real-world compositions: status lists and activity feeds.
-
-<Canvas of={Stories.Patterns} />
-
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/Dot/Dot.stories.tsx
+++ b/components/ui/Dot/Dot.stories.tsx
@@ -14,10 +14,15 @@ const meta: Meta<typeof Dot> = {
     status: {
       control: 'select',
       options: ['default', 'positive', 'warning', 'error', 'info', 'neutral'],
+      description: 'Color: `default` brand, `positive` green, `warning` yellow, `error` red, `info` blue, `neutral` gray.',
     },
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
+    },
+    pulse: {
+      control: 'boolean',
+      description: 'Pulse animation — use for active/running states.',
     },
   },
 };
@@ -25,139 +30,12 @@ const meta: Meta<typeof Dot> = {
 export default meta;
 type Story = StoryObj<typeof Dot>;
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-lg)', flexWrap: 'wrap', alignItems: 'center' }}>{children}</div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Default ─────────────────────────────────────────────────── */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     status: 'default',
     size: 'md',
   },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — All statuses × all sizes
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Statuses</SectionLabel>
-        <Row>
-          <Dot status="default" />
-          <Dot status="positive" />
-          <Dot status="warning" />
-          <Dot status="error" />
-          <Dot status="info" />
-          <Dot status="neutral" />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>Sizes</SectionLabel>
-        <Row>
-          {(['sm', 'md', 'lg'] as const).map((size) => (
-            <div key={size} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--gap-md)' }}>
-              <Dot size={size} status="positive" />
-              <span style={{
-                fontFamily: 'var(--font-family-label)',
-                fontSize: 'var(--label-sm)', // bds-lint-ignore
-                color: 'var(--text-secondary)',
-              }}>
-                {size}
-              </span>
-            </div>
-          ))}
-        </Row>
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world usage
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Patterns',
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Status list</SectionLabel>
-        <Stack gap="var(--gap-md)">
-          {[
-            { status: 'positive' as const, label: 'All systems operational' },
-            { status: 'warning' as const, label: 'Minor service disruption' },
-            { status: 'error' as const, label: 'Service outage detected' },
-          ].map(({ status, label }) => (
-            <div key={status} style={{ display: 'flex', gap: 'var(--gap-md)', alignItems: 'center' }}>
-              <Dot status={status} size="sm" />
-              <span style={{ fontFamily: 'var(--font-family-body)', fontSize: 'var(--body-md)' }}>{label}</span>
-            </div>
-          ))}
-        </Stack>
-      </div>
-      <div>
-        <SectionLabel>Activity feed</SectionLabel>
-        <div style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--gap-lg)',
-          padding: 'var(--padding-md)',
-          backgroundColor: 'var(--background-secondary)',
-          borderRadius: 'var(--border-radius-md)',
-          width: '300px',
-        }}>
-          {[
-            { status: 'positive' as const, title: 'Deployment successful', time: '2 minutes ago' },
-            { status: 'info' as const, title: 'Build started', time: '5 minutes ago' },
-            { status: 'neutral' as const, title: 'Code pushed to main', time: '10 minutes ago' },
-          ].map(({ status, title, time }) => (
-            <div key={title} style={{ display: 'flex', gap: 'var(--padding-sm)' }}>
-              <Dot status={status} style={{ marginTop: 'var(--gap-xs)' }} />
-              <div>
-                <div style={{
-                  fontFamily: 'var(--font-family-body)',
-                  fontSize: 'var(--body-md)', // bds-lint-ignore
-                  fontWeight: 'var(--font-weight-semibold)',
-                }}>{title}</div>
-                <div style={{
-                  fontFamily: 'var(--font-family-body)',
-                  fontSize: 'var(--body-sm)', // bds-lint-ignore
-                  color: 'var(--text-secondary)',
-                }}>{time}</div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </Stack>
-  ),
 };

--- a/components/ui/FileCard/FileCard.mdx
+++ b/components/ui/FileCard/FileCard.mdx
@@ -12,21 +12,25 @@ Populated state of a file upload — a card surface showing one uploaded asset w
 
 The `aspectRatio` slug consumes the `--aspect-*` token family so CMS uploaders can encode the target image shape once — the same slug feeds `<Frame ratio="…">` on the consumer side.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Preview modes (image, SVG, icon), aspect ratios (1:1 default, 16:9 hero), and action-row presence (Replace, Delete, both, neither, disabled).
+### Svg
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Svg} />
+
+### Icon
+
+<Canvas of={Stories.Icon} />
 
 ## Patterns
 
 Composition with `FileUploader` — render `FileUploader` while the slot is empty, then swap to `FileCard` once a file has been uploaded.
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.UploadFlow} />
 
 ## Props
 

--- a/components/ui/FileCard/FileCard.stories.tsx
+++ b/components/ui/FileCard/FileCard.stories.tsx
@@ -1,26 +1,8 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
 import { FileCard } from './FileCard';
 import { FileUploader } from '../FileUploader/FileUploader';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
 
 const SAMPLE_IMAGE = 'https://images.unsplash.com/photo-1503602642458-232111445657?auto=format&fit=crop&w=400&q=80';
 const SAMPLE_SVG = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28"><path fill="%23333" d="M14 4l3 7h7l-5.5 4 2 7L14 18l-6.5 4 2-7L4 11h7z"/></svg>';
@@ -33,17 +15,61 @@ const meta: Meta<typeof FileCard> = {
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   decorators: [(Story) => <div style={{ width: 440 }}><Story /></div>],
-} satisfies Meta<typeof FileCard>;
+  argTypes: {
+    preview: {
+      control: 'select',
+      options: ['image', 'svg', 'icon'],
+      description: 'Render mode for the preview thumbnail. `icon` renders a generic placeholder for non-renderable types.',
+    },
+    src: {
+      control: 'text',
+      description: 'Source URL for the preview. Required for `preview="image"` and `preview="svg"`.',
+    },
+    aspectRatio: {
+      control: 'select',
+      options: ['1-1', '3-2', '2-3', '4-3', '3-4', '16-9', '9-16', '21-9', 'square', 'photo-landscape', 'photo-portrait', 'cinema'],
+      description: 'Aspect-ratio slug applied to the preview thumbnail. Maps to the `--aspect-*` token family.',
+    },
+    name: {
+      control: 'text',
+      description: 'Filename label.',
+    },
+    meta: {
+      control: 'text',
+      description: 'Optional metadata line — typically dimensions / size / mime info.',
+    },
+    href: {
+      control: 'text',
+      description: 'When set, the preview becomes a link that opens the file in a new tab.',
+    },
+    onReplace: {
+      action: 'replace',
+      description: 'Replace action handler. When omitted, the Replace button is not rendered.',
+    },
+    onDelete: {
+      action: 'delete',
+      description: 'Delete action handler. When omitted, the Delete button is not rendered.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disable action buttons while preserving the visual.',
+    },
+    previewAlt: {
+      control: 'text',
+      description: 'Accessible alt text for image / svg previews. Falls back to `name`.',
+    },
+  },
+};
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — preview="image", all variation via Controls
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Interactive playground for prop tweaking. */
-export const Playground: Story = {
+/** @summary Interactive playground for prop tweaking */
+export const Default: Story = {
   args: {
     preview: 'image',
     src: SAMPLE_IMAGE,
@@ -51,131 +77,68 @@ export const Playground: Story = {
     name: 'hero.jpg',
     meta: '1600 × 900 • 248 KB',
     href: SAMPLE_IMAGE,
+    onReplace: fn(),
+    onDelete: fn(),
   },
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Preview modes + aspect ratios + actions
+   Q3 — dedicated stories per `preview` value
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side — preview modes, aspect ratios, and action presence. */
-export const Variants: Story = {
-  decorators: [(Story) => <div style={{ width: 480 }}><Story /></div>],
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Preview: image (1:1)</SectionLabel>
-        <FileCard
-          preview="image"
-          src={SAMPLE_IMAGE}
-          name="profile-photo.jpg"
-          meta="600 × 600 • 142 KB"
-          href={SAMPLE_IMAGE}
-          onReplace={() => {}}
-          onDelete={() => {}}
-        />
-      </div>
+/** @summary SVG preview — renders `src` directly, no aspect-ratio crop */
+export const Svg: Story = {
+  args: {
+    preview: 'svg',
+    src: SAMPLE_SVG,
+    name: 'industry-small-biz-primary.svg',
+    meta: '28 × 28 • 673 B',
+    onReplace: fn(),
+    onDelete: fn(),
+  },
+};
 
-      <div>
-        <SectionLabel>Preview: image (16:9 — hero)</SectionLabel>
-        <FileCard
-          preview="image"
-          src={SAMPLE_IMAGE}
-          aspectRatio="16-9"
-          name="hero-banner.jpg"
-          meta="1600 × 900 • 248 KB"
-          href={SAMPLE_IMAGE}
-          onReplace={() => {}}
-          onDelete={() => {}}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Preview: svg</SectionLabel>
-        <FileCard
-          preview="svg"
-          src={SAMPLE_SVG}
-          name="industry-small-biz-primary.svg"
-          meta="28 × 28 • 673 B"
-          onReplace={() => {}}
-          onDelete={() => {}}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Preview: icon (non-renderable type)</SectionLabel>
-        <FileCard
-          preview="icon"
-          name="brand-guidelines.pdf"
-          meta="PDF • 2.4 MB"
-          onReplace={() => {}}
-          onDelete={() => {}}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>No actions (read-only display)</SectionLabel>
-        <FileCard
-          preview="image"
-          src={SAMPLE_IMAGE}
-          name="archived-photo.jpg"
-          meta="800 × 600 • 96 KB"
-          href={SAMPLE_IMAGE}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Disabled</SectionLabel>
-        <FileCard
-          preview="image"
-          src={SAMPLE_IMAGE}
-          name="locked-asset.jpg"
-          meta="400 × 400 • 64 KB"
-          onReplace={() => {}}
-          onDelete={() => {}}
-          disabled
-        />
-      </div>
-    </Stack>
-  ),
+/** @summary Icon preview — generic placeholder for non-renderable file types */
+export const Icon: Story = {
+  args: {
+    preview: 'icon',
+    name: 'brand-guidelines.pdf',
+    meta: 'PDF • 2.4 MB',
+    onReplace: fn(),
+    onDelete: fn(),
+  },
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Composition with FileUploader
+   Q4 — irreducible: FileUploader/FileCard swap driven by upload state
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary Common composition with `FileUploader` — empty state vs populated state. */
-export const Patterns: Story = {
-  decorators: [(Story) => <div style={{ width: 480 }}><Story /></div>],
+/** @summary Empty-to-populated upload flow composed with `FileUploader` */
+export const UploadFlow: Story = {
   render: () => {
     function UploaderPair() {
       const [url, setUrl] = useState<string | null>(null);
-      return (
-        <Stack gap="var(--gap-md)">
-          <SectionLabel>Empty + populated states</SectionLabel>
-          {url ? (
-            <FileCard
-              preview="image"
-              src={url}
-              aspectRatio="16-9"
-              name="uploaded.jpg"
-              meta="1600 × 900 • image/jpeg"
-              href={url}
-              onReplace={() => setUrl(null)}
-              onDelete={() => setUrl(null)}
-            />
-          ) : (
-            <FileUploader
-              label="Drop or click to upload"
-              helperText="JPEG · PNG · WebP · AVIF — max 10MB"
-              accept="image/*"
-              onChange={(files) => {
-                const file = files[0];
-                if (file) setUrl(URL.createObjectURL(file));
-              }}
-            />
-          )}
-        </Stack>
+      return url ? (
+        <FileCard
+          preview="image"
+          src={url}
+          aspectRatio="16-9"
+          name="uploaded.jpg"
+          meta="1600 × 900 • image/jpeg"
+          href={url}
+          onReplace={() => setUrl(null)}
+          onDelete={() => setUrl(null)}
+        />
+      ) : (
+        <FileUploader
+          label="Drop or click to upload"
+          helperText="JPEG · PNG · WebP · AVIF — max 10MB"
+          accept="image/*"
+          onChange={(files) => {
+            const file = files[0];
+            if (file) setUrl(URL.createObjectURL(file));
+          }}
+        />
       );
     }
     return <UploaderPair />;

--- a/components/ui/FileUploader/FileUploader.mdx
+++ b/components/ui/FileUploader/FileUploader.mdx
@@ -10,23 +10,22 @@ import * as Stories from './FileUploader.stories';
 
 Drag-and-drop file upload zone with click-to-browse fallback. Supports file type filtering, size limits, multiple files, and error states.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Default, size limit, error, and disabled states.
+All variation — file type restrictions, size limits, error, and disabled — is exposed via Controls above.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 ## Patterns
 
-Real-world usage: interactive uploader with file list display.
+Multi-file selection with a live list of selected files.
 
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.WithFileList} />
 
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/FileUploader/FileUploader.stories.tsx
+++ b/components/ui/FileUploader/FileUploader.stories.tsx
@@ -1,26 +1,6 @@
-import React from 'react';
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { FileUploader } from './FileUploader';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
 
 /* ─── Meta ────────────────────────────────────────────────────── */
 
@@ -30,17 +10,51 @@ const meta: Meta<typeof FileUploader> = {
   tags: ['surface-shared'],
   parameters: { layout: 'centered' },
   decorators: [(Story) => <div style={{ width: 400 }}><Story /></div>],
-} satisfies Meta<typeof FileUploader>;
+  argTypes: {
+    accept: {
+      control: 'text',
+      description: 'Accepted file types — extension (`.svg`), MIME type (`image/svg+xml`), or wildcard (`image/*`).',
+    },
+    multiple: {
+      control: 'boolean',
+      description: 'Allow selecting more than one file at a time.',
+    },
+    maxSize: {
+      control: 'number',
+      description: 'Maximum file size in bytes. Oversized files are rejected with an inline error.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Locks the dropzone — non-interactive, muted appearance.',
+    },
+    label: {
+      control: 'text',
+      description: 'Label text shown inside the dropzone.',
+    },
+    helperText: {
+      control: 'text',
+      description: 'Hint text below the label. Hidden when `error` is present.',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message. Replaces `helperText` and applies the error style.',
+    },
+    onChange: {
+      action: 'changed',
+      description: 'Called with the accepted `File[]` after validation.',
+    },
+  },
+};
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox, all variation via Controls
    ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     label: 'Drag and drop files here',
     helperText: 'PDF, JPG, PNG, or SVG up to 10MB',
@@ -49,100 +63,37 @@ export const Playground: Story = {
 };
 
 /* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — States: default, size limit, error, disabled
+   Q4 — irreducible: live selected-file list, args can't express
    ═══════════════════════════════════════════════════════════════ */
 
-/** @summary All variants side by side */
-export const Variants: Story = {
-  decorators: [(Story) => <div style={{ width: 440 }}><Story /></div>],
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Default</SectionLabel>
-        <FileUploader
-          label="Drag and drop files here"
-          helperText="PDF, JPG, PNG, or SVG up to 10MB"
-          accept=".pdf,.jpg,.png,.svg"
-        />
-      </div>
-
-      <div>
-        <SectionLabel>SVG icon (single)</SectionLabel>
-        <FileUploader
-          label="Upload an SVG icon"
-          helperText="SVG up to 100KB · for industry / category icons"
-          accept=".svg,image/svg+xml"
-          maxSize={100 * 1024}
-        />
-      </div>
-
-      <div>
-        <SectionLabel>With size limit</SectionLabel>
-        <FileUploader
-          label="Upload document"
-          helperText="Max 2MB"
-          maxSize={2 * 1024 * 1024}
-          accept=".pdf"
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Error state</SectionLabel>
-        <FileUploader
-          label="Upload files"
-          error="File type not supported"
-        />
-      </div>
-
-      <div>
-        <SectionLabel>Disabled</SectionLabel>
-        <FileUploader
-          label="Upload files"
-          helperText="Uploads are currently disabled"
-          disabled
-        />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Interactive with file list
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  decorators: [(Story) => <div style={{ width: 440 }}><Story /></div>],
+/** @summary Multi-file selection with a live selected-file list */
+export const WithFileList: Story = {
   render: () => {
     function UploadWithFileList() {
       const [files, setFiles] = useState<File[]>([]);
       return (
-        <div>
-          <SectionLabel>Upload with file list</SectionLabel>
-          <Stack gap="var(--gap-md)">
-            <FileUploader
-              label="Upload images"
-              accept="image/*"
-              multiple
-              helperText="Select one or more images"
-              onChange={setFiles}
-            />
-            {files.length > 0 && (
-              <div style={{
-                fontFamily: 'var(--font-family-body)',
-                fontSize: 'var(--body-sm)',
-                color: 'var(--text-secondary)',
-              }}>
-                {files.map((f) => (
-                  <div key={f.name}>{f.name} ({(f.size / 1024).toFixed(1)} KB)</div>
-                ))}
-              </div>
-            )}
-          </Stack>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
+          <FileUploader
+            label="Upload images"
+            accept="image/*"
+            multiple
+            helperText="Select one or more images"
+            onChange={setFiles}
+          />
+          {files.length > 0 && (
+            <div style={{
+              fontFamily: 'var(--font-family-body)',
+              fontSize: 'var(--body-sm)',
+              color: 'var(--text-secondary)',
+            }}>
+              {files.map((f) => (
+                <div key={f.name}>{f.name} ({(f.size / 1024).toFixed(1)} KB)</div>
+              ))}
+            </div>
+          )}
         </div>
       );
     }
-
     return <UploadWithFileList />;
   },
 };

--- a/components/ui/ProgressBar/ProgressBar.mdx
+++ b/components/ui/ProgressBar/ProgressBar.mdx
@@ -10,21 +10,15 @@ import * as Stories from './ProgressBar.stories';
 
 Visual indicator showing completion progress. Use for file uploads, multi-step forms, loading states, and any task with measurable progress.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Empty, partial, half, and complete states.
+All progress states — empty, partial, and complete — are explored via the `value` Control above.
 
-<Canvas of={Stories.Variants} />
-
-## Patterns
-
-Real-world usage: animated loading indicator and multi-step form progress.
-
-<Canvas of={Stories.Patterns} />
+<Canvas of={Stories.Default} />
 
 ## Props
 

--- a/components/ui/ProgressBar/ProgressBar.stories.tsx
+++ b/components/ui/ProgressBar/ProgressBar.stories.tsx
@@ -1,26 +1,5 @@
-import React from 'react';
-import { useState, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ProgressBar } from './ProgressBar';
-
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
 
 /* ─── Meta ────────────────────────────────────────────── */
 
@@ -31,114 +10,32 @@ const meta: Meta<typeof ProgressBar> = {
   parameters: { layout: 'padded' },
   decorators: [(Story) => <div style={{ width: 400 }}><Story /></div>],
   argTypes: {
-    value: { control: { type: 'range', min: 0, max: 100, step: 1 } },
-    label: { control: 'text' },
+    value: {
+      control: { type: 'range', min: 0, max: 100, step: 1 },
+      description: 'Progress value from 0 to 100. Clamped to range.',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label for screen readers (`aria-label`).',
+    },
+    fillColor: {
+      control: 'color',
+      description: 'Override fill bar color. Defaults to brand-primary.',
+    },
   },
 };
 
 export default meta;
-type Story = StoryObj<typeof ProgressBar>;
+type Story = StoryObj<typeof meta>;
 
 /* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
+   DEFAULT — args-driven sandbox, all variation via Controls
    ═══════════════════════════════════════════════════════════════ */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     value: 35,
     label: 'Progress',
-  },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — Empty, partial, complete
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Empty (0%)</SectionLabel>
-        <ProgressBar value={0} label="Not started" />
-      </div>
-      <div>
-        <SectionLabel>Partial (35%)</SectionLabel>
-        <ProgressBar value={35} label="In progress" />
-      </div>
-      <div>
-        <SectionLabel>Half (50%)</SectionLabel>
-        <ProgressBar value={50} label="Halfway" />
-      </div>
-      <div>
-        <SectionLabel>Complete (100%)</SectionLabel>
-        <ProgressBar value={100} label="Complete" />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Animated loading + step progress
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  render: () => {
-    function ProgressPatterns() {
-      const [progress, setProgress] = useState(0);
-
-      useEffect(() => {
-        const timer = setInterval(() => {
-          setProgress((prev) => (prev >= 100 ? 0 : prev + 1));
-        }, 50);
-        return () => clearInterval(timer);
-      }, []);
-
-      const steps = [
-        { label: 'Account', complete: true },
-        { label: 'Profile', complete: true },
-        { label: 'Preferences', complete: false },
-        { label: 'Review', complete: false },
-        { label: 'Confirm', complete: false },
-      ];
-      const completedCount = steps.filter((s) => s.complete).length;
-      const stepProgress = (completedCount / steps.length) * 100;
-
-      return (
-        <Stack>
-          <div>
-            <SectionLabel>Animated loading</SectionLabel>
-            <ProgressBar value={progress} label="Loading" />
-            <p style={{
-              fontFamily: 'var(--font-family-body)',
-              fontSize: 'var(--body-sm)',
-              color: 'var(--text-secondary)',
-              marginTop: 'var(--gap-md)',
-            }}>
-              {progress}%
-            </p>
-          </div>
-
-          <div>
-            <SectionLabel>Multi-step form</SectionLabel>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              fontFamily: 'var(--font-family-body)',
-              fontSize: 'var(--body-sm)',
-              color: 'var(--text-secondary)',
-              marginBottom: 'var(--gap-md)',
-            }}>
-              <span>Step {completedCount} of {steps.length}</span>
-              <span>{Math.round(stepProgress)}%</span>
-            </div>
-            <ProgressBar value={stepProgress} label={`Step ${completedCount} of ${steps.length}`} />
-          </div>
-        </Stack>
-      );
-    }
-    return <ProgressPatterns />;
   },
 };

--- a/components/ui/Skeleton/Skeleton.mdx
+++ b/components/ui/Skeleton/Skeleton.mdx
@@ -10,27 +10,20 @@ import * as Stories from './Skeleton.stories';
 
 Content placeholder with shimmer animation for loading states. Maintains layout and reduces perceived load time.
 
-## Playground
+## Default
 
-<Canvas of={Stories.Playground} />
+<Canvas of={Stories.Default} />
 
 ## Variants
 
-Three shape variants: text, circular, and rectangular.
+Three shape variants, available via the `variant` Control.
 
-<Canvas of={Stories.Variants} />
+<Canvas of={Stories.Default} />
 
 - **`text`** -- 100% x 1em. Use for text line placeholders.
 - **`circular`** -- 40px. Use for avatar and icon placeholders.
 - **`rectangular`** -- 100% x 140px. Use for image, card, and section placeholders.
 
-## Patterns
-
-Real-world loading states: article cards and comment lists.
-
-<Canvas of={Stories.Patterns} />
-
 ## Props
 
 <ArgTypes of={Stories} />
-

--- a/components/ui/Skeleton/Skeleton.stories.tsx
+++ b/components/ui/Skeleton/Skeleton.stories.tsx
@@ -14,131 +14,22 @@ const meta: Meta<typeof Skeleton> = {
     variant: {
       control: 'select',
       options: ['text', 'circular', 'rectangular'],
+      description: 'Shape: `text` (line), `circular` (avatar/icon), or `rectangular` (image/card block).',
     },
-    width: { control: 'text' },
-    height: { control: 'text' },
+    width: { control: 'text', description: 'CSS width value or number of px.' },
+    height: { control: 'text', description: 'CSS height value or number of px.' },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Skeleton>;
 
-/* ─── Layout Helpers (story-only) ─────────────────────────────── */
-
-const SectionLabel = ({ children }: { children: string }) => (
-  <div style={{
-    fontFamily: 'var(--font-family-label)',
-    fontSize: 'var(--body-xs)', // bds-lint-ignore
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
-    marginBottom: 'var(--gap-md)',
-    color: 'var(--text-muted)',
-  }}>
-    {children}
-  </div>
-);
-
-const Row = ({ children }: { children: React.ReactNode }) => (
-  <div style={{ display: 'flex', gap: 'var(--gap-lg)', flexWrap: 'wrap', alignItems: 'center' }}>{children}</div>
-);
-
-const Stack = ({ children, gap = 'var(--gap-xl)' }: { children: React.ReactNode; gap?: string }) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap }}>{children}</div>
-);
-
-/* ═══════════════════════════════════════════════════════════════
-   1. PLAYGROUND — Args-based, use Controls panel to explore
-   ═══════════════════════════════════════════════════════════════ */
+/* ─── Default ─────────────────────────────────────────────────── */
 
 /** @summary Interactive playground for prop tweaking */
-export const Playground: Story = {
+export const Default: Story = {
   args: {
     variant: 'text',
     width: '200px',
   },
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   2. VARIANTS — All shape variants
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary All variants side by side */
-export const Variants: Story = {
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Text</SectionLabel>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)', maxWidth: '400px' }}>
-          <Skeleton variant="text" />
-          <Skeleton variant="text" width="85%" />
-          <Skeleton variant="text" width="70%" />
-        </div>
-      </div>
-      <div>
-        <SectionLabel>Circular</SectionLabel>
-        <Row>
-          <Skeleton variant="circular" width={32} height={32} />
-          <Skeleton variant="circular" width={48} height={48} />
-          <Skeleton variant="circular" width={64} height={64} />
-        </Row>
-      </div>
-      <div>
-        <SectionLabel>Rectangular</SectionLabel>
-        <Skeleton variant="rectangular" width="300px" height="180px" />
-      </div>
-    </Stack>
-  ),
-};
-
-/* ═══════════════════════════════════════════════════════════════
-   3. PATTERNS — Real-world loading states
-   ═══════════════════════════════════════════════════════════════ */
-
-/** @summary Common usage patterns */
-export const Patterns: Story = {
-  name: 'Patterns',
-  render: () => (
-    <Stack>
-      <div>
-        <SectionLabel>Article card</SectionLabel>
-        <div style={{
-          width: '300px',
-          padding: 'var(--padding-md)',
-          backgroundColor: 'var(--background-primary)',
-          border: 'var(--border-width-md) solid var(--border-secondary)',
-          borderRadius: 'var(--border-radius-lg)',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--padding-sm)',
-        }}>
-          <Skeleton variant="rectangular" width="100%" height="160px" />
-          <Skeleton variant="text" width="80%" height="24px" />
-          <Skeleton variant="text" width="100%" />
-          <Skeleton variant="text" width="60%" />
-        </div>
-      </div>
-      <div>
-        <SectionLabel>Comment list</SectionLabel>
-        <div style={{ width: '400px', display: 'flex', flexDirection: 'column', gap: 'var(--gap-lg)' }}>
-          {[1, 2, 3].map((i) => (
-            <div key={i} style={{
-              display: 'flex',
-              gap: 'var(--padding-sm)',
-              padding: 'var(--padding-sm)',
-              backgroundColor: 'var(--background-primary)',
-              border: 'var(--border-width-md) solid var(--border-secondary)',
-              borderRadius: 'var(--border-radius-md)',
-            }}>
-              <Skeleton variant="circular" width={40} height={40} />
-              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 'var(--gap-md)' }}>
-                <Skeleton variant="text" width="30%" height="14px" />
-                <Skeleton variant="text" width="100%" />
-                <Skeleton variant="text" width="85%" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </Stack>
-  ),
 };


### PR DESCRIPTION
Final batch of the Phase 3 grandfathered story-shape sweep (umbrella #587). Applies the ADR-006 two-shape model + ADR-010 story-vs-control matrix to the last 9 display-primitive story files tracked in #1279.

## What changed (9 components)
Skeleton, ProgressBar, FileUploader, FileCard, Dot, Divider, Counter, Chip, Avatar.

- `Playground` → `Default` throughout.
- Banned `Variants` / `Patterns` galleries deleted. Boolean/state/dimension props → `argTypes` Controls (Q2); genuine semantic values → args-driven state stories (Q3: FileCard `Svg`/`Icon`, Avatar `Initials`); genuine irreducible compositions kept as Q4 (FileUploader `WithFileList`, FileCard `UploadFlow`, Avatar `AvatarGroup`).
- `## Patterns` MDX H2 dropped where no Q4 composition survives.

## This is the set-emptying batch
Repo-wide `rg "export const (Variants|Patterns|Tones|Examples)" components/ui --glob '*.stories.tsx'` now returns **zero**. This unblocks **#569** — the lint gate can ship with no grandfather allowlist.

## Scope
Only `*.stories.tsx` + `*.mdx` touched — no component `.tsx`/`.css`/`index.ts`, no `meta.title` (#629), no surface-tag changes.

## Verification
- Zero banned exports **repo-wide** ✓
- `npm run typecheck` ✓
- `node scripts/lint-storybook-recipe.js --enforce` → 91/91 ✓
- `npm run lint-jsdoc` ✓
- `npm run build-storybook` ✓
- `npm run lint-doc-links` → all links resolve ✓

**Chromatic skipped** — snapshot quota exhausted (#771); functional CI covers this PR.

Closes #1279
Refs #587, #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)