### PR TITLE
Add NoPrice story to HeroSplitImageCardOverlay (closes #500)

### DIFF
--- a/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
+++ b/content-system/blueprints/react/HeroSplitImageCardOverlay.stories.tsx
@@ -296,3 +296,33 @@ export const PriceCtaActionButton: Story = {
     await userEvent.click(cta);
   },
 };
+
+/**
+ * @summary Price-suppressed card (#500) — omit `priceCard.price`/`priceLabel`
+ * to render the deliverable image + CTA with no price overlay text. The
+ * blueprint guards both the label (`priceLabel && price`) and the value
+ * (`price`), so a priceCard carrying only an image and a CTA renders an
+ * image-and-action card — the shape for services with no fixed/published price.
+ */
+export const NoPrice: Story = {
+  args: {
+    ...baseProps,
+    section: {
+      ...interiorHeroSection,
+      sectionKey: 'hero-img-card-no-price',
+      priceCard: {
+        imageUrl: 'https://placehold.co/600x600/eaf1fb/1f3d70?text=Deliverable',
+        imageAlt: '',
+        cta: { label: 'Request a quote', url: '#contact' },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Price text is suppressed — neither the label nor the value renders...
+    await expect(canvasElement.querySelector('.bds-hero__price-label')).toBeNull();
+    await expect(canvasElement.querySelector('.bds-hero__price-value')).toBeNull();
+    // ...while the image card and its CTA still render.
+    await expect(canvas.getByRole('link', { name: 'Request a quote' })).toBeVisible();
+  },
+};


### PR DESCRIPTION
## Summary
- test(hero): add NoPrice story for HeroSplitImageCardOverlay price-suppression (#500)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)