### PR TITLE
Wire story-shape lint gate — ban Variants/Patterns exports (#569)

### DIFF
--- a/.github/workflows/storybook-story-shape-check.yml
+++ b/.github/workflows/storybook-story-shape-check.yml
@@ -1,0 +1,50 @@
+name: Storybook Story-Shape Check
+
+# Enforces ADR-006 Part B (two-shape model) on every PR and on every push to
+# main. Fails the build if any `*.stories.tsx` file exports a banned render-mode
+# gallery name (Variants / Tones / Patterns / Examples) or an `*And*` axis-merge
+# compound (e.g. SizesAndVariants).
+#
+# Why this is a CI gate (not just pre-commit):
+#   - Pre-commit only runs when a story file is staged. CI catches regressions
+#     introduced by surrounding edits (a story export renamed into a banned name
+#     by a refactor) that wouldn't trip the staged-file filter.
+#   - Cloud-agent commits (scheduled routines) bypass local hooks.
+#   - PRs from forks or fresh clones may not have husky installed.
+#
+# No grandfather allowlist: the Phase 3 sweep (#1278, #1279) emptied the set
+# repo-wide before this gate shipped. See #569.
+#
+# Source of truth: docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md
+# Lint script: scripts/lint-story-shape.js
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: storybook-story-shape-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  storybook-story-shape-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Storybook story-shape check
+        run: node scripts/lint-story-shape.js --enforce

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -99,6 +99,15 @@ if [ -n "$STAGED_MDX" ]; then
   node scripts/lint-storybook-recipe.js --enforce
 fi
 
+# ── Storybook story-shape (ADR-006) ──
+# Whole-repo scan; fires only when a story file is staged. Bans render-mode
+# gallery exports (Variants/Tones/Patterns/Examples/*And*). See #569.
+STAGED_STORIES=$(git diff --cached --name-only --diff-filter=ACM -- '*.stories.tsx')
+if [ -n "$STAGED_STORIES" ]; then
+  echo "Linting Storybook story shape (ADR-006)..."
+  node scripts/lint-story-shape.js --enforce
+fi
+
 # ── Blueprint naming lint ──
 # Scans staged blueprint files for banned BEM slot suffixes (__eyebrow,
 # __headline, __heading, __body), invented `variant` axis values,

--- a/docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md
+++ b/docs/adrs/ADR-006-storybook-taxonomy-and-story-shape.md
@@ -154,7 +154,7 @@ Pre-existing `*.stories.tsx` files keep whatever shape ADR-007's page-recipe pas
 - [ADR-010](./ADR-010-storybook-axes-of-information.md) carries the story-vs-control matrix referenced by Part B above.
 - BDS `CLAUDE.md` "Storybook" section carries a one-line pointer to this ADR and to ADR-010.
 - New component story files reviewed against the two-shape model + matrix in PR review.
-- **Lint enforcement is page-recipe-scoped today** ([`scripts/lint-storybook-recipe.js`](../../scripts/lint-storybook-recipe.js), gated on pre-commit + CI per ADR-007). A complementary lint for the story-shape rule (no `Variants`/`Tones`/`Patterns` gallery exports) is tracked in [#569](https://github.com/brikdesigns/brik-bds/issues/569) and not yet wired.
+- **Story-shape lint is wired** ([`scripts/lint-story-shape.js`](../../scripts/lint-story-shape.js), gated on pre-commit + CI via [`.github/workflows/storybook-story-shape-check.yml`](../../.github/workflows/storybook-story-shape-check.yml)) — rejects banned render-mode gallery exports (`Variants` / `Tones` / `Patterns` / `Examples`) and `*And*` axis-merge compounds in any `*.stories.tsx`. The Phase 3 sweep ([#1278](https://github.com/brikdesigns/brik-bds/issues/1278), [#1279](https://github.com/brikdesigns/brik-bds/issues/1279)) emptied the set repo-wide first, so **no grandfather allowlist is needed** — every file is expected to pass from day one ([#569](https://github.com/brikdesigns/brik-bds/issues/569)). The complementary page-recipe lint ([`scripts/lint-storybook-recipe.js`](../../scripts/lint-storybook-recipe.js)) covers `*.mdx` per ADR-007; the two operate at different layers (see §Reconciliation with ADR-007).
 - Existing files are not retroactively swept. See Migration above for why.
 
 ## Amendments

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "lint-tokens:grid": "node scripts/lint-tokens.js --check-grid",
     "lint-jsdoc": "node scripts/lint-jsdoc.js",
     "lint-storybook-recipe": "node scripts/lint-storybook-recipe.js",
+    "lint-story-shape": "node scripts/lint-story-shape.js",
     "lint-blueprints:naming": "node scripts/lint-blueprint-naming.mjs",
     "audit:grid": "node scripts/audit-grid.js",
     "health": "node scripts/health.js",

--- a/scripts/lint-story-shape.js
+++ b/scripts/lint-story-shape.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+/**
+ * Storybook Story-Shape Linter (ADR-006 §Enforcement)
+ *
+ * Rejects banned story export names in `*.stories.tsx` files. Per ADR-006
+ * Part B + the story-vs-control matrix (ADR-010), a story export must be named
+ * after the state it demonstrates — never after a render-mode gallery. Gallery
+ * exports duplicate the sidebar and forfeit per-state Chromatic / MCP / Controls
+ * / a11y coverage, and `*And*` compounds merge two axes that should split.
+ *
+ * Banned exact names:  Variants, Tones, Patterns, Examples
+ * Banned compound:     any PascalCase `…AndY` join (e.g. SizesAndVariants) —
+ *                      matched as `[a-z]And[A-Z]` so real words like `Expanded`
+ *                      or `Android` never trip it.
+ *
+ * There is NO grandfather allowlist: the Phase 3 sweep (#1278, #1279) emptied
+ * the set repo-wide before this gate shipped, so every file is expected to pass
+ * from day one. A new violation means a newly-authored file broke the rule.
+ *
+ * `## Variants` / `## Patterns` are REQUIRED/optional *MDX H2 headings* on the
+ * docs page (ADR-007) — a different layer. This lint only inspects `.stories.tsx`
+ * export names, never MDX. See ADR-006 §Reconciliation with ADR-007.
+ *
+ * Usage:
+ *   node scripts/lint-story-shape.js               # full report (exit 0)
+ *   node scripts/lint-story-shape.js --json        # machine-readable
+ *   node scripts/lint-story-shape.js --enforce     # exit 1 on violations
+ *   node scripts/lint-story-shape.js <file>...     # lint only the given files
+ *
+ * Exit codes:
+ *   0 — report printed (default; --enforce changes this)
+ *   1 — fatal error (no story files found) OR violations under --enforce
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const FLAG_ENFORCE = args.includes('--enforce');
+const FLAG_JSON = args.includes('--json');
+const EXPLICIT_FILES = args.filter((a) => !a.startsWith('--'));
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// Story files live under these roots (mirrors the story-shape standard's scope).
+const STORY_ROOTS = ['components/ui', 'stories', 'content-system/blueprints'];
+
+// Directories never worth walking.
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'storybook-static', '.git', 'coverage']);
+
+// ---------------------------------------------------------------------------
+// Rules (mirror of ADR-006 §Part B banned-export table)
+// ---------------------------------------------------------------------------
+
+const BANNED_EXACT = new Set(['Variants', 'Tones', 'Patterns', 'Examples']);
+// PascalCase "X and Y" join — a lowercase char, `And`, then an uppercase char.
+const BANNED_COMPOUND = /[a-z]And[A-Z]/;
+
+function reasonFor(name) {
+  if (BANNED_EXACT.has(name)) {
+    return `\`export const ${name}\` is a banned render-mode gallery name (ADR-006 Part B). Split into args-driven stories named after each state, or keep one axis-only gallery named after the axis (e.g. \`Sizes\`).`;
+  }
+  if (BANNED_COMPOUND.test(name)) {
+    return `\`export const ${name}\` merges two axes ("And" in a story name). Split into one story per axis.`;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+function walkStoryFiles(dir, acc) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc; // root may not exist in every checkout (e.g. stories/)
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walkStoryFiles(path.join(dir, entry.name), acc);
+    } else if (entry.isFile() && entry.name.endsWith('.stories.tsx')) {
+      acc.push(path.join(dir, entry.name));
+    }
+  }
+  return acc;
+}
+
+function findStoryFiles() {
+  if (EXPLICIT_FILES.length > 0) {
+    return EXPLICIT_FILES.map((f) => path.resolve(REPO_ROOT, f)).filter(
+      (f) => f.endsWith('.stories.tsx') && fs.existsSync(f),
+    );
+  }
+  const acc = [];
+  for (const root of STORY_ROOTS) walkStoryFiles(path.join(REPO_ROOT, root), acc);
+  return acc;
+}
+
+// ---------------------------------------------------------------------------
+// Lint one file
+// ---------------------------------------------------------------------------
+
+function lintFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const violations = [];
+  const lines = content.split('\n');
+  const exportRe = /^export const ([A-Z][A-Za-z0-9_]*)\b/;
+
+  lines.forEach((text, i) => {
+    const m = text.match(exportRe);
+    if (!m) return;
+    const name = m[1];
+    const reason = reasonFor(name);
+    if (reason) violations.push({ rule: 'banned-story-export', name, message: reason, line: i + 1 });
+  });
+
+  return { file: path.relative(REPO_ROOT, filePath), violations };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const files = findStoryFiles();
+  if (files.length === 0) {
+    if (EXPLICIT_FILES.length > 0) process.exit(0); // no story files among the given paths
+    console.error(`No *.stories.tsx files found under ${STORY_ROOTS.join(', ')}`);
+    process.exit(1);
+  }
+
+  const results = files.map(lintFile);
+  const conforming = results.filter((r) => r.violations.length === 0);
+  const violating = results.filter((r) => r.violations.length > 0);
+
+  if (FLAG_JSON) {
+    console.log(
+      JSON.stringify(
+        { total: results.length, conforming: conforming.length, violating: violating.length, results },
+        null,
+        2,
+      ),
+    );
+    process.exit(FLAG_ENFORCE && violating.length > 0 ? 1 : 0);
+  }
+
+  console.log(`\nADR-006 Storybook story-shape lint`);
+  console.log(`════════════════════════════════════════════════════════════`);
+  console.log(`Total story files:  ${results.length}`);
+  console.log(`Conforming:         ${conforming.length}`);
+  console.log(`Violating:          ${violating.length}\n`);
+
+  if (violating.length === 0) {
+    console.log(`✓ No banned story exports (Variants / Tones / Patterns / Examples / *And* compounds).\n`);
+    process.exit(0);
+  }
+
+  console.log('Banned story exports:');
+  for (const r of violating) {
+    console.log(`\n  ${r.file}`);
+    for (const v of r.violations) console.log(`    [${v.rule}] L${v.line}: ${v.message}`);
+  }
+  console.log('');
+
+  if (FLAG_ENFORCE) {
+    console.log('--enforce: banned story exports detected, exiting 1');
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
Wires the durable static enforcement layer for ADR-006 Part B — the closing gate of the Storybook standards rearchitect (umbrella #587). The Phase 3 sweep (#1278, #1279) already emptied the banned-export set repo-wide, so this ships **with no grandfather allowlist**.

## What
`scripts/lint-story-shape.js` rejects, in any `*.stories.tsx`:
- Exact banned gallery names: `Variants`, `Tones`, `Patterns`, `Examples`
- `*And*` axis-merge compounds (e.g. `SizesAndVariants`) — matched as the PascalCase join `[a-z]And[A-Z]` so real words like `Expanded` / `Android` never false-positive.

Scope covers `components/ui/`, `stories/`, and `content-system/blueprints/` (the story-shape standard's scope). This is a `.stories.tsx` export-name lint only — it never touches MDX. `## Variants` / `## Patterns` MDX **H2 headings** remain required/optional per ADR-007; different layer.

## Wiring (mirrors the ADR-007 recipe-lint pattern)
- `npm run lint-story-shape` (+ `--enforce`, `--json`, explicit-file args)
- Pre-commit: whole-repo `--enforce` scan gated on staged `*.stories.tsx`
- CI: `.github/workflows/storybook-story-shape-check.yml` on PR + push to `main`
- ADR-006 §Enforcement amended — the lint is now wired (was "tracked in #569 and not yet wired")

## Verification
- `node scripts/lint-story-shape.js --enforce` → **137/137 conforming**, exit 0
- Positive test — temp fixture exporting `Variants` / `Patterns` / `SizesAndVariants` / `WithIconAndLabel` → exits 1; `Default` / `Expanded` / `AndroidView` pass
- `npm run typecheck` → clean

Closes #569
Refs #587