### PR TITLE
Retire redundant --border-on-color-dark gap-fill (closes #981)

### DIFF
--- a/tokens/gap-fills.css
+++ b/tokens/gap-fills.css
@@ -266,12 +266,6 @@
    higher specificity, in theme-brand-brik.css).
    RETIRE each entry once the Figma source is corrected and re-synced. */
 :root[data-theme="dark"] {
-  /* Context-pinned on-color border: stays white in dark mode like its
-     --text-on-color-dark / --background-on-color-dark siblings, so borders on
-     a fixed dark/colored surface stay visible. Figma source still emits black
-     here — correct it and drop this line. (#980) */
-  --border-on-color-dark: var(--color-grayscale-white);
-
   /* Dark value for the --background-tertiary gap-fill (light value above, in
      :root). It's a hover/preview fill (e.g. SegmentedControl inactive hover),
      so in dark mode it must read as a step TOWARD the active surface


### PR DESCRIPTION
## Summary
- fix(tokens): retire redundant --border-on-color-dark dark-mode gap-fill (#981)

## Consumer sync plan
- [ ] Portal: `npm update @brikdesigns/bds` after merge + version publish
- [ ] renew-pms: submodule bump (until npm migration lands)
- [ ] brikdesigns: `./scripts/bds-sync.sh`

## Test plan
- [ ] Storybook: visual verification on affected stories
- [ ] `npm test -- --run` passes
- [ ] `npm run lint-tokens` passes
- [ ] Dark mode checked (if applicable)

## Knowledge capture
- [ ] Non-obvious decisions / learnings captured: `brik-rag remember "<key insight>"`

Generated with [Claude Code](https://claude.ai/code)